### PR TITLE
Convert Notebook to Jupyter format

### DIFF
--- a/tutorial_exercises/01-Symbols-Derivatives-Functions.ipynb
+++ b/tutorial_exercises/01-Symbols-Derivatives-Functions.ipynb
@@ -1,708 +1,748 @@
 {
- "metadata": {
-  "name": "",
-  "signature": "sha256:437ff553e16c427aa371f5c52fda93906589a1a37288c616087493dc6dbb1491"
- },
- "nbformat": 3,
- "nbformat_minor": 0,
- "worksheets": [
+ "cells": [
   {
-   "cells": [
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Introduction\n",
+    "\n",
+    "In this section we learn to do the following:\n",
+    "\n",
+    "* Import SymPy and set up pretty printing\n",
+    "* Use mathematical operations like `sqrt` and `sin`\n",
+    "* Make SymPy Symbols\n",
+    "* Take derivatives of expressions\n",
+    "* Simplify expressions"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Preamble"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Just like NumPy and Pandas replace functions like `sin`, `cos`, `exp`, and `log` to powerful numeric implementations, SymPy replaces `sin`, `cos`, `exp` and `log` with powerful mathematical implementations."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from sympy import *\n",
+    "init_printing()  # Set up fancy printing"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
     {
-     "cell_type": "markdown",
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAIAAAAASCAYAAACTkNaDAAAABHNCSVQICAgIfAhkiAAABIFJREFU\naIHt2W/MVnMYB/DPUz2eJLRKNWOyJLygWtJE879lbawxGiu8sYT8mzEiMizGNEQzHjEk/15oCy9q\nelF4gc2fIWv5F7IVKpUlL67fXec5z7mf+9z3c+eN57udnd3X7zrf67rO+Z3r9z2/mx78r9FSxd4P\na3FiN7hvQSseaFKManzjcRsOxBH4EHfhxwbjTsDV+Ctx9sP9+DTn9xXmYyW2YVzK4zp8mfM9FvMS\n5850noc/G6ijTH5T8FSyVWL+kxn/CE9Uqd/JyWFPNYcSOErclHlNilGNbyzexYD0uz/ex68Y3kDc\nMXgbfTO2RfgDo3O+e3LHLswu4DwB3+HU9HsY1udqKVtH2fxuLsgve0wpyNPxWI528YZ0ZwIsTtfP\na1KManzLcUzONib5vtJA3EfT2CUZ29RkW5jz3ZDyehMLUow8+ohOcUPGdiQ2YU4DdZTNb1GK04pe\nGftEPF6QZye0a3wCTMOlih9YIzG64tsq3q4hOftm/NZA3Bn4HedmbJXYD+Z8V1VPeS+uEp1hQA2/\nsnWUza/oIffHCrFk7EWvAsfuoD/O13HW7k++9RiKg3L2nWJ9rBdLcCjey9jGYjdeboBvOtZhSw2/\nsnWUze/aghgP4W5szxr71EisXtyuuujbH3wTcDB+ztgOFzdzVRPiH42ZuEZnEdiGuRiEvzFCiLiv\n03gLThNibhLOExN6OO7Bx02oo6v8spiI3vggP9DMCTBatLJv/0O+benI4nqheO/oRuypOAUX4DE8\nU+BzmFhOvk+/L8dqnCQe5CAh1oYIIXhn8jtDCLwJ+LzBOsrkl8VCXFTDpwPa1acBeuF5HJCxdUcD\nNMJHCKmtuK/BuHn0Ee12LQYX5JhFb9FeK2JsaIqzQ+fl6Aeh5quhTB218qvgbHxRg6cT2tU3AWbh\nzJytOxOgEb420W4f6cKnVtwiTEr+r5Xw3ZAOQoHvwWcFfmvF+t5WMFa2jrL5vY5nq13cDBE4TLS4\nlU3gapSvBc8JlXtTN2Ifp/MG0SfpPE2s4UQLX11wfW/x5hO6YJNQ8nnsFN1tYM5eq46y+VXQisnY\nWMCF5miAc1Jib+UCE58oo4V6fWM/8s0Xu2/zM7YZya8sDhHCrBWj7NMeu9O5RTxg4ht9XQHHYPs6\nAPGmjyzwaxOTYFPO3lUd9eRXwXjxZVHtk7gq2nXdJkfq+jNruObtA9TiuxL3FtgX1xm3r3hrv9Hx\nzRyX/LMKepkQeVlUNm7mZmzThS7I3qsW8Vn4au76WnXUk18FM9PYrIIxVO8Ala3GfnLfjWLNWSXE\nx+Qq17fmzvXGKMt3lvi+XYEXM/Y+qk+uanF3JK6NOrbtOUKQZW/iAjwt3s7t4qHeiDVprIKlQs3P\nxsPJdrF4kLfWWUc9+VVQ2VjaVTBW6PyOEC2VPeNNYi2+LOM3Cr/gyQKOQ5L/T/Yp4DW4sM4YZfk2\nZ3jyR7aN1hP3CrGp8oKY5EvFnzl5nC46wRKxXM3XcY++goGi6yzDS4l7RM6nbB315Efcpy2iS/Sg\nBz3oQQ96kMW/xkOALTogtx0AAAAASUVORK5CYII=\n",
+      "text/latex": [
+       "$$1.41421356237$$"
+      ],
+      "text/plain": [
+       "1.41421356237"
+      ]
+     },
+     "execution_count": 2,
      "metadata": {},
-     "source": [
-      "# Introduction\n",
-      "\n",
-      "In this section we learn to do the following:\n",
-      "\n",
-      "* Import SymPy and set up pretty printing\n",
-      "* Use mathematical operations like `sqrt` and `sin`\n",
-      "* Make SymPy Symbols\n",
-      "* Take derivatives of expressions\n",
-      "* Simplify expressions"
-     ]
-    },
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import math\n",
+    "math.sqrt(2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
     {
-     "cell_type": "markdown",
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAACIAAAAbCAYAAAAZMl2nAAAABHNCSVQICAgIfAhkiAAAAZdJREFU\nSInt1j9IVWEYx/GPJRh5lQiUSJAEBzdRoaEmm+7k1hQETkJLS2MO/hkCyUGQsD9LVAiBQ5D9G6LG\nRp0Cp4iIEi74JxIqHV4TPVzPvee8Z7xfOMN5nvP8nh/Ped9zXhocpakgnd2CdKJZxqkYgRMFmCjj\nA34XoBXFC7THisRO5DJWsBFrJJbn6ChCKGYi/fiGn0UYieExulPyF7GEV1jFI3QVbaIXD1Pyg3iL\nM/v3JXzED1wo0sgC+lLyLwWzhxkQPnyLWRq1peS68KxG/Ra+oDMRr2C9HgOn8RTzKc/cxVANnVXs\noCcR/47tWiaacRtT2FT9I3VWWIC1aMW5ROy88Gre11F/0OwXblbJTWC4XqEEd/AXl7IUPcBnR//O\nJWER5qFXWDfTWQv7hTGWD8VuYSSHiRZ8wmyOWoR9/38CLXgj+/mlSdhhk3lNwFX8E8Y6hms5NKYx\nnohdzyrSjK+YwzuczFg/qvok7h/X7Dj+4J6wnW8IK75ermAGr/Ek0S/XsbIDa7IfAyv7DatdU3mM\nNGiwB8TFSHRLCRDNAAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$$\\sqrt{2}$$"
+      ],
+      "text/plain": [
+       "  ___\n",
+       "╲╱ 2 "
+      ]
+     },
+     "execution_count": 3,
      "metadata": {},
-     "source": [
-      "## Preamble"
-     ]
-    },
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sqrt(2)  # This `sqrt` comes from SymPy"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
     {
-     "cell_type": "markdown",
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAAsAAAASCAYAAACNdSR1AAAABHNCSVQICAgIfAhkiAAAAF5JREFU\nKJFjYKAC4GJgYLhEjEJTBgaG0wwMDP/RJViQ2JoMDAw9DAwMrxkYGP6S4owF2ExmIsWEUcVUV8wB\npblwaRRjYGDYycDAcIUBEnv/GSBRv5+BgSGaFBfQGAAA/84M5lOscPUAAAAASUVORK5CYII=\n",
+      "text/latex": [
+       "$$1$$"
+      ],
+      "text/plain": [
+       "1"
+      ]
+     },
+     "execution_count": 4,
      "metadata": {},
-     "source": [
-      "Just like NumPy and Pandas replace functions like `sin`, `cos`, `exp`, and `log` to powerful numeric implementations, SymPy replaces `sin`, `cos`, `exp` and `log` with powerful mathematical implementations."
-     ]
-    },
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "cos(0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise\n",
+    "\n",
+    "Use the function `acos` on `-1` to find when cosine equals `-1`.  Try this same function with the math library.  Do you get the same result?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Call acos on -1 to find where on the circle the x coordinate equals -1\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Call `math.acos` on -1 to find the same result using the builtin math module.  \n",
+    "# Is the result the same?  \n",
+    "# What do you think `numpy.acos` give you?\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Symbols\n",
+    "\n",
+    "Just like the NumPy `ndarray` or the Pandas `DataFrame`, SymPy has the `Symbol`, which represents a mathematical variable.\n",
+    "\n",
+    "We create symbols using the function `symbols`.  Operations on these symbols don't do numeric work like with NumPy or Pandas, instead they build up mathematical expressions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "x, y, z = symbols('x,y,z')\n",
+    "alpha, beta, gamma = symbols('alpha,beta,gamma')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [
     {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "from sympy import *\n",
-      "init_printing()  # Set up fancy printing"
-     ],
-     "language": "python",
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAACsAAAAUCAYAAAAUccS4AAAABHNCSVQICAgIfAhkiAAAAUtJREFU\nSInt1c8qRVEUx/EPGfgzMTIR+ZMkoYi8gImHkFAyMCMTZWQiDJUyuJIX8AKSQgklmUnKzEAM5D+D\nfeXQVcflXIrv5Jy99zpr/c7aa+/FP1+iGPs/LSIO7djGU6bFggQDN+MQ9zFsGzCNMzwkqOlDUqjK\n8ruMmc3PXkvueV8GbegRtqIKAxhEKcoxgaMc6ntDVGwN+jCMR2E7ttCLPKxjDzM5VRghKnYEY4JQ\nKME5NlCBWeEHfgXV78anmPyCv5RvPmDRzB5H3uuFGl2N4XwRLRnmK9GB2wxr/diJ4TsWQ7gRuskL\ntZ/0kZLQ1VWEKTSlx11Cy7uK2I1mEfhbeSmDbkHMLu5Qh4uI3biw3bmgMP0s9posvIpdE9LfhlZ0\nYg7zQs2tYDNBgWVYEs5JY3ruBAdYwHKCsZF9zX5Iku32EtcJ+v/nb/IMFVU7EHvbWc8AAAAASUVO\nRK5CYII=\n",
+      "text/latex": [
+       "$$x + 1$$"
+      ],
+      "text/plain": [
+       "x + 1"
+      ]
+     },
+     "execution_count": 8,
      "metadata": {},
-     "outputs": [],
-     "prompt_number": 1
-    },
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "x + 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
     {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "import math\n",
-      "math.sqrt(2)"
-     ],
-     "language": "python",
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAF8AAAAbCAYAAAAahVOPAAAABHNCSVQICAgIfAhkiAAABGVJREFU\naIHt2GmIVmUUwPGfS+NS0YTmVolbpeVSGkqiVgRmhBlFREq2SMuHFie/tEAUlQRWoEFl67QvEJRB\nJkYQFLSCloF+EcXJcqkEM22dPpx78frOnXefqYH3Dy+X59znnue8zz3bc2nQoJtpxtI66ZqHq3El\nVqApZ85dOKpO6/VomvA6BtVB10U4OTNeg7Ny5k3C6kJh7zoY0NNYinfwU416xmA3diTj08UL3ZQz\n91tsx8Ia1+zRHI8N6FsHXVck1zvxGPZiVJH5zdiYXfu/9vxL8Sk2Y1k3rHetSA1/1VHn9yKKtuPW\nIvP2iQiYX8e1a2YUDuC+blhrPS6sg55hmF4guwVvlXjuZryUDrrK8ycrP7S3YU8X2ZGlCbPxZR10\nzcJXBbKp+LDEc5/jnHTQVZt/B07qIt3VMhS98HMddM3CyMx4svi/z5Z4bg/GStrRehSensIQkXfr\nwWe4DPuFAw/CJfinxHO/CAdoxu7s5vcSeaslUfaaKCBpceorDhEt9bG/LGYkNuxK1m/GcmwpmHe9\nOOzsEB64HuNxNt7AU+ij9OaMF1F7AANxHG4TLSWxR2OwNdFbKZ0W+lWicj+Dl0Xr9Ejm/kLMKXOR\nVsXbrkK26Vhw54tNPiEjm5DMzR5kbsKvYqPgFPwtNn6e8EgYjUNFbFiANkzJyB4Qub1PMl6JRarP\nGCMS245I93PwJo7NyIaIFjD98x1OaEVoVdvmHyNeft4ngJWiV0/5RhSyLLuEA2UZIP740Tk6J+Eg\nFhfIJ6Adc3Ei7hVRVi0TsTMdpG9gpuiB92cm7sb9wiPOw0c1LFopF4vUtznn3hbhndOS8V70K5jT\nT0fvPIgv5B//V4hi+GqBvC25nokloqA+X9r8Tpma2EDGwIc7mbxW5NhxuCfn/ouODNOUkaIP/iPn\n3hJ8XcLIMck1L0f+mVzHJXoexAc4A9+JVNOER3OeXSui/JOMbLDw7CdFZGRJnXGKiM6damM23k0H\npXLXPgzHjzmGwTWdPNcq0si2Sq1L+CG5Dsm5l34Q25VcD4l0cIN4MU3Cw/Ki5hVxEFqekY0VhbSw\nb88ySThNLfQXdej2VFBO4ZiGu2tcuFLew284LefeNJEOUu+difdF7i/FVhEt80S0cLiT2Z8zf4Do\nkNYoXqzL4To8Lf5X2ayrYqFWlRXcNpE+sixK5MMzstEix5+fkV0lXtYFOFd4/TDhzXk0i83MNhfr\nRLeXZYZIRRtEs9FbfLOvhhF4W4Vd0mjRXVRKq/I2f4HwxHbRW38swjNltjhvPIHH8ZxIAVkGiw9b\n7QW/NvEC8xiLhzLjZrwgCuoK0WIvFi3mDJGSVosoq4ZVjmyZy2IpbqxisVaVeX61jBS5fa7DvXh/\nUbCX4Xec2g12dAlrdfS0clglQr+raZHpHnLYiMu7wY6601t0K53lzv8DE8Unhbx0MFcU2KHdalEF\nFCsAg0WRaO8mW6phkyiyLSI9ph+6BoqefLoo0A0aNGjQoMF/yr9ULdlTCdhRNAAAAABJRU5ErkJg\ngg==\n",
+      "text/latex": [
+       "$$\\gamma + \\log{\\left (\\alpha^{\\beta} \\right )}$$"
+      ],
+      "text/plain": [
+       "       ⎛ β⎞\n",
+       "γ + log⎝α ⎠"
+      ]
+     },
+     "execution_count": 9,
      "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$1.41421356237$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAIAAAAASCAYAAACTkNaDAAAABHNCSVQICAgIfAhkiAAABIFJREFU\naIHt2W/MVnMYB/DPUz2eJLRKNWOyJLygWtJE879lbawxGiu8sYT8mzEiMizGNEQzHjEk/15oCy9q\nelF4gc2fIWv5F7IVKpUlL67fXec5z7mf+9z3c+eN57udnd3X7zrf67rO+Z3r9z2/mx78r9FSxd4P\na3FiN7hvQSseaFKManzjcRsOxBH4EHfhxwbjTsDV+Ctx9sP9+DTn9xXmYyW2YVzK4zp8mfM9FvMS\n5850noc/G6ijTH5T8FSyVWL+kxn/CE9Uqd/JyWFPNYcSOErclHlNilGNbyzexYD0uz/ex68Y3kDc\nMXgbfTO2RfgDo3O+e3LHLswu4DwB3+HU9HsY1udqKVtH2fxuLsgve0wpyNPxWI528YZ0ZwIsTtfP\na1KManzLcUzONib5vtJA3EfT2CUZ29RkW5jz3ZDyehMLUow8+ohOcUPGdiQ2YU4DdZTNb1GK04pe\nGftEPF6QZye0a3wCTMOlih9YIzG64tsq3q4hOftm/NZA3Bn4HedmbJXYD+Z8V1VPeS+uEp1hQA2/\nsnWUza/oIffHCrFk7EWvAsfuoD/O13HW7k++9RiKg3L2nWJ9rBdLcCjey9jGYjdeboBvOtZhSw2/\nsnWUze/aghgP4W5szxr71EisXtyuuujbH3wTcDB+ztgOFzdzVRPiH42ZuEZnEdiGuRiEvzFCiLiv\n03gLThNibhLOExN6OO7Bx02oo6v8spiI3vggP9DMCTBatLJv/0O+benI4nqheO/oRuypOAUX4DE8\nU+BzmFhOvk+/L8dqnCQe5CAh1oYIIXhn8jtDCLwJ+LzBOsrkl8VCXFTDpwPa1acBeuF5HJCxdUcD\nNMJHCKmtuK/BuHn0Ee12LQYX5JhFb9FeK2JsaIqzQ+fl6Aeh5quhTB218qvgbHxRg6cT2tU3AWbh\nzJytOxOgEb420W4f6cKnVtwiTEr+r5Xw3ZAOQoHvwWcFfmvF+t5WMFa2jrL5vY5nq13cDBE4TLS4\nlU3gapSvBc8JlXtTN2Ifp/MG0SfpPE2s4UQLX11wfW/x5hO6YJNQ8nnsFN1tYM5eq46y+VXQisnY\nWMCF5miAc1Jib+UCE58oo4V6fWM/8s0Xu2/zM7YZya8sDhHCrBWj7NMeu9O5RTxg4ht9XQHHYPs6\nAPGmjyzwaxOTYFPO3lUd9eRXwXjxZVHtk7gq2nXdJkfq+jNruObtA9TiuxL3FtgX1xm3r3hrv9Hx\nzRyX/LMKepkQeVlUNm7mZmzThS7I3qsW8Vn4au76WnXUk18FM9PYrIIxVO8Ala3GfnLfjWLNWSXE\nx+Qq17fmzvXGKMt3lvi+XYEXM/Y+qk+uanF3JK6NOrbtOUKQZW/iAjwt3s7t4qHeiDVprIKlQs3P\nxsPJdrF4kLfWWUc9+VVQ2VjaVTBW6PyOEC2VPeNNYi2+LOM3Cr/gyQKOQ5L/T/Yp4DW4sM4YZfk2\nZ3jyR7aN1hP3CrGp8oKY5EvFnzl5nC46wRKxXM3XcY++goGi6yzDS4l7RM6nbB315Efcpy2iS/Sg\nBz3oQQ96kMW/xkOALTogtx0AAAAASUVORK5CYII=\n",
-       "prompt_number": 2,
-       "text": [
-        "1.41421356237"
-       ]
-      }
-     ],
-     "prompt_number": 2
-    },
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "log(alpha ** beta) + gamma"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
     {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "sqrt(2)  # This `sqrt` comes from SymPy"
-     ],
-     "language": "python",
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAIIAAAAZCAYAAAD9ovZ9AAAABHNCSVQICAgIfAhkiAAABH1JREFU\naIHt2VuIVVUcx/GPppVlpZiVXchGQ0WUzExTypKKiO5QEYhZRlEkWBb0EF3sQncq6AZRYz3UU3Qz\niKCkxNJ8iAqioLQMw8y8RWVp9fBfG9ccz8zZZ+bMOE7nC4e911r/vdd//fb6r9uhSRP068G6pmI6\nDsEM3IMPe7D+Jr2AwXggS1+G33HUnnFnr2AqbsJdeA+n7VFvGsRE/INRKX0w/hUdosnu9NnA6Sd6\neDEVjRcdYdIe86h302sD53T8ipsb9L6X8WiD3tUX6bWBc0Vy5LkGvGseHtKzC9W9nV4VOKMxoIvv\nOE90BNgfI7v4vkYwUdfb1Z30ucCZKRp1RPpdhFP2qEdBq97RIavRY4FTJhL2Sw4Mx2/4rBP1tOBt\nsRrOOaQT7/q/MBOHY4kInGlYjzXdUVneES4WEbpJ9L5hKf9ZMT+djcWYm9kvwgg8gU9wBg7EFCzE\nx8n2OxxU0qf+OAvvZnmTMQc7Rae8BtdhiNhS3Zna8gd+KFlPZzkBd2Az/kz+Po9Vmc1UzBcfbkDy\n8358ndm0p/eN6gucSr3KaPUtxqii1zi8X1HBbDFsFqyqSEvObxO9dl6W/6TO99xLtRWgBU+JBks+\nfCNOKWeIbdbCVJb7UJZW5Yfc6dgqdlEFL+H7LH2++ODDs7xxQo9JWbqW3mXJ9apHKzK9igcm4jBt\no/Z1MRUU5PcFG9OvBS9k+V/iWG3FKMuIirpuwW2iEcSIswnLRW9+zC4BV4utVnfQDy/iIyzN8jdi\nRbofnGyewYbM5iu8kcoop3dZcr3q0Yoqeh2Jn7FFbFXm2/0jLlW9x67BKxV5c8V2c2TtdrRhEBZU\n5B1Xkf4R97Xz/DBcVWedrcr5OU20aVEHNpcnm3OqlN2QyiYrp3cZKvWqRysyvYoRYZ2Y114Vw96T\nWCvOD8qwvaRdLYbaPSpWZ/djxDz3QTvPbxELq2osFgvdyt8FeKedssnZ8yPT9ccO/G9J1x1Vyv5O\n19G6rndBpV71aEWmV7FYnCKGuOtS+hjcKw6QXtO4D12LzXZfIOXMwl9iqCsYJRY/xFC7rZ1nr2wn\nv1X8sbOmhm/r0nVoBzY/pethVcqKxeB6jdO7I71qaUWmVzEijNe2N67F1WKuGVLSqUbwO/bJ0oPE\nYcqElD4Lnyc7wv9bM/sJ+LSbfFsuRoNZVcouEXP1W8m3MVVsJqfnl2mc3rle9WpFplf/LHOBmLsK\njhYrzvUpPVD1c4dq+QMrrvWwQWyn4Fzh/HiMxfHaRsvtYsgvGIuVnaizDDvEx5qJC7P84UL0n0SU\nXytW4yMym+PE1nqOXdNGLb3LUuhVr1ZkehXHlrPFKv9QsbcseuaDYt57BCeJeW6Z2CKdKfbTJ6b8\nlWIr80QqGyqG2xd1vMCqZF8h7JLkz8P4RSy07sbTYv/+F94U/9UTUThQ7FjqoVW5qaHg5GS/WXz8\n7UKnLZnNqbg+2ezEAXgcX6TyjvReW6f/hV4rlNeKzuvVZ2nVe4+Ye4z+tU36PFtF1DRp0qRJkyZN\nmjSp4D+SOyJ3naugoAAAAABJRU5ErkJggg==\n",
+      "text/latex": [
+       "$$\\sin^{2}{\\left (x \\right )} + \\cos^{2}{\\left (x \\right )}$$"
+      ],
+      "text/plain": [
+       "   2         2   \n",
+       "sin (x) + cos (x)"
+      ]
+     },
+     "execution_count": 10,
      "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\sqrt{2}$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAACIAAAAbCAYAAAAZMl2nAAAABHNCSVQICAgIfAhkiAAAAZdJREFU\nSInt1j9IVWEYx/GPJRh5lQiUSJAEBzdRoaEmm+7k1hQETkJLS2MO/hkCyUGQsD9LVAiBQ5D9G6LG\nRp0Cp4iIEi74JxIqHV4TPVzPvee8Z7xfOMN5nvP8nh/Ped9zXhocpakgnd2CdKJZxqkYgRMFmCjj\nA34XoBXFC7THisRO5DJWsBFrJJbn6ChCKGYi/fiGn0UYieExulPyF7GEV1jFI3QVbaIXD1Pyg3iL\nM/v3JXzED1wo0sgC+lLyLwWzhxkQPnyLWRq1peS68KxG/Ra+oDMRr2C9HgOn8RTzKc/cxVANnVXs\noCcR/47tWiaacRtT2FT9I3VWWIC1aMW5ROy88Gre11F/0OwXblbJTWC4XqEEd/AXl7IUPcBnR//O\nJWER5qFXWDfTWQv7hTGWD8VuYSSHiRZ8wmyOWoR9/38CLXgj+/mlSdhhk3lNwFX8E8Y6hms5NKYx\nnohdzyrSjK+YwzuczFg/qvok7h/X7Dj+4J6wnW8IK75ermAGr/Ek0S/XsbIDa7IfAyv7DatdU3mM\nNGiwB8TFSHRLCRDNAAAAAElFTkSuQmCC\n",
-       "prompt_number": 3,
-       "text": [
-        "  ___\n",
-        "\u2572\u2571 2 "
-       ]
-      }
-     ],
-     "prompt_number": 3
-    },
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sin(x)**2 + cos(x)**2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise\n",
+    "\n",
+    "Use `symbols` to create two variables, `mu` and `sigma`.  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
     {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "cos(0)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$1$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAAsAAAASCAYAAACNdSR1AAAABHNCSVQICAgIfAhkiAAAAF5JREFU\nKJFjYKAC4GJgYLhEjEJTBgaG0wwMDP/RJViQ2JoMDAw9DAwMrxkYGP6S4owF2ExmIsWEUcVUV8wB\npblwaRRjYGDYycDAcIUBEnv/GSBRv5+BgSGaFBfQGAAA/84M5lOscPUAAAAASUVORK5CYII=\n",
-       "prompt_number": 4,
-       "text": [
-        "1"
-       ]
-      }
-     ],
-     "prompt_number": 4
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "### Exercise\n",
-      "\n",
-      "Use the function `acos` on `-1` to find when cosine equals `-1`.  Try this same function with the math library.  Do you get the same result?"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "# Call acos on -1 to find where on the circle the x coordinate equals -1\n",
-      "\n"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 5
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "# Call `math.acos` on -1 to find the same result using the builtin math module.  \n",
-      "# Is the result the same?  \n",
-      "# What do you think `numpy.acos` give you?\n",
-      "\n"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 6
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "## Symbols\n",
-      "\n",
-      "Just like the NumPy `ndarray` or the Pandas `DataFrame`, SymPy has the `Symbol`, which represents a mathematical variable.\n",
-      "\n",
-      "We create symbols using the function `symbols`.  Operations on these symbols don't do numeric work like with NumPy or Pandas, instead they build up mathematical expressions."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "x, y, z = symbols('x,y,z')\n",
-      "alpha, beta, gamma = symbols('alpha,beta,gamma')"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 7
-    },
-    {
-     "cell_type": "code",
-     "collapsed": true,
-     "input": [
-      "x + 1"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$x + 1$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAACsAAAAUCAYAAAAUccS4AAAABHNCSVQICAgIfAhkiAAAAUtJREFU\nSInt1c8qRVEUx/EPGfgzMTIR+ZMkoYi8gImHkFAyMCMTZWQiDJUyuJIX8AKSQgklmUnKzEAM5D+D\nfeXQVcflXIrv5Jy99zpr/c7aa+/FP1+iGPs/LSIO7djGU6bFggQDN+MQ9zFsGzCNMzwkqOlDUqjK\n8ruMmc3PXkvueV8GbegRtqIKAxhEKcoxgaMc6ntDVGwN+jCMR2E7ttCLPKxjDzM5VRghKnYEY4JQ\nKME5NlCBWeEHfgXV78anmPyCv5RvPmDRzB5H3uuFGl2N4XwRLRnmK9GB2wxr/diJ4TsWQ7gRuskL\ntZ/0kZLQ1VWEKTSlx11Cy7uK2I1mEfhbeSmDbkHMLu5Qh4uI3biw3bmgMP0s9posvIpdE9LfhlZ0\nYg7zQs2tYDNBgWVYEs5JY3ruBAdYwHKCsZF9zX5Iku32EtcJ+v/nb/IMFVU7EHvbWc8AAAAASUVO\nRK5CYII=\n",
-       "prompt_number": 8,
-       "text": [
-        "x + 1"
-       ]
-      }
-     ],
-     "prompt_number": 8
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "log(alpha ** beta) + gamma"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\gamma + \\log{\\left (\\alpha^{\\beta} \\right )}$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAF8AAAAbCAYAAAAahVOPAAAABHNCSVQICAgIfAhkiAAABGVJREFU\naIHt2GmIVmUUwPGfS+NS0YTmVolbpeVSGkqiVgRmhBlFREq2SMuHFie/tEAUlQRWoEFl67QvEJRB\nJkYQFLSCloF+EcXJcqkEM22dPpx78frOnXefqYH3Dy+X59znnue8zz3bc2nQoJtpxtI66ZqHq3El\nVqApZ85dOKpO6/VomvA6BtVB10U4OTNeg7Ny5k3C6kJh7zoY0NNYinfwU416xmA3diTj08UL3ZQz\n91tsx8Ia1+zRHI8N6FsHXVck1zvxGPZiVJH5zdiYXfu/9vxL8Sk2Y1k3rHetSA1/1VHn9yKKtuPW\nIvP2iQiYX8e1a2YUDuC+blhrPS6sg55hmF4guwVvlXjuZryUDrrK8ycrP7S3YU8X2ZGlCbPxZR10\nzcJXBbKp+LDEc5/jnHTQVZt/B07qIt3VMhS98HMddM3CyMx4svi/z5Z4bg/GStrRehSensIQkXfr\nwWe4DPuFAw/CJfinxHO/CAdoxu7s5vcSeaslUfaaKCBpceorDhEt9bG/LGYkNuxK1m/GcmwpmHe9\nOOzsEB64HuNxNt7AU+ij9OaMF1F7AANxHG4TLSWxR2OwNdFbKZ0W+lWicj+Dl0Xr9Ejm/kLMKXOR\nVsXbrkK26Vhw54tNPiEjm5DMzR5kbsKvYqPgFPwtNn6e8EgYjUNFbFiANkzJyB4Qub1PMl6JRarP\nGCMS245I93PwJo7NyIaIFjD98x1OaEVoVdvmHyNeft4ngJWiV0/5RhSyLLuEA2UZIP740Tk6J+Eg\nFhfIJ6Adc3Ei7hVRVi0TsTMdpG9gpuiB92cm7sb9wiPOw0c1LFopF4vUtznn3hbhndOS8V70K5jT\nT0fvPIgv5B//V4hi+GqBvC25nokloqA+X9r8Tpma2EDGwIc7mbxW5NhxuCfn/ouODNOUkaIP/iPn\n3hJ8XcLIMck1L0f+mVzHJXoexAc4A9+JVNOER3OeXSui/JOMbLDw7CdFZGRJnXGKiM6damM23k0H\npXLXPgzHjzmGwTWdPNcq0si2Sq1L+CG5Dsm5l34Q25VcD4l0cIN4MU3Cw/Ki5hVxEFqekY0VhbSw\nb88ySThNLfQXdej2VFBO4ZiGu2tcuFLew284LefeNJEOUu+difdF7i/FVhEt80S0cLiT2Z8zf4Do\nkNYoXqzL4To8Lf5X2ayrYqFWlRXcNpE+sixK5MMzstEix5+fkV0lXtYFOFd4/TDhzXk0i83MNhfr\nRLeXZYZIRRtEs9FbfLOvhhF4W4Vd0mjRXVRKq/I2f4HwxHbRW38swjNltjhvPIHH8ZxIAVkGiw9b\n7QW/NvEC8xiLhzLjZrwgCuoK0WIvFi3mDJGSVosoq4ZVjmyZy2IpbqxisVaVeX61jBS5fa7DvXh/\nUbCX4Xec2g12dAlrdfS0clglQr+raZHpHnLYiMu7wY6601t0K53lzv8DE8Unhbx0MFcU2KHdalEF\nFCsAg0WRaO8mW6phkyiyLSI9ph+6BoqefLoo0A0aNGjQoMF/yr9ULdlTCdhRNAAAAABJRU5ErkJg\ngg==\n",
-       "prompt_number": 9,
-       "text": [
-        "       \u239b \u03b2\u239e\n",
-        "\u03b3 + log\u239d\u03b1 \u23a0"
-       ]
-      }
-     ],
-     "prompt_number": 9
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "sin(x)**2 + cos(x)**2"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\sin^{2}{\\left (x \\right )} + \\cos^{2}{\\left (x \\right )}$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAIIAAAAZCAYAAAD9ovZ9AAAABHNCSVQICAgIfAhkiAAABH1JREFU\naIHt2VuIVVUcx/GPppVlpZiVXchGQ0WUzExTypKKiO5QEYhZRlEkWBb0EF3sQncq6AZRYz3UU3Qz\niKCkxNJ8iAqioLQMw8y8RWVp9fBfG9ccz8zZZ+bMOE7nC4e911r/vdd//fb6r9uhSRP068G6pmI6\nDsEM3IMPe7D+Jr2AwXggS1+G33HUnnFnr2AqbsJdeA+n7VFvGsRE/INRKX0w/hUdosnu9NnA6Sd6\neDEVjRcdYdIe86h302sD53T8ipsb9L6X8WiD3tUX6bWBc0Vy5LkGvGseHtKzC9W9nV4VOKMxoIvv\nOE90BNgfI7v4vkYwUdfb1Z30ucCZKRp1RPpdhFP2qEdBq97RIavRY4FTJhL2Sw4Mx2/4rBP1tOBt\nsRrOOaQT7/q/MBOHY4kInGlYjzXdUVneES4WEbpJ9L5hKf9ZMT+djcWYm9kvwgg8gU9wBg7EFCzE\nx8n2OxxU0qf+OAvvZnmTMQc7Rae8BtdhiNhS3Zna8gd+KFlPZzkBd2Az/kz+Po9Vmc1UzBcfbkDy\n8358ndm0p/eN6gucSr3KaPUtxqii1zi8X1HBbDFsFqyqSEvObxO9dl6W/6TO99xLtRWgBU+JBks+\nfCNOKWeIbdbCVJb7UJZW5Yfc6dgqdlEFL+H7LH2++ODDs7xxQo9JWbqW3mXJ9apHKzK9igcm4jBt\no/Z1MRUU5PcFG9OvBS9k+V/iWG3FKMuIirpuwW2iEcSIswnLRW9+zC4BV4utVnfQDy/iIyzN8jdi\nRbofnGyewYbM5iu8kcoop3dZcr3q0Yoqeh2Jn7FFbFXm2/0jLlW9x67BKxV5c8V2c2TtdrRhEBZU\n5B1Xkf4R97Xz/DBcVWedrcr5OU20aVEHNpcnm3OqlN2QyiYrp3cZKvWqRysyvYoRYZ2Y114Vw96T\nWCvOD8qwvaRdLYbaPSpWZ/djxDz3QTvPbxELq2osFgvdyt8FeKedssnZ8yPT9ccO/G9J1x1Vyv5O\n19G6rndBpV71aEWmV7FYnCKGuOtS+hjcKw6QXtO4D12LzXZfIOXMwl9iqCsYJRY/xFC7rZ1nr2wn\nv1X8sbOmhm/r0nVoBzY/pethVcqKxeB6jdO7I71qaUWmVzEijNe2N67F1WKuGVLSqUbwO/bJ0oPE\nYcqElD4Lnyc7wv9bM/sJ+LSbfFsuRoNZVcouEXP1W8m3MVVsJqfnl2mc3rle9WpFplf/LHOBmLsK\njhYrzvUpPVD1c4dq+QMrrvWwQWyn4Fzh/HiMxfHaRsvtYsgvGIuVnaizDDvEx5qJC7P84UL0n0SU\nXytW4yMym+PE1nqOXdNGLb3LUuhVr1ZkehXHlrPFKv9QsbcseuaDYt57BCeJeW6Z2CKdKfbTJ6b8\nlWIr80QqGyqG2xd1vMCqZF8h7JLkz8P4RSy07sbTYv/+F94U/9UTUThQ7FjqoVW5qaHg5GS/WXz8\n7UKnLZnNqbg+2ezEAXgcX6TyjvReW6f/hV4rlNeKzuvVZ2nVe4+Ye4z+tU36PFtF1DRp0qRJkyZN\nmjSp4D+SOyJ3naugoAAAAABJRU5ErkJggg==\n",
-       "prompt_number": 10,
-       "text": [
-        "   2         2   \n",
-        "sin (x) + cos (x)"
-       ]
-      }
-     ],
-     "prompt_number": 10
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "### Exercise\n",
-      "\n",
-      "Use `symbols` to create two variables, `mu` and `sigma`.  "
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "?, ? = symbols('?')"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "Object `` not found.\n"
-       ]
-      }
-     ],
-     "prompt_number": 11
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "### Exercise\n",
-      "\n",
-      "Use `exp`, `sqrt`, and Python's arithmetic operators like `+, -, *, **` to create the standard bell curve with SymPy objects\n",
-      "\n",
-      "$$ e^{\\frac{(x - \\mu)^2}{ \\sigma^2}} $$"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "exp(?)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "ename": "SyntaxError",
-       "evalue": "invalid syntax (<ipython-input-12-d859cfc67a14>, line 1)",
-       "output_type": "pyerr",
-       "traceback": [
-        "\u001b[1;36m  File \u001b[1;32m\"<ipython-input-12-d859cfc67a14>\"\u001b[1;36m, line \u001b[1;32m1\u001b[0m\n\u001b[1;33m    exp(?)\u001b[0m\n\u001b[1;37m        ^\u001b[0m\n\u001b[1;31mSyntaxError\u001b[0m\u001b[1;31m:\u001b[0m invalid syntax\n"
-       ]
-      }
-     ],
-     "prompt_number": 12
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "## Derivatives\n",
-      "\n",
-      "One of the most commonly requested operations in SymPy is the derivative.  To take the derivative of an expression use the `.diff` method"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "(x**2).diff(x)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$2 x$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAABcAAAASCAYAAACw50UTAAAABHNCSVQICAgIfAhkiAAAAVpJREFU\nOI3t1L1Ll1EUB/CPIoSVECgJSpBvODlYEKJOUYt/hCAI4ixuhvgGUdFWW6AgEgQOghS1RFsODbkJ\nEoSDiCCCiCa+DPc+eLlkP1Fx6izPOd/7Pd9zz3MOl2u0R5jHRyzjHeqvQvgBPuNOjG/jGzZw/7Li\ni2jOsHYc4/1lxXfwG3czfAubFxEsT/xfqMWtjLOPyouIVyR+B6qwnmB1seDXLO8henEozKMfA8K8\n6jGK1VLFn0eBzgRrxBunXU9jJXK6cIShUsLNwhwmM/yt0GFhH/A9+vfwCtX/Er6BJbz+y1lDFq9h\nqtRNCyvDHMbPwW0VVvXJecUn8SzDes/gDgrbdDPBmgqnPCP3CQOZyPDu+K3EC7TF+Cl+YjfRGy6S\n0lV8jJf4hNkErxBah56Y/AMHaMF2wh3BTBGUJQdbTt+V3IpfVRMvsBkLjgnbs4c/WMCXMzT+W7AT\nqVU9myY95twAAAAASUVORK5CYII=\n",
-       "prompt_number": 13,
-       "text": [
-        "2\u22c5x"
-       ]
-      }
-     ],
-     "prompt_number": 13
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "sin(x).diff(x)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\cos{\\left (x \\right )}$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAC4AAAANCAYAAADWgVyvAAAABHNCSVQICAgIfAhkiAAAAjdJREFU\nSInt1Ftoz2EYB/DP5jhtNTE5xA4U0oqWc4rVyo2ExKLllEVIye0cihrKIYeUC3HjcKd2IcWNVg4X\nwg03DtPWUAwxh5mL9/23t5//yq3ac/M+z/t9n+f9vs/zvA//qRRk7Jlowkd0oxAX8DDic7ETnRiM\nUhzGsyTGCszHBwzHqLi/I66FqMPNxKcGDehBBbagMcafgH3xvm94nX3EAnzC4mTvEl5FfVkkWJbg\n0/ESsxL7dibuelxM7NUoTuwqnIkPEs8+j3wW4jf2RGxzlnRBJNWS2T+Oa/Gi99iddcRJPIr6GjxF\nSYIX43Ri78r4n82cv457UZ+IY/qqVosZqfM89OJgHmI5Qr1YmgfbHrEajMdbdOGy0FZphYr8/fjK\njP0Gh/rhMQob6StPReKUT6ri+isP9jOuU9Au/IMrQsudQhvq45mR+JLxf5HoU4WevtMPjy6MTYm3\nJ4HzSUdcx+TBcmXsxGyh7RqFMk/CVZzHMOHTF+eJkZNa/EBrsjc50UvwOSXeKmS7Nk+wlbiFr0JG\nslITfe8K/VefYG3YJHyw0hhjUIIX4Qiqo12Hx/Fcjt/e5Hw1HmQJ1AkjcHmyV4ZzUV8XCY5L8Erh\n0y6J9ga8E3o9J+W4n9gNwpiEVcL/WItpeCIkICdNwmjNyVZxhGfn+BzsF0rage9oFnoLFmFbxHsw\nAifihYTRV47RwszNZbpZyD4MFZLUEs8djY/vxQFhynQLLXNDqDah2kOEqTUgA/Kv8gckw3USQik8\njwAAAABJRU5ErkJggg==\n",
-       "prompt_number": 14,
-       "text": [
-        "cos(x)"
-       ]
-      }
-     ],
-     "prompt_number": 14
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "(x**2 + x*y + y**2).diff(x)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$2 x + y$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAADYAAAAWCAYAAACL6W/rAAAABHNCSVQICAgIfAhkiAAAAldJREFU\nWIXt1kuITmEYB/DfTHKfEmKayW2MKCHkzkZsbDQpC2pKlGRhITvXjAjZiBX5yK1IUszEwrCjSJSi\nGGQhlEhyibF4z5jX6cw4M81nlPlvvud2nvf/nPM8z/fyn2AmLqAeD3AUld3KqAswDVcxKNEH4iZe\nY3Q3ceoSXEZ1yjYVzThbxHMno1cR8/uIFxiWsr/D2yKeW1CEjiiN5CYMx4BUzBf06+qDi424BWaj\nDK8iW4VQbGPquemoxXfhba/BWmE+K7ENT4rAdzQ2ogqncDryrUcNFuVJtEcgPzeyVeGQ1q9dwOMk\nZh5+JIfnRUH+VjyM3tiA+ynfLTl3QbUwd3UZycsi/VySFEZgP4bkJEr+wuZjRSLX43zkG4BvWPen\nJH1wGwcyfGNS+kvsykGsLRTkK6w84VUpdFFN5FssbO+JLYasNVuCY2jA1gx/UySPTw66noPYcUzJ\nsI8ULgZfM3yrcSeRW2Z/udBJV6K4BcLmftgegTpsSdlq24hdJ2zN/pFtbHvJM1DQsXXfgIspW6Nw\nY/qF0lTAKmH4d6bs85PfftiLSYm+WBjiT1G+TR0g2RmMwqNI74NZwi3pF+JWXIh9whs5mYppTuQl\nAvG7wrCOw/sodrPQcsXEcwyO9D3oixtxUEkkv9N6T0yjpT2HCsW/FYrdIWzJz8KMXMK1DhItYDue\n5YyfgCO4J3TKHKGDBgvd9s+goPNXqlJhqZzIcnQ3PghfPA/O+P2PeanwpXZ3Nam/jTc4mMgVeIqV\nWYElWcZ/GMswQ1ho5UKRt9p9ogc96F78BNPZcBPkGPZHAAAAAElFTkSuQmCC\n",
-       "prompt_number": 15,
-       "text": [
-        "2\u22c5x + y"
-       ]
-      }
-     ],
-     "prompt_number": 15
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "(x**2 + x*y + y**2).diff(y)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$x + 2 y$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAADYAAAAWCAYAAACL6W/rAAAABHNCSVQICAgIfAhkiAAAAlhJREFU\nWIXt1kuojVEUB/DflbwuJYTcvIkSQt7XRExMJGVAKVG6GRjIzDPkhkzkjsghryJJecTAY0aRKEVx\nkYG4JZI88hjs77DtznXPOc5xDe5/8n3rv9Ze39p7Pb5NB6qOaTiDi7iPg6hr14gqgMm4jN6Z3BM3\n8ArD2immVjEBnYu0PY9RCTcJ33GykkFVAjnFn/Z7PEf/hH+DlnI+3qmcRVVAMwagNuE/oXs5DtNS\nmYLl+Cqc9iqsFmq/DpvxuJwPtYEZ6IWXETdI2Oy1iBuGdRiBYzge6dZgEealzkdgv19ZzOERZmE2\nvmVOi0XO3zV+o3DAsyKuCV2wFvcS+5ta6ccm4dTyOJUZw2DsQd8SAsspf2OjhL7bHnH1WJq9X8Tp\nSFeLL2go5Gx4Ir/AjjIDo/yNdcUt7E34gZmuTsjkokg3X5ig4/JE3GPN0fuYzMHVIgI5jIkF+CHC\nT/dzAd1K3C7A1+AQLmFTosv33xIhmxci3Rxhej5oK9gGYSL1iLiRbS1KkFN6xrZjY8ItT+RLOJtw\n14Rby0/kB0V37ML4TJ4vNOeHyG59iUGWihXCgNqW8PWJPBQPI7krpgs3lZ/Il+ICIfA7QhOOxtvI\nboNQctXCXOwWsnE0ie97YvsMfSK5Ed1wPTaqyZ79MsctmaOtwpT8KPTIOVwpMdgctuBpEbZv/Lon\npkjLcywO4K5QUTOFSusjZLzqyKn+BbaTMFSOFFJUC++EjFcSJ/z+Y14oZGpnhb/zz/Ea+7L3QXiC\nZYUMawqR/zEWY6owVAYKm7z5xxUd6ED74gccwXATFU7b3AAAAABJRU5ErkJggg==\n",
-       "prompt_number": 16,
-       "text": [
-        "x + 2\u22c5y"
-       ]
-      }
-     ],
-     "prompt_number": 16
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "### Exercise\n",
-      "\n",
-      "In the last section you made a normal distribution"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "mu, sigma = symbols('mu,sigma')"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 17
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "bell = exp((x - mu)**2 / sigma**2)\n",
-      "bell"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$e^{\\frac{1}{\\sigma^{2}} \\left(- \\mu + x\\right)^{2}}$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAE4AAAAgCAYAAAC8VE43AAAABHNCSVQICAgIfAhkiAAAAxxJREFU\naIHt2FuIlVUUwPHfjGM6xIxQg3YhKH2QIqILBYNdGAqEYKiQAsVsoCLoYimiREQD3cigoMtDQYHY\nQwbVSz30Jj6IEU76pC8ShkSiZCldjexh7dP5On3neM7smdMZ/P7w8a19WXsv9rf3Wmt/VHSdfrz2\nfxvRBfrxBDanJ4tF2Iip3IHmAOO4LMkf4wZiNafDT2K3ncy3q+dZhtVJPqS+iFnsnIlBepwFGEry\nF7iE6e+4Thns0jwzQaOtv+MUbhEb5Tu6s3Arpa/URR7P0B3EAw11izCGl2sVs71wi4VPODTL8zQy\nkqH7A37E9YW6tWLR5uOOjLEN4ikcFdG12VF8BsMZ8zyLBwvlDzHaht7kWdpXYAKvi0V5BJ9gaWrv\nx9YkrxFB8DhO4Oo25s/m7Uz9KVyX5AFh+FDz7v8w2aJtWP1j3IUvk7wNFxX6vdlqgoE2jMhhQUP5\nUfWvWsZX2JHkC4Rv3JfKN+KgcNRFlojd31eouxkLC+VTeDHJf2B7kkfxaZIb/dqfOC/1z+JMhw+8\nnzHfPfioUH4aLwn/1VeqUWeyzTn2ig9CBIAiL+DiZoqdBIe+Dh/4q4PxGxnDN0meh1XYJZLRM82U\n2mAcG3C58FdfC3snGvoNiyBRSu5RXSGO41V4q6T9l4yxx8TRXCeCzw5xBHOveSPiNjAugs+T+E0E\nnkZ+zZyrKevTu1kQWO/fDrddFuPwtCwKtmToEr7t+cwxzsqQ5j7lfPFnoVPuwwfTNWgGuB9XtOow\nEwnwvXijSdvP2KPz3OcafJZjVAaX4pi6fy2lLDpdK9KGEyJTHsFj/psGEMnvMuELNmUYO+eZwH6x\n6jU2i0SRyLBfxbd4B7d107heZRSnRaSscRM+F856JR5O9RvU859zkmI6MimO590i+ZyHAyJvOok7\n8Vzquxzvds3KHqTm4+YLP/WeOI5l3Coy6dP4Hrtn3boeprbjLhQ7rNXvn12zb87coZaOHBfHsewm\ncSUe6ppFc5CtYlcVU5TbxUV9YanGOUxxkQbwikhFjohrx5T4T5Vzqa6oqKioqKioaMHf1siB0YOG\ncaUAAAAASUVORK5CYII=\n",
-       "prompt_number": 18,
-       "text": [
-        "         2\n",
-        " (-\u03bc + x) \n",
-        " \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n",
-        "      2   \n",
-        "     \u03c3    \n",
-        "\u212f         "
-       ]
-      }
-     ],
-     "prompt_number": 18
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Take the derivative of this expression with respect to $x$"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "?.diff(?)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "Object `.diff` not found.\n"
-       ]
-      }
-     ],
-     "prompt_number": 19
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "### Exercise\n",
-      "\n",
-      "There are three symbols in that expression.  We normally are interested in the derivative with repspect to `x`, but we could just as easily ask for the derivative with respect to `sigma`.  Try this now"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "# Derivative of bell curve with respect to sigma\n",
-      "\n"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 20
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "### Exercise\n",
-      "\n",
-      "The second derivative of an expression is just the derivative of the derivative.  Chain `.diff( )` calls to find the second and third derivatives of your expression."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "#  Find the second and third derivative of `bell`\n",
-      "\n"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 21
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "## Functions\n",
-      "\n",
-      "SymPy has a number of useful routines to manipulate expressions.  The most commonly used function is `simplify`."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "expr = sin(x)**2 + cos(x)**2\n",
-      "expr"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\sin^{2}{\\left (x \\right )} + \\cos^{2}{\\left (x \\right )}$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAIIAAAAZCAYAAAD9ovZ9AAAABHNCSVQICAgIfAhkiAAABH1JREFU\naIHt2VuIVVUcx/GPppVlpZiVXchGQ0WUzExTypKKiO5QEYhZRlEkWBb0EF3sQncq6AZRYz3UU3Qz\niKCkxNJ8iAqioLQMw8y8RWVp9fBfG9ccz8zZZ+bMOE7nC4e911r/vdd//fb6r9uhSRP068G6pmI6\nDsEM3IMPe7D+Jr2AwXggS1+G33HUnnFnr2AqbsJdeA+n7VFvGsRE/INRKX0w/hUdosnu9NnA6Sd6\neDEVjRcdYdIe86h302sD53T8ipsb9L6X8WiD3tUX6bWBc0Vy5LkGvGseHtKzC9W9nV4VOKMxoIvv\nOE90BNgfI7v4vkYwUdfb1Z30ucCZKRp1RPpdhFP2qEdBq97RIavRY4FTJhL2Sw4Mx2/4rBP1tOBt\nsRrOOaQT7/q/MBOHY4kInGlYjzXdUVneES4WEbpJ9L5hKf9ZMT+djcWYm9kvwgg8gU9wBg7EFCzE\nx8n2OxxU0qf+OAvvZnmTMQc7Rae8BtdhiNhS3Zna8gd+KFlPZzkBd2Az/kz+Po9Vmc1UzBcfbkDy\n8358ndm0p/eN6gucSr3KaPUtxqii1zi8X1HBbDFsFqyqSEvObxO9dl6W/6TO99xLtRWgBU+JBks+\nfCNOKWeIbdbCVJb7UJZW5Yfc6dgqdlEFL+H7LH2++ODDs7xxQo9JWbqW3mXJ9apHKzK9igcm4jBt\no/Z1MRUU5PcFG9OvBS9k+V/iWG3FKMuIirpuwW2iEcSIswnLRW9+zC4BV4utVnfQDy/iIyzN8jdi\nRbofnGyewYbM5iu8kcoop3dZcr3q0Yoqeh2Jn7FFbFXm2/0jLlW9x67BKxV5c8V2c2TtdrRhEBZU\n5B1Xkf4R97Xz/DBcVWedrcr5OU20aVEHNpcnm3OqlN2QyiYrp3cZKvWqRysyvYoRYZ2Y114Vw96T\nWCvOD8qwvaRdLYbaPSpWZ/djxDz3QTvPbxELq2osFgvdyt8FeKedssnZ8yPT9ccO/G9J1x1Vyv5O\n19G6rndBpV71aEWmV7FYnCKGuOtS+hjcKw6QXtO4D12LzXZfIOXMwl9iqCsYJRY/xFC7rZ1nr2wn\nv1X8sbOmhm/r0nVoBzY/pethVcqKxeB6jdO7I71qaUWmVzEijNe2N67F1WKuGVLSqUbwO/bJ0oPE\nYcqElD4Lnyc7wv9bM/sJ+LSbfFsuRoNZVcouEXP1W8m3MVVsJqfnl2mc3rle9WpFplf/LHOBmLsK\njhYrzvUpPVD1c4dq+QMrrvWwQWyn4Fzh/HiMxfHaRsvtYsgvGIuVnaizDDvEx5qJC7P84UL0n0SU\nXytW4yMym+PE1nqOXdNGLb3LUuhVr1ZkehXHlrPFKv9QsbcseuaDYt57BCeJeW6Z2CKdKfbTJ6b8\nlWIr80QqGyqG2xd1vMCqZF8h7JLkz8P4RSy07sbTYv/+F94U/9UTUThQ7FjqoVW5qaHg5GS/WXz8\n7UKnLZnNqbg+2ezEAXgcX6TyjvReW6f/hV4rlNeKzuvVZ2nVe4+Ye4z+tU36PFtF1DRp0qRJkyZN\nmjSp4D+SOyJ3naugoAAAAABJRU5ErkJggg==\n",
-       "prompt_number": 22,
-       "text": [
-        "   2         2   \n",
-        "sin (x) + cos (x)"
-       ]
-      }
-     ],
-     "prompt_number": 22
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "simplify(expr)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$1$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAAsAAAASCAYAAACNdSR1AAAABHNCSVQICAgIfAhkiAAAAF5JREFU\nKJFjYKAC4GJgYLhEjEJTBgaG0wwMDP/RJViQ2JoMDAw9DAwMrxkYGP6S4owF2ExmIsWEUcVUV8wB\npblwaRRjYGDYycDAcIUBEnv/GSBRv5+BgSGaFBfQGAAA/84M5lOscPUAAAAASUVORK5CYII=\n",
-       "prompt_number": 23,
-       "text": [
-        "1"
-       ]
-      }
-     ],
-     "prompt_number": 23
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "### Exercise\n",
-      "\n",
-      "In the last section you found the third derivative of the bell curve"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "bell.diff(x).diff(x).diff(x)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\frac{1}{\\sigma^{4}} \\left(- 8 \\mu + 8 x\\right) e^{\\frac{1}{\\sigma^{2}} \\left(- \\mu + x\\right)^{2}} + \\frac{2}{\\sigma^{4}} \\left(- 2 \\mu + 2 x\\right) e^{\\frac{1}{\\sigma^{2}} \\left(- \\mu + x\\right)^{2}} + \\frac{1}{\\sigma^{6}} \\left(- 2 \\mu + 2 x\\right)^{3} e^{\\frac{1}{\\sigma^{2}} \\left(- \\mu + x\\right)^{2}}$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAnIAAAArCAYAAAD8MGWDAAAABHNCSVQICAgIfAhkiAAADJpJREFU\neJztnXvQ3FQZh59eoFRoQcByh1JBLAK2dEQKFFpAQAqjyGW8AJYpomUQKSIXRaajlYsyIAJKVTRo\nQaqCIwMKXqsMgzewiiKKBXQABwGLYAWk8vnHm3XzZZPdk+Qk2c3+nplOd/Pl8n775dnkvDnnPSCE\nEEIIIYQYCMYCl9UdREWMBd4PnB3+E6IM5JQQ9TEs/sk9AcDGwJnAvXUHUhFHAtuFr28CZtUYi2gm\nckqI+hgm/1LdG1tLOKIu/om1XJ6tO5CKeDXwjvD1atoSCOELOSVEfQyTf3JPjGJl3QFUxARgUvj6\nDmDrGmMRzWZl3QFUhJwS/cjKugOogFT3lJETvZhYdwCOJMX5IvAcMAcT/fEqAxIihUFxCjpjlVNi\nkGmke7qRE904lOpb3Kfl3G4i8O6E5RsD84CLckckhD8GySlI9kpOiUGkse7pRk6kMQV7Br+64uNu\nnnO7fwDPAHvGlh+PnfTrAQcXiEuIogyaU5DslZwSg4bcE41hInAG8AQ20qdbmvkjwOQCx/oosDDy\n/kZgtsN2S7r8bF9gAXA5dkK/F7gZmBb+fCzwycj678Q6wT4FrAF2czi+EFkYdKcgm1dySvQTrv4N\ntXuTgG8C27tuIBrD1QW3vxeYGb4ej514k9JX/z9LUpZPpi3SW4Cfh6+vA7aMrHdlpiir5Y3AYux3\n/D6wf63RiKrpN6egGV7pOtX/7A+cAJwMLKf6bFKj3Rvf5WcnA9sCRwNn9dqRaBwTYu9Ppd1KSOKX\nwIrw9aZYX4RV4fs3AA9gHTWjbIG1psZElu0HbBB5/xzwCeA/wFfDZbOBb4Wv430I1gHrh+v3ExsB\nRwHnhu+PA24HdgYeqysoUSn95hQMvle6Tg0GNwMfBL6IlQy5BTtX4+dvWcTdA3f/GuHeCDC1yA5E\nrYzk+AfwpQLHPAr4euT9ecCFWH+BMYlbtFnisP97MJnAOn9GWQps5bCPqtkDeBmrBQTWGhvBbujE\nYNFEp2AwvWqh61R/sxuwYfj6GOAl3DJaSeTxr9HulTnYYQcsleqLbbH06FXAF4Drgd097t8nPmMd\nB5xD7xMmjTE5/oHddORlHvBw+Hoc1lr+KVbMcCRtox4ciT2WnIp9Kfwai3VBbL3JWAfRfuM+rNX1\nUPi+VczxwQz78O0UwF5Ya/m7WIzXAtt4PoYPfMYpp9oMulc+8O3VMDoF3b36HbA2fP027AYnbzYu\nj3+Ndq/bo9UibIKlD0/ytL/NsJuiRcDfwmU7Yo+mjiDbxbBsfMf6X+Bu4OPA+Z5iBOtkOQHYFYs3\nzr8L7Hselno+Eet8ugJLMReZRmVzLJt1JNbx9APAC1in0zjPFzhOWYzQ7gMB9oj1MkxeF3w7BTYa\naimWFXwGe/z7nTCmvYBHPB6rCL7jlFNtBt2rovj2alidgt5e7QkciN3QXZ5j/73o5t/Qu5cnZX0N\nnWUgivAhbLLYOB8GLvF4nDT2wP2mt6xYP4OdPL44Pfw/rRPo6YzucOnKFOAvuSIyzimw7frYl0iZ\nZDkX0liIjUTKkhHy7RTAbcBOsWUzMeeTvkx8kuVzLCtOOeVG2V75cCrvo1XfXg27U9Dbq1OwR4kb\nFTxOnG7+Db17WQXZBfihjwNH+BztjoBRzsSyGmUT4P4ZlBXrNODHBbZPYhLpz/A3JPmGtBfHYaOS\n6uAELPtZJgHF+uIcQXuk0gaO+yrDKYB/AX/FvqyirMGGuJdJgPvnWFaccsqNsr0KKN6/Lc+NXBle\nDbtT0OnV3lh5kNY59Frs73VMweMkkeZfo90ro4/c6cBXPO9zFfBW4AbgleGyCVjdlcDzsYpSVqwP\nYX+vGUWCi3Es1npKYi3wM7LXidoDuLVIUDnZBniSdl+GfuQAbGTTbVjr8DDcOpCX4RTYZ7UF7U7I\nLV6kv6ayKStOOdWbQfAqL2V4NexOQadX64Df055Saho22GFV56aFSfNvaN17F5ZdaqVaXaeaWE17\nZJ4vJmBDgUewfmfHY3fJb05Zfz7Jv/zd4bZZCXBv6WSJdRZwBZapuxkb5nwe9gh2OZ2f44XAx1KO\nOwP4fLjtZdgXVLdRQWdiKehLe/1CYhQB+bIH07DOvfHRVC5FKstwCuxLPP64YWssrqRMlU+vAtw/\nxyxxyqnBIyB/Ri7vdQrK8UpOGXGvjsfKjywGbgIOcYhR/tXEDsDTJe17EjZgoHUBvBVrUSSxHHsG\nH2V6uN1BOY4dkO2LxiXWadhJ18qKBsCfgH2wTpsvYyd+lKOwQrJxFgC/YfSIo7OxIoNg1aI/haXS\nl2GZIZGPgGrLHJTpVBIXY52W90n4mU+vAop9jklxyqnBJKD60iFVejVsTkG6V64sQP7VxhzgDyXt\n+1yslMd8LHXbyngllfV4lM678lOwgnqvyHHsgGyCuMT6WUa3Lr5Be1Tjdlj8m8X2ux/2u0WZjaWp\n940s2wt7fDcFmyj4PeHyxbRr1Yh8BFR70SnTqTg7YX1nlqb83KdXAfk/x7Q45dRgElD9jVxVXg2j\nU5DslSvyr2aOxp5D+2Yx9kdssSE2fPll7K49ys7YjdP82PLlwF05jx/gLohrrPEOjI/Srvicxuvo\nHEZ9B/B3rHVyaXisU2g/srsCG2IPNkIr3idCZCOg2otOWU7FmQD8gvQBOb69Csj3OXaLU04NJgHV\n38hV4dWwOgXJXrki/zLiu47cONIL7+2OPe92LbmwCnhfuP4FWAuqxVrshumPWP+I6bRbV3Ox9PCd\nsf3NwQYgdOM64PUJy7fHWgRJU2QspJ0azxJrtF/ELlgKudcIunWx9+th6fdrsbInSdyEtWBewvoY\nrE1ZT4ym6LngizKcijMG+DLWHeCClG3nks8rn59jrzjlVH/TL05BuldyajR5nIJOr1yRfwXIM+VF\n0hQ08/Cfrp4S7j9prrQx2LxtMyPLbqBzNMzUcB+HYTevu2aMIcCtpZM11haLsNFC0VR6UgfS2Ywu\n1LhleLyzHWITfghwOxf62ak4S7GClFFOjL337VVA9uyBS5wt5NTgEFCtU1C+V8PsFHR65Yr8y0Gr\nA2OeKS+SpqB5jOTn5UV4EqtBk/QcfCNsJOD9kWVz6Zw94RDs5LgLa7H4LqzawjXWiVhB2FafuTcB\nv6Wdih5LcmtkU9pDuMHq/TxLcmZ1OjahtKiHfnYqyklYZiJedDJe0HMu9XkFveOUU83Hl1NQrlfD\n7hR0euWK/MtBlkerk7Ehx+d1WedBLFW8Nfn+iEmMYFNXLMP6EjwSieda4AyslQCW+t0qPH6L6dgJ\n+zR2IzWf8oYnu8Z6NCbAvVh6eGcsW9fifCx9Hmcm1pehxbrwWIcBF9FucR6EDcs/teDvI8qnl1dl\nONXiQKwfyu2MLno5ntHZi7q9conzcOSUsOmOdsRu2q7osl5ZXskpI+6VK/IvB1lu5I6ld/HSEeB7\n2DP+FXmDSmAFNurz09iN0AjWx+FqYGVkvbnYibAaO8GexjJkB4f7uAabvHeNx9jyxPoTLA0+C2tx\n7Y2NDlqG9W+4BasjFGc/Oqf5ak399TWsI+r6mHgLKTahr6iGXl6V5RRYX5NNsC/IONHRa3Op1yuX\nOOWU2Bx4O3aeLMfOmbTJxsvySk4ZSV65Iv9KYgdsaqHAYd0DsSHKdXAj6SdWEQKqH1UV51XYKCvX\nTriiHAL8nQuuXtXpFJTjVYCcEkaAn3NhEe1pmJL6Kcdp2rUqoH6nQF5VjusUXTOw1oELP8IeF5VR\nib4XB4TH982zwAsl7DcLp2HVstUiqRef54KrV3U6BeV4JadEC1/nwm5Y4+hQkkeSxmnataofnAJ5\n1ZfMwoY1T8V9rtAdgeup9o68VQ374AqPWRWvod6Je4V/snpVh1PQXK/kVPNYhvXbAusfN91hG12r\n/CKvasAlIzcdS0Efg1V/nu2wzcPAVVgRv6rYHvgz+Yv+9ivjsMmdF9UdiPBKVq/qcAqa6ZWcaiaP\nY/2TwbJTLqU7dK3yh7waAKbinpETQrgxFXklhA/m0C5qeyXZ64UKMZDEM3KLgfuwkT7PAw8A38ZG\njZyG1Ufbv8oAhRhw0pwCeSVEHtKcuhNzaiHW9/T+tB0I0VQuxmpZjcEmyX0Q2KDWiIQYbOSUEH6R\nU0KksCtWMybKr4AtaohFiCYgp4Twi5wSIoHWo9XDgdsiyzfFUtRPVB6REM1ATgnhFzklRAKtG7mn\nGF1/5nzgrOrDEaIxyCkh/CKnhEigVTtnPLAEmy5kCnAP8IOaYhKiCcgpIfwip4QQQgghhBBCCCGE\nEEIIIYQQQgghhBBCCCGEEEIIIYQQQgghhBCiFP4Hx1a0RoYHygIAAAAASUVORK5CYII=\n",
-       "prompt_number": 24,
-       "text": [
-        "                      2                           2                          2\n",
-        "              (-\u03bc + x)                    (-\u03bc + x)                   (-\u03bc + x) \n",
-        "              \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500                   \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500                  \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n",
-        "                   2                           2                          2   \n",
-        "                  \u03c3                           \u03c3                   3      \u03c3    \n",
-        "(-8\u22c5\u03bc + 8\u22c5x)\u22c5\u212f            2\u22c5(-2\u22c5\u03bc + 2\u22c5x)\u22c5\u212f            (-2\u22c5\u03bc + 2\u22c5x) \u22c5\u212f         \n",
-        "\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500 + \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500 + \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n",
-        "            4                          4                          6           \n",
-        "           \u03c3                          \u03c3                          \u03c3            "
-       ]
-      }
-     ],
-     "prompt_number": 24
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "You might notice that this expression has lots of shared structure.  We can factor out some terms to simplify this expression.  \n",
-      "\n",
-      "Call `simplify` on this expression and observe the result."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "# Call simplify on the third derivative of the bell expression\n",
-      "\n"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 25
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "## Sympify\n",
-      "\n",
-      "The `sympify` function transforms Python objects (ints, floats, strings) into SymPy objects (Integers, Reals, Symbols). \n",
-      "\n",
-      "*note the difference between `sympify` and `simplify`.  These are not the same function.*"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "sympify('r * cos(theta)^2')"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$r \\cos^{2}{\\left (\\theta \\right )}$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAEMAAAAXCAYAAABQ1fKSAAAABHNCSVQICAgIfAhkiAAAA4pJREFU\nWIXt1n2o3mMYB/DPmWfbodkhtmPjHDMrIbLEYfN2SLZlyWSjTc38IXKiDkryLmyIjRIpYm1DVv5Y\n7A/CEmkkNKTkrR1j8pa3sc0f1/3bcz+/8zzNeew4q51vPf2e6+W+7+u+r1eGsQMtQ21AA3RhGtow\nHXfg9SG1aIgwBvdk9Fz8hoOHxpyhxbHYhsMTPRbbxaPscWgRaVKk8NHiMab+Hwfv7nga36J3J3oj\nRSp9XuJPwg34UUTbpdgHW/DDLrRz0HEZlti50yq4RVwyxyS8iwmJ7sUyjMDddfR3W5wrHgNaxcUa\noVfUmhyj8A4WZbwL8WX6PwH35QtGNGnoYON0tGMNDsIMVe+Wsa9ow++X+FenNcszXhs6REr1ic7V\nucusHgRMxi+iaOa/sQ305+DaEq8Vm8V8kuP+tNfoRM/FdYWwkilegG7xcheLkDoKh2Ap3k56x+Fm\nUZD+ENH1ONYneRd6sCntvx/uwifZWefjZFHAWnFA4l+Fz4S3/y3OwPMl3kVpz1Ul/nTx0H8mej3m\n495cabQoVPCpCM9T04Zf4OEkm4afkwEFnko6MFtcelwmP1JU+KkZ/UrJyAV4UnNYLdpvjhfwO17K\nfi9jK9Zlem34oLzhOcJbo4S370z8DrwnLt8iLrqmtPYBPCvybzOuqWPw0rQPzMOHar0/RvXBB4q1\nmJLRe4moXVHSmyVS5PaMN1JtxIKTxCudlhaUK3OhU94sx7wkn1FHdmWSHY+JYm74ScwQPWojaaBY\njhMyujOd1VPSeyjxj8l442WRUnSTt5JxZ+J7dUJHtbV93cCoyen7dx3ZX+k7BRtFXVklIm4ZvhJ1\nqhl8LOpagfb03ZDxKqJYrlN7tw58VBDl1tqN18QLlrExffdvYFRf+o6vIysK5CbhxRZcnozpxDN4\nVLXKDwQvivpWoHDGNxlvZrLrptLaU/RPe7C3qLLl8CpQER5cW0c2R4zCv+K2OvLn0toKFuLGkrzI\n83bNYaXIf+Lht+OITP4qHquzboWok/1wlv45VcbZosCel/HG4ZH0f75Io3xAOkwU1u5EL8R3onYU\nOFS1dTeDE9VOmm9kNi7Cm6KF55glxocdyGf+S0RUdKmfJvnBtwpP9oloWixqDhGyVyT5VjH/P6ia\nqwvE5Q8U7W+bmEUWi+hpFjNFi98g5qMlwjFbcL1wYoGJooM+8R/OG8YwhrGH4x+A+7Tv2FKoNAAA\nAABJRU5ErkJggg==\n",
-       "prompt_number": 26,
-       "text": [
-        "     2   \n",
-        "r\u22c5cos (\u03b8)"
-       ]
-      }
-     ],
-     "prompt_number": 26
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "It's useful whenever you interact with the real world, or for quickly copy-pasting an expression from an external source."
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Object `` not found.\n"
      ]
     }
    ],
-   "metadata": {}
+   "source": [
+    "?, ? = symbols('?')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise\n",
+    "\n",
+    "Use `exp`, `sqrt`, and Python's arithmetic operators like `+, -, *, **` to create the standard bell curve with SymPy objects\n",
+    "\n",
+    "$$ e^{\\frac{(x - \\mu)^2}{ \\sigma^2}} $$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "ename": "SyntaxError",
+     "evalue": "invalid syntax (<ipython-input-12-d859cfc67a14>, line 1)",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[1;36m  File \u001b[1;32m\"<ipython-input-12-d859cfc67a14>\"\u001b[1;36m, line \u001b[1;32m1\u001b[0m\n\u001b[1;33m    exp(?)\u001b[0m\n\u001b[1;37m        ^\u001b[0m\n\u001b[1;31mSyntaxError\u001b[0m\u001b[1;31m:\u001b[0m invalid syntax\n"
+     ]
+    }
+   ],
+   "source": [
+    "exp(?)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Derivatives\n",
+    "\n",
+    "One of the most commonly requested operations in SymPy is the derivative.  To take the derivative of an expression use the `.diff` method"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABcAAAASCAYAAACw50UTAAAABHNCSVQICAgIfAhkiAAAAVpJREFU\nOI3t1L1Ll1EUB/CPIoSVECgJSpBvODlYEKJOUYt/hCAI4ixuhvgGUdFWW6AgEgQOghS1RFsODbkJ\nEoSDiCCCiCa+DPc+eLlkP1Fx6izPOd/7Pd9zz3MOl2u0R5jHRyzjHeqvQvgBPuNOjG/jGzZw/7Li\ni2jOsHYc4/1lxXfwG3czfAubFxEsT/xfqMWtjLOPyouIVyR+B6qwnmB1seDXLO8henEozKMfA8K8\n6jGK1VLFn0eBzgRrxBunXU9jJXK6cIShUsLNwhwmM/yt0GFhH/A9+vfwCtX/Er6BJbz+y1lDFq9h\nqtRNCyvDHMbPwW0VVvXJecUn8SzDes/gDgrbdDPBmgqnPCP3CQOZyPDu+K3EC7TF+Cl+YjfRGy6S\n0lV8jJf4hNkErxBah56Y/AMHaMF2wh3BTBGUJQdbTt+V3IpfVRMvsBkLjgnbs4c/WMCXMzT+W7AT\nqVU9myY95twAAAAASUVORK5CYII=\n",
+      "text/latex": [
+       "$$2 x$$"
+      ],
+      "text/plain": [
+       "2⋅x"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "(x**2).diff(x)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAC4AAAANCAYAAADWgVyvAAAABHNCSVQICAgIfAhkiAAAAjdJREFU\nSInt1Ftoz2EYB/DP5jhtNTE5xA4U0oqWc4rVyo2ExKLllEVIye0cihrKIYeUC3HjcKd2IcWNVg4X\nwg03DtPWUAwxh5mL9/23t5//yq3ac/M+z/t9n+f9vs/zvA//qRRk7Jlowkd0oxAX8DDic7ETnRiM\nUhzGsyTGCszHBwzHqLi/I66FqMPNxKcGDehBBbagMcafgH3xvm94nX3EAnzC4mTvEl5FfVkkWJbg\n0/ESsxL7dibuelxM7NUoTuwqnIkPEs8+j3wW4jf2RGxzlnRBJNWS2T+Oa/Gi99iddcRJPIr6GjxF\nSYIX43Ri78r4n82cv457UZ+IY/qqVosZqfM89OJgHmI5Qr1YmgfbHrEajMdbdOGy0FZphYr8/fjK\njP0Gh/rhMQob6StPReKUT6ri+isP9jOuU9Au/IMrQsudQhvq45mR+JLxf5HoU4WevtMPjy6MTYm3\nJ4HzSUdcx+TBcmXsxGyh7RqFMk/CVZzHMOHTF+eJkZNa/EBrsjc50UvwOSXeKmS7Nk+wlbiFr0JG\nslITfe8K/VefYG3YJHyw0hhjUIIX4Qiqo12Hx/Fcjt/e5Hw1HmQJ1AkjcHmyV4ZzUV8XCY5L8Erh\n0y6J9ga8E3o9J+W4n9gNwpiEVcL/WItpeCIkICdNwmjNyVZxhGfn+BzsF0rage9oFnoLFmFbxHsw\nAifihYTRV47RwszNZbpZyD4MFZLUEs8djY/vxQFhynQLLXNDqDah2kOEqTUgA/Kv8gckw3USQik8\njwAAAABJRU5ErkJggg==\n",
+      "text/latex": [
+       "$$\\cos{\\left (x \\right )}$$"
+      ],
+      "text/plain": [
+       "cos(x)"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sin(x).diff(x)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAADYAAAAWCAYAAACL6W/rAAAABHNCSVQICAgIfAhkiAAAAldJREFU\nWIXt1kuITmEYB/DfTHKfEmKayW2MKCHkzkZsbDQpC2pKlGRhITvXjAjZiBX5yK1IUszEwrCjSJSi\nGGQhlEhyibF4z5jX6cw4M81nlPlvvud2nvf/nPM8z/fyn2AmLqAeD3AUld3KqAswDVcxKNEH4iZe\nY3Q3ceoSXEZ1yjYVzThbxHMno1cR8/uIFxiWsr/D2yKeW1CEjiiN5CYMx4BUzBf06+qDi424BWaj\nDK8iW4VQbGPquemoxXfhba/BWmE+K7ENT4rAdzQ2ogqncDryrUcNFuVJtEcgPzeyVeGQ1q9dwOMk\nZh5+JIfnRUH+VjyM3tiA+ynfLTl3QbUwd3UZycsi/VySFEZgP4bkJEr+wuZjRSLX43zkG4BvWPen\nJH1wGwcyfGNS+kvsykGsLRTkK6w84VUpdFFN5FssbO+JLYasNVuCY2jA1gx/UySPTw66noPYcUzJ\nsI8ULgZfM3yrcSeRW2Z/udBJV6K4BcLmftgegTpsSdlq24hdJ2zN/pFtbHvJM1DQsXXfgIspW6Nw\nY/qF0lTAKmH4d6bs85PfftiLSYm+WBjiT1G+TR0g2RmMwqNI74NZwi3pF+JWXIh9whs5mYppTuQl\nAvG7wrCOw/sodrPQcsXEcwyO9D3oixtxUEkkv9N6T0yjpT2HCsW/FYrdIWzJz8KMXMK1DhItYDue\n5YyfgCO4J3TKHKGDBgvd9s+goPNXqlJhqZzIcnQ3PghfPA/O+P2PeanwpXZ3Nam/jTc4mMgVeIqV\nWYElWcZ/GMswQ1ho5UKRt9p9ogc96F78BNPZcBPkGPZHAAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$$2 x + y$$"
+      ],
+      "text/plain": [
+       "2⋅x + y"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "(x**2 + x*y + y**2).diff(x)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAADYAAAAWCAYAAACL6W/rAAAABHNCSVQICAgIfAhkiAAAAlhJREFU\nWIXt1kuojVEUB/DflbwuJYTcvIkSQt7XRExMJGVAKVG6GRjIzDPkhkzkjsghryJJecTAY0aRKEVx\nkYG4JZI88hjs77DtznXPOc5xDe5/8n3rv9Ze39p7Pb5NB6qOaTiDi7iPg6hr14gqgMm4jN6Z3BM3\n8ArD2immVjEBnYu0PY9RCTcJ33GykkFVAjnFn/Z7PEf/hH+DlnI+3qmcRVVAMwagNuE/oXs5DtNS\nmYLl+Cqc9iqsFmq/DpvxuJwPtYEZ6IWXETdI2Oy1iBuGdRiBYzge6dZgEealzkdgv19ZzOERZmE2\nvmVOi0XO3zV+o3DAsyKuCV2wFvcS+5ta6ccm4dTyOJUZw2DsQd8SAsspf2OjhL7bHnH1WJq9X8Tp\nSFeLL2go5Gx4Ir/AjjIDo/yNdcUt7E34gZmuTsjkokg3X5ig4/JE3GPN0fuYzMHVIgI5jIkF+CHC\nT/dzAd1K3C7A1+AQLmFTosv33xIhmxci3Rxhej5oK9gGYSL1iLiRbS1KkFN6xrZjY8ItT+RLOJtw\n14Rby0/kB0V37ML4TJ4vNOeHyG59iUGWihXCgNqW8PWJPBQPI7krpgs3lZ/Il+ICIfA7QhOOxtvI\nboNQctXCXOwWsnE0ie97YvsMfSK5Ed1wPTaqyZ79MsctmaOtwpT8KPTIOVwpMdgctuBpEbZv/Lon\npkjLcywO4K5QUTOFSusjZLzqyKn+BbaTMFSOFFJUC++EjFcSJ/z+Y14oZGpnhb/zz/Ea+7L3QXiC\nZYUMawqR/zEWY6owVAYKm7z5xxUd6ED74gccwXATFU7b3AAAAABJRU5ErkJggg==\n",
+      "text/latex": [
+       "$$x + 2 y$$"
+      ],
+      "text/plain": [
+       "x + 2⋅y"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "(x**2 + x*y + y**2).diff(y)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise\n",
+    "\n",
+    "In the last section you made a normal distribution"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "mu, sigma = symbols('mu,sigma')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAE4AAAAgCAYAAAC8VE43AAAABHNCSVQICAgIfAhkiAAAAxxJREFU\naIHt2FuIlVUUwPHfjGM6xIxQg3YhKH2QIqILBYNdGAqEYKiQAsVsoCLoYimiREQD3cigoMtDQYHY\nQwbVSz30Jj6IEU76pC8ShkSiZCldjexh7dP5On3neM7smdMZ/P7w8a19WXsv9rf3Wmt/VHSdfrz2\nfxvRBfrxBDanJ4tF2Iip3IHmAOO4LMkf4wZiNafDT2K3ncy3q+dZhtVJPqS+iFnsnIlBepwFGEry\nF7iE6e+4Thns0jwzQaOtv+MUbhEb5Tu6s3Arpa/URR7P0B3EAw11izCGl2sVs71wi4VPODTL8zQy\nkqH7A37E9YW6tWLR5uOOjLEN4ikcFdG12VF8BsMZ8zyLBwvlDzHaht7kWdpXYAKvi0V5BJ9gaWrv\nx9YkrxFB8DhO4Oo25s/m7Uz9KVyX5AFh+FDz7v8w2aJtWP1j3IUvk7wNFxX6vdlqgoE2jMhhQUP5\nUfWvWsZX2JHkC4Rv3JfKN+KgcNRFlojd31eouxkLC+VTeDHJf2B7kkfxaZIb/dqfOC/1z+JMhw+8\nnzHfPfioUH4aLwn/1VeqUWeyzTn2ig9CBIAiL+DiZoqdBIe+Dh/4q4PxGxnDN0meh1XYJZLRM82U\n2mAcG3C58FdfC3snGvoNiyBRSu5RXSGO41V4q6T9l4yxx8TRXCeCzw5xBHOveSPiNjAugs+T+E0E\nnkZ+zZyrKevTu1kQWO/fDrddFuPwtCwKtmToEr7t+cwxzsqQ5j7lfPFnoVPuwwfTNWgGuB9XtOow\nEwnwvXijSdvP2KPz3OcafJZjVAaX4pi6fy2lLDpdK9KGEyJTHsFj/psGEMnvMuELNmUYO+eZwH6x\n6jU2i0SRyLBfxbd4B7d107heZRSnRaSscRM+F856JR5O9RvU859zkmI6MimO590i+ZyHAyJvOok7\n8Vzquxzvds3KHqTm4+YLP/WeOI5l3Coy6dP4Hrtn3boeprbjLhQ7rNXvn12zb87coZaOHBfHsewm\ncSUe6ppFc5CtYlcVU5TbxUV9YanGOUxxkQbwikhFjohrx5T4T5Vzqa6oqKioqKioaMHf1siB0YOG\ncaUAAAAASUVORK5CYII=\n",
+      "text/latex": [
+       "$$e^{\\frac{1}{\\sigma^{2}} \\left(- \\mu + x\\right)^{2}}$$"
+      ],
+      "text/plain": [
+       "         2\n",
+       " (-μ + x) \n",
+       " ─────────\n",
+       "      2   \n",
+       "     σ    \n",
+       "ℯ         "
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "bell = exp((x - mu)**2 / sigma**2)\n",
+    "bell"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Take the derivative of this expression with respect to $x$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Object `.diff` not found.\n"
+     ]
+    }
+   ],
+   "source": [
+    "?.diff(?)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise\n",
+    "\n",
+    "There are three symbols in that expression.  We normally are interested in the derivative with repspect to `x`, but we could just as easily ask for the derivative with respect to `sigma`.  Try this now"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Derivative of bell curve with respect to sigma\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise\n",
+    "\n",
+    "The second derivative of an expression is just the derivative of the derivative.  Chain `.diff( )` calls to find the second and third derivatives of your expression."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "#  Find the second and third derivative of `bell`\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Functions\n",
+    "\n",
+    "SymPy has a number of useful routines to manipulate expressions.  The most commonly used function is `simplify`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAIIAAAAZCAYAAAD9ovZ9AAAABHNCSVQICAgIfAhkiAAABH1JREFU\naIHt2VuIVVUcx/GPppVlpZiVXchGQ0WUzExTypKKiO5QEYhZRlEkWBb0EF3sQncq6AZRYz3UU3Qz\niKCkxNJ8iAqioLQMw8y8RWVp9fBfG9ccz8zZZ+bMOE7nC4e911r/vdd//fb6r9uhSRP068G6pmI6\nDsEM3IMPe7D+Jr2AwXggS1+G33HUnnFnr2AqbsJdeA+n7VFvGsRE/INRKX0w/hUdosnu9NnA6Sd6\neDEVjRcdYdIe86h302sD53T8ipsb9L6X8WiD3tUX6bWBc0Vy5LkGvGseHtKzC9W9nV4VOKMxoIvv\nOE90BNgfI7v4vkYwUdfb1Z30ucCZKRp1RPpdhFP2qEdBq97RIavRY4FTJhL2Sw4Mx2/4rBP1tOBt\nsRrOOaQT7/q/MBOHY4kInGlYjzXdUVneES4WEbpJ9L5hKf9ZMT+djcWYm9kvwgg8gU9wBg7EFCzE\nx8n2OxxU0qf+OAvvZnmTMQc7Rae8BtdhiNhS3Zna8gd+KFlPZzkBd2Az/kz+Po9Vmc1UzBcfbkDy\n8358ndm0p/eN6gucSr3KaPUtxqii1zi8X1HBbDFsFqyqSEvObxO9dl6W/6TO99xLtRWgBU+JBks+\nfCNOKWeIbdbCVJb7UJZW5Yfc6dgqdlEFL+H7LH2++ODDs7xxQo9JWbqW3mXJ9apHKzK9igcm4jBt\no/Z1MRUU5PcFG9OvBS9k+V/iWG3FKMuIirpuwW2iEcSIswnLRW9+zC4BV4utVnfQDy/iIyzN8jdi\nRbofnGyewYbM5iu8kcoop3dZcr3q0Yoqeh2Jn7FFbFXm2/0jLlW9x67BKxV5c8V2c2TtdrRhEBZU\n5B1Xkf4R97Xz/DBcVWedrcr5OU20aVEHNpcnm3OqlN2QyiYrp3cZKvWqRysyvYoRYZ2Y114Vw96T\nWCvOD8qwvaRdLYbaPSpWZ/djxDz3QTvPbxELq2osFgvdyt8FeKedssnZ8yPT9ccO/G9J1x1Vyv5O\n19G6rndBpV71aEWmV7FYnCKGuOtS+hjcKw6QXtO4D12LzXZfIOXMwl9iqCsYJRY/xFC7rZ1nr2wn\nv1X8sbOmhm/r0nVoBzY/pethVcqKxeB6jdO7I71qaUWmVzEijNe2N67F1WKuGVLSqUbwO/bJ0oPE\nYcqElD4Lnyc7wv9bM/sJ+LSbfFsuRoNZVcouEXP1W8m3MVVsJqfnl2mc3rle9WpFplf/LHOBmLsK\njhYrzvUpPVD1c4dq+QMrrvWwQWyn4Fzh/HiMxfHaRsvtYsgvGIuVnaizDDvEx5qJC7P84UL0n0SU\nXytW4yMym+PE1nqOXdNGLb3LUuhVr1ZkehXHlrPFKv9QsbcseuaDYt57BCeJeW6Z2CKdKfbTJ6b8\nlWIr80QqGyqG2xd1vMCqZF8h7JLkz8P4RSy07sbTYv/+F94U/9UTUThQ7FjqoVW5qaHg5GS/WXz8\n7UKnLZnNqbg+2ezEAXgcX6TyjvReW6f/hV4rlNeKzuvVZ2nVe4+Ye4z+tU36PFtF1DRp0qRJkyZN\nmjSp4D+SOyJ3naugoAAAAABJRU5ErkJggg==\n",
+      "text/latex": [
+       "$$\\sin^{2}{\\left (x \\right )} + \\cos^{2}{\\left (x \\right )}$$"
+      ],
+      "text/plain": [
+       "   2         2   \n",
+       "sin (x) + cos (x)"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "expr = sin(x)**2 + cos(x)**2\n",
+    "expr"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAAsAAAASCAYAAACNdSR1AAAABHNCSVQICAgIfAhkiAAAAF5JREFU\nKJFjYKAC4GJgYLhEjEJTBgaG0wwMDP/RJViQ2JoMDAw9DAwMrxkYGP6S4owF2ExmIsWEUcVUV8wB\npblwaRRjYGDYycDAcIUBEnv/GSBRv5+BgSGaFBfQGAAA/84M5lOscPUAAAAASUVORK5CYII=\n",
+      "text/latex": [
+       "$$1$$"
+      ],
+      "text/plain": [
+       "1"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "simplify(expr)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise\n",
+    "\n",
+    "In the last section you found the third derivative of the bell curve"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAnIAAAArCAYAAAD8MGWDAAAABHNCSVQICAgIfAhkiAAADJpJREFU\neJztnXvQ3FQZh59eoFRoQcByh1JBLAK2dEQKFFpAQAqjyGW8AJYpomUQKSIXRaajlYsyIAJKVTRo\nQaqCIwMKXqsMgzewiiKKBXQABwGLYAWk8vnHm3XzZZPdk+Qk2c3+nplOd/Pl8n775dnkvDnnPSCE\nEEIIIYQYCMYCl9UdREWMBd4PnB3+E6IM5JQQ9TEs/sk9AcDGwJnAvXUHUhFHAtuFr28CZtUYi2gm\nckqI+hgm/1LdG1tLOKIu/om1XJ6tO5CKeDXwjvD1atoSCOELOSVEfQyTf3JPjGJl3QFUxARgUvj6\nDmDrGmMRzWZl3QFUhJwS/cjKugOogFT3lJETvZhYdwCOJMX5IvAcMAcT/fEqAxIihUFxCjpjlVNi\nkGmke7qRE904lOpb3Kfl3G4i8O6E5RsD84CLckckhD8GySlI9kpOiUGkse7pRk6kMQV7Br+64uNu\nnnO7fwDPAHvGlh+PnfTrAQcXiEuIogyaU5DslZwSg4bcE41hInAG8AQ20qdbmvkjwOQCx/oosDDy\n/kZgtsN2S7r8bF9gAXA5dkK/F7gZmBb+fCzwycj678Q6wT4FrAF2czi+EFkYdKcgm1dySvQTrv4N\ntXuTgG8C27tuIBrD1QW3vxeYGb4ej514k9JX/z9LUpZPpi3SW4Cfh6+vA7aMrHdlpiir5Y3AYux3\n/D6wf63RiKrpN6egGV7pOtX/7A+cAJwMLKf6bFKj3Rvf5WcnA9sCRwNn9dqRaBwTYu9Ppd1KSOKX\nwIrw9aZYX4RV4fs3AA9gHTWjbIG1psZElu0HbBB5/xzwCeA/wFfDZbOBb4Wv430I1gHrh+v3ExsB\nRwHnhu+PA24HdgYeqysoUSn95hQMvle6Tg0GNwMfBL6IlQy5BTtX4+dvWcTdA3f/GuHeCDC1yA5E\nrYzk+AfwpQLHPAr4euT9ecCFWH+BMYlbtFnisP97MJnAOn9GWQps5bCPqtkDeBmrBQTWGhvBbujE\nYNFEp2AwvWqh61R/sxuwYfj6GOAl3DJaSeTxr9HulTnYYQcsleqLbbH06FXAF4Drgd097t8nPmMd\nB5xD7xMmjTE5/oHddORlHvBw+Hoc1lr+KVbMcCRtox4ciT2WnIp9Kfwai3VBbL3JWAfRfuM+rNX1\nUPi+VczxwQz78O0UwF5Ya/m7WIzXAtt4PoYPfMYpp9oMulc+8O3VMDoF3b36HbA2fP027AYnbzYu\nj3+Ndq/bo9UibIKlD0/ytL/NsJuiRcDfwmU7Yo+mjiDbxbBsfMf6X+Bu4OPA+Z5iBOtkOQHYFYs3\nzr8L7Hselno+Eet8ugJLMReZRmVzLJt1JNbx9APAC1in0zjPFzhOWYzQ7gMB9oj1MkxeF3w7BTYa\naimWFXwGe/z7nTCmvYBHPB6rCL7jlFNtBt2rovj2alidgt5e7QkciN3QXZ5j/73o5t/Qu5cnZX0N\nnWUgivAhbLLYOB8GLvF4nDT2wP2mt6xYP4OdPL44Pfw/rRPo6YzucOnKFOAvuSIyzimw7frYl0iZ\nZDkX0liIjUTKkhHy7RTAbcBOsWUzMeeTvkx8kuVzLCtOOeVG2V75cCrvo1XfXg27U9Dbq1OwR4kb\nFTxOnG7+Db17WQXZBfihjwNH+BztjoBRzsSyGmUT4P4ZlBXrNODHBbZPYhLpz/A3JPmGtBfHYaOS\n6uAELPtZJgHF+uIcQXuk0gaO+yrDKYB/AX/FvqyirMGGuJdJgPvnWFaccsqNsr0KKN6/Lc+NXBle\nDbtT0OnV3lh5kNY59Frs73VMweMkkeZfo90ro4/c6cBXPO9zFfBW4AbgleGyCVjdlcDzsYpSVqwP\nYX+vGUWCi3Es1npKYi3wM7LXidoDuLVIUDnZBniSdl+GfuQAbGTTbVjr8DDcOpCX4RTYZ7UF7U7I\nLV6kv6ayKStOOdWbQfAqL2V4NexOQadX64Df055Saho22GFV56aFSfNvaN17F5ZdaqVaXaeaWE17\nZJ4vJmBDgUewfmfHY3fJb05Zfz7Jv/zd4bZZCXBv6WSJdRZwBZapuxkb5nwe9gh2OZ2f44XAx1KO\nOwP4fLjtZdgXVLdRQWdiKehLe/1CYhQB+bIH07DOvfHRVC5FKstwCuxLPP64YWssrqRMlU+vAtw/\nxyxxyqnBIyB/Ri7vdQrK8UpOGXGvjsfKjywGbgIOcYhR/tXEDsDTJe17EjZgoHUBvBVrUSSxHHsG\nH2V6uN1BOY4dkO2LxiXWadhJ18qKBsCfgH2wTpsvYyd+lKOwQrJxFgC/YfSIo7OxIoNg1aI/haXS\nl2GZIZGPgGrLHJTpVBIXY52W90n4mU+vAop9jklxyqnBJKD60iFVejVsTkG6V64sQP7VxhzgDyXt\n+1yslMd8LHXbyngllfV4lM678lOwgnqvyHHsgGyCuMT6WUa3Lr5Be1Tjdlj8m8X2ux/2u0WZjaWp\n940s2wt7fDcFmyj4PeHyxbRr1Yh8BFR70SnTqTg7YX1nlqb83KdXAfk/x7Q45dRgElD9jVxVXg2j\nU5DslSvyr2aOxp5D+2Yx9kdssSE2fPll7K49ys7YjdP82PLlwF05jx/gLohrrPEOjI/Srvicxuvo\nHEZ9B/B3rHVyaXisU2g/srsCG2IPNkIr3idCZCOg2otOWU7FmQD8gvQBOb69Csj3OXaLU04NJgHV\n38hV4dWwOgXJXrki/zLiu47cONIL7+2OPe92LbmwCnhfuP4FWAuqxVrshumPWP+I6bRbV3Ox9PCd\nsf3NwQYgdOM64PUJy7fHWgRJU2QspJ0azxJrtF/ELlgKudcIunWx9+th6fdrsbInSdyEtWBewvoY\nrE1ZT4ym6LngizKcijMG+DLWHeCClG3nks8rn59jrzjlVH/TL05BuldyajR5nIJOr1yRfwXIM+VF\n0hQ08/Cfrp4S7j9prrQx2LxtMyPLbqBzNMzUcB+HYTevu2aMIcCtpZM11haLsNFC0VR6UgfS2Ywu\n1LhleLyzHWITfghwOxf62ak4S7GClFFOjL337VVA9uyBS5wt5NTgEFCtU1C+V8PsFHR65Yr8y0Gr\nA2OeKS+SpqB5jOTn5UV4EqtBk/QcfCNsJOD9kWVz6Zw94RDs5LgLa7H4LqzawjXWiVhB2FafuTcB\nv6Wdih5LcmtkU9pDuMHq/TxLcmZ1OjahtKiHfnYqyklYZiJedDJe0HMu9XkFveOUU83Hl1NQrlfD\n7hR0euWK/MtBlkerk7Ehx+d1WedBLFW8Nfn+iEmMYFNXLMP6EjwSieda4AyslQCW+t0qPH6L6dgJ\n+zR2IzWf8oYnu8Z6NCbAvVh6eGcsW9fifCx9Hmcm1pehxbrwWIcBF9FucR6EDcs/teDvI8qnl1dl\nONXiQKwfyu2MLno5ntHZi7q9conzcOSUsOmOdsRu2q7osl5ZXskpI+6VK/IvB1lu5I6ld/HSEeB7\n2DP+FXmDSmAFNurz09iN0AjWx+FqYGVkvbnYibAaO8GexjJkB4f7uAabvHeNx9jyxPoTLA0+C2tx\n7Y2NDlqG9W+4BasjFGc/Oqf5ak399TWsI+r6mHgLKTahr6iGXl6V5RRYX5NNsC/IONHRa3Op1yuX\nOOWU2Bx4O3aeLMfOmbTJxsvySk4ZSV65Iv9KYgdsaqHAYd0DsSHKdXAj6SdWEQKqH1UV51XYKCvX\nTriiHAL8nQuuXtXpFJTjVYCcEkaAn3NhEe1pmJL6Kcdp2rUqoH6nQF5VjusUXTOw1oELP8IeF5VR\nib4XB4TH982zwAsl7DcLp2HVstUiqRef54KrV3U6BeV4JadEC1/nwm5Y4+hQkkeSxmnataofnAJ5\n1ZfMwoY1T8V9rtAdgeup9o68VQ374AqPWRWvod6Je4V/snpVh1PQXK/kVPNYhvXbAusfN91hG12r\n/CKvasAlIzcdS0Efg1V/nu2wzcPAVVgRv6rYHvgz+Yv+9ivjsMmdF9UdiPBKVq/qcAqa6ZWcaiaP\nY/2TwbJTLqU7dK3yh7waAKbinpETQrgxFXklhA/m0C5qeyXZ64UKMZDEM3KLgfuwkT7PAw8A38ZG\njZyG1Ufbv8oAhRhw0pwCeSVEHtKcuhNzaiHW9/T+tB0I0VQuxmpZjcEmyX0Q2KDWiIQYbOSUEH6R\nU0KksCtWMybKr4AtaohFiCYgp4Twi5wSIoHWo9XDgdsiyzfFUtRPVB6REM1ATgnhFzklRAKtG7mn\nGF1/5nzgrOrDEaIxyCkh/CKnhEigVTtnPLAEmy5kCnAP8IOaYhKiCcgpIfwip4QQQgghhBBCCCGE\nEEIIIYQQQgghhBBCCCGEEEIIIYQQQgghhBCiFP4Hx1a0RoYHygIAAAAASUVORK5CYII=\n",
+      "text/latex": [
+       "$$\\frac{1}{\\sigma^{4}} \\left(- 8 \\mu + 8 x\\right) e^{\\frac{1}{\\sigma^{2}} \\left(- \\mu + x\\right)^{2}} + \\frac{2}{\\sigma^{4}} \\left(- 2 \\mu + 2 x\\right) e^{\\frac{1}{\\sigma^{2}} \\left(- \\mu + x\\right)^{2}} + \\frac{1}{\\sigma^{6}} \\left(- 2 \\mu + 2 x\\right)^{3} e^{\\frac{1}{\\sigma^{2}} \\left(- \\mu + x\\right)^{2}}$$"
+      ],
+      "text/plain": [
+       "                      2                           2                          2\n",
+       "              (-μ + x)                    (-μ + x)                   (-μ + x) \n",
+       "              ─────────                   ─────────                  ─────────\n",
+       "                   2                           2                          2   \n",
+       "                  σ                           σ                   3      σ    \n",
+       "(-8⋅μ + 8⋅x)⋅ℯ            2⋅(-2⋅μ + 2⋅x)⋅ℯ            (-2⋅μ + 2⋅x) ⋅ℯ         \n",
+       "─────────────────────── + ───────────────────────── + ────────────────────────\n",
+       "            4                          4                          6           \n",
+       "           σ                          σ                          σ            "
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "bell.diff(x).diff(x).diff(x)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You might notice that this expression has lots of shared structure.  We can factor out some terms to simplify this expression.  \n",
+    "\n",
+    "Call `simplify` on this expression and observe the result."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Call simplify on the third derivative of the bell expression\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Sympify\n",
+    "\n",
+    "The `sympify` function transforms Python objects (ints, floats, strings) into SymPy objects (Integers, Reals, Symbols). \n",
+    "\n",
+    "*note the difference between `sympify` and `simplify`.  These are not the same function.*"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAEMAAAAXCAYAAABQ1fKSAAAABHNCSVQICAgIfAhkiAAAA4pJREFU\nWIXt1n2o3mMYB/DPmWfbodkhtmPjHDMrIbLEYfN2SLZlyWSjTc38IXKiDkryLmyIjRIpYm1DVv5Y\n7A/CEmkkNKTkrR1j8pa3sc0f1/3bcz+/8zzNeew4q51vPf2e6+W+7+u+r1eGsQMtQ21AA3RhGtow\nHXfg9SG1aIgwBvdk9Fz8hoOHxpyhxbHYhsMTPRbbxaPscWgRaVKk8NHiMab+Hwfv7nga36J3J3oj\nRSp9XuJPwg34UUTbpdgHW/DDLrRz0HEZlti50yq4RVwyxyS8iwmJ7sUyjMDddfR3W5wrHgNaxcUa\noVfUmhyj8A4WZbwL8WX6PwH35QtGNGnoYON0tGMNDsIMVe+Wsa9ow++X+FenNcszXhs6REr1ic7V\nucusHgRMxi+iaOa/sQ305+DaEq8Vm8V8kuP+tNfoRM/FdYWwkilegG7xcheLkDoKh2Ap3k56x+Fm\nUZD+ENH1ONYneRd6sCntvx/uwifZWefjZFHAWnFA4l+Fz4S3/y3OwPMl3kVpz1Ul/nTx0H8mej3m\n495cabQoVPCpCM9T04Zf4OEkm4afkwEFnko6MFtcelwmP1JU+KkZ/UrJyAV4UnNYLdpvjhfwO17K\nfi9jK9Zlem34oLzhOcJbo4S370z8DrwnLt8iLrqmtPYBPCvybzOuqWPw0rQPzMOHar0/RvXBB4q1\nmJLRe4moXVHSmyVS5PaMN1JtxIKTxCudlhaUK3OhU94sx7wkn1FHdmWSHY+JYm74ScwQPWojaaBY\njhMyujOd1VPSeyjxj8l442WRUnSTt5JxZ+J7dUJHtbV93cCoyen7dx3ZX+k7BRtFXVklIm4ZvhJ1\nqhl8LOpagfb03ZDxKqJYrlN7tw58VBDl1tqN18QLlrExffdvYFRf+o6vIysK5CbhxRZcnozpxDN4\nVLXKDwQvivpWoHDGNxlvZrLrptLaU/RPe7C3qLLl8CpQER5cW0c2R4zCv+K2OvLn0toKFuLGkrzI\n83bNYaXIf+Lht+OITP4qHquzboWok/1wlv45VcbZosCel/HG4ZH0f75Io3xAOkwU1u5EL8R3onYU\nOFS1dTeDE9VOmm9kNi7Cm6KF55glxocdyGf+S0RUdKmfJvnBtwpP9oloWixqDhGyVyT5VjH/P6ia\nqwvE5Q8U7W+bmEUWi+hpFjNFi98g5qMlwjFbcL1wYoGJooM+8R/OG8YwhrGH4x+A+7Tv2FKoNAAA\nAABJRU5ErkJggg==\n",
+      "text/latex": [
+       "$$r \\cos^{2}{\\left (\\theta \\right )}$$"
+      ],
+      "text/plain": [
+       "     2   \n",
+       "r⋅cos (θ)"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sympify('r * cos(theta)^2')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "It's useful whenever you interact with the real world, or for quickly copy-pasting an expression from an external source."
+   ]
   }
- ]
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
 }

--- a/tutorial_exercises/02-Solve-Subs-Plot.ipynb
+++ b/tutorial_exercises/02-Solve-Subs-Plot.ipynb
@@ -1,561 +1,575 @@
 {
- "metadata": {
-  "name": "",
-  "signature": "sha256:daa6eac8936225c392c04e7bc0306c213e669afac73b2ee5b23df1a02748c721"
- },
- "nbformat": 3,
- "nbformat_minor": 0,
- "worksheets": [
+ "cells": [
   {
-   "cells": [
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from sympy import *\n",
+    "init_printing()\n",
+    "x, y, z = symbols('x,y,z')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Solve\n",
+    "\n",
+    "Equation solving is both a common need also a common building block for more complicated symbolic algorithms.  \n",
+    "\n",
+    "Here we introduce the `solve` function"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
     {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "from sympy import *\n",
-      "init_printing()\n",
-      "x, y, z = symbols('x,y,z')"
-     ],
-     "language": "python",
+     "data": {
+      "text/latex": [
+       "$$\\begin{bmatrix}-2, & 2\\end{bmatrix}$$"
+      ],
+      "text/plain": [
+       "[-2, 2]"
+      ]
+     },
+     "execution_count": 7,
      "metadata": {},
-     "outputs": [],
-     "prompt_number": 4
-    },
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "solve(x**2 - 4, x)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Solve takes two arguments, an equation like $x^2 - 4$ and a variable on which we want to solve, like $x$.  \n",
+    "\n",
+    "Solve returns the values of the variable, $x$, for which the equation, $x^2 - 4$ equals 0."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise\n",
+    "\n",
+    "What would the following code produce?  Are you sure?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "solve(x**2 - 9 == 0, x)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Symbolic use of `solve`\n",
+    "\n",
+    "Results of `solve` don't need to be numeric, like `[-2, 2]`.  We can use solve to perform algebraic manipulations.  For example if we know a simple equation for the area of a square\n",
+    "\n",
+    "    area = height * width\n",
+    "    \n",
+    "we can solve this equation for any of the variables.  For example how would we solve this system for the `height`, given the `area` and `width`?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
     {
-     "cell_type": "markdown",
+     "data": {
+      "text/latex": [
+       "$$\\begin{bmatrix}\\frac{area}{width}\\end{bmatrix}$$"
+      ],
+      "text/plain": [
+       "⎡ area⎤\n",
+       "⎢─────⎥\n",
+       "⎣width⎦"
+      ]
+     },
+     "execution_count": 10,
      "metadata": {},
-     "source": [
-      "## Solve\n",
-      "\n",
-      "Equation solving is both a common need also a common building block for more complicated symbolic algorithms.  \n",
-      "\n",
-      "Here we introduce the `solve` function"
-     ]
-    },
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "height, width, area = symbols('height,width,area')\n",
+    "solve(area - height*width, height)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that we would have liked to have written\n",
+    "\n",
+    "    solve(area == height * width, height)\n",
+    "    \n",
+    "But the `==` gotcha bites us.  Instead we remember that `solve` expects an expression that is equal to zero, so we rewrite the equation\n",
+    "\n",
+    "    area = height * width\n",
+    "    \n",
+    "into the equation\n",
+    "\n",
+    "    0 = height * width - area\n",
+    "    \n",
+    "and that is what we give to solve."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise\n",
+    "\n",
+    "Compute the radius of a sphere, given the volume.  Reminder, the volume of a sphere of radius `r` is given by\n",
+    "\n",
+    "$$ V = \\frac{4}{3}\\pi r^3 $$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Solve for the radius of a sphere, given the volume\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You will probably get several solutions, this is fine.  The first one is probably the one that you want."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Substitution\n",
+    "\n",
+    "We often want to substitute in one expression for another.  For this we use the subs method"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
     {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "solve(x**2 - 4, x)"
-     ],
-     "language": "python",
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABQAAAAXCAYAAAALHW+jAAAABHNCSVQICAgIfAhkiAAAASRJREFU\nOI3t0z8oRWEcxvHPvRbEpZRFhDtQom4GcQcGJWVTsrBQMtsZpCRGMiqjshkNZJHRpmx3Mypl8Gd4\nz63jb87bHT116jznPed7fr/397zUWLnI70YwhhaUsYnL2CKasJ3yc3hCRyxwCK8oJr6AtwQcpZzQ\ncnW7BhJgKRb4WcfYqxVsCTvih/tBMwkQ6tENdZGwcXThTJj6hFBlJQbWi0dhEOmrwNfeh7GIF6GF\nZaygVcjZBu6z/Hkf+cQf4U44EWUhe2tZWjlAc8qf4Dq578Qu2rIAez75CrayAH5Tn7DRk7UCruIZ\njalnxR/e/VYNQuIHE3+Km9R6HodZgLNCi/Poxy2uUuvrGP0LqHpSHtAu5K2EBSEu05jCOS6yVPiv\neL0DViMs6ugPO8EAAAAASUVORK5CYII=\n",
+      "text/latex": [
+       "$$x^{2}$$"
+      ],
+      "text/plain": [
+       " 2\n",
+       "x "
+      ]
+     },
+     "execution_count": 14,
      "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\begin{bmatrix}-2, & 2\\end{bmatrix}$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 7,
-       "text": [
-        "[-2, 2]"
-       ]
-      }
-     ],
-     "prompt_number": 7
-    },
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "x**2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
     {
-     "cell_type": "markdown",
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABMAAAAbCAYAAACeA7ShAAAABHNCSVQICAgIfAhkiAAAAVtJREFU\nSInt1LFLHFEQx/GPZ/ACygmpJEI8tFFEIYJIVIxNiIXNIVhoaZki5F/Q5gikOkhlpYX+A3aCaNLY\nSbqkEIQUgatEEBTUFO8drKshu8ulyw+WZXbe+87svJlHG9WRc/0UptGLGWzgqEjgHtQT9jIu0V8E\nNo5bDEW7grsIza0O4TdbpRmNsJdFYGlt41M7QGv4KP8BPtBihMFTVFuOzpyg13iBPeF052N2P/Nm\nNIgLoejJp/LY4ioaMepKyvcO+3kif0YX3uNbyneM3b8BSvE9i6+4xgJ+JNZ0YwKHWbPqQ1kYjRvU\nEr43Qm1Gs8Ja+oDzCG5pHU0ZeqqUst/iAFeJb3P4ErPLBRvA94RdFuYx0zWThp3hWcKuC12eqfjp\nOgxjEyfCXfUKYzHAbRbgn1TCL2wV2bzjfrPWhL4bKQJrCuMEz3GK1TyAZM2WMIknQhM3hDH6r3+o\n38LwOEuimErTAAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$$y^{2}$$"
+      ],
+      "text/plain": [
+       " 2\n",
+       "y "
+      ]
+     },
+     "execution_count": 13,
      "metadata": {},
-     "source": [
-      "Solve takes two arguments, an equation like $x^2 - 4$ and a variable on which we want to solve, like $x$.  \n",
-      "\n",
-      "Solve returns the values of the variable, $x$, for which the equation, $x^2 - 4$ equals 0."
-     ]
-    },
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Replace x with y\n",
+    "(x**2).subs({x: y})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise\n",
+    "\n",
+    "Subsitute $x$ for $sin(x)$ in the equation $x^2 + 2\\cdot x + 1$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Replace x with sin(x)\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Subs + Solve\n",
+    "\n",
+    "We can use subs and solve together to plug the solution of one equation into another"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
     {
-     "cell_type": "markdown",
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAGYAAAAZCAYAAADDq1t2AAAABHNCSVQICAgIfAhkiAAABKtJREFU\naIHt2WmoVlUUBuDHriNZGppYectUckgqoswMx0gLoyhpUAltIMkMJSozggIbtCQzS/JHSCQNZBFZ\npFJUpFmZNv6QtKiQ0pAGlSYt+7H2yeO557t6Tble+1643LPX3nutd++119rrnI8qqjhAuLSxCVRR\nF73wUmOTOBA4rLEJ/EeMwTP7UV8HrMctezH2IXyLnRi6l/oH4d005+V9IdhUsAZt9qO+4/ARztvL\n8ZPwRwmH7vgOJ5TMaYHfces+cjzo0Q9PNTKHZ7G8RD5FbH7rkr4BImL61ae4KaeysXi6kTkMxNsV\n5O8L5xQxBNtEtB9yqMGnaN6IHLqLkz+8pG8TpleYtwxL96S8bGHDMAHf4Gi8IULzjNQ/Slx2tRiN\ny9AHXTAHH+R0nYaJ+Enk1o64EVsbYK8Mw/AOdhTkvXCTyO0LRarJsAgfYgY6JZ6Pp3afxKtsXpHn\n12iPz5L9Fan/ClyNo5L+oViCxXgsjWkhUtnDuAttcYzww3jlEQauFd7uktpd0+DMw63wQHpeh1dF\n2HYQG/toTtd4fCIu1Ay34eIG2KuEBTinIKvBfLHIySKiMrTDXxiX2h2wEa+JzZqf5k8pzKvE83j8\nipUlYycoLwjYdb+syOlqLg7qNSXjwanYLqIgj824Mz2PwCVoKTbwniSvxccif8LZSVd+8/oJR3Zq\ngL0ytE62mhXkF2Fkel6C53N9I8WGnJiTjRHFw+VpXfC6utFSH88ZJfwqFQRwB/5E34L8F/VUaa/g\nR3GCMvQWCxqc2v3F6RuU5KdU0LUUP+BBzMJsXI8jG2ivDKNwf4m8Vpy+WhEdF+b6Zop3jjwG2JX2\natANf9vlpPp49kk8LyjhsRH3VuC+LP3l0VPlu0p7kS+fK8hvEGFZLPvuFiemeGqJBewQ6aESGmov\nj0Xqnrg8bld3I1eqW1pPFndShvvE/ZGvVCvxnJjkRxTkJ6u8yS1ENTatIJ8qIqZVXpiR6CFOTTFn\nDsEqkba65eRDRZm4s4RAh6Try5K+DA21l6GdyO+f16N7uCggtqd2DU4X5WsefbE2PTcXF/cTImoy\n25V4DhXl7lZ192WHeLsnHFubns/E4XiroGs0XhAH8l9dmWO2pP/5cG8jNiozMjkn719iIMPmpK+s\n4uuN6xpoL49ReLGC3Qyd8VWh3bIg6yk+vWQYIe6+BWnspCSvxHOwXe8veZ4Dxf23LdeXVY5DknxV\nbnxfcYctKOrKHLNOVCNdU7uFqLBai/DuKDacyM0tVXZMlsbOt3uqO1dccAsbaC+PK+3529hqcdIz\njBWpLauCanCz3SvInonPBpGmso0q4zlPpJ31wpmbcnpqEn8iQn7D96k9RFRj+RL/JPEqsVwcuiVZ\nR7PCoNn4IhmYK6qq8YngNLFZV4lL8yzlqYyIlpmiVN4gHLkGT+bm7K29DJ1Frq+vMCCc+ohIDVvw\npihEpot3jxrxXrE2N+dY4fDViefCXF8lnuOEc6YKxxOnfx7eEw6bJVIjkUrnFnS3FV/H16Y1z9nD\n2g5KTBGnuYqDDCtENPwv0FQ+YvbAz8rvnUMSTcUx+/sHsSr2ExaLi7KKKqqoooqmg38A2SEmPBfg\nAAEAAAAASUVORK5CYII=\n",
+      "text/latex": [
+       "$$\\frac{area}{width}$$"
+      ],
+      "text/plain": [
+       " area\n",
+       "─────\n",
+       "width"
+      ]
+     },
+     "execution_count": 25,
      "metadata": {},
-     "source": [
-      "### Exercise\n",
-      "\n",
-      "What would the following code produce?  Are you sure?"
-     ]
-    },
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Solve for the height of a rectangle given area and width\n",
+    "\n",
+    "soln = solve(area - height*width, height)[0]\n",
+    "soln"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Define perimeter of rectangle in terms of height and width\n",
+    "\n",
+    "perimeter = 2*(height + width)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
     {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "solve(x**2 - 9 == 0, x)"
-     ],
-     "language": "python",
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAMAAAAAZCAYAAABn7SHgAAAABHNCSVQICAgIfAhkiAAABhBJREFU\neJzt22uMXVUVwPEfToeWUKRKlQpWESqFSsAHNqXyrFE0GEEafICP4ouINTRG8RGNxmdVWnygkRDs\nGI1CQGJEQ0HRolQivlASv0BUjA8wBCISBUXxw9ond8+ZfaZnZu6deyeef3Iz96z9Wmedvfdae507\ndHR0/F9w5rAV6OgYFkfgm8NWomP0eEztei2uwXW4HZfj4PlWagCcja/3sb8DcCfe0aLudvwBj+KU\nlv2fiB+nNt+ajYJzZD7mwSBtOCv7PRs3YFm6Xoof4q84pG0nI8ovsE8f+zsYv8QLWtbfjIcLOhyG\nP+OphTbjeAjvnKWOs2W+5kE/bNhX+30Hq2qyZ4lVdEXbTkaQtfjKkHW4AjcX5FvEQ1pSKFsvbL+2\nD+MfjUUt647qPCjZsK/2e1C4mSfW5Pfj3tZqjh6fwYuHrMOf8NGC/Bu4qaHNe/F37SfudExov3uP\n6jwo2XDO9svPAL/Dgdi3VqfkuhcKYyJm/O4QdTgMByk/qONFeFHiZBHHPjIYtRoZxXnQZMM52y9f\nHeuwH+7OZAcJY+wqtN2A83AXnoAbhUs6NpVvFJNvJV6Fs7AGTxa78q1ZX8/E+WKXGcdyvFWs4Lbj\nldiAH5lqhCPwNhE7ftVk1341foatYhe8FV9M12uSXqV2dT1/L+Lo29P4u1P5K3AuHpf6PwU7cS0+\nn+qMCxf+aXxAxOFPEs9rk3D7g6LtPBiWDefVflvxn9RZzhtwj5jMhHt9CNen68X4ZPp+h4grTxAn\n/7twSdbXJvzK5CzDhTh9BuM1sQPPq8nGcKkwxgX4dVa2v7jf16XrA8REuE4Y9dLUfkutXZOeT8E/\ncEuh7nmad9Uqft2d9bVIbAivL9TfExPmdoCtz4NRsOHA7bdKxIMfqcmPwb/Frp5zL96Xvp+Kl2Fv\nMVGrPlbiNuGe4LjUVz5J14oFU8WgbcYrsSSNtVdN/lKclr7vxFVZ2WnCcE/LZGeLQ/TL033B90zd\nuabTc2tBv6aDMRG//gtH1eR/M7us0ITZL4DSPBgFGw7UfouF29peKPs27hOrueJIcdMnpet1Yic4\nMcmPbhjnepFe+xQuwsV4Mx47w/FKbMTHC/KVYjdYKXaql2RlnxAHwJz1eq5+DIfiv3oPcjo91yQ9\nS4fwu5UPxkQa8oaabHXq64UNbaZjwuwWQNM8GAUbDsx+e+Fr+FChbJmIxa6syd8i3FE9HfVBsXrr\nuzBxk48Il9jETMfLudrUHSDn3aYa+xZTU6YXiHi34mMiNs0TCE16np/k+9Xkz9D8MMbFjvuemvxd\nYgdbXGhT8WXh9eqf+/CbhrLnNPQ13TyoGJYNB2U/hKt7f0322vT32DTwllr5lXru6NBMfpNIVZVY\nkfq6cBpdZjpexf4mH7JLfN9k1z0mFtXmWr3Lsu+L8Bc9+1RjN+l5VaZHrudm4eqXputlYjelF78e\nV+vrNnyp0FcbJszcA0w3DyqGZcO+2a/+U4hzhWv6cE1+fPr7QPqbu7h99FJOxGqv5OuUM0iEZ3hA\nOU97JN44w/FyNopX+dOxAr+tXe9dk60Wr+srThVnkx2pbvWgm/Q8SS91l+t5gnggD2ZlVabq5CT/\naVb/KBEf7yj0NQj2NA8qhmXDvtkvn3wbRCy+U6Sn8jqPpu93iJP7Iel6XGR0lgiXtlzvZcn6dIO7\nlKnCnxeJWL0a4/k4R7i+h2cwXs4r8aaGcSt+bvIbz3OEO6+yBmN4e/pUrE76/FHsVJVBS3b5gnC3\nd4oHfk/Wz1jSH56Lf4pdkXiAu01O3R4uUsQ3i8W9cw/3NhfazIOKYdlwIPa7P91g6ZPvBIeLLM3F\n+CyeLlKZu4SrW57qvUa4rlL8X7EI28SJ/qLU36Zam7bjVazQ/HYwZ7mIcXeI9xJniEV7o8gff87k\nuJXey5jteHWtrEnPHyQ9H5/VPUY8pG0iBMw98U8KfS8VWZNLzG73n9A+BGo7DxieDefbfguKLcJ7\ndPSYsPB/0DgQ+vE7k1HjLJNfonVEfD3It8cdI8Iq4UI7OlpRzwItdPr9jy8dHQuKa/Vywx0dHR0d\nHR0dHR0dU/kfLywOMJQIn3wAAAAASUVORK5CYII=\n",
+      "text/latex": [
+       "$$\\frac{2 area}{width} + 2 width$$"
+      ],
+      "text/plain": [
+       "2⋅area          \n",
+       "────── + 2⋅width\n",
+       "width           "
+      ]
+     },
+     "execution_count": 27,
      "metadata": {},
-     "outputs": []
-    },
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Substitute the solution for height into the expression for perimeter\n",
+    "\n",
+    "perimeter.subs({height: soln})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise\n",
+    "\n",
+    "In the last section you solved for the radius of a sphere given its volume"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
     {
-     "cell_type": "markdown",
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAD4AAAAcCAYAAAA5pQx5AAAABHNCSVQICAgIfAhkiAAAAytJREFU\nWIXt2FuIVlUUwPHfeKlRbIzowR7KLK0hqCyi5iWb7oViNRJ4KRUhJTEw6iHwJSjt8hJBl5egUrpa\nmlgvFYmBZEV2f5JAX4TAym42lTU9rH2a0/E733eOM9NXzPzhg33W3nvtdfZea531bUYpHe02AHMw\nHcejF8/g7Tba869xEMtS+2Ycxgkjvei4kV6gAr14JbUHMPEYdPQNmzVt4nmsqzmnG6/VXWhCi/67\nxQk8UFdxTS7EFfgZj9ScuxgvFGQ9WIVfMAmTsQGfVlE4PRlyb01DhsJKfIQpNebsES+XcQFeR2dO\n9iR+wOxM0CzG14mdGkl68DVmpOd3xelfV3H+xfhSnGzGUszFDTnZGyJhrsgEZS/eh3cqLj4UjgjD\nD6TnM/A7Pqk4f4nIC3k+Fqf7bU6WedDhZsqm4KnUHjDyrn4L7sKdeBXXVJw3Hp9pnafgYbHJ5zcb\ntB5npnajF+/Ci8K9Bkp+f+JSLMBj2CbCZhkewnPCTYfC1Xi8wrgZIpxW5oXF3ZqNn/BViZIObBTu\n9LQIiQ+xD2vxBH5Df5LfhzXYi814UCSePfgOH1QwvIzFBj2zEfNwiYj1R5uNHYdncVxOVjzxpbg+\n97xZuBxsL+i7Fjclff24P8lPFTHc28ToVnQmHVVK7gl4C7txcqMBt+PygqxZjJ+Irak9OSnO04Op\nohYfwHkVjKzKAvVqi8yGrEL8O6tPwznYUUPZEryX2t34o9C/G9+LwuQbfF5DdysWiTzRiG5Hb3L2\nleiTMnwW41c5uvTLauaFIvY3Ykuu/7b0g1OUuJHwop1ix4eDqTgNXzTo6xL5ZyLONpirskPpMBia\npZyu3NXniOSUKVkksnxnYdwk/Io7Wi1WgxW4p6SvU9QBe3FSTn6ReJf3qywwKw1e36BvG17OPV+W\nxs4rjLsyyc+tsmBF3hTldBkbxEbnE98m/CiqwlK6RKwfEEb3i1i+MTdmn38WGl3Yj/kFXbeKT9Zw\nXXhME2HTiuXij8smkdFfwlnDZENbWIvV7TaiHexSnkRr8V+4ganKTBwSV1VD5v/04o0uHEYF29W7\noBhjjDFGMX8BujKdmTfmfkUAAAAASUVORK5CYII=\n",
+      "text/latex": [
+       "$$\\frac{4 \\pi}{3} r^{3}$$"
+      ],
+      "text/plain": [
+       "     3\n",
+       "4⋅π⋅r \n",
+       "──────\n",
+       "  3   "
+      ]
+     },
+     "execution_count": 34,
      "metadata": {},
-     "source": [
-      "## Symbolic use of `solve`\n",
-      "\n",
-      "Results of `solve` don't need to be numeric, like `[-2, 2]`.  We can use solve to perform algebraic manipulations.  For example if we know a simple equation for the area of a square\n",
-      "\n",
-      "    area = height * width\n",
-      "    \n",
-      "we can solve this equation for any of the variables.  For example how would we solve this system for the `height`, given the `area` and `width`?"
-     ]
-    },
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "V, r = symbols('V,r', real=True)\n",
+    "4*pi/3 * r**3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
     {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "height, width, area = symbols('height,width,area')\n",
-      "solve(area - height*width, height)"
-     ],
-     "language": "python",
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAG4AAAAgCAYAAADzCU3nAAAABHNCSVQICAgIfAhkiAAABONJREFU\naIHt2XmMnVMYx/HPdFrdGM1Eqb0YYi9FI5Zah1qTWmNJk1ZFbSFSO6FaSxsECUktIZYSe1GiJCjV\nRoJGhVgSuwiiEqUI5Y/nbea979zlvXfunda43+Qm55z3Oe/vfd9zzvM851yaNGmyelgHp+FUzEZr\nzn7/1OGXV3P3Oumt+vUJjsKNSflt7JKz3/MY1EuaPdHqs/QTq24glmBojj7jcHEvafZUq0+zCW5A\nZ077Z9DWS5r10OrTtOBlDK9gtzdm9JJmPbUaQa35QV1oSZXnYHwF+8dUHtx6adZDqxqOqdK+1vyg\nZvqlyjNxZlLeDF+W6TcK3+KHHurn0ayXVl62xYQq+8zDNBGrW/FJCbtpGpAR74iTcQYuqPCg94sP\nXYptxAq6B3fgJuFOsuTRLKc1G9+IF/kLi3FcEbv5WJnYLcGeZZ79GpyYaRuDJ/EClor32jhjUylW\n74SJZXQbTgfuLnN9e7Fy9krqI/AZrm6AFuwgBmROBbt3cUgOzXcwOFUfLQZ+WFJfGwvwPUZm+paL\n1bMwIId+w5gt3Ekx+uMjnJ9q21S4ufPqrLWKwWLgXi1jMx7n5tAbgwcybfPEBEqza6L5SFKvFKu3\nE16loRRzaavYWPmZPQl/6pqdjdRK8x2+KHGtDU8ojOeluBWHZdqWCw+yfqZ9GX5MyrN0xeo3sFvG\ndqaIfw1hCB7C7WVsbiryUGlewge9pJVmkYhxxVzRLSLBqUQr3hNeI81S/IEtMu3f4dekXC5Wd+Cc\nHPo10R9XYDp+UXyj2y4CdClasAKvYazYd92Cp4VrqadWljnCdW2Zad8T1+e8R6fiE2moiNNpNkr0\nXslx3+sVxsw0bcLdrlA6e1yJfSuJtOM3xePRNBxQpu96idCHmJJq318M0A511MpyXaJ9UKptAOaK\n1Z2He8VGPw834G9dCVg7ti5iN1JhvE/TIib1VThUxPPJOBjP4fCkvI98bt5dIsFIB9y1RZAuxwbi\n4/2u+wz7OnmYemllOT3Rnpxqu1R8kDwMEtuElkqGwvUt13WSs7MY9IeL2F4r3qcYExTG08d0nbg8\nm+M5ujFKfIRxqbapOLpCvwFJv/eLXFss4kQ2QNeqlaUzuc+1Sb1D7LXycqx8LnUg3sLNqbZWkYwt\nU7i32wQX5tQfhqeS8hDxvWpiga5ZPxAvyjcbv8frRdpfEx92wzpqpelI7v9QUn9UeIC8PC4SjHK0\niFh6TYnrt+uaOEQMz3sofjYuSsqjsTBnv24cL4Jih8iUTsnZ7xkR47IsFi40m7H1RCvNWiLmvClc\n0OTy5gWsK1ZRJWbgykxb+mhsGzFxB4lk5pIqnmEJ9kjKR4jwURP9RVy6TaT4eU+7TxIJRzrGteBn\nsQrqqZXlK/wk9mzVrNhJKn/kiYqvtDsz9Xli0lwtEpY8jBVudtV7nySyzJr/ML5crIQplQxT9BN7\nqqmpthPEycnIOmtlWSDiaKWTlizzsXmZ6weKjfaDmd8juicknfhYbHfyMlfhpN5PuP0jq7hHAcPx\nqepHvh33iSxpjni5rRqkleZOXFZlnxEi/pZjmdJ7rOlF7Bep7i+ozxWeobaJU6BqE7T/FefjrNX9\nEE2qZ6E4OPjPkWtH3kfpEEnTj5UM10T+zwN3suKnHU3WcJ5V+jiqSZMmTZo0abKa+BdhmUdtJ3/Y\n5QAAAABJRU5ErkJggg==\n",
+      "text/latex": [
+       "$$\\frac{\\sqrt[3]{6} \\sqrt[3]{V}}{2 \\sqrt[3]{\\pi}}$$"
+      ],
+      "text/plain": [
+       "3 ___ 3 ___\n",
+       "╲╱ 6 ⋅╲╱ V \n",
+       "───────────\n",
+       "    3 ___  \n",
+       "  2⋅╲╱ π   "
+      ]
+     },
+     "execution_count": 36,
      "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\begin{bmatrix}\\frac{area}{width}\\end{bmatrix}$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 10,
-       "text": [
-        "\u23a1 area\u23a4\n",
-        "\u23a2\u2500\u2500\u2500\u2500\u2500\u23a5\n",
-        "\u23a3width\u23a6"
-       ]
-      }
-     ],
-     "prompt_number": 10
-    },
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "solve(V - 4*pi/3 * r**3, r)[0]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now lets compute the surface area of a sphere in terms of the volume.  Recall that the surface area of a sphere is given by\n",
+    "\n",
+    "$$ 4 \\pi r^2 $$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 49,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
     {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Note that we would have liked to have written\n",
-      "\n",
-      "    solve(area == height * width, height)\n",
-      "    \n",
-      "But the `==` gotcha bites us.  Instead we remember that `solve` expects an expression that is equal to zero, so we rewrite the equation\n",
-      "\n",
-      "    area = height * width\n",
-      "    \n",
-      "into the equation\n",
-      "\n",
-      "    0 = height * width - area\n",
-      "    \n",
-      "and that is what we give to solve."
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "### Exercise\n",
-      "\n",
-      "Compute the radius of a sphere, given the volume.  Reminder, the volume of a sphere of radius `r` is given by\n",
-      "\n",
-      "$$ V = \\frac{4}{3}\\pi r^3 $$"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "# Solve for the radius of a sphere, given the volume\n",
-      "\n"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 11
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "You will probably get several solutions, this is fine.  The first one is probably the one that you want."
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "## Substitution\n",
-      "\n",
-      "We often want to substitute in one expression for another.  For this we use the subs method"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "x**2"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$x^{2}$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAABQAAAAXCAYAAAALHW+jAAAABHNCSVQICAgIfAhkiAAAASRJREFU\nOI3t0z8oRWEcxvHPvRbEpZRFhDtQom4GcQcGJWVTsrBQMtsZpCRGMiqjshkNZJHRpmx3Mypl8Gd4\nz63jb87bHT116jznPed7fr/397zUWLnI70YwhhaUsYnL2CKasJ3yc3hCRyxwCK8oJr6AtwQcpZzQ\ncnW7BhJgKRb4WcfYqxVsCTvih/tBMwkQ6tENdZGwcXThTJj6hFBlJQbWi0dhEOmrwNfeh7GIF6GF\nZaygVcjZBu6z/Hkf+cQf4U44EWUhe2tZWjlAc8qf4Dq578Qu2rIAez75CrayAH5Tn7DRk7UCruIZ\njalnxR/e/VYNQuIHE3+Km9R6HodZgLNCi/Poxy2uUuvrGP0LqHpSHtAu5K2EBSEu05jCOS6yVPiv\neL0DViMs6ugPO8EAAAAASUVORK5CYII=\n",
-       "prompt_number": 14,
-       "text": [
-        " 2\n",
-        "x "
-       ]
-      }
-     ],
-     "prompt_number": 14
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "# Replace x with y\n",
-      "(x**2).subs({x: y})"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$y^{2}$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAABMAAAAbCAYAAACeA7ShAAAABHNCSVQICAgIfAhkiAAAAVtJREFU\nSInt1LFLHFEQx/GPZ/ACygmpJEI8tFFEIYJIVIxNiIXNIVhoaZki5F/Q5gikOkhlpYX+A3aCaNLY\nSbqkEIQUgatEEBTUFO8drKshu8ulyw+WZXbe+87svJlHG9WRc/0UptGLGWzgqEjgHtQT9jIu0V8E\nNo5bDEW7grsIza0O4TdbpRmNsJdFYGlt41M7QGv4KP8BPtBihMFTVFuOzpyg13iBPeF052N2P/Nm\nNIgLoejJp/LY4ioaMepKyvcO+3kif0YX3uNbyneM3b8BSvE9i6+4xgJ+JNZ0YwKHWbPqQ1kYjRvU\nEr43Qm1Gs8Ja+oDzCG5pHU0ZeqqUst/iAFeJb3P4ErPLBRvA94RdFuYx0zWThp3hWcKuC12eqfjp\nOgxjEyfCXfUKYzHAbRbgn1TCL2wV2bzjfrPWhL4bKQJrCuMEz3GK1TyAZM2WMIknQhM3hDH6r3+o\n38LwOEuimErTAAAAAElFTkSuQmCC\n",
-       "prompt_number": 13,
-       "text": [
-        " 2\n",
-        "y "
-       ]
-      }
-     ],
-     "prompt_number": 13
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "### Exercise\n",
-      "\n",
-      "Subsitute $x$ for $sin(x)$ in the equation $x^2 + 2\\cdot x + 1$"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "# Replace x with sin(x)\n",
-      "\n"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 21
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "## Subs + Solve\n",
-      "\n",
-      "We can use subs and solve together to plug the solution of one equation into another"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "# Solve for the height of a rectangle given area and width\n",
-      "\n",
-      "soln = solve(area - height*width, height)[0]\n",
-      "soln"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\frac{area}{width}$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAGYAAAAZCAYAAADDq1t2AAAABHNCSVQICAgIfAhkiAAABKtJREFU\naIHt2WmoVlUUBuDHriNZGppYectUckgqoswMx0gLoyhpUAltIMkMJSozggIbtCQzS/JHSCQNZBFZ\npFJUpFmZNv6QtKiQ0pAGlSYt+7H2yeO557t6Tble+1643LPX3nutd++119rrnI8qqjhAuLSxCVRR\nF73wUmOTOBA4rLEJ/EeMwTP7UV8HrMctezH2IXyLnRi6l/oH4d005+V9IdhUsAZt9qO+4/ARztvL\n8ZPwRwmH7vgOJ5TMaYHfces+cjzo0Q9PNTKHZ7G8RD5FbH7rkr4BImL61ae4KaeysXi6kTkMxNsV\n5O8L5xQxBNtEtB9yqMGnaN6IHLqLkz+8pG8TpleYtwxL96S8bGHDMAHf4Gi8IULzjNQ/Slx2tRiN\ny9AHXTAHH+R0nYaJ+Enk1o64EVsbYK8Mw/AOdhTkvXCTyO0LRarJsAgfYgY6JZ6Pp3afxKtsXpHn\n12iPz5L9Fan/ClyNo5L+oViCxXgsjWkhUtnDuAttcYzww3jlEQauFd7uktpd0+DMw63wQHpeh1dF\n2HYQG/toTtd4fCIu1Ay34eIG2KuEBTinIKvBfLHIySKiMrTDXxiX2h2wEa+JzZqf5k8pzKvE83j8\nipUlYycoLwjYdb+syOlqLg7qNSXjwanYLqIgj824Mz2PwCVoKTbwniSvxccif8LZSVd+8/oJR3Zq\ngL0ytE62mhXkF2Fkel6C53N9I8WGnJiTjRHFw+VpXfC6utFSH88ZJfwqFQRwB/5E34L8F/VUaa/g\nR3GCMvQWCxqc2v3F6RuU5KdU0LUUP+BBzMJsXI8jG2ivDKNwf4m8Vpy+WhEdF+b6Zop3jjwG2JX2\natANf9vlpPp49kk8LyjhsRH3VuC+LP3l0VPlu0p7kS+fK8hvEGFZLPvuFiemeGqJBewQ6aESGmov\nj0Xqnrg8bld3I1eqW1pPFndShvvE/ZGvVCvxnJjkRxTkJ6u8yS1ENTatIJ8qIqZVXpiR6CFOTTFn\nDsEqkba65eRDRZm4s4RAh6Try5K+DA21l6GdyO+f16N7uCggtqd2DU4X5WsefbE2PTcXF/cTImoy\n25V4DhXl7lZ192WHeLsnHFubns/E4XiroGs0XhAH8l9dmWO2pP/5cG8jNiozMjkn719iIMPmpK+s\n4uuN6xpoL49ReLGC3Qyd8VWh3bIg6yk+vWQYIe6+BWnspCSvxHOwXe8veZ4Dxf23LdeXVY5DknxV\nbnxfcYctKOrKHLNOVCNdU7uFqLBai/DuKDacyM0tVXZMlsbOt3uqO1dccAsbaC+PK+3529hqcdIz\njBWpLauCanCz3SvInonPBpGmso0q4zlPpJ31wpmbcnpqEn8iQn7D96k9RFRj+RL/JPEqsVwcuiVZ\nR7PCoNn4IhmYK6qq8YngNLFZV4lL8yzlqYyIlpmiVN4gHLkGT+bm7K29DJ1Frq+vMCCc+ohIDVvw\npihEpot3jxrxXrE2N+dY4fDViefCXF8lnuOEc6YKxxOnfx7eEw6bJVIjkUrnFnS3FV/H16Y1z9nD\n2g5KTBGnuYqDDCtENPwv0FQ+YvbAz8rvnUMSTcUx+/sHsSr2ExaLi7KKKqqoooqmg38A2SEmPBfg\nAAEAAAAASUVORK5CYII=\n",
-       "prompt_number": 25,
-       "text": [
-        " area\n",
-        "\u2500\u2500\u2500\u2500\u2500\n",
-        "width"
-       ]
-      }
-     ],
-     "prompt_number": 25
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "# Define perimeter of rectangle in terms of height and width\n",
-      "\n",
-      "perimeter = 2*(height + width)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 26
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "# Substitute the solution for height into the expression for perimeter\n",
-      "\n",
-      "perimeter.subs({height: soln})"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\frac{2 area}{width} + 2 width$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAMAAAAAZCAYAAABn7SHgAAAABHNCSVQICAgIfAhkiAAABhBJREFU\neJzt22uMXVUVwPEfToeWUKRKlQpWESqFSsAHNqXyrFE0GEEafICP4ouINTRG8RGNxmdVWnygkRDs\nGI1CQGJEQ0HRolQivlASv0BUjA8wBCISBUXxw9ond8+ZfaZnZu6deyeef3Iz96z9Wmedvfdae507\ndHR0/F9w5rAV6OgYFkfgm8NWomP0eEztei2uwXW4HZfj4PlWagCcja/3sb8DcCfe0aLudvwBj+KU\nlv2fiB+nNt+ajYJzZD7mwSBtOCv7PRs3YFm6Xoof4q84pG0nI8ovsE8f+zsYv8QLWtbfjIcLOhyG\nP+OphTbjeAjvnKWOs2W+5kE/bNhX+30Hq2qyZ4lVdEXbTkaQtfjKkHW4AjcX5FvEQ1pSKFsvbL+2\nD+MfjUUt647qPCjZsK/2e1C4mSfW5Pfj3tZqjh6fwYuHrMOf8NGC/Bu4qaHNe/F37SfudExov3uP\n6jwo2XDO9svPAL/Dgdi3VqfkuhcKYyJm/O4QdTgMByk/qONFeFHiZBHHPjIYtRoZxXnQZMM52y9f\nHeuwH+7OZAcJY+wqtN2A83AXnoAbhUs6NpVvFJNvJV6Fs7AGTxa78q1ZX8/E+WKXGcdyvFWs4Lbj\nldiAH5lqhCPwNhE7ftVk1341foatYhe8FV9M12uSXqV2dT1/L+Lo29P4u1P5K3AuHpf6PwU7cS0+\nn+qMCxf+aXxAxOFPEs9rk3D7g6LtPBiWDefVflvxn9RZzhtwj5jMhHt9CNen68X4ZPp+h4grTxAn\n/7twSdbXJvzK5CzDhTh9BuM1sQPPq8nGcKkwxgX4dVa2v7jf16XrA8REuE4Y9dLUfkutXZOeT8E/\ncEuh7nmad9Uqft2d9bVIbAivL9TfExPmdoCtz4NRsOHA7bdKxIMfqcmPwb/Frp5zL96Xvp+Kl2Fv\nMVGrPlbiNuGe4LjUVz5J14oFU8WgbcYrsSSNtVdN/lKclr7vxFVZ2WnCcE/LZGeLQ/TL033B90zd\nuabTc2tBv6aDMRG//gtH1eR/M7us0ITZL4DSPBgFGw7UfouF29peKPs27hOrueJIcdMnpet1Yic4\nMcmPbhjnepFe+xQuwsV4Mx47w/FKbMTHC/KVYjdYKXaql2RlnxAHwJz1eq5+DIfiv3oPcjo91yQ9\nS4fwu5UPxkQa8oaabHXq64UNbaZjwuwWQNM8GAUbDsx+e+Fr+FChbJmIxa6syd8i3FE9HfVBsXrr\nuzBxk48Il9jETMfLudrUHSDn3aYa+xZTU6YXiHi34mMiNs0TCE16np/k+9Xkz9D8MMbFjvuemvxd\nYgdbXGhT8WXh9eqf+/CbhrLnNPQ13TyoGJYNB2U/hKt7f0322vT32DTwllr5lXru6NBMfpNIVZVY\nkfq6cBpdZjpexf4mH7JLfN9k1z0mFtXmWr3Lsu+L8Bc9+1RjN+l5VaZHrudm4eqXputlYjelF78e\nV+vrNnyp0FcbJszcA0w3DyqGZcO+2a/+U4hzhWv6cE1+fPr7QPqbu7h99FJOxGqv5OuUM0iEZ3hA\nOU97JN44w/FyNopX+dOxAr+tXe9dk60Wr+srThVnkx2pbvWgm/Q8SS91l+t5gnggD2ZlVabq5CT/\naVb/KBEf7yj0NQj2NA8qhmXDvtkvn3wbRCy+U6Sn8jqPpu93iJP7Iel6XGR0lgiXtlzvZcn6dIO7\nlKnCnxeJWL0a4/k4R7i+h2cwXs4r8aaGcSt+bvIbz3OEO6+yBmN4e/pUrE76/FHsVJVBS3b5gnC3\nd4oHfk/Wz1jSH56Lf4pdkXiAu01O3R4uUsQ3i8W9cw/3NhfazIOKYdlwIPa7P91g6ZPvBIeLLM3F\n+CyeLlKZu4SrW57qvUa4rlL8X7EI28SJ/qLU36Zam7bjVazQ/HYwZ7mIcXeI9xJniEV7o8gff87k\nuJXey5jteHWtrEnPHyQ9H5/VPUY8pG0iBMw98U8KfS8VWZNLzG73n9A+BGo7DxieDefbfguKLcJ7\ndPSYsPB/0DgQ+vE7k1HjLJNfonVEfD3It8cdI8Iq4UI7OlpRzwItdPr9jy8dHQuKa/Vywx0dHR0d\nHR0dHR0dU/kfLywOMJQIn3wAAAAASUVORK5CYII=\n",
-       "prompt_number": 27,
-       "text": [
-        "2\u22c5area          \n",
-        "\u2500\u2500\u2500\u2500\u2500\u2500 + 2\u22c5width\n",
-        "width           "
-       ]
-      }
-     ],
-     "prompt_number": 27
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "### Exercise\n",
-      "\n",
-      "In the last section you solved for the radius of a sphere given its volume"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "V, r = symbols('V,r', real=True)\n",
-      "4*pi/3 * r**3"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\frac{4 \\pi}{3} r^{3}$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAD4AAAAcCAYAAAA5pQx5AAAABHNCSVQICAgIfAhkiAAAAytJREFU\nWIXt2FuIVlUUwPHfeKlRbIzowR7KLK0hqCyi5iWb7oViNRJ4KRUhJTEw6iHwJSjt8hJBl5egUrpa\nmlgvFYmBZEV2f5JAX4TAym42lTU9rH2a0/E733eOM9NXzPzhg33W3nvtdfZea531bUYpHe02AHMw\nHcejF8/g7Tba869xEMtS+2Ycxgkjvei4kV6gAr14JbUHMPEYdPQNmzVt4nmsqzmnG6/VXWhCi/67\nxQk8UFdxTS7EFfgZj9ScuxgvFGQ9WIVfMAmTsQGfVlE4PRlyb01DhsJKfIQpNebsES+XcQFeR2dO\n9iR+wOxM0CzG14mdGkl68DVmpOd3xelfV3H+xfhSnGzGUszFDTnZGyJhrsgEZS/eh3cqLj4UjgjD\nD6TnM/A7Pqk4f4nIC3k+Fqf7bU6WedDhZsqm4KnUHjDyrn4L7sKdeBXXVJw3Hp9pnafgYbHJ5zcb\ntB5npnajF+/Ci8K9Bkp+f+JSLMBj2CbCZhkewnPCTYfC1Xi8wrgZIpxW5oXF3ZqNn/BViZIObBTu\n9LQIiQ+xD2vxBH5Df5LfhzXYi814UCSePfgOH1QwvIzFBj2zEfNwiYj1R5uNHYdncVxOVjzxpbg+\n97xZuBxsL+i7Fjclff24P8lPFTHc28ToVnQmHVVK7gl4C7txcqMBt+PygqxZjJ+Irak9OSnO04Op\nohYfwHkVjKzKAvVqi8yGrEL8O6tPwznYUUPZEryX2t34o9C/G9+LwuQbfF5DdysWiTzRiG5Hb3L2\nleiTMnwW41c5uvTLauaFIvY3Ykuu/7b0g1OUuJHwop1ix4eDqTgNXzTo6xL5ZyLONpirskPpMBia\npZyu3NXniOSUKVkksnxnYdwk/Io7Wi1WgxW4p6SvU9QBe3FSTn6ReJf3qywwKw1e36BvG17OPV+W\nxs4rjLsyyc+tsmBF3hTldBkbxEbnE98m/CiqwlK6RKwfEEb3i1i+MTdmn38WGl3Yj/kFXbeKT9Zw\nXXhME2HTiuXij8smkdFfwlnDZENbWIvV7TaiHexSnkRr8V+4ganKTBwSV1VD5v/04o0uHEYF29W7\noBhjjDFGMX8BujKdmTfmfkUAAAAASUVORK5CYII=\n",
-       "prompt_number": 34,
-       "text": [
-        "     3\n",
-        "4\u22c5\u03c0\u22c5r \n",
-        "\u2500\u2500\u2500\u2500\u2500\u2500\n",
-        "  3   "
-       ]
-      }
-     ],
-     "prompt_number": 34
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "solve(V - 4*pi/3 * r**3, r)[0]"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\frac{\\sqrt[3]{6} \\sqrt[3]{V}}{2 \\sqrt[3]{\\pi}}$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAG4AAAAgCAYAAADzCU3nAAAABHNCSVQICAgIfAhkiAAABONJREFU\naIHt2XmMnVMYx/HPdFrdGM1Eqb0YYi9FI5Zah1qTWmNJk1ZFbSFSO6FaSxsECUktIZYSe1GiJCjV\nRoJGhVgSuwiiEqUI5Y/nbea979zlvXfunda43+Qm55z3Oe/vfd9zzvM851yaNGmyelgHp+FUzEZr\nzn7/1OGXV3P3Oumt+vUJjsKNSflt7JKz3/MY1EuaPdHqs/QTq24glmBojj7jcHEvafZUq0+zCW5A\nZ077Z9DWS5r10OrTtOBlDK9gtzdm9JJmPbUaQa35QV1oSZXnYHwF+8dUHtx6adZDqxqOqdK+1vyg\nZvqlyjNxZlLeDF+W6TcK3+KHHurn0ayXVl62xYQq+8zDNBGrW/FJCbtpGpAR74iTcQYuqPCg94sP\nXYptxAq6B3fgJuFOsuTRLKc1G9+IF/kLi3FcEbv5WJnYLcGeZZ79GpyYaRuDJ/EClor32jhjUylW\n74SJZXQbTgfuLnN9e7Fy9krqI/AZrm6AFuwgBmROBbt3cUgOzXcwOFUfLQZ+WFJfGwvwPUZm+paL\n1bMwIId+w5gt3Ekx+uMjnJ9q21S4ufPqrLWKwWLgXi1jMx7n5tAbgwcybfPEBEqza6L5SFKvFKu3\nE16loRRzaavYWPmZPQl/6pqdjdRK8x2+KHGtDU8ojOeluBWHZdqWCw+yfqZ9GX5MyrN0xeo3sFvG\ndqaIfw1hCB7C7WVsbiryUGlewge9pJVmkYhxxVzRLSLBqUQr3hNeI81S/IEtMu3f4dekXC5Wd+Cc\nHPo10R9XYDp+UXyj2y4CdClasAKvYazYd92Cp4VrqadWljnCdW2Zad8T1+e8R6fiE2moiNNpNkr0\nXslx3+sVxsw0bcLdrlA6e1yJfSuJtOM3xePRNBxQpu96idCHmJJq318M0A511MpyXaJ9UKptAOaK\n1Z2He8VGPw834G9dCVg7ti5iN1JhvE/TIib1VThUxPPJOBjP4fCkvI98bt5dIsFIB9y1RZAuxwbi\n4/2u+wz7OnmYemllOT3Rnpxqu1R8kDwMEtuElkqGwvUt13WSs7MY9IeL2F4r3qcYExTG08d0nbg8\nm+M5ujFKfIRxqbapOLpCvwFJv/eLXFss4kQ2QNeqlaUzuc+1Sb1D7LXycqx8LnUg3sLNqbZWkYwt\nU7i32wQX5tQfhqeS8hDxvWpiga5ZPxAvyjcbv8frRdpfEx92wzpqpelI7v9QUn9UeIC8PC4SjHK0\niFh6TYnrt+uaOEQMz3sofjYuSsqjsTBnv24cL4Jih8iUTsnZ7xkR47IsFi40m7H1RCvNWiLmvClc\n0OTy5gWsK1ZRJWbgykxb+mhsGzFxB4lk5pIqnmEJ9kjKR4jwURP9RVy6TaT4eU+7TxIJRzrGteBn\nsQrqqZXlK/wk9mzVrNhJKn/kiYqvtDsz9Xli0lwtEpY8jBVudtV7nySyzJr/ML5crIQplQxT9BN7\nqqmpthPEycnIOmtlWSDiaKWTlizzsXmZ6weKjfaDmd8juicknfhYbHfyMlfhpN5PuP0jq7hHAcPx\nqepHvh33iSxpjni5rRqkleZOXFZlnxEi/pZjmdJ7rOlF7Bep7i+ozxWeobaJU6BqE7T/FefjrNX9\nEE2qZ6E4OPjPkWtH3kfpEEnTj5UM10T+zwN3suKnHU3WcJ5V+jiqSZMmTZo0abKa+BdhmUdtJ3/Y\n5QAAAABJRU5ErkJggg==\n",
-       "prompt_number": 36,
-       "text": [
-        "3 ___ 3 ___\n",
-        "\u2572\u2571 6 \u22c5\u2572\u2571 V \n",
-        "\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n",
-        "    3 ___  \n",
-        "  2\u22c5\u2572\u2571 \u03c0   "
-       ]
-      }
-     ],
-     "prompt_number": 36
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Now lets compute the surface area of a sphere in terms of the volume.  Recall that the surface area of a sphere is given by\n",
-      "\n",
-      "$$ 4 \\pi r^2 $$"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "(?).subs(?)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "ename": "SyntaxError",
-       "evalue": "invalid syntax (<ipython-input-49-df38c236f23a>, line 1)",
-       "output_type": "pyerr",
-       "traceback": [
-        "\u001b[1;36m  File \u001b[1;32m\"<ipython-input-49-df38c236f23a>\"\u001b[1;36m, line \u001b[1;32m1\u001b[0m\n\u001b[1;33m    (?).subs(?)\u001b[0m\n\u001b[1;37m     ^\u001b[0m\n\u001b[1;31mSyntaxError\u001b[0m\u001b[1;31m:\u001b[0m invalid syntax\n"
-       ]
-      }
-     ],
-     "prompt_number": 49
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Does the expression look right?  How would you expect the surface area to scale with respect to the volume?  What is the exponent on $V$?"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "## Plotting\n",
-      "\n",
-      "SymPy can plot expressions easily using the `plot` function.  By default this links against matplotlib."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": true,
-     "input": [
-      "%matplotlib inline"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 41
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "plot(x**2)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "display_data",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAWwAAAEMCAYAAADga4zjAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAIABJREFUeJzt3XuczdXCx/HPdknOEZpqxmXUnIeZxriOUCkaNCNOpMil\nwxmhlDohFXW6OBVGUolHyu0ZqoNOhdKR25moSBIRGmHcmpkuY3I3jN/zxzozoWIue++1f3t/369X\nL82w9/6a1/adNeu3fmt5HMdxEBGRgFfGdgARESkaFbaIiEuosEVEXEKFLSLiEipsERGXUGGLiLiE\nCltExCXK2Q4gwSc3N5dVq1aRkZGBx+MhKiqKa6+9lipVqtiOJuJqHt04I96ycuVKxo4dS0ZGBvHx\n8dSoUQPHccjMzOTLL78kKiqKRx55hOuvv952VBFX0ghbvObdd99l3LhxREdH/+bvp6enM3nyZBW2\nSAlphC0Bo2/fvixcuJDw8HA2btwIQE5ODt27d2fXrl1ERUUxd+5cqlatCsDo0aOZPn06ZcuW5eWX\nXyYpKclmfBGf00VH8bpevXqRm5tb+HFGRgZt2rQ57+PuvPNOFi1adMbnUlJSSExMJD09nbZt25KS\nkgLA5s2bmTNnDps3b2bRokUMHDiQU6dOefcvIhJgVNjidS1btuTqq69m4cKFvPbaayQlJTFkyJAi\nPe7iiy8+43MLFiwgOTkZgOTkZObNmwfA/Pnz6dmzJ+XLlycqKoo6deqwZs0a7/9lRAKI5rDF6wYM\nGEBcXBxt2rTh0ksvZd26dVSvXr1Ez5WdnU1ERAQAERERZGdnA/Ddd99xzTXXFP65yMhI9u3bV/rw\nIgHMKyPsDh288SwSLGbNmkXfvn2ZOXMmffr0oUOHDqxfv77Uz+vxePB4POf8/d/63IgRIwr/S0tL\nK3UOkdL66CNo0KD4j/PKCHv1ati3D2rW9Mazidu9/fbbfPLJJ4SHh9OzZ09uvfVW+vTpU6LSjoiI\nICsri2rVqpGZmUl4eDgANWvWZM+ePYV/bu/evdT8nTfgiBEjSvT3EPGV6dOhb9/iP84rI+zbb4eZ\nM73xTBIM5s2bV1isAM2bN+ezzz4r0XN16tSJ1NRUAFJTU+ncuXPh52fPnk1eXh47d+5k27ZtNG/e\nvPThRXzswAGYPx969Sr+Y71S2HfeCTNmgBYIhrYRI0YUzjGfrUKFCmRmZvLUU0/97uN79uxJixYt\n+Oabb6hVqxYzZsxg+PDhLFmyhJiYGJYvX87w4cMBiIuLo1u3bsTFxdG+fXsmTZp0zukSkUAxdy60\naQOXXVb8x3plHbbjQL168NproHsiQtfChQt5/vnnycvLo0mTJlSvXh3HccjKymLdunVUqFCBhx56\niA5+vOjh8XjQrQYSSFq0gMceg5tvLv5jvXbjzNixsGWLmZuR0NS7d29mzZrFs88+S3R0dOFeIldc\ncQXXXXcdkZGRfs+kwpZAsmWLGV3v2QPlSnAF0WuFnZUFdeuaIJUqeeMZxW3i4uJYunQpN910E2lp\naWcUpcfjISwszO+ZVNgSSIYNM7+OGVOyx3v11vRbboHOnc2ctoSel19+mVdeeYUdO3ZQo0aNM37P\n4/GwY8cOv2dSYUugOHkSatWC//wHYmNL9hxeLex58+CFF2DFCm89o7jRPffcw+TJk23HAFTYEjje\nfx9GjYJPPy35c3i1sE+cgMhIWLkSYmK89awiJafClkBx223mJsP+/Uv+HF7frW/oUKhQwXwnEbFN\nhS2B4PvvzSB2926oXLnkz+P1zZ/uvNPcRJOf7+1nFhFxpzfeMNf4SlPW4IPCrl/f3KK+eLG3n1lE\nxH0cB6ZNK9mt6GfzyfaqffuaCXYRkVC3di0cPQqtWpX+uXxy4szPP8MVV8C2bSW7/VLEWzSHLbbd\nc4+Zv37wwdI/l8+OCOvTx0yPPPSQL55dpGhU2GLToUNw+eWwcaN3djP12Ykzd90FU6dqQygRCV1z\n58J113lv62mfFXaLFlCmjFmTLSISiqZONYNXb/FZYXs8cPfdZgc/EZFQ8/XXkJHh3RO5fDaHDfDT\nT1C7NuzYARb2/RHRHLZYM3gw/PGPMHKk957Tp6emX3KJ+e7y+uu+fBURkcBy7JjpvX79vPu8Pi1s\nMPM3U6bo4qOIhI5334X4ePif//Hu8/q8sBMSzHebEh7pJyLiOlOmePdiYwGfF7bHY4Lr4qOIhIJv\nv4VNm8zeId7m04uOBbKzzYbdu3aVfvMTkeLQRUfxt0cfhbw8GDfO+8/t8xE2QEQEtG0Lb77pj1cT\nEbHjxAlISyvdntfn4pfChl8uPoqIBKsFC8zhunXr+ub5/VbYiYlmXfYXX/jrFUVE/GvyZBg40HfP\n77fCLlPG/JigUbaIBKNvv4UNG8xRYL7il4uOBfbtg0aNzO2alSr561UllOmio/jLI4+YX597znev\n4dfCBvjLX8zabF+sURQ5mwpb/OH4cahVy5yIXqeO717Hb1MiBf76V3jlFd35KCLB4+23oXFj35Y1\nWCjsxEQ4cADWrPH3K4uI+MbkyeZkGV/ze2GXKQMDBphRtoiI223ebC44duzo+9fy+xw2wI8/QnQ0\nbN+ubVfFtzSHLb42aJC5g/uZZ3z/WlYKG6B3b7OblTcOphT5PSps8aUjR8zFxi+/NGc3+prfp0QK\n3HuvmRY5dcpWAhGR0pkzxxyH6I+yBouFfe218Ic/wLJlthKIiJTO8uW+vbPxbNYK2+Mxf1FdfBQR\nN/r8c3PIeFKS/17T2hw2wKFD5keJjRu9dwy8yOk0hy2+cuedcOWVMHy4/17TamED3HcfXHYZjBhh\nM4UEKxW2+ELBAePbtpn+8hdrUyIF7r3XbAh14oTtJBLIRo8eTb169WjQoAF33HEHx48fJycnh8TE\nRGJiYkhKSiI3N9d2TAkR06dDp07+LWsIgMKuX98cVLlgge0kEqgyMjKYMmUK69atY+PGjeTn5zN7\n9mxSUlJITEwkPT2dtm3bkpKSYjuqhID8fHPt7b77/P/a1gsbYPBgmDrVdgoJVJUrV6Z8+fIcOXKE\nkydPcuTIEWrUqMGCBQtITk4GIDk5mXnz5llOKqFg0SJzw1/z5v5/7XL+f8lf69gR7r8fvv4a6tWz\nnUYCTVhYGEOHDuXyyy+nYsWKtGvXjsTERLKzs4mIiAAgIiKC7Ozs33z8iNMukCQkJJCQkOCH1BKs\nJk0yo2uPx/+vbf2iY4ERI8xhvVrmJ2fbvn07HTt2ZOXKlVSpUoXbb7+dLl268Le//Y39+/cX/rmw\nsDBycnLOeKwuOoo37dgBV18Nu3dDxYr+f/2AmBIBsyHU7Nmg60ZytrVr19KiRQsuueQSypUrx223\n3caqVauoVq0aWVlZAGRmZhIeHm45qQS7V16BPn3slDUEUGFXrw7t28OMGbaTSKCJjY1l9erVHD16\nFMdxWLp0KXFxcXTs2JHU1FQAUlNT6dy5s+WkEsyOHoX16/2zjervCZgpEYBVq8ymUOnpZhtWkQLP\nPfccqamplClThiZNmjB16lQOHjxIt27d2L17N1FRUcydO5eqVaue8ThNiYi3TJ0K8+fDe+/ZyxBQ\nhe040LSp2aawQwfbaSQYqLDFGxzHnEc7bpw5hMWWgBrHejzwt7/BhAm2k4iI/CItDU6ehBtvtJsj\noEbYAMeOmf1FPv4YYmJspxG30whbvOHWW6FdO7vz1xCAhQ3w2GNw+DCMH287ibidCltKa+dOaNYM\ndu2CP/7RbpaALOzdu80JxLt2wUUX2U4jbqbCltIaOtQsghg71naSAC1sgK5dzTK/fv1sJxE3U2FL\naRw6BFdcAevWmV9tC6iLjqd74AF47jkdISYi9sycCQkJgVHWEMCF3bIlVKpkNloREfG3U6fMirUH\nHrCd5BcBW9gej9nF78UXbScRkVC0ZAlUqACtWtlO8ouALWyA7t3NDn6bNtlOIiKh5uWXzejaxq58\nvydgLzoWePZZs1pkyhTbScSNdNFRSiI9Ha6/3qxYu/BC22l+EfCF/cMP5gaa9HT/H8cj7qfClpJ4\n6CEzHTJypO0kZwr4wgbo3x+iouDxx20nEbdRYUtx7d8P0dGwYQPUrGk7zZlcUdibNkFSEmRkwAUX\n2E4jbqLCluIaM8ZcO5s503aSXwvoi44F6tc3R4fNmWM7iYgEs7w8s5Rv6FDbSX6bKwobYMgQsyZb\ngyUR8ZU5cyA21mylGohcU9g33WRuD01Ls51ERIKR45j9rgN1dA0uKuwyZcwX8vnnbScRkWC0fDmc\nOGEGh4HKFRcdCxw7ZlaLLFtm5rRFzkcXHaWoOnSALl0Ce8M5VxU2mBtpdu6EadNsJxE3UGFLUWze\nDG3amJVogXSjzNlcV9g//WTWSH79tTlpXeRcVNhSFP37m5OunnzSdpJzc11hA9x/P1SpEnh3IUng\nUWHL+WRnm5Uhbrib2pWF/e23cM015seXSpVsp5FApsKW83nySfj+e5g82XaS83NlYYO5OJCQYE5Z\nF/k9Kmw5lyNHzEKGlSvhyittpzk/1xb2qlXwl7+YH2PKlbOdRgKVClvO5ZVXYONGmDTJdpKicc06\n7LNde605qPf9920nERE3OnnSHKzbq5ftJEXn2sIG6NMHnnlGt6uLSPH9619mN74WLWwnKTpXF/bN\nN5ubaZYutZ1ERNzEcSAlBYYNs52keFxd2GXKmC94SortJCLiJosXQ36+ubvRTVxd2AA9e5plfmvW\n2E4iIm4xZgw88ogZ9LmJy+L+WvnyZlOoMWNsJxERN/j8c9i+HXr0sJ2k+Fy7rO90hw/Dn/4EK1aY\nO5ZECmhZn5yta1do2RIGDbKdpPiCorABnn7anK6uTaHkdCpsOd0335jT0DMy4I9/tJ2m+IKmsAs2\nhfrqK4iMtJ1GAoUKW043aBBUrQr/+IftJCUTNIUN8OCD4PGYUyNEQIUtv9i7F+LjzVaqgb7J0+8J\nqsLeuxcaNjSrRsLCbKeRQKDClgKDBplFCm4+tSqoChvg73+HihXh8cdtJ5FAoMIWMFuo1q3r/n30\nXb+s72x9+sD48XDggO0k4k25ubl07dqVunXrEhcXx2effUZOTg6JiYnExMSQlJREbm6u7ZgSoF58\n0dyz4eayhiAs7OhoSEpyz+5bUjSDBg2iQ4cObNmyha+++orY2FhSUlJITEwkPT2dtm3bkqJbXuU3\n5OTAlCnmRhm3C7opETAXFVq3hh073Ll0R870888/Ex8fz44dO874fGxsLB999BERERFkZWWRkJDA\n1q1bz/gzmhKRf/zDLPmdPt12ktILysIGszj+uutgyBDbSaS01q9fz4ABA4iLi2PDhg1cddVVvPTS\nS0RGRrJ//34AHMchLCys8OMCHo+Hp556qvDjhIQEEhIS/BlfLDpwAGrXhk8+gZgY22lKL2gL+8sv\nzW5+27cH9inIcn5r167l2muv5dNPP6VZs2YMHjyYiy66iIkTJ55R0GFhYeTk5JzxWI2wQ9uYMbBh\nA7z5pu0k3hF0c9gF4uOhSZPg+DEo1EVGRhIZGUmzZs0A6Nq1K+vWraNatWpkZWUBkJmZSXh4uM2Y\nEmCOHDEXGx97zHYS7wnawgaztG/MGMjLs51ESqNatWrUqlWL9PR0AJYuXUq9evXo2LEjqampAKSm\nptK5c2ebMSXATJ1qTqaqX992Eu8J2imRAklJ0L079OtnO4mUxoYNG+jfvz95eXnUrl2bGTNmkJ+f\nT7du3di9ezdRUVHMnTuXqlWrnvE4TYmEpmPHzE/Yr79ufg0WQV/YK1bACy+Y44B0WG/oUWGHpokT\n4cMP4b33bCfxrqCeEgFo1cpcKZ41y3YSEfGHY8fMKVSnLQ4KGkE/wgb4+GPo3dtsrXjBBbbTiD9p\nhB16gnV0DSFS2ADt2kGXLnD33baTiD+psEPLsWNQpw7MmwdNm9pO430hU9irV0O3brBtG1SoYDuN\n+IsKO7RMnGgO2F2wwHYS3wiZwgb485/NfwMH2k4i/qLCDh0Fo+v58+Gqq2yn8Y2QKuy1a6FzZ7Nf\ntu5+DA0q7NAR7KNrCIFVIqdr2tR85331VdtJRMSbjh41Zf3kk7aT+FZIFTaYnbtSUsxtqyISHCZN\ngrJlg/NC4+lCakqkQNeu5pbVoUNtJxFf05RI8Dt40MxdL1sWXLeh/5aQLOxNm+DGG81cdqVKttOI\nL6mwg98zz8DWrfDGG7aT+F5IFjZAjx5mR79hw2wnEV9SYQe3nByzz/Xq1WaUHexCtrC3bIEbbjCj\n7MqVbacRX1FhB7dHH4UffzRHgIWCkC1sgF69zE5eDz5oO4n4igo7eGVlQVwcrF8Pl19uO41/hHRh\nf/stXHON2WPkkktspxFfUGEHr0GDzK/jx9vN4U8hXdhg7nqsWBHGjbOdRHxBhR2cdu+Gxo3N1GZE\nhO00/hPyhZ2VBfXqwbp1cMUVttOIt6mwg9Ndd8Gll8Lo0baT+FfI3ThztmrVzCg7GPfOFQlG6emw\nZw88/LDtJP4X8iNsMAccREfD0qXQoIHtNOJNGmEHn9tvN1tMDB9uO4n/qbD/66WXzJ1SwbjpeShT\nYQeXzz4z+9qnp8Mf/mA7jf+psP/r+HGIjYWZM6FlS9tpxFtU2MHDcaB1a7Mct39/22nsCPk57AIV\nKsDTT5s7H/XvWyTwLFoE2dnQp4/tJPaosE9zxx1w+HBw76cr4kb5+WYwNXo0lCtnO409KuzTlC1r\n3hCPPgonT9pOIyIF3nwTLroIbrnFdhK7VNhnad8ewsMhNdV2EhEBczjB3LkwZgx4PLbT2KXCPovH\nYw44eO01HXIgEgjGj4fy5eH6620nsU+rRH5Hjx5mM/THH7edREpDq0Tc7fvvzQZPq1aZeyVCnQr7\nd+zYAc2awcaNUKOG7TRSUipsdxs4EC64wNwnISrscxo2DH74AaZPt51ESkqF7V5btkCrVmY3zbAw\n22kCgwr7HA4cgCuvhIULzb7Z4j4qbPe6+WZo00b71Z9OFx3PoXJlGDHCvGH0b17Ef5YtMyPs++6z\nnSSwqLDPo18/+OknmDfPdhKR0JCfD6++alZrVahgO01gUWGfR7ly8MILZivH48dtpxEJftOmmX3q\nu3a1nSTwaA67iDSf5k6aw3aX/fuhbl34978hPt52msCjwi6irVvNLn5btpiTLsQdVNjuMmSI2c/n\ntddsJwlMKuxiGDQIqlQxu/qJO6iw3aNgGd/mzXDZZbbTBCbNYRfDU0+ZiyHr19tOEpry8/OJj4+n\nY8eOAOTk5JCYmEhMTAxJSUnk5uZaTigl5ThmdP3YYyrrc1FhF0NYGDz7rFlqdOqU7TShZ/z48cTF\nxeH57w5AKSkpJCYmkp6eTtu2bUlJSbGcUEpq4ULYtQvuv992ksCmwi6mfv3gxAl4/XXbSULL3r17\n+eCDD+jfv3/hFMeCBQtITk4GIDk5mXlae+lKx4+bbY1ffNFs8iS/T4VdTGXKwMSJ5gDQn3+2nSZ0\nDBkyhLFjx1KmzC9v2ezsbCIiIgCIiIggOzvbVjwphXHjoFo1uOkm20kCXwif3VByzZvDn/9s5rS1\nKY3vvf/++4SHhxMfH09aWtpv/hmPx1M4VXK2ESNGFP5/QkICCQkJ3g8pJbJrlynstWttJ3EHrRIp\noR9/NNs+LlsGDRrYThPcHnvsMWbNmkW5cuU4duwYBw4c4LbbbuPzzz8nLS2NatWqkZmZSevWrdm6\ndesZj9UqkcB2661mn54nnrCdxB1U2KUwaRLMmQNpaToJw18++ugjnn/+ed577z0eeeQRLrnkEoYN\nG0ZKSgq5ubm/uvCowg5cH3xglspu3AgXXmg7jTtoDrsUBgyAgwfhn/+0nSS0FEx9DB8+nCVLlhAT\nE8Py5csZPny45WRSVMeOwQMPwIQJKuvi0Ai7lD79FG6/3Sz6r1zZdho5m0bYgenpp2HDBnj7bdtJ\n3EWF7QWPPQZ5efD887aTyNlU2IFn+3a4+mpYtw4uv9x2GndRYXvBjz+a8x/fe88cKyaBQ4UdWBwH\nOnQwm6lpr+vi0xy2F1x6KYwdC3ffDSdP2k4jErjmzIG9e82/FSk+FbaX9OplilvrskV+2/79Znvi\n117THY0lpSkRLyqYm/v8c/jTn2ynEdCUSCAZMADKljXLYaVkVNhelpICH31k1phqbbZ9KuzA8Mkn\n0K2b2Tq1ShXbadxLUyJeNnQo7Ntn5upExKygevJJM12osi4dFbaXlS9v5ugefNDM2YmEutGjTVHr\njMbS05SIj9x/v9k2csoU20lCm6ZE7Nq0CVq3hi+/hMhI22ncTyNsHxk1Cr7/HpYvt51ExI6TJ6Fv\nXxg5UmXtLSpsH6lcGe65xxx4cPCg7TQi/jd+PFSqBHfdZTtJ8NCUiI/17w/lysHkybaThCZNidix\nbRtcey189hnUrm07TfBQYfvYzz9Dw4YwdSokJtpOE3pU2P6Xn2/e6z17anTtbZoS8bEqVcyFx/79\n4cAB22lEfO+ll0xp9+tnO0nw0QjbTwYMMCeta9WIf2mE7V9ffw0JCbBmje729QUVtp8cPGiOEps8\nWYeN+pMK239OnDDz1gMGaCrEVzQl4icXXQTTppk3cm6u7TQi3jdqFISHm+k/8Q2NsP1s4EA4ehRm\nzLCdJDRohO0fX3xh9rn+8kuoUcN2muClEbafPfcc7N5tDjsQCQbHjsFf/2ouNqqsfUsjbAs++QS6\ndDFHJOkN7lsaYfveww9DRgbMnasdKn1NI2wLrrsO7r0XkpPNyhERt0pLM1umvvKKytofVNiW/P3v\nZi77xRdtJxEpmR9/hN694YEHzGlL4nuaErEoI8Mc2vvhh9Ckie00wUlTIr7hONC5M0RHw/PP204T\nOjTCtigqCl5+Ge64Aw4ftp1GpOgmTTIHdYwaZTtJaNEIOwD89a9QsSK8+qrtJMFHI2zv++oraNsW\nPv3UjLDFfzTCDgATJ8LSpfDuu7aTiJzbkSPQoweMG6eytkGFHQAqV4Y33jA7+u3aZTuNyO8bMsRc\nb+nd23aS0KTCDhDXXGOOUurWzRwtJhJo5s+HZcvM/LWW8NmhOewA4jhw223mOKUJE2ynCQ6aw/aO\n9HS4/npYtEgrmmzSCDuAeDxmj5F//xtmz7adRsQ4fNjcmfvssypr2zTCDkDr15sTO1asgLp1badx\nN42wS8dxoFcvKF/eDCY0FWKXRtgBqHFjSEkxo5pDh2ynkVA2aZI5lEDz1oFBI+wA5TjQt6/ZFH7W\nLP1jKSmNsEtu9Wro1Mmst65Tx3YaAY2wA5bHA//7v7Bxozn4QMSffvjBrFiaOlVlHUg0wg5w27fD\nDTfAm29Cq1a207iPRtjFd/KkGVk3bqxbzwONCtsFliwxt6+vXg1XXGE7jbuosItvyBCzE9+MGVCu\nnO00cjpNibhAYiIMH25GPaF4EXLPnj20bt2aevXqUb9+fV5++WUAcnJySExMJCYmhqSkJHJ1WGap\nTZsGCxeaTclU1oFHI2yXcBxzuGluLrz1FpQJoW+1WVlZZGVl0bhxYw4dOsRVV13FvHnzmDFjBpde\neimPPPIIY8aMYf/+/aSkpJzxWI2wi27lSrMyacUKiI21nUZ+Swj9s3c3j8csrcrKgqeftp3Gv6pV\nq0bjxo0BqFSpEnXr1mXfvn0sWLCA5ORkAJKTk5k3b57NmK6WkWEuMs6apbIOZBphu0x2NjRvbjaN\nv/1222n8LyMjgxtuuIFNmzZx+eWXs3//fgAcxyEsLKzw4wIej4ennnqq8OOEhAQSEhL8GTngHToE\nLVpAv34waJDtNHIuKmwXWrcO7rsPxo835R0qDh06xA033MATTzxB586dufjii88o6LCwMHJycs54\njKZEzi0/35T0iRMwebLW+wc6TYm4UJMm5kzIzp3Nsr9QcOLECbp06ULv3r3p3LkzABEREWRlZQGQ\nmZlJeHi4zYiu4zjmPMatW81FRpV14FNhu9TNN8OTT0L79mYJVjBzHId+/foRFxfH4MGDCz/fqVMn\nUlNTAUhNTS0scimasWPh44/h7behQgXbaaQoNCXicsOHm6v6y5aZY8aC0ccff0yrVq1o2LAhnv8O\nA0ePHk3z5s3p1q0bu3fvJioqirlz51K1atUzHqspkd/25pvmvbNqFdSsaTuNFJUK2+VOnTK7qR0/\nDnPnQtmythMFFhX2r/3nP9C9OyxfDvXr204jxaEpEZcrU8bckXb4MPzjH2ZeUuT3bNpkzmScM0dl\n7Ua6lykIVKhgDjxo08Z8HGrrtKVotm+Hdu3MapDWrW2nkZJQYQeJqlXN8U2tWkGVKjB0qO1EEkj2\n7jVbHDz1FNx6q+00UlIq7CASHg5Ll0LLluYk9rvusp1IAsEPP5iyHjgQ7r7bdhopDRV2kImMhMWL\nISHBlHb37rYTiU25uWYapGtXeOgh22mktLRKJEh99ZX50Xf8eLNmO1SF8iqRgwfh/vvNFNn48box\nJhholUiQatjQrATo1w/efdd2GvG3AwfgppvM2vyXXlJZBwtNiQSxpk3h3/+GDh3MnhFdu9pOJP7w\n88+mrOPjYeLE0NqKN9ipsINckybw4YfmH/DJk2YNrgSvgjnrZs1gwgSNrIONCjsENGpkLkS2a2dK\nu1cv24nEF3JyoGNHuPpqzVkHKxV2iGjQwCz5S0w0d0P27m07kXjTd9+Zb8jdu5udHFXWwUmzWyEk\nLs7sHzFmjNmpLUQXTwSd9HS47jr4y19U1sFOy/pC0N69Zk47KcmcXBPMF6WCfVnfF1+YZZvPPGPO\n/JTgpsIOUfv3m1PYL7/cbB51wQW2E/lGMBf28uXmIvJrr5nDLCT4BfHYSs7l4ovNhcjDh80I7cAB\n24mkON55x5T1W2+prEOJCjuEVawI//qXWVVw/fWwc6ftRHI+p06Zk4aGDDGHVtxwg+1E4k9aJRLi\nypUz27Fedpk5OXv2bJVAoDp0CJKTISsL1qyBiAjbicTfNMIWPB5zGOvMmdCtm5kTlcCya5dZCVK1\nqpm7VlmHJhW2FEpMNIeyvvgi/O1v5iYbse/jj+Gaa+DOO2HqVB2YG8pU2HKG6GhYvdqcTnLXXeaG\nDLHDcSDEwjX1AAAIr0lEQVQ1Fbp0gf/7Pxg8WGusQ50KW36lShV47z3405/MXiQffGA7UejJzTV3\nLb74Iqxcae5iFFFhy28qW9asRpg7FwYMMEeO5eXZThUaVq0yO+1FRJifdmJibCeSQKHClnNq1QrW\nr4dt28xFr+3bbScKXvn5MGqUWVf90ktmt70LL7SdSgKJClvO65JLYP58s2HUNdeYpX9BevOgNXv2\nmO0CPvwQ1q6FW26xnUgCkQpbiqRg6d+yZWbzqPbtdaONN5w6BZMnm2sFnTqZJXu1atlOJYFKhS3F\n0rChuWkjIcFskv/CC1r+V1Lp6dC6tVkJkpZmllKWLWs7lQQyFbYUW/nyMHy4uTj2/vtmmmT9etup\n3OPECRg92txZ2qWLWWddr57tVOIGKmwpsehoM0UycKDZqnXkSLMcTX6b48C8eaacd+82c9UPPKBR\ntRSdCltKxeOBvn3hq69g3z6zBG3cODh2zHaywPLFF2b644knzOqPV16BqCjbqcRtVNjiFdWqwaRJ\n8J//wIoVcOWVZm+S/Hzbyezas8esrunY0ZwIs369boKRktMBBuITK1fCsGFmv+2UFLNkzcZt1bYO\nMNi925zms369uUD78MNw0UV+jyFBRoUtPuM4Zv32tGnmhptBg8xo8w9/8F8Gfxf25s1m2eP770O/\nfmbf6urV/fbyEuRU2OJzjmOWrb30Enz6qdlU6r77oGZN37+2Pwr71CkzFfTGG7BwobmQOHCgOdVH\nxJtU2OJX27aZi26vv25uvhk40Cxv89V0iS8L+7vvzC5606ZBpUrw4INw++3+/QlCQosKW6zIzTUX\nJV991awouesuc6df3breLW9vF/b+/Wa649NPYc4cU9D9+0PTptr6VHzPK6tE0tLSvPE08l+h8PWs\nWtVMHWzaZIovP9+snoiNhccfNxctT5w4//MsWrSI2NhYoqOjGTNmjE+y7t1rVsAkJsIVV8Dbb5sL\nibt3m284zZqFTlmHwnvTn4r79VRhB6BQ+np6PGZ0+ve/mwJ84w2zmmLwYLj0Urj3XrPa4rPPfr22\nOz8/n/vvv59FixaxefNm/vnPf7Jly5ZS5XEccxzXO+/APfeYbyB9+pi7Ou+9FzIzzc0v3bubaZBQ\nE0rvTX8o7tdTh/BKwCgo76ZNzZLAH34wUw9LlphDFBzHTEk0bQqNG8PRo2uIiKhD5cpRlCsHPXr0\nYP78+dStW/e8r3X8uJmD3rMHtm413ywyMmDxYqhd22zGFBNj9gJv2FB3I0pgUGFLwLrsMrPNaMFW\no0ePmimUr74yRbt69T52765Fz55w8CAcOxbJzz9/xpdfmlNzCm7auftuczr80aOQnW2K//hxM0IO\nC4MyZUxBt2hhluTVqBE6UxziLl656OjRu1tEpESKU8FeGWFroYnYsHr1akaMGMGiRYsAGD16NGXK\nlGHYsGGWk4n4hvYSEddq2rQp27ZtIyMjg7y8PObMmUOnTp1sxxLxGc1hi2uVK1eOiRMn0q5dO/Lz\n8+nXr1+RLjiKuFWJR9hvvfUW9erVo2zZsqxbt+6M3xs9ejTR0dHExsayePHiUocMNSNGjCAyMpL4\n+Hji4+MLf+SXX2vfvj3ffPMN3377LY8++ugZv+ePNdqhJCoqioYNGxIfH0/z5s1tx3GVvn37EhER\nQYMGDQo/l5OTQ2JiIjExMSQlJZFblM3knRLasmWL88033zgJCQnOF198Ufj5r7/+2mnUqJGTl5fn\n7Ny506ldu7aTn59f0pcJSSNGjHDGjRtnO4arnTx50qldu7azc+dOJy8vz2nUqJGzefNm27FcLSoq\nyvnpp59sx3ClFStWOOvWrXPq169f+LmHH37YGTNmjOM4jpOSkuIMGzbsvM9T4hF2bGwsMTExv/r8\n/Pnz6dmzJ+XLlycqKoo6deqwZs2akr5MyHJ0IbdU1qxZQ506dYiKiqJ8+fKFa7SldPS+LJmWLVty\n8Vm7gS1YsIDk5GQAkpOTmTdv3nmfx+sXHb/77jsiIyMLP46MjGTfvn3efpmgN2HCBBo1akS/fv2K\n9qOSnGHfvn3UOu34cb0PS8/j8XDjjTfStGlTpkyZYjuO62VnZxMREQFAREQE2dnZ533MOS86JiYm\nkpWV9avPjxo1io4dOxY5mNZp/9rvfW1HjhzJvffey5NPPgnAE088wdChQ5k2bZq/I7qa3nPe98kn\nn1C9enV++OEHEhMTiY2NpWXLlrZjBQWPx1Ok9+w5C3vJkiXFfuGaNWuyZ8+ewo/37t1LTX9sfOwy\nRf3a9u/fv1jfHMU4+324Z8+eM37yk+Kr/t+TGC677DJuvfVW1qxZo8IuhYiICLKysqhWrRqZmZmE\nh4ef9zFemRI5fV6rU6dOzJ49m7y8PHbu3Mm2bdt0RbmYMjMzC///3XffPePKshSN1mh715EjRzh4\n8CAAhw8fZvHixXpfllKnTp1ITU0FIDU1lc6dO5//QSW96vnOO+84kZGRzoUXXuhEREQ4N910U+Hv\njRw50qldu7Zz5ZVXOosWLSrpS4Ss3r17Ow0aNHAaNmzo3HLLLU5WVpbtSK70wQcfODExMU7t2rWd\nUaNG2Y7jajt27HAaNWrkNGrUyKlXr56+nsXUo0cPp3r16k758uWdyMhIZ/r06c5PP/3ktG3b1omO\njnYSExOd/fv3n/d5dICBiIhL6NZ0ERGXUGGLiLiECltExCVU2CIiLqHCFhHxo88//5xGjRpx/Phx\nDh8+TP369dm8eXORHqtVIiIifvbEE09w7Ngxjh49Sq1atYp86IYKW0TEz06cOEHTpk2pWLEiq1at\nKvJWCpoSERHxsx9//JHDhw9z6NAhjh49WuTHaYQtIuJnnTp14o477mDHjh1kZmYyYcKEIj1OR4SJ\niPjRzJkzqVChAj169ODUqVO0aNGCtLQ0EhISzvtYjbBFRFxCc9giIi6hwhYRcQkVtoiIS6iwRURc\nQoUtIuISKmwREZf4f3hrutPlcLgYAAAAAElFTkSuQmCC\n",
-       "text": [
-        "<matplotlib.figure.Figure at 0x7f58e010c190>"
-       ]
-      },
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 42,
-       "text": [
-        "<sympy.plotting.plot.Plot at 0x7f58e1de6710>"
-       ]
-      }
-     ],
-     "prompt_number": 42
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "### Exercise\n",
-      "\n",
-      "In the last exercise you derived a relationship between the volume of a sphere and the surface area.  Plot this relationship using `plot`."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "plot(?)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "## Low dependencies\n",
-      "\n",
-      "You may know that SymPy tries to be a very low-dependency project.  Our user base is very broad.  Some entertaining aspects result.  For example, `textplot`."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "textplot(x**2, -3, 3)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "      9 |                                                        \n",
-        "        |  .                                                    /\n",
-        "        |   \\                                                  / \n",
-        "        |    \\                                                /  \n",
-        "        |     \\                                              /   \n",
-        "        |      \\                                            .    \n",
-        "        |       \\                                                \n",
-        "        |        \\                                        ..     \n",
-        "4.50149 | --------\\--------------------------------------/-------\n",
-        "        |          \\                                    /        \n",
-        "        |           \\                                  /         \n",
-        "        |            \\                                /          \n",
-        "        |             ..                            ..           \n",
-        "        |               \\                          /             \n",
-        "        |                ..                      ..              \n",
-        "        |                  ..                  ..                \n",
-        "        |                    ..              ..                  \n",
-        "0.00297 |                      ..............                    \n",
-        "          -3                     0                          3\n"
-       ]
-      }
-     ],
-     "prompt_number": 50
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "### Exercise\n",
-      "\n",
-      "Play with `textplot` and enjoy :)"
+     "ename": "SyntaxError",
+     "evalue": "invalid syntax (<ipython-input-49-df38c236f23a>, line 1)",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[1;36m  File \u001b[1;32m\"<ipython-input-49-df38c236f23a>\"\u001b[1;36m, line \u001b[1;32m1\u001b[0m\n\u001b[1;33m    (?).subs(?)\u001b[0m\n\u001b[1;37m     ^\u001b[0m\n\u001b[1;31mSyntaxError\u001b[0m\u001b[1;31m:\u001b[0m invalid syntax\n"
      ]
     }
    ],
-   "metadata": {}
+   "source": [
+    "(?).subs(?)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Does the expression look right?  How would you expect the surface area to scale with respect to the volume?  What is the exponent on $V$?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Plotting\n",
+    "\n",
+    "SymPy can plot expressions easily using the `plot` function.  By default this links against matplotlib."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAWwAAAEMCAYAAADga4zjAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAIABJREFUeJzt3XuczdXCx/HPdknOEZpqxmXUnIeZxriOUCkaNCNOpMil\nwxmhlDohFXW6OBVGUolHyu0ZqoNOhdKR25moSBIRGmHcmpkuY3I3jN/zxzozoWIue++1f3t/369X\nL82w9/6a1/adNeu3fmt5HMdxEBGRgFfGdgARESkaFbaIiEuosEVEXEKFLSLiEipsERGXUGGLiLiE\nCltExCXK2Q4gwSc3N5dVq1aRkZGBx+MhKiqKa6+9lipVqtiOJuJqHt04I96ycuVKxo4dS0ZGBvHx\n8dSoUQPHccjMzOTLL78kKiqKRx55hOuvv952VBFX0ghbvObdd99l3LhxREdH/+bvp6enM3nyZBW2\nSAlphC0Bo2/fvixcuJDw8HA2btwIQE5ODt27d2fXrl1ERUUxd+5cqlatCsDo0aOZPn06ZcuW5eWX\nXyYpKclmfBGf00VH8bpevXqRm5tb+HFGRgZt2rQ57+PuvPNOFi1adMbnUlJSSExMJD09nbZt25KS\nkgLA5s2bmTNnDps3b2bRokUMHDiQU6dOefcvIhJgVNjidS1btuTqq69m4cKFvPbaayQlJTFkyJAi\nPe7iiy8+43MLFiwgOTkZgOTkZObNmwfA/Pnz6dmzJ+XLlycqKoo6deqwZs0a7/9lRAKI5rDF6wYM\nGEBcXBxt2rTh0ksvZd26dVSvXr1Ez5WdnU1ERAQAERERZGdnA/Ddd99xzTXXFP65yMhI9u3bV/rw\nIgHMKyPsDh288SwSLGbNmkXfvn2ZOXMmffr0oUOHDqxfv77Uz+vxePB4POf8/d/63IgRIwr/S0tL\nK3UOkdL66CNo0KD4j/PKCHv1ati3D2rW9Mazidu9/fbbfPLJJ4SHh9OzZ09uvfVW+vTpU6LSjoiI\nICsri2rVqpGZmUl4eDgANWvWZM+ePYV/bu/evdT8nTfgiBEjSvT3EPGV6dOhb9/iP84rI+zbb4eZ\nM73xTBIM5s2bV1isAM2bN+ezzz4r0XN16tSJ1NRUAFJTU+ncuXPh52fPnk1eXh47d+5k27ZtNG/e\nvPThRXzswAGYPx969Sr+Y71S2HfeCTNmgBYIhrYRI0YUzjGfrUKFCmRmZvLUU0/97uN79uxJixYt\n+Oabb6hVqxYzZsxg+PDhLFmyhJiYGJYvX87w4cMBiIuLo1u3bsTFxdG+fXsmTZp0zukSkUAxdy60\naQOXXVb8x3plHbbjQL168NproHsiQtfChQt5/vnnycvLo0mTJlSvXh3HccjKymLdunVUqFCBhx56\niA5+vOjh8XjQrQYSSFq0gMceg5tvLv5jvXbjzNixsGWLmZuR0NS7d29mzZrFs88+S3R0dOFeIldc\ncQXXXXcdkZGRfs+kwpZAsmWLGV3v2QPlSnAF0WuFnZUFdeuaIJUqeeMZxW3i4uJYunQpN910E2lp\naWcUpcfjISwszO+ZVNgSSIYNM7+OGVOyx3v11vRbboHOnc2ctoSel19+mVdeeYUdO3ZQo0aNM37P\n4/GwY8cOv2dSYUugOHkSatWC//wHYmNL9hxeLex58+CFF2DFCm89o7jRPffcw+TJk23HAFTYEjje\nfx9GjYJPPy35c3i1sE+cgMhIWLkSYmK89awiJafClkBx223mJsP+/Uv+HF7frW/oUKhQwXwnEbFN\nhS2B4PvvzSB2926oXLnkz+P1zZ/uvNPcRJOf7+1nFhFxpzfeMNf4SlPW4IPCrl/f3KK+eLG3n1lE\nxH0cB6ZNK9mt6GfzyfaqffuaCXYRkVC3di0cPQqtWpX+uXxy4szPP8MVV8C2bSW7/VLEWzSHLbbd\nc4+Zv37wwdI/l8+OCOvTx0yPPPSQL55dpGhU2GLToUNw+eWwcaN3djP12Ykzd90FU6dqQygRCV1z\n58J113lv62mfFXaLFlCmjFmTLSISiqZONYNXb/FZYXs8cPfdZgc/EZFQ8/XXkJHh3RO5fDaHDfDT\nT1C7NuzYARb2/RHRHLZYM3gw/PGPMHKk957Tp6emX3KJ+e7y+uu+fBURkcBy7JjpvX79vPu8Pi1s\nMPM3U6bo4qOIhI5334X4ePif//Hu8/q8sBMSzHebEh7pJyLiOlOmePdiYwGfF7bHY4Lr4qOIhIJv\nv4VNm8zeId7m04uOBbKzzYbdu3aVfvMTkeLQRUfxt0cfhbw8GDfO+8/t8xE2QEQEtG0Lb77pj1cT\nEbHjxAlISyvdntfn4pfChl8uPoqIBKsFC8zhunXr+ub5/VbYiYlmXfYXX/jrFUVE/GvyZBg40HfP\n77fCLlPG/JigUbaIBKNvv4UNG8xRYL7il4uOBfbtg0aNzO2alSr561UllOmio/jLI4+YX597znev\n4dfCBvjLX8zabF+sURQ5mwpb/OH4cahVy5yIXqeO717Hb1MiBf76V3jlFd35KCLB4+23oXFj35Y1\nWCjsxEQ4cADWrPH3K4uI+MbkyeZkGV/ze2GXKQMDBphRtoiI223ebC44duzo+9fy+xw2wI8/QnQ0\nbN+ubVfFtzSHLb42aJC5g/uZZ3z/WlYKG6B3b7OblTcOphT5PSps8aUjR8zFxi+/NGc3+prfp0QK\n3HuvmRY5dcpWAhGR0pkzxxyH6I+yBouFfe218Ic/wLJlthKIiJTO8uW+vbPxbNYK2+Mxf1FdfBQR\nN/r8c3PIeFKS/17T2hw2wKFD5keJjRu9dwy8yOk0hy2+cuedcOWVMHy4/17TamED3HcfXHYZjBhh\nM4UEKxW2+ELBAePbtpn+8hdrUyIF7r3XbAh14oTtJBLIRo8eTb169WjQoAF33HEHx48fJycnh8TE\nRGJiYkhKSiI3N9d2TAkR06dDp07+LWsIgMKuX98cVLlgge0kEqgyMjKYMmUK69atY+PGjeTn5zN7\n9mxSUlJITEwkPT2dtm3bkpKSYjuqhID8fHPt7b77/P/a1gsbYPBgmDrVdgoJVJUrV6Z8+fIcOXKE\nkydPcuTIEWrUqMGCBQtITk4GIDk5mXnz5llOKqFg0SJzw1/z5v5/7XL+f8lf69gR7r8fvv4a6tWz\nnUYCTVhYGEOHDuXyyy+nYsWKtGvXjsTERLKzs4mIiAAgIiKC7Ozs33z8iNMukCQkJJCQkOCH1BKs\nJk0yo2uPx/+vbf2iY4ERI8xhvVrmJ2fbvn07HTt2ZOXKlVSpUoXbb7+dLl268Le//Y39+/cX/rmw\nsDBycnLOeKwuOoo37dgBV18Nu3dDxYr+f/2AmBIBsyHU7Nmg60ZytrVr19KiRQsuueQSypUrx223\n3caqVauoVq0aWVlZAGRmZhIeHm45qQS7V16BPn3slDUEUGFXrw7t28OMGbaTSKCJjY1l9erVHD16\nFMdxWLp0KXFxcXTs2JHU1FQAUlNT6dy5s+WkEsyOHoX16/2zjervCZgpEYBVq8ymUOnpZhtWkQLP\nPfccqamplClThiZNmjB16lQOHjxIt27d2L17N1FRUcydO5eqVaue8ThNiYi3TJ0K8+fDe+/ZyxBQ\nhe040LSp2aawQwfbaSQYqLDFGxzHnEc7bpw5hMWWgBrHejzwt7/BhAm2k4iI/CItDU6ehBtvtJsj\noEbYAMeOmf1FPv4YYmJspxG30whbvOHWW6FdO7vz1xCAhQ3w2GNw+DCMH287ibidCltKa+dOaNYM\ndu2CP/7RbpaALOzdu80JxLt2wUUX2U4jbqbCltIaOtQsghg71naSAC1sgK5dzTK/fv1sJxE3U2FL\naRw6BFdcAevWmV9tC6iLjqd74AF47jkdISYi9sycCQkJgVHWEMCF3bIlVKpkNloREfG3U6fMirUH\nHrCd5BcBW9gej9nF78UXbScRkVC0ZAlUqACtWtlO8ouALWyA7t3NDn6bNtlOIiKh5uWXzejaxq58\nvydgLzoWePZZs1pkyhTbScSNdNFRSiI9Ha6/3qxYu/BC22l+EfCF/cMP5gaa9HT/H8cj7qfClpJ4\n6CEzHTJypO0kZwr4wgbo3x+iouDxx20nEbdRYUtx7d8P0dGwYQPUrGk7zZlcUdibNkFSEmRkwAUX\n2E4jbqLCluIaM8ZcO5s503aSXwvoi44F6tc3R4fNmWM7iYgEs7w8s5Rv6FDbSX6bKwobYMgQsyZb\ngyUR8ZU5cyA21mylGohcU9g33WRuD01Ls51ERIKR45j9rgN1dA0uKuwyZcwX8vnnbScRkWC0fDmc\nOGEGh4HKFRcdCxw7ZlaLLFtm5rRFzkcXHaWoOnSALl0Ce8M5VxU2mBtpdu6EadNsJxE3UGFLUWze\nDG3amJVogXSjzNlcV9g//WTWSH79tTlpXeRcVNhSFP37m5OunnzSdpJzc11hA9x/P1SpEnh3IUng\nUWHL+WRnm5Uhbrib2pWF/e23cM015seXSpVsp5FApsKW83nySfj+e5g82XaS83NlYYO5OJCQYE5Z\nF/k9Kmw5lyNHzEKGlSvhyittpzk/1xb2qlXwl7+YH2PKlbOdRgKVClvO5ZVXYONGmDTJdpKicc06\n7LNde605qPf9920nERE3OnnSHKzbq5ftJEXn2sIG6NMHnnlGt6uLSPH9619mN74WLWwnKTpXF/bN\nN5ubaZYutZ1ERNzEcSAlBYYNs52keFxd2GXKmC94SortJCLiJosXQ36+ubvRTVxd2AA9e5plfmvW\n2E4iIm4xZgw88ogZ9LmJy+L+WvnyZlOoMWNsJxERN/j8c9i+HXr0sJ2k+Fy7rO90hw/Dn/4EK1aY\nO5ZECmhZn5yta1do2RIGDbKdpPiCorABnn7anK6uTaHkdCpsOd0335jT0DMy4I9/tJ2m+IKmsAs2\nhfrqK4iMtJ1GAoUKW043aBBUrQr/+IftJCUTNIUN8OCD4PGYUyNEQIUtv9i7F+LjzVaqgb7J0+8J\nqsLeuxcaNjSrRsLCbKeRQKDClgKDBplFCm4+tSqoChvg73+HihXh8cdtJ5FAoMIWMFuo1q3r/n30\nXb+s72x9+sD48XDggO0k4k25ubl07dqVunXrEhcXx2effUZOTg6JiYnExMSQlJREbm6u7ZgSoF58\n0dyz4eayhiAs7OhoSEpyz+5bUjSDBg2iQ4cObNmyha+++orY2FhSUlJITEwkPT2dtm3bkqJbXuU3\n5OTAlCnmRhm3C7opETAXFVq3hh073Ll0R870888/Ex8fz44dO874fGxsLB999BERERFkZWWRkJDA\n1q1bz/gzmhKRf/zDLPmdPt12ktILysIGszj+uutgyBDbSaS01q9fz4ABA4iLi2PDhg1cddVVvPTS\nS0RGRrJ//34AHMchLCys8OMCHo+Hp556qvDjhIQEEhIS/BlfLDpwAGrXhk8+gZgY22lKL2gL+8sv\nzW5+27cH9inIcn5r167l2muv5dNPP6VZs2YMHjyYiy66iIkTJ55R0GFhYeTk5JzxWI2wQ9uYMbBh\nA7z5pu0k3hF0c9gF4uOhSZPg+DEo1EVGRhIZGUmzZs0A6Nq1K+vWraNatWpkZWUBkJmZSXh4uM2Y\nEmCOHDEXGx97zHYS7wnawgaztG/MGMjLs51ESqNatWrUqlWL9PR0AJYuXUq9evXo2LEjqampAKSm\nptK5c2ebMSXATJ1qTqaqX992Eu8J2imRAklJ0L079OtnO4mUxoYNG+jfvz95eXnUrl2bGTNmkJ+f\nT7du3di9ezdRUVHMnTuXqlWrnvE4TYmEpmPHzE/Yr79ufg0WQV/YK1bACy+Y44B0WG/oUWGHpokT\n4cMP4b33bCfxrqCeEgFo1cpcKZ41y3YSEfGHY8fMKVSnLQ4KGkE/wgb4+GPo3dtsrXjBBbbTiD9p\nhB16gnV0DSFS2ADt2kGXLnD33baTiD+psEPLsWNQpw7MmwdNm9pO430hU9irV0O3brBtG1SoYDuN\n+IsKO7RMnGgO2F2wwHYS3wiZwgb485/NfwMH2k4i/qLCDh0Fo+v58+Gqq2yn8Y2QKuy1a6FzZ7Nf\ntu5+DA0q7NAR7KNrCIFVIqdr2tR85331VdtJRMSbjh41Zf3kk7aT+FZIFTaYnbtSUsxtqyISHCZN\ngrJlg/NC4+lCakqkQNeu5pbVoUNtJxFf05RI8Dt40MxdL1sWXLeh/5aQLOxNm+DGG81cdqVKttOI\nL6mwg98zz8DWrfDGG7aT+F5IFjZAjx5mR79hw2wnEV9SYQe3nByzz/Xq1WaUHexCtrC3bIEbbjCj\n7MqVbacRX1FhB7dHH4UffzRHgIWCkC1sgF69zE5eDz5oO4n4igo7eGVlQVwcrF8Pl19uO41/hHRh\nf/stXHON2WPkkktspxFfUGEHr0GDzK/jx9vN4U8hXdhg7nqsWBHGjbOdRHxBhR2cdu+Gxo3N1GZE\nhO00/hPyhZ2VBfXqwbp1cMUVttOIt6mwg9Ndd8Gll8Lo0baT+FfI3ThztmrVzCg7GPfOFQlG6emw\nZw88/LDtJP4X8iNsMAccREfD0qXQoIHtNOJNGmEHn9tvN1tMDB9uO4n/qbD/66WXzJ1SwbjpeShT\nYQeXzz4z+9qnp8Mf/mA7jf+psP/r+HGIjYWZM6FlS9tpxFtU2MHDcaB1a7Mct39/22nsCPk57AIV\nKsDTT5s7H/XvWyTwLFoE2dnQp4/tJPaosE9zxx1w+HBw76cr4kb5+WYwNXo0lCtnO409KuzTlC1r\n3hCPPgonT9pOIyIF3nwTLroIbrnFdhK7VNhnad8ewsMhNdV2EhEBczjB3LkwZgx4PLbT2KXCPovH\nYw44eO01HXIgEgjGj4fy5eH6620nsU+rRH5Hjx5mM/THH7edREpDq0Tc7fvvzQZPq1aZeyVCnQr7\nd+zYAc2awcaNUKOG7TRSUipsdxs4EC64wNwnISrscxo2DH74AaZPt51ESkqF7V5btkCrVmY3zbAw\n22kCgwr7HA4cgCuvhIULzb7Z4j4qbPe6+WZo00b71Z9OFx3PoXJlGDHCvGH0b17Ef5YtMyPs++6z\nnSSwqLDPo18/+OknmDfPdhKR0JCfD6++alZrVahgO01gUWGfR7ly8MILZivH48dtpxEJftOmmX3q\nu3a1nSTwaA67iDSf5k6aw3aX/fuhbl34978hPt52msCjwi6irVvNLn5btpiTLsQdVNjuMmSI2c/n\ntddsJwlMKuxiGDQIqlQxu/qJO6iw3aNgGd/mzXDZZbbTBCbNYRfDU0+ZiyHr19tOEpry8/OJj4+n\nY8eOAOTk5JCYmEhMTAxJSUnk5uZaTigl5ThmdP3YYyrrc1FhF0NYGDz7rFlqdOqU7TShZ/z48cTF\nxeH57w5AKSkpJCYmkp6eTtu2bUlJSbGcUEpq4ULYtQvuv992ksCmwi6mfv3gxAl4/XXbSULL3r17\n+eCDD+jfv3/hFMeCBQtITk4GIDk5mXlae+lKx4+bbY1ffNFs8iS/T4VdTGXKwMSJ5gDQn3+2nSZ0\nDBkyhLFjx1KmzC9v2ezsbCIiIgCIiIggOzvbVjwphXHjoFo1uOkm20kCXwif3VByzZvDn/9s5rS1\nKY3vvf/++4SHhxMfH09aWtpv/hmPx1M4VXK2ESNGFP5/QkICCQkJ3g8pJbJrlynstWttJ3EHrRIp\noR9/NNs+LlsGDRrYThPcHnvsMWbNmkW5cuU4duwYBw4c4LbbbuPzzz8nLS2NatWqkZmZSevWrdm6\ndesZj9UqkcB2661mn54nnrCdxB1U2KUwaRLMmQNpaToJw18++ugjnn/+ed577z0eeeQRLrnkEoYN\nG0ZKSgq5ubm/uvCowg5cH3xglspu3AgXXmg7jTtoDrsUBgyAgwfhn/+0nSS0FEx9DB8+nCVLlhAT\nE8Py5csZPny45WRSVMeOwQMPwIQJKuvi0Ai7lD79FG6/3Sz6r1zZdho5m0bYgenpp2HDBnj7bdtJ\n3EWF7QWPPQZ5efD887aTyNlU2IFn+3a4+mpYtw4uv9x2GndRYXvBjz+a8x/fe88cKyaBQ4UdWBwH\nOnQwm6lpr+vi0xy2F1x6KYwdC3ffDSdP2k4jErjmzIG9e82/FSk+FbaX9OplilvrskV+2/79Znvi\n117THY0lpSkRLyqYm/v8c/jTn2ynEdCUSCAZMADKljXLYaVkVNhelpICH31k1phqbbZ9KuzA8Mkn\n0K2b2Tq1ShXbadxLUyJeNnQo7Ntn5upExKygevJJM12osi4dFbaXlS9v5ugefNDM2YmEutGjTVHr\njMbS05SIj9x/v9k2csoU20lCm6ZE7Nq0CVq3hi+/hMhI22ncTyNsHxk1Cr7/HpYvt51ExI6TJ6Fv\nXxg5UmXtLSpsH6lcGe65xxx4cPCg7TQi/jd+PFSqBHfdZTtJ8NCUiI/17w/lysHkybaThCZNidix\nbRtcey189hnUrm07TfBQYfvYzz9Dw4YwdSokJtpOE3pU2P6Xn2/e6z17anTtbZoS8bEqVcyFx/79\n4cAB22lEfO+ll0xp9+tnO0nw0QjbTwYMMCeta9WIf2mE7V9ffw0JCbBmje729QUVtp8cPGiOEps8\nWYeN+pMK239OnDDz1gMGaCrEVzQl4icXXQTTppk3cm6u7TQi3jdqFISHm+k/8Q2NsP1s4EA4ehRm\nzLCdJDRohO0fX3xh9rn+8kuoUcN2muClEbafPfcc7N5tDjsQCQbHjsFf/2ouNqqsfUsjbAs++QS6\ndDFHJOkN7lsaYfveww9DRgbMnasdKn1NI2wLrrsO7r0XkpPNyhERt0pLM1umvvKKytofVNiW/P3v\nZi77xRdtJxEpmR9/hN694YEHzGlL4nuaErEoI8Mc2vvhh9Ckie00wUlTIr7hONC5M0RHw/PP204T\nOjTCtigqCl5+Ge64Aw4ftp1GpOgmTTIHdYwaZTtJaNEIOwD89a9QsSK8+qrtJMFHI2zv++oraNsW\nPv3UjLDFfzTCDgATJ8LSpfDuu7aTiJzbkSPQoweMG6eytkGFHQAqV4Y33jA7+u3aZTuNyO8bMsRc\nb+nd23aS0KTCDhDXXGOOUurWzRwtJhJo5s+HZcvM/LWW8NmhOewA4jhw223mOKUJE2ynCQ6aw/aO\n9HS4/npYtEgrmmzSCDuAeDxmj5F//xtmz7adRsQ4fNjcmfvssypr2zTCDkDr15sTO1asgLp1badx\nN42wS8dxoFcvKF/eDCY0FWKXRtgBqHFjSEkxo5pDh2ynkVA2aZI5lEDz1oFBI+wA5TjQt6/ZFH7W\nLP1jKSmNsEtu9Wro1Mmst65Tx3YaAY2wA5bHA//7v7Bxozn4QMSffvjBrFiaOlVlHUg0wg5w27fD\nDTfAm29Cq1a207iPRtjFd/KkGVk3bqxbzwONCtsFliwxt6+vXg1XXGE7jbuosItvyBCzE9+MGVCu\nnO00cjpNibhAYiIMH25GPaF4EXLPnj20bt2aevXqUb9+fV5++WUAcnJySExMJCYmhqSkJHJ1WGap\nTZsGCxeaTclU1oFHI2yXcBxzuGluLrz1FpQJoW+1WVlZZGVl0bhxYw4dOsRVV13FvHnzmDFjBpde\neimPPPIIY8aMYf/+/aSkpJzxWI2wi27lSrMyacUKiI21nUZ+Swj9s3c3j8csrcrKgqeftp3Gv6pV\nq0bjxo0BqFSpEnXr1mXfvn0sWLCA5ORkAJKTk5k3b57NmK6WkWEuMs6apbIOZBphu0x2NjRvbjaN\nv/1222n8LyMjgxtuuIFNmzZx+eWXs3//fgAcxyEsLKzw4wIej4ennnqq8OOEhAQSEhL8GTngHToE\nLVpAv34waJDtNHIuKmwXWrcO7rsPxo835R0qDh06xA033MATTzxB586dufjii88o6LCwMHJycs54\njKZEzi0/35T0iRMwebLW+wc6TYm4UJMm5kzIzp3Nsr9QcOLECbp06ULv3r3p3LkzABEREWRlZQGQ\nmZlJeHi4zYiu4zjmPMatW81FRpV14FNhu9TNN8OTT0L79mYJVjBzHId+/foRFxfH4MGDCz/fqVMn\nUlNTAUhNTS0scimasWPh44/h7behQgXbaaQoNCXicsOHm6v6y5aZY8aC0ccff0yrVq1o2LAhnv8O\nA0ePHk3z5s3p1q0bu3fvJioqirlz51K1atUzHqspkd/25pvmvbNqFdSsaTuNFJUK2+VOnTK7qR0/\nDnPnQtmythMFFhX2r/3nP9C9OyxfDvXr204jxaEpEZcrU8bckXb4MPzjH2ZeUuT3bNpkzmScM0dl\n7Ua6lykIVKhgDjxo08Z8HGrrtKVotm+Hdu3MapDWrW2nkZJQYQeJqlXN8U2tWkGVKjB0qO1EEkj2\n7jVbHDz1FNx6q+00UlIq7CASHg5Ll0LLluYk9rvusp1IAsEPP5iyHjgQ7r7bdhopDRV2kImMhMWL\nISHBlHb37rYTiU25uWYapGtXeOgh22mktLRKJEh99ZX50Xf8eLNmO1SF8iqRgwfh/vvNFNn48box\nJhholUiQatjQrATo1w/efdd2GvG3AwfgppvM2vyXXlJZBwtNiQSxpk3h3/+GDh3MnhFdu9pOJP7w\n88+mrOPjYeLE0NqKN9ipsINckybw4YfmH/DJk2YNrgSvgjnrZs1gwgSNrIONCjsENGpkLkS2a2dK\nu1cv24nEF3JyoGNHuPpqzVkHKxV2iGjQwCz5S0w0d0P27m07kXjTd9+Zb8jdu5udHFXWwUmzWyEk\nLs7sHzFmjNmpLUQXTwSd9HS47jr4y19U1sFOy/pC0N69Zk47KcmcXBPMF6WCfVnfF1+YZZvPPGPO\n/JTgpsIOUfv3m1PYL7/cbB51wQW2E/lGMBf28uXmIvJrr5nDLCT4BfHYSs7l4ovNhcjDh80I7cAB\n24mkON55x5T1W2+prEOJCjuEVawI//qXWVVw/fWwc6ftRHI+p06Zk4aGDDGHVtxwg+1E4k9aJRLi\nypUz27Fedpk5OXv2bJVAoDp0CJKTISsL1qyBiAjbicTfNMIWPB5zGOvMmdCtm5kTlcCya5dZCVK1\nqpm7VlmHJhW2FEpMNIeyvvgi/O1v5iYbse/jj+Gaa+DOO2HqVB2YG8pU2HKG6GhYvdqcTnLXXeaG\nDLHDcSDEwjX1AAAIr0lEQVQ1Fbp0gf/7Pxg8WGusQ50KW36lShV47z3405/MXiQffGA7UejJzTV3\nLb74Iqxcae5iFFFhy28qW9asRpg7FwYMMEeO5eXZThUaVq0yO+1FRJifdmJibCeSQKHClnNq1QrW\nr4dt28xFr+3bbScKXvn5MGqUWVf90ktmt70LL7SdSgKJClvO65JLYP58s2HUNdeYpX9BevOgNXv2\nmO0CPvwQ1q6FW26xnUgCkQpbiqRg6d+yZWbzqPbtdaONN5w6BZMnm2sFnTqZJXu1atlOJYFKhS3F\n0rChuWkjIcFskv/CC1r+V1Lp6dC6tVkJkpZmllKWLWs7lQQyFbYUW/nyMHy4uTj2/vtmmmT9etup\n3OPECRg92txZ2qWLWWddr57tVOIGKmwpsehoM0UycKDZqnXkSLMcTX6b48C8eaacd+82c9UPPKBR\ntRSdCltKxeOBvn3hq69g3z6zBG3cODh2zHaywPLFF2b644knzOqPV16BqCjbqcRtVNjiFdWqwaRJ\n8J//wIoVcOWVZm+S/Hzbyezas8esrunY0ZwIs369boKRktMBBuITK1fCsGFmv+2UFLNkzcZt1bYO\nMNi925zms369uUD78MNw0UV+jyFBRoUtPuM4Zv32tGnmhptBg8xo8w9/8F8Gfxf25s1m2eP770O/\nfmbf6urV/fbyEuRU2OJzjmOWrb30Enz6qdlU6r77oGZN37+2Pwr71CkzFfTGG7BwobmQOHCgOdVH\nxJtU2OJX27aZi26vv25uvhk40Cxv89V0iS8L+7vvzC5606ZBpUrw4INw++3+/QlCQosKW6zIzTUX\nJV991awouesuc6df3breLW9vF/b+/Wa649NPYc4cU9D9+0PTptr6VHzPK6tE0tLSvPE08l+h8PWs\nWtVMHWzaZIovP9+snoiNhccfNxctT5w4//MsWrSI2NhYoqOjGTNmjE+y7t1rVsAkJsIVV8Dbb5sL\nibt3m284zZqFTlmHwnvTn4r79VRhB6BQ+np6PGZ0+ve/mwJ84w2zmmLwYLj0Urj3XrPa4rPPfr22\nOz8/n/vvv59FixaxefNm/vnPf7Jly5ZS5XEccxzXO+/APfeYbyB9+pi7Ou+9FzIzzc0v3bubaZBQ\nE0rvTX8o7tdTh/BKwCgo76ZNzZLAH34wUw9LlphDFBzHTEk0bQqNG8PRo2uIiKhD5cpRlCsHPXr0\nYP78+dStW/e8r3X8uJmD3rMHtm413ywyMmDxYqhd22zGFBNj9gJv2FB3I0pgUGFLwLrsMrPNaMFW\no0ePmimUr74yRbt69T52765Fz55w8CAcOxbJzz9/xpdfmlNzCm7auftuczr80aOQnW2K//hxM0IO\nC4MyZUxBt2hhluTVqBE6UxziLl656OjRu1tEpESKU8FeGWFroYnYsHr1akaMGMGiRYsAGD16NGXK\nlGHYsGGWk4n4hvYSEddq2rQp27ZtIyMjg7y8PObMmUOnTp1sxxLxGc1hi2uVK1eOiRMn0q5dO/Lz\n8+nXr1+RLjiKuFWJR9hvvfUW9erVo2zZsqxbt+6M3xs9ejTR0dHExsayePHiUocMNSNGjCAyMpL4\n+Hji4+MLf+SXX2vfvj3ffPMN3377LY8++ugZv+ePNdqhJCoqioYNGxIfH0/z5s1tx3GVvn37EhER\nQYMGDQo/l5OTQ2JiIjExMSQlJZFblM3knRLasmWL88033zgJCQnOF198Ufj5r7/+2mnUqJGTl5fn\n7Ny506ldu7aTn59f0pcJSSNGjHDGjRtnO4arnTx50qldu7azc+dOJy8vz2nUqJGzefNm27FcLSoq\nyvnpp59sx3ClFStWOOvWrXPq169f+LmHH37YGTNmjOM4jpOSkuIMGzbsvM9T4hF2bGwsMTExv/r8\n/Pnz6dmzJ+XLlycqKoo6deqwZs2akr5MyHJ0IbdU1qxZQ506dYiKiqJ8+fKFa7SldPS+LJmWLVty\n8Vm7gS1YsIDk5GQAkpOTmTdv3nmfx+sXHb/77jsiIyMLP46MjGTfvn3efpmgN2HCBBo1akS/fv2K\n9qOSnGHfvn3UOu34cb0PS8/j8XDjjTfStGlTpkyZYjuO62VnZxMREQFAREQE2dnZ533MOS86JiYm\nkpWV9avPjxo1io4dOxY5mNZp/9rvfW1HjhzJvffey5NPPgnAE088wdChQ5k2bZq/I7qa3nPe98kn\nn1C9enV++OEHEhMTiY2NpWXLlrZjBQWPx1Ok9+w5C3vJkiXFfuGaNWuyZ8+ewo/37t1LTX9sfOwy\nRf3a9u/fv1jfHMU4+324Z8+eM37yk+Kr/t+TGC677DJuvfVW1qxZo8IuhYiICLKysqhWrRqZmZmE\nh4ef9zFemRI5fV6rU6dOzJ49m7y8PHbu3Mm2bdt0RbmYMjMzC///3XffPePKshSN1mh715EjRzh4\n8CAAhw8fZvHixXpfllKnTp1ITU0FIDU1lc6dO5//QSW96vnOO+84kZGRzoUXXuhEREQ4N910U+Hv\njRw50qldu7Zz5ZVXOosWLSrpS4Ss3r17Ow0aNHAaNmzo3HLLLU5WVpbtSK70wQcfODExMU7t2rWd\nUaNG2Y7jajt27HAaNWrkNGrUyKlXr56+nsXUo0cPp3r16k758uWdyMhIZ/r06c5PP/3ktG3b1omO\njnYSExOd/fv3n/d5dICBiIhL6NZ0ERGXUGGLiLiECltExCVU2CIiLqHCFhHxo88//5xGjRpx/Phx\nDh8+TP369dm8eXORHqtVIiIifvbEE09w7Ngxjh49Sq1atYp86IYKW0TEz06cOEHTpk2pWLEiq1at\nKvJWCpoSERHxsx9//JHDhw9z6NAhjh49WuTHaYQtIuJnnTp14o477mDHjh1kZmYyYcKEIj1OR4SJ\niPjRzJkzqVChAj169ODUqVO0aNGCtLQ0EhISzvtYjbBFRFxCc9giIi6hwhYRcQkVtoiIS6iwRURc\nQoUtIuISKmwREZf4f3hrutPlcLgYAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x7f58e010c190>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<sympy.plotting.plot.Plot at 0x7f58e1de6710>"
+      ]
+     },
+     "execution_count": 42,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "plot(x**2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise\n",
+    "\n",
+    "In the last exercise you derived a relationship between the volume of a sphere and the surface area.  Plot this relationship using `plot`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "plot(?)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Low dependencies\n",
+    "\n",
+    "You may know that SymPy tries to be a very low-dependency project.  Our user base is very broad.  Some entertaining aspects result.  For example, `textplot`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      9 |                                                        \n",
+      "        |  .                                                    /\n",
+      "        |   \\                                                  / \n",
+      "        |    \\                                                /  \n",
+      "        |     \\                                              /   \n",
+      "        |      \\                                            .    \n",
+      "        |       \\                                                \n",
+      "        |        \\                                        ..     \n",
+      "4.50149 | --------\\--------------------------------------/-------\n",
+      "        |          \\                                    /        \n",
+      "        |           \\                                  /         \n",
+      "        |            \\                                /          \n",
+      "        |             ..                            ..           \n",
+      "        |               \\                          /             \n",
+      "        |                ..                      ..              \n",
+      "        |                  ..                  ..                \n",
+      "        |                    ..              ..                  \n",
+      "0.00297 |                      ..............                    \n",
+      "          -3                     0                          3\n"
+     ]
+    }
+   ],
+   "source": [
+    "textplot(x**2, -3, 3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise\n",
+    "\n",
+    "Play with `textplot` and enjoy :)"
+   ]
   }
- ]
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 0
 }

--- a/tutorial_exercises/03-Integrals.ipynb
+++ b/tutorial_exercises/03-Integrals.ipynb
@@ -1,190 +1,189 @@
 {
- "metadata": {
-  "name": "",
-  "signature": "sha256:bec7cbf6bf5a2743f26f8494b78056ea168f06558b51516fa932958b691e990b"
- },
- "nbformat": 3,
- "nbformat_minor": 0,
- "worksheets": [
+ "cells": [
   {
-   "cells": [
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from sympy import *\n",
+    "init_printing(use_latex='mathjax')\n",
+    "n, m = symbols('n,m', integer=True)\n",
+    "x, y, z = symbols('x,y,z')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Integrals\n",
+    "\n",
+    "In the last section we learned symbolic differentiation with `.diff`.  Here we'll cover symbolic integration with `integrate`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here is how we write the indefinite integral\n",
+    "\n",
+    "$$ \\int x^2 dx = \\frac{x^3}{3}$$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
     {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "from sympy import *\n",
-      "init_printing(use_latex='mathjax')\n",
-      "n, m = symbols('n,m', integer=True)\n",
-      "x, y, z = symbols('x,y,z')"
-     ],
-     "language": "python",
+     "data": {
+      "text/latex": [
+       "$$\\frac{x^{3}}{3}$$"
+      ],
+      "text/plain": [
+       " 3\n",
+       "x \n",
+       "──\n",
+       "3 "
+      ]
+     },
+     "execution_count": 2,
      "metadata": {},
-     "outputs": [],
-     "prompt_number": 1
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "## Integrals\n",
-      "\n",
-      "In the last section we learned symbolic differentiation with `.diff`.  Here we'll cover symbolic integration with `integrate`."
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Here is how we write the indefinite integral\n",
-      "\n",
-      "$$ \\int x^2 dx = \\frac{x^3}{3}$$"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "# Indefinite integral\n",
-      "integrate(x**2, x)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\frac{x^{3}}{3}$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 2,
-       "text": [
-        " 3\n",
-        "x \n",
-        "\u2500\u2500\n",
-        "3 "
-       ]
-      }
-     ],
-     "prompt_number": 2
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "And the definite integral\n",
-      "\n",
-      "$$ \\int_0^3 x^2 dx = \\left.\\frac{x^3}{3} \\right|_0^3 = \\frac{3^3}{3} - \\frac{0^3}{3} = 9 $$"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "# Definite integral\n",
-      "integrate(x**2, (x, 0, 3))"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$9$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 3,
-       "text": [
-        "9"
-       ]
-      }
-     ],
-     "prompt_number": 3
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "As always, because we're using symbolics, we could use a symbol whenever we previously used a number\n",
-      "\n",
-      "$$ \\int_y^z x^n dx $$"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "integrate(x**n, (x, y, z))"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\begin{cases} - \\log{\\left (y \\right )} + \\log{\\left (z \\right )} & \\text{for}\\: n = -1 \\\\- \\frac{y^{n + 1}}{n + 1} + \\frac{z^{n + 1}}{n + 1} & \\text{otherwise} \\end{cases}$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 4,
-       "text": [
-        "\u23a7-log(y) + log(z)   for n = -1\n",
-        "\u23aa                             \n",
-        "\u23aa   n + 1    n + 1            \n",
-        "\u23a8  y        z                 \n",
-        "\u23aa- \u2500\u2500\u2500\u2500\u2500\u2500 + \u2500\u2500\u2500\u2500\u2500\u2500  otherwise \n",
-        "\u23aa  n + 1    n + 1             \n",
-        "\u23a9                             "
-       ]
-      }
-     ],
-     "prompt_number": 4
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "### Exercise\n",
-      "\n",
-      "Compute the following integrals:\n",
-      "\n",
-      "$$ \\int \\sin(x) dx $$\n",
-      "$$ \\int_0^{\\pi} \\sin(x) dx $$\n",
-      "$$ \\int_0^y x^5 + 12x^3 - 2x + 1  $$\n",
-      "$$ \\int e^{\\frac{(x - \\mu)^2}{\\sigma^2}} $$\n",
-      "\n",
-      "Feel free to play with various parameters and settings and see how the results change."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "# Use `integrate` to solve the integrals above\n",
-      "\n"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 7
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Are there some integrals that SymPy can't do?  Find some."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "# Use `integrate` on other equations.  Symbolic integration has it limits, find them."
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
+     "output_type": "execute_result"
     }
    ],
-   "metadata": {}
+   "source": [
+    "# Indefinite integral\n",
+    "integrate(x**2, x)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And the definite integral\n",
+    "\n",
+    "$$ \\int_0^3 x^2 dx = \\left.\\frac{x^3}{3} \\right|_0^3 = \\frac{3^3}{3} - \\frac{0^3}{3} = 9 $$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$$9$$"
+      ],
+      "text/plain": [
+       "9"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Definite integral\n",
+    "integrate(x**2, (x, 0, 3))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As always, because we're using symbolics, we could use a symbol whenever we previously used a number\n",
+    "\n",
+    "$$ \\int_y^z x^n dx $$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$$\\begin{cases} - \\log{\\left (y \\right )} + \\log{\\left (z \\right )} & \\text{for}\\: n = -1 \\\\- \\frac{y^{n + 1}}{n + 1} + \\frac{z^{n + 1}}{n + 1} & \\text{otherwise} \\end{cases}$$"
+      ],
+      "text/plain": [
+       "⎧-log(y) + log(z)   for n = -1\n",
+       "⎪                             \n",
+       "⎪   n + 1    n + 1            \n",
+       "⎨  y        z                 \n",
+       "⎪- ────── + ──────  otherwise \n",
+       "⎪  n + 1    n + 1             \n",
+       "⎩                             "
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "integrate(x**n, (x, y, z))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise\n",
+    "\n",
+    "Compute the following integrals:\n",
+    "\n",
+    "$$ \\int \\sin(x) dx $$\n",
+    "$$ \\int_0^{\\pi} \\sin(x) dx $$\n",
+    "$$ \\int_0^y x^5 + 12x^3 - 2x + 1  $$\n",
+    "$$ \\int e^{\\frac{(x - \\mu)^2}{\\sigma^2}} $$\n",
+    "\n",
+    "Feel free to play with various parameters and settings and see how the results change."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Use `integrate` to solve the integrals above\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Are there some integrals that SymPy can't do?  Find some."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Use `integrate` on other equations.  Symbolic integration has it limits, find them."
+   ]
   }
- ]
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 0
 }

--- a/tutorial_exercises/04-Matrices.ipynb
+++ b/tutorial_exercises/04-Matrices.ipynb
@@ -1,580 +1,604 @@
 {
- "metadata": {
-  "name": "",
-  "signature": "sha256:d9d23a333ea98b5147b9b834deb489d4fb34fe7c497a5fe205c341cf24321b7b"
- },
- "nbformat": 3,
- "nbformat_minor": 0,
- "worksheets": [
+ "cells": [
   {
-   "cells": [
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from sympy import *\n",
+    "init_printing(use_latex='mathjax')\n",
+    "x, y, z = symbols('x,y,z')\n",
+    "r, theta = symbols('r,theta', positive=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Matrices\n",
+    "\n",
+    "The SymPy `Matrix` object helps us with small problems in linear algebra."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
     {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "from sympy import *\n",
-      "init_printing(use_latex='mathjax')\n",
-      "x, y, z = symbols('x,y,z')\n",
-      "r, theta = symbols('r,theta', positive=True)"
-     ],
-     "language": "python",
+     "data": {
+      "text/latex": [
+       "$$\\left[\\begin{matrix}r \\cos{\\left (\\theta \\right )} & - r \\sin{\\left (\\theta \\right )}\\\\r \\sin{\\left (\\theta \\right )} & r \\cos{\\left (\\theta \\right )}\\end{matrix}\\right]$$"
+      ],
+      "text/plain": [
+       "⎡r⋅cos(θ)  -r⋅sin(θ)⎤\n",
+       "⎢                   ⎥\n",
+       "⎣r⋅sin(θ)  r⋅cos(θ) ⎦"
+      ]
+     },
+     "execution_count": 2,
      "metadata": {},
-     "outputs": [],
-     "prompt_number": 1
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "## Matrices\n",
-      "\n",
-      "The SymPy `Matrix` object helps us with small problems in linear algebra."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "rot = Matrix([[r*cos(theta), -r*sin(theta)],\n",
-      "              [r*sin(theta),  r*cos(theta)]])\n",
-      "rot"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\left[\\begin{matrix}r \\cos{\\left (\\theta \\right )} & - r \\sin{\\left (\\theta \\right )}\\\\r \\sin{\\left (\\theta \\right )} & r \\cos{\\left (\\theta \\right )}\\end{matrix}\\right]$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 2,
-       "text": [
-        "\u23a1r\u22c5cos(\u03b8)  -r\u22c5sin(\u03b8)\u23a4\n",
-        "\u23a2                   \u23a5\n",
-        "\u23a3r\u22c5sin(\u03b8)  r\u22c5cos(\u03b8) \u23a6"
-       ]
-      }
-     ],
-     "prompt_number": 2
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "### Standard methods"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "rot.det()"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$r^{2} \\sin^{2}{\\left (\\theta \\right )} + r^{2} \\cos^{2}{\\left (\\theta \\right )}$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 3,
-       "text": [
-        " 2    2       2    2   \n",
-        "r \u22c5sin (\u03b8) + r \u22c5cos (\u03b8)"
-       ]
-      }
-     ],
-     "prompt_number": 3
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "rot.inv()"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\left[\\begin{matrix}- \\frac{\\sin^{2}{\\left (\\theta \\right )}}{r \\cos{\\left (\\theta \\right )}} + \\frac{1}{r \\cos{\\left (\\theta \\right )}} & \\frac{1}{r} \\sin{\\left (\\theta \\right )}\\\\- \\frac{1}{r} \\sin{\\left (\\theta \\right )} & \\frac{1}{r} \\cos{\\left (\\theta \\right )}\\end{matrix}\\right]$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 4,
-       "text": [
-        "\u23a1     2                       \u23a4\n",
-        "\u23a2  sin (\u03b8)       1      sin(\u03b8)\u23a5\n",
-        "\u23a2- \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500 + \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500  \u2500\u2500\u2500\u2500\u2500\u2500\u23a5\n",
-        "\u23a2  r\u22c5cos(\u03b8)   r\u22c5cos(\u03b8)    r   \u23a5\n",
-        "\u23a2                             \u23a5\n",
-        "\u23a2      -sin(\u03b8)          cos(\u03b8)\u23a5\n",
-        "\u23a2      \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500         \u2500\u2500\u2500\u2500\u2500\u2500\u23a5\n",
-        "\u23a3         r               r   \u23a6"
-       ]
-      }
-     ],
-     "prompt_number": 4
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "rot.singular_values()"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\begin{bmatrix}r, & r\\end{bmatrix}$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 5,
-       "text": [
-        "[r, r]"
-       ]
-      }
-     ],
-     "prompt_number": 5
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "### Exercise\n",
-      "\n",
-      "Find the inverse of the following Matrix:\n",
-      "\n",
-      "$$ \\left[\\begin{matrix}1 & x\\\\y & 1\\end{matrix}\\right] $$"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "# Create a matrix and use the `.inv` method to find the inverse\n",
-      "\n"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 7
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "### Operators\n",
-      "\n",
-      "The standard SymPy operators work on matrices"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "rot * 2"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\left[\\begin{matrix}2 r \\cos{\\left (\\theta \\right )} & - 2 r \\sin{\\left (\\theta \\right )}\\\\2 r \\sin{\\left (\\theta \\right )} & 2 r \\cos{\\left (\\theta \\right )}\\end{matrix}\\right]$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 8,
-       "text": [
-        "\u23a12\u22c5r\u22c5cos(\u03b8)  -2\u22c5r\u22c5sin(\u03b8)\u23a4\n",
-        "\u23a2                       \u23a5\n",
-        "\u23a32\u22c5r\u22c5sin(\u03b8)  2\u22c5r\u22c5cos(\u03b8) \u23a6"
-       ]
-      }
-     ],
-     "prompt_number": 8
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "rot * rot"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\left[\\begin{matrix}- r^{2} \\sin^{2}{\\left (\\theta \\right )} + r^{2} \\cos^{2}{\\left (\\theta \\right )} & - 2 r^{2} \\sin{\\left (\\theta \\right )} \\cos{\\left (\\theta \\right )}\\\\2 r^{2} \\sin{\\left (\\theta \\right )} \\cos{\\left (\\theta \\right )} & - r^{2} \\sin^{2}{\\left (\\theta \\right )} + r^{2} \\cos^{2}{\\left (\\theta \\right )}\\end{matrix}\\right]$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 9,
-       "text": [
-        "\u23a1   2    2       2    2            2                 \u23a4\n",
-        "\u23a2- r \u22c5sin (\u03b8) + r \u22c5cos (\u03b8)     -2\u22c5r \u22c5sin(\u03b8)\u22c5cos(\u03b8)   \u23a5\n",
-        "\u23a2                                                    \u23a5\n",
-        "\u23a2      2                       2    2       2    2   \u23a5\n",
-        "\u23a3   2\u22c5r \u22c5sin(\u03b8)\u22c5cos(\u03b8)      - r \u22c5sin (\u03b8) + r \u22c5cos (\u03b8)\u23a6"
-       ]
-      }
-     ],
-     "prompt_number": 9
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "v = Matrix([[x], [y]])\n",
-      "v"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\left[\\begin{matrix}x\\\\y\\end{matrix}\\right]$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 10,
-       "text": [
-        "\u23a1x\u23a4\n",
-        "\u23a2 \u23a5\n",
-        "\u23a3y\u23a6"
-       ]
-      }
-     ],
-     "prompt_number": 10
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "rot * v"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\left[\\begin{matrix}r x \\cos{\\left (\\theta \\right )} - r y \\sin{\\left (\\theta \\right )}\\\\r x \\sin{\\left (\\theta \\right )} + r y \\cos{\\left (\\theta \\right )}\\end{matrix}\\right]$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 11,
-       "text": [
-        "\u23a1r\u22c5x\u22c5cos(\u03b8) - r\u22c5y\u22c5sin(\u03b8)\u23a4\n",
-        "\u23a2                       \u23a5\n",
-        "\u23a3r\u22c5x\u22c5sin(\u03b8) + r\u22c5y\u22c5cos(\u03b8)\u23a6"
-       ]
-      }
-     ],
-     "prompt_number": 11
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "### Exercise\n",
-      "\n",
-      "In the last exercise you found the inverse of the following matrix"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "M = Matrix([[1, x], [y, 1]])\n",
-      "M"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\left[\\begin{matrix}1 & x\\\\y & 1\\end{matrix}\\right]$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 12,
-       "text": [
-        "\u23a11  x\u23a4\n",
-        "\u23a2    \u23a5\n",
-        "\u23a3y  1\u23a6"
-       ]
-      }
-     ],
-     "prompt_number": 12
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "M.inv()"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\left[\\begin{matrix}\\frac{x y}{- x y + 1} + 1 & - \\frac{x}{- x y + 1}\\\\- \\frac{y}{- x y + 1} & \\frac{1}{- x y + 1}\\end{matrix}\\right]$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 13,
-       "text": [
-        "\u23a1  x\u22c5y           -x    \u23a4\n",
-        "\u23a2\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500 + 1  \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u23a5\n",
-        "\u23a2-x\u22c5y + 1      -x\u22c5y + 1\u23a5\n",
-        "\u23a2                      \u23a5\n",
-        "\u23a2    -y           1    \u23a5\n",
-        "\u23a2  \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500    \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u23a5\n",
-        "\u23a3  -x\u22c5y + 1    -x\u22c5y + 1\u23a6"
-       ]
-      }
-     ],
-     "prompt_number": 13
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Now verify that this is the true inverse by multiplying the matrix times its inverse.  Do you get the identity matrix back?"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "# Multiply `M` by its inverse.  Do you get back the identity matrix?\n",
-      "\n"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 14
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "### Exercise\n",
-      "\n",
-      "What are the eigenvectors and eigenvalues of `M`?"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": true,
-     "input": [
-      "# Find the methods to compute eigenvectors and eigenvalues. Use these methods on `M`\n",
-      "\n"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 15
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "### NumPy-like Item access"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "rot[0, 0]"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$r \\cos{\\left (\\theta \\right )}$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 16,
-       "text": [
-        "r\u22c5cos(\u03b8)"
-       ]
-      }
-     ],
-     "prompt_number": 16
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "rot[:, 0]"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\left[\\begin{matrix}r \\cos{\\left (\\theta \\right )}\\\\r \\sin{\\left (\\theta \\right )}\\end{matrix}\\right]$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 17,
-       "text": [
-        "\u23a1r\u22c5cos(\u03b8)\u23a4\n",
-        "\u23a2        \u23a5\n",
-        "\u23a3r\u22c5sin(\u03b8)\u23a6"
-       ]
-      }
-     ],
-     "prompt_number": 17
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "rot[1, :]"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\left[\\begin{matrix}r \\sin{\\left (\\theta \\right )} & r \\cos{\\left (\\theta \\right )}\\end{matrix}\\right]$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 18,
-       "text": [
-        "[r\u22c5sin(\u03b8)  r\u22c5cos(\u03b8)]"
-       ]
-      }
-     ],
-     "prompt_number": 18
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "### Mutation\n",
-      "\n",
-      "We can change elements in the matrix."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "rot[0, 0] += 1\n",
-      "rot"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\left[\\begin{matrix}r \\cos{\\left (\\theta \\right )} + 1 & - r \\sin{\\left (\\theta \\right )}\\\\r \\sin{\\left (\\theta \\right )} & r \\cos{\\left (\\theta \\right )}\\end{matrix}\\right]$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 19,
-       "text": [
-        "\u23a1r\u22c5cos(\u03b8) + 1  -r\u22c5sin(\u03b8)\u23a4\n",
-        "\u23a2                       \u23a5\n",
-        "\u23a3  r\u22c5sin(\u03b8)    r\u22c5cos(\u03b8) \u23a6"
-       ]
-      }
-     ],
-     "prompt_number": 19
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "simplify(rot.det())"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$r \\left(r + \\cos{\\left (\\theta \\right )}\\right)$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 20,
-       "text": [
-        "r\u22c5(r + cos(\u03b8))"
-       ]
-      }
-     ],
-     "prompt_number": 20
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "rot.singular_values()"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\begin{bmatrix}\\sqrt{r^{2} + r \\cos{\\left (\\theta \\right )} + \\frac{1}{2} \\sqrt{4 r^{2} + 4 r \\cos{\\left (\\theta \\right )} + 1} + \\frac{1}{2}}, & \\sqrt{r^{2} + r \\cos{\\left (\\theta \\right )} - \\frac{1}{2} \\sqrt{4 r^{2} + 4 r \\cos{\\left (\\theta \\right )} + 1} + \\frac{1}{2}}\\end{bmatrix}$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 21,
-       "text": [
-        "\u23a1      ________________________________________________        _______________\n",
-        "\u23a2     \u2571                    _______________________            \u2571               \n",
-        "\u23a2    \u2571                    \u2571    2                             \u2571                \n",
-        "\u23a2   \u2571    2              \u2572\u2571  4\u22c5r  + 4\u22c5r\u22c5cos(\u03b8) + 1    1      \u2571    2            \n",
-        "\u23a2  \u2571    r  + r\u22c5cos(\u03b8) + \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500 + \u2500 ,   \u2571    r  + r\u22c5cos(\u03b8) \n",
-        "\u23a3\u2572\u2571                                 2                2   \u2572\u2571                   \n",
-        "\n",
-        "_________________________________\u23a4\n",
-        "     _______________________     \u23a5\n",
-        "    \u2571    2                       \u23a5\n",
-        "  \u2572\u2571  4\u22c5r  + 4\u22c5r\u22c5cos(\u03b8) + 1    1 \u23a5\n",
-        "- \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500 + \u2500 \u23a5\n",
-        "              2                2 \u23a6"
-       ]
-      }
-     ],
-     "prompt_number": 21
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "### Exercise\n",
-      "\n",
-      "Play around with your matrix `M`, manipulating elements in a NumPy like way.  Then try the various methods that we've talked about (or others).  See what sort of answers you get."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "# Play with matrices\n",
-      "\n"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 22
+     "output_type": "execute_result"
     }
    ],
-   "metadata": {}
+   "source": [
+    "rot = Matrix([[r*cos(theta), -r*sin(theta)],\n",
+    "              [r*sin(theta),  r*cos(theta)]])\n",
+    "rot"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Standard methods"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$$r^{2} \\sin^{2}{\\left (\\theta \\right )} + r^{2} \\cos^{2}{\\left (\\theta \\right )}$$"
+      ],
+      "text/plain": [
+       " 2    2       2    2   \n",
+       "r ⋅sin (θ) + r ⋅cos (θ)"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "rot.det()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$$\\left[\\begin{matrix}- \\frac{\\sin^{2}{\\left (\\theta \\right )}}{r \\cos{\\left (\\theta \\right )}} + \\frac{1}{r \\cos{\\left (\\theta \\right )}} & \\frac{1}{r} \\sin{\\left (\\theta \\right )}\\\\- \\frac{1}{r} \\sin{\\left (\\theta \\right )} & \\frac{1}{r} \\cos{\\left (\\theta \\right )}\\end{matrix}\\right]$$"
+      ],
+      "text/plain": [
+       "⎡     2                       ⎤\n",
+       "⎢  sin (θ)       1      sin(θ)⎥\n",
+       "⎢- ──────── + ────────  ──────⎥\n",
+       "⎢  r⋅cos(θ)   r⋅cos(θ)    r   ⎥\n",
+       "⎢                             ⎥\n",
+       "⎢      -sin(θ)          cos(θ)⎥\n",
+       "⎢      ────────         ──────⎥\n",
+       "⎣         r               r   ⎦"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "rot.inv()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$$\\begin{bmatrix}r, & r\\end{bmatrix}$$"
+      ],
+      "text/plain": [
+       "[r, r]"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "rot.singular_values()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise\n",
+    "\n",
+    "Find the inverse of the following Matrix:\n",
+    "\n",
+    "$$ \\left[\\begin{matrix}1 & x\\\\y & 1\\end{matrix}\\right] $$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Create a matrix and use the `.inv` method to find the inverse\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Operators\n",
+    "\n",
+    "The standard SymPy operators work on matrices"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$$\\left[\\begin{matrix}2 r \\cos{\\left (\\theta \\right )} & - 2 r \\sin{\\left (\\theta \\right )}\\\\2 r \\sin{\\left (\\theta \\right )} & 2 r \\cos{\\left (\\theta \\right )}\\end{matrix}\\right]$$"
+      ],
+      "text/plain": [
+       "⎡2⋅r⋅cos(θ)  -2⋅r⋅sin(θ)⎤\n",
+       "⎢                       ⎥\n",
+       "⎣2⋅r⋅sin(θ)  2⋅r⋅cos(θ) ⎦"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "rot * 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$$\\left[\\begin{matrix}- r^{2} \\sin^{2}{\\left (\\theta \\right )} + r^{2} \\cos^{2}{\\left (\\theta \\right )} & - 2 r^{2} \\sin{\\left (\\theta \\right )} \\cos{\\left (\\theta \\right )}\\\\2 r^{2} \\sin{\\left (\\theta \\right )} \\cos{\\left (\\theta \\right )} & - r^{2} \\sin^{2}{\\left (\\theta \\right )} + r^{2} \\cos^{2}{\\left (\\theta \\right )}\\end{matrix}\\right]$$"
+      ],
+      "text/plain": [
+       "⎡   2    2       2    2            2                 ⎤\n",
+       "⎢- r ⋅sin (θ) + r ⋅cos (θ)     -2⋅r ⋅sin(θ)⋅cos(θ)   ⎥\n",
+       "⎢                                                    ⎥\n",
+       "⎢      2                       2    2       2    2   ⎥\n",
+       "⎣   2⋅r ⋅sin(θ)⋅cos(θ)      - r ⋅sin (θ) + r ⋅cos (θ)⎦"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "rot * rot"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$$\\left[\\begin{matrix}x\\\\y\\end{matrix}\\right]$$"
+      ],
+      "text/plain": [
+       "⎡x⎤\n",
+       "⎢ ⎥\n",
+       "⎣y⎦"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "v = Matrix([[x], [y]])\n",
+    "v"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$$\\left[\\begin{matrix}r x \\cos{\\left (\\theta \\right )} - r y \\sin{\\left (\\theta \\right )}\\\\r x \\sin{\\left (\\theta \\right )} + r y \\cos{\\left (\\theta \\right )}\\end{matrix}\\right]$$"
+      ],
+      "text/plain": [
+       "⎡r⋅x⋅cos(θ) - r⋅y⋅sin(θ)⎤\n",
+       "⎢                       ⎥\n",
+       "⎣r⋅x⋅sin(θ) + r⋅y⋅cos(θ)⎦"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "rot * v"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise\n",
+    "\n",
+    "In the last exercise you found the inverse of the following matrix"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$$\\left[\\begin{matrix}1 & x\\\\y & 1\\end{matrix}\\right]$$"
+      ],
+      "text/plain": [
+       "⎡1  x⎤\n",
+       "⎢    ⎥\n",
+       "⎣y  1⎦"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "M = Matrix([[1, x], [y, 1]])\n",
+    "M"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$$\\left[\\begin{matrix}\\frac{x y}{- x y + 1} + 1 & - \\frac{x}{- x y + 1}\\\\- \\frac{y}{- x y + 1} & \\frac{1}{- x y + 1}\\end{matrix}\\right]$$"
+      ],
+      "text/plain": [
+       "⎡  x⋅y           -x    ⎤\n",
+       "⎢──────── + 1  ────────⎥\n",
+       "⎢-x⋅y + 1      -x⋅y + 1⎥\n",
+       "⎢                      ⎥\n",
+       "⎢    -y           1    ⎥\n",
+       "⎢  ────────    ────────⎥\n",
+       "⎣  -x⋅y + 1    -x⋅y + 1⎦"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "M.inv()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now verify that this is the true inverse by multiplying the matrix times its inverse.  Do you get the identity matrix back?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Multiply `M` by its inverse.  Do you get back the identity matrix?\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise\n",
+    "\n",
+    "What are the eigenvectors and eigenvalues of `M`?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# Find the methods to compute eigenvectors and eigenvalues. Use these methods on `M`\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### NumPy-like Item access"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$$r \\cos{\\left (\\theta \\right )}$$"
+      ],
+      "text/plain": [
+       "r⋅cos(θ)"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "rot[0, 0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$$\\left[\\begin{matrix}r \\cos{\\left (\\theta \\right )}\\\\r \\sin{\\left (\\theta \\right )}\\end{matrix}\\right]$$"
+      ],
+      "text/plain": [
+       "⎡r⋅cos(θ)⎤\n",
+       "⎢        ⎥\n",
+       "⎣r⋅sin(θ)⎦"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "rot[:, 0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$$\\left[\\begin{matrix}r \\sin{\\left (\\theta \\right )} & r \\cos{\\left (\\theta \\right )}\\end{matrix}\\right]$$"
+      ],
+      "text/plain": [
+       "[r⋅sin(θ)  r⋅cos(θ)]"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "rot[1, :]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Mutation\n",
+    "\n",
+    "We can change elements in the matrix."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$$\\left[\\begin{matrix}r \\cos{\\left (\\theta \\right )} + 1 & - r \\sin{\\left (\\theta \\right )}\\\\r \\sin{\\left (\\theta \\right )} & r \\cos{\\left (\\theta \\right )}\\end{matrix}\\right]$$"
+      ],
+      "text/plain": [
+       "⎡r⋅cos(θ) + 1  -r⋅sin(θ)⎤\n",
+       "⎢                       ⎥\n",
+       "⎣  r⋅sin(θ)    r⋅cos(θ) ⎦"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "rot[0, 0] += 1\n",
+    "rot"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$$r \\left(r + \\cos{\\left (\\theta \\right )}\\right)$$"
+      ],
+      "text/plain": [
+       "r⋅(r + cos(θ))"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "simplify(rot.det())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$$\\begin{bmatrix}\\sqrt{r^{2} + r \\cos{\\left (\\theta \\right )} + \\frac{1}{2} \\sqrt{4 r^{2} + 4 r \\cos{\\left (\\theta \\right )} + 1} + \\frac{1}{2}}, & \\sqrt{r^{2} + r \\cos{\\left (\\theta \\right )} - \\frac{1}{2} \\sqrt{4 r^{2} + 4 r \\cos{\\left (\\theta \\right )} + 1} + \\frac{1}{2}}\\end{bmatrix}$$"
+      ],
+      "text/plain": [
+       "⎡      ________________________________________________        _______________\n",
+       "⎢     ╱                    _______________________            ╱               \n",
+       "⎢    ╱                    ╱    2                             ╱                \n",
+       "⎢   ╱    2              ╲╱  4⋅r  + 4⋅r⋅cos(θ) + 1    1      ╱    2            \n",
+       "⎢  ╱    r  + r⋅cos(θ) + ────────────────────────── + ─ ,   ╱    r  + r⋅cos(θ) \n",
+       "⎣╲╱                                 2                2   ╲╱                   \n",
+       "\n",
+       "_________________________________⎤\n",
+       "     _______________________     ⎥\n",
+       "    ╱    2                       ⎥\n",
+       "  ╲╱  4⋅r  + 4⋅r⋅cos(θ) + 1    1 ⎥\n",
+       "- ────────────────────────── + ─ ⎥\n",
+       "              2                2 ⎦"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "rot.singular_values()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise\n",
+    "\n",
+    "Play around with your matrix `M`, manipulating elements in a NumPy like way.  Then try the various methods that we've talked about (or others).  See what sort of answers you get."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Play with matrices\n",
+    "\n"
+   ]
   }
- ]
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 0
 }

--- a/tutorial_exercises/05-Numeric-Evaluation.ipynb
+++ b/tutorial_exercises/05-Numeric-Evaluation.ipynb
@@ -1,452 +1,462 @@
 {
- "metadata": {
-  "name": "",
-  "signature": "sha256:c647e541e0a6733fe4204f7380440e35897b4926c6ef0ba602d6bbf456f4aa1f"
- },
- "nbformat": 3,
- "nbformat_minor": 0,
- "worksheets": [
+ "cells": [
   {
-   "cells": [
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from sympy import *\n",
+    "init_printing(use_latex='mathjax')\n",
+    "x, y, z = symbols('x,y,z')\n",
+    "n, m = symbols('n,m', integer=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Numeric Evaluation\n",
+    "\n",
+    "In this section we'll learn how to use our symbolic equations to drive numeric computations"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## `.subs` and `.evalf`\n",
+    "\n",
+    "The simplest (and slowest) ways to evaluate an expression numerically is with the `.subs` and `.evalf` methods "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
     {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "from sympy import *\n",
-      "init_printing(use_latex='mathjax')\n",
-      "x, y, z = symbols('x,y,z')\n",
-      "n, m = symbols('n,m', integer=True)"
-     ],
-     "language": "python",
+     "data": {
+      "text/latex": [
+       "$$\\sin{\\left (x \\right )}$$"
+      ],
+      "text/plain": [
+       "sin(x)"
+      ]
+     },
+     "execution_count": 3,
      "metadata": {},
-     "outputs": [],
-     "prompt_number": 1
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "%matplotlib inline"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 2
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "# Numeric Evaluation\n",
-      "\n",
-      "In this section we'll learn how to use our symbolic equations to drive numeric computations"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "## `.subs` and `.evalf`\n",
-      "\n",
-      "The simplest (and slowest) ways to evaluate an expression numerically is with the `.subs` and `.evalf` methods "
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "sin(x)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\sin{\\left (x \\right )}$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 3,
-       "text": [
-        "sin(x)"
-       ]
-      }
-     ],
-     "prompt_number": 3
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "sin(x).subs({x: 0})"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$0$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 4,
-       "text": [
-        "0"
-       ]
-      }
-     ],
-     "prompt_number": 4
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "acos(x).subs({x: -1})"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\pi$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 5,
-       "text": [
-        "\u03c0"
-       ]
-      }
-     ],
-     "prompt_number": 5
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "acos(x).subs({x: -1}).evalf()"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$3.14159265358979$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 6,
-       "text": [
-        "3.14159265358979"
-       ]
-      }
-     ],
-     "prompt_number": 6
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "acos(x).subs({x: -1}).evalf(n=100)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$3.141592653589793238462643383279502884197169399375105820974944592307816406286208998628034825342117068$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 7,
-       "text": [
-        "3.1415926535897932384626433832795028841971693993751058209749445923078164062862\n",
-        "08998628034825342117068"
-       ]
-      }
-     ],
-     "prompt_number": 7
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "### Exercise\n",
-      "\n",
-      "In a previous section we computed the following symbolic integral\n",
-      "\n",
-      "$$ \\int_y^z x^n dx $$"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "result = integrate(x**n, (x, y, z))\n",
-      "result"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\begin{cases} - \\log{\\left (y \\right )} + \\log{\\left (z \\right )} & \\text{for}\\: n = -1 \\\\- \\frac{y^{n + 1}}{n + 1} + \\frac{z^{n + 1}}{n + 1} & \\text{otherwise} \\end{cases}$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 8,
-       "text": [
-        "\u23a7-log(y) + log(z)   for n = -1\n",
-        "\u23aa                             \n",
-        "\u23aa   n + 1    n + 1            \n",
-        "\u23a8  y        z                 \n",
-        "\u23aa- \u2500\u2500\u2500\u2500\u2500\u2500 + \u2500\u2500\u2500\u2500\u2500\u2500  otherwise \n",
-        "\u23aa  n + 1    n + 1             \n",
-        "\u23a9                             "
-       ]
-      }
-     ],
-     "prompt_number": 8
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Use `.subs` and a dictionary with keys `n, y, z` to evaluate this result when \n",
-      "\n",
-      "    n == 2\n",
-      "    y == 0\n",
-      "    z == 3"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "# Evaluate the resulting integral on the above values\n",
-      "\n"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 9
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "### Exercise\n",
-      "\n",
-      "This integral takes on a special form when $n = -1$.  Use subs to find the expression when \n",
-      "\n",
-      "    n == -1\n",
-      "    y == 5\n",
-      "    z == 100\n",
-      "    \n",
-      "Then use `.evalf` to evaluate this subs-ed expression as a float."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "# Evaluate the resulting integral for the values {n: -1, y: 5, z: 100}\n",
-      "# Then use evalf to get a numeric result\n",
-      "\n"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 10
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "## `lambdify`\n",
-      "\n",
-      "The `.subs` and `.evalf` methods are great for when you want to evaluate an expression at a single point.  When you want to evaluate your expression on lots of points they quickly become slow. \n",
-      "\n",
-      "To resolve this problem SymPy can rewrite its expressions as normal Python functions using the `math` library, vectorized computations using the NumPy library, C or Fortran Code using code printers, or even more sophisticated systems.\n",
-      "\n",
-      "We'll talk about some of the more advanced topics later.  For now, lambdify..."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "# function = lambdify(input, output)\n",
-      "\n",
-      "f = lambdify(x, x**2)\n",
-      "f(3)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$9$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 11,
-       "text": [
-        "9"
-       ]
-      }
-     ],
-     "prompt_number": 11
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "import numpy as np\n",
-      "f = lambdify(x, x**2, 'numpy')  # Use numpy backend\n",
-      "data = np.array([1, 2, 3, 4, 5])\n",
-      "f(data)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 12,
-       "text": [
-        "array([ 1,  4,  9, 16, 25])"
-       ]
-      }
-     ],
-     "prompt_number": 12
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "### Exercise\n",
-      "\n",
-      "Here is a radial wave function for the Carbon atom at $n=3$, $l=1$"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "from sympy.physics.hydrogen import R_nl\n",
-      "n = 3\n",
-      "l = 1\n",
-      "r = 6 # Carbon\n",
-      "expr = R_nl(n, l, x, r)\n",
-      "expr"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\frac{8 x}{3} \\left(- 4 x + 4\\right) e^{- 2 x}$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 13,
-       "text": [
-        "                -2\u22c5x\n",
-        "8\u22c5x\u22c5(-4\u22c5x + 4)\u22c5\u212f    \n",
-        "\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n",
-        "         3          "
-       ]
-      }
-     ],
-     "prompt_number": 13
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Create a function, `f`, that evaluate this expression using the `'numpy'` backend"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "# Create Numpy function mapping x to expr with the numpy backend\n",
-      "\n"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 14
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "We can plot your function from $x \\in [0, 5]$ with the following numpy/matplotlib code"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "from matplotlib.pyplot import plot\n",
-      "nx = np.linspace(0, 5, 1000)\n",
-      "plot(nx, f(nx))"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 73
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "### Exercise\n",
-      "\n",
-      "Create a numpy function that computes the derivative of our expression.  Plot the result alongside the original."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "# Compute derivative of expr with respect to x\n",
-      "\n"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 15
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "# Create new fprime function using lambdify\n",
-      "\n"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 16
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "# Plot results alongside f(nx)\n",
-      "\n"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 17
+     "output_type": "execute_result"
     }
    ],
-   "metadata": {}
+   "source": [
+    "sin(x)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$$0$$"
+      ],
+      "text/plain": [
+       "0"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sin(x).subs({x: 0})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$$\\pi$$"
+      ],
+      "text/plain": [
+       "π"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "acos(x).subs({x: -1})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$$3.14159265358979$$"
+      ],
+      "text/plain": [
+       "3.14159265358979"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "acos(x).subs({x: -1}).evalf()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$$3.141592653589793238462643383279502884197169399375105820974944592307816406286208998628034825342117068$$"
+      ],
+      "text/plain": [
+       "3.1415926535897932384626433832795028841971693993751058209749445923078164062862\n",
+       "08998628034825342117068"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "acos(x).subs({x: -1}).evalf(n=100)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise\n",
+    "\n",
+    "In a previous section we computed the following symbolic integral\n",
+    "\n",
+    "$$ \\int_y^z x^n dx $$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$$\\begin{cases} - \\log{\\left (y \\right )} + \\log{\\left (z \\right )} & \\text{for}\\: n = -1 \\\\- \\frac{y^{n + 1}}{n + 1} + \\frac{z^{n + 1}}{n + 1} & \\text{otherwise} \\end{cases}$$"
+      ],
+      "text/plain": [
+       "⎧-log(y) + log(z)   for n = -1\n",
+       "⎪                             \n",
+       "⎪   n + 1    n + 1            \n",
+       "⎨  y        z                 \n",
+       "⎪- ────── + ──────  otherwise \n",
+       "⎪  n + 1    n + 1             \n",
+       "⎩                             "
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "result = integrate(x**n, (x, y, z))\n",
+    "result"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Use `.subs` and a dictionary with keys `n, y, z` to evaluate this result when \n",
+    "\n",
+    "    n == 2\n",
+    "    y == 0\n",
+    "    z == 3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Evaluate the resulting integral on the above values\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise\n",
+    "\n",
+    "This integral takes on a special form when $n = -1$.  Use subs to find the expression when \n",
+    "\n",
+    "    n == -1\n",
+    "    y == 5\n",
+    "    z == 100\n",
+    "    \n",
+    "Then use `.evalf` to evaluate this subs-ed expression as a float."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Evaluate the resulting integral for the values {n: -1, y: 5, z: 100}\n",
+    "# Then use evalf to get a numeric result\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## `lambdify`\n",
+    "\n",
+    "The `.subs` and `.evalf` methods are great for when you want to evaluate an expression at a single point.  When you want to evaluate your expression on lots of points they quickly become slow. \n",
+    "\n",
+    "To resolve this problem SymPy can rewrite its expressions as normal Python functions using the `math` library, vectorized computations using the NumPy library, C or Fortran Code using code printers, or even more sophisticated systems.\n",
+    "\n",
+    "We'll talk about some of the more advanced topics later.  For now, lambdify..."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$$9$$"
+      ],
+      "text/plain": [
+       "9"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# function = lambdify(input, output)\n",
+    "\n",
+    "f = lambdify(x, x**2)\n",
+    "f(3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([ 1,  4,  9, 16, 25])"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "f = lambdify(x, x**2, 'numpy')  # Use numpy backend\n",
+    "data = np.array([1, 2, 3, 4, 5])\n",
+    "f(data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise\n",
+    "\n",
+    "Here is a radial wave function for the Carbon atom at $n=3$, $l=1$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$$\\frac{8 x}{3} \\left(- 4 x + 4\\right) e^{- 2 x}$$"
+      ],
+      "text/plain": [
+       "                -2⋅x\n",
+       "8⋅x⋅(-4⋅x + 4)⋅ℯ    \n",
+       "────────────────────\n",
+       "         3          "
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from sympy.physics.hydrogen import R_nl\n",
+    "n = 3\n",
+    "l = 1\n",
+    "r = 6 # Carbon\n",
+    "expr = R_nl(n, l, x, r)\n",
+    "expr"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Create a function, `f`, that evaluate this expression using the `'numpy'` backend"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Create Numpy function mapping x to expr with the numpy backend\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can plot your function from $x \\in [0, 5]$ with the following numpy/matplotlib code"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 73,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from matplotlib.pyplot import plot\n",
+    "nx = np.linspace(0, 5, 1000)\n",
+    "plot(nx, f(nx))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise\n",
+    "\n",
+    "Create a numpy function that computes the derivative of our expression.  Plot the result alongside the original."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Compute derivative of expr with respect to x\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Create new fprime function using lambdify\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Plot results alongside f(nx)\n",
+    "\n"
+   ]
   }
- ]
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 0
 }

--- a/tutorial_exercises/Advanced-Advanced Expression Manipulation Solutions.ipynb
+++ b/tutorial_exercises/Advanced-Advanced Expression Manipulation Solutions.ipynb
@@ -1,494 +1,518 @@
 {
- "metadata": {
-  "name": "",
-  "signature": "sha256:e0b439f2a97b0911a972c7ec62c1840ed5b08a289ea36787dc6abfb4315c683d"
- },
- "nbformat": 3,
- "nbformat_minor": 0,
- "worksheets": [
+ "cells": [
   {
-   "cells": [
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Advanced Expression Manipulation Solutions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from sympy import *\n",
+    "x, y, z = symbols('x y z')\n",
+    "init_printing()\n",
+    "from IPython.display import display"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For each exercise, fill in the function according to its docstring. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Creating expressions from classes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Create the following objects without using any mathematical operators like `+`, `-`, `*`, `/`, or `**` by explicitly using the classes `Add`, `Mul`, and `Pow`.  You may use `x` instead of `Symbol('x')` and `4` instead of `Integer(4)`.\n",
+    "\n",
+    "$$x^2 + 4xyz$$\n",
+    "$$x^{(x^y)}$$\n",
+    "$$x - \\frac{y}{z}$$\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def explicit_classes1():\n",
+    "    \"\"\"\n",
+    "    Returns the expression x**2 + 4*x*y*z, built using SymPy classes explicitly.\n",
+    "\n",
+    "    >>> explicit_classes1()\n",
+    "    x**2 + 4*x*y*z\n",
+    "    \"\"\"\n",
+    "    return Add(Pow(x, 2), Mul(4, x, y, z))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
     {
-     "cell_type": "heading",
-     "level": 1,
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAFkAAAAYBAMAAABjIUxVAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIol2q1SZEGbd7zK7\nzUTvhYErAAABd0lEQVQ4EZWSPUjDQBiG3zZNL01rCf6AWw8sBbdipWsFC67Fn7kdHBysRl07dBLH\njiIOLm5FOugkgoOCiIODODUOurlYcBAqWK+XuzR4FtIb8r3f9zz3kUAA92RubJEClKgdfQygCSVm\nhb6D22aJ/AS3Af1rFHuMjmKnFflcmXgDg3pRhmMZ1PqKS3e4I5nWlEmp8du1JXe4Itl0Wyalmr1e\n549N/7XH56fy2cF1uduwmM0ZyVCkbLyfhbIg1Dg0G6q9h7Zg4WQHBYTu8ptAGFpHb6k2ZbbLLqIN\nPICAsC8jiFwPXEC8CVvAdnNmm1l8MmWSa6yRp+o4R47zxNpdMBvgrGzH2S+XrHAr1YLNA3+I3avF\nYncR4KwK7QRY7mPDKkBTbUaakj0jsQCdIgKU6/eY6F8TR+xmXVOydXzUcbV/8ALU5nZn6lJl1bPT\nvQ3BarltCxWjW/JpInq2H836G39+8zc8RxrkVBkOHcRogg6FCtBzW3L2C+XCUpwgHYYtAAAAAElF\nTkSuQmCC\n",
+      "text/latex": [
+       "$$x^{2} + 4 x y z$$"
+      ],
+      "text/plain": [
+       " 2          \n",
+       "x  + 4⋅x⋅y⋅z"
+      ]
+     },
+     "execution_count": 36,
      "metadata": {},
-     "source": [
-      "Advanced Expression Manipulation Solutions"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "from sympy import *\n",
-      "x, y, z = symbols('x y z')\n",
-      "init_printing()\n",
-      "from IPython.display import display"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 34
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "For each exercise, fill in the function according to its docstring. "
-     ]
-    },
-    {
-     "cell_type": "heading",
-     "level": 2,
-     "metadata": {},
-     "source": [
-      "Creating expressions from classes"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Create the following objects without using any mathematical operators like `+`, `-`, `*`, `/`, or `**` by explicitly using the classes `Add`, `Mul`, and `Pow`.  You may use `x` instead of `Symbol('x')` and `4` instead of `Integer(4)`.\n",
-      "\n",
-      "$$x^2 + 4xyz$$\n",
-      "$$x^{(x^y)}$$\n",
-      "$$x - \\frac{y}{z}$$\n"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def explicit_classes1():\n",
-      "    \"\"\"\n",
-      "    Returns the expression x**2 + 4*x*y*z, built using SymPy classes explicitly.\n",
-      "\n",
-      "    >>> explicit_classes1()\n",
-      "    x**2 + 4*x*y*z\n",
-      "    \"\"\"\n",
-      "    return Add(Pow(x, 2), Mul(4, x, y, z))"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 35
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "explicit_classes1()"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$x^{2} + 4 x y z$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAFkAAAAYBAMAAABjIUxVAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIol2q1SZEGbd7zK7\nzUTvhYErAAABd0lEQVQ4EZWSPUjDQBiG3zZNL01rCf6AWw8sBbdipWsFC67Fn7kdHBysRl07dBLH\njiIOLm5FOugkgoOCiIODODUOurlYcBAqWK+XuzR4FtIb8r3f9zz3kUAA92RubJEClKgdfQygCSVm\nhb6D22aJ/AS3Af1rFHuMjmKnFflcmXgDg3pRhmMZ1PqKS3e4I5nWlEmp8du1JXe4Itl0Wyalmr1e\n549N/7XH56fy2cF1uduwmM0ZyVCkbLyfhbIg1Dg0G6q9h7Zg4WQHBYTu8ptAGFpHb6k2ZbbLLqIN\nPICAsC8jiFwPXEC8CVvAdnNmm1l8MmWSa6yRp+o4R47zxNpdMBvgrGzH2S+XrHAr1YLNA3+I3avF\nYncR4KwK7QRY7mPDKkBTbUaakj0jsQCdIgKU6/eY6F8TR+xmXVOydXzUcbV/8ALU5nZn6lJl1bPT\nvQ3BarltCxWjW/JpInq2H836G39+8zc8RxrkVBkOHcRogg6FCtBzW3L2C+XCUpwgHYYtAAAAAElF\nTkSuQmCC\n",
-       "prompt_number": 36,
-       "text": [
-        " 2          \n",
-        "x  + 4\u22c5x\u22c5y\u22c5z"
-       ]
-      }
-     ],
-     "prompt_number": 36
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def explicit_classes2():\n",
-      "    \"\"\"\n",
-      "    Returns the expression x**(x**y), built using SymPy classes explicitly.\n",
-      "\n",
-      "    >>> explicit_classes2()\n",
-      "    x**(x**y)\n",
-      "    \"\"\"\n",
-      "    return Pow(x, Pow(x, y))"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 37
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "explicit_classes2()"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$x^{x^{y}}$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAUBAMAAABscEDKAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIol2q1SZEGbd7zK7\nRM2RoJmtAAAAlUlEQVQYGWNgQIBgBT4Eh4GhN2ELMpdlgwUyl5PhNIyr7Guygdl4AZTLVODDFSDB\nqgDl8jK8YGDY1gzlAamPCCaQxb2AG4m/n+kBExK3xjRZHcIVMhE1M4DLsCtwzOCaAOcyMTB/YN0A\n57IzsByAc0AMLoROEFd+A0MBiAYDDgF7BmYEN77hFIMwTI6BocaoSLkBzgUAQBUYbmElZeQAAAAA\nSUVORK5CYII=\n",
-       "prompt_number": 38,
-       "text": [
-        " \u239b y\u239e\n",
-        " \u239dx \u23a0\n",
-        "x    "
-       ]
-      }
-     ],
-     "prompt_number": 38
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def explicit_classes3():\n",
-      "    \"\"\"\n",
-      "    Returns the expression x - y/z, built using SymPy classes explicitly.\n",
-      "\n",
-      "    >>> explicit_classes3()\n",
-      "    x - y/z\n",
-      "    \"\"\"\n",
-      "    return Add(x, Mul(-1, Mul(y, Pow(z, -1))))"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 39
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "explicit_classes3()"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$x - \\frac{y}{z}$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAADMAAAAlBAMAAAAdAMyfAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIol2q1SZEGbd7zK7\nzUTvhYErAAAA7UlEQVQoFWNgwALY1RQY5AuwSDAwMPF9YLDHKsOwlW0CwxnsUgVcBgyfsUsxxBdw\n/8YhlcvAvACH1DUGHgccUikM7xtwSNUY5wvgkGJg0MQhwzKBfSkOKU4FHgUcUqzGeThk4MJCJqJm\nBnAeMoNdgWMG1wRkETibiYH5A+sGOBeZwc7AcgDMl50JAvNA7P8g8AHIAMYALiC/gaEAqxyHgD0D\nM3ap+IZTDMJYNTHUGBUpN2CXGsyifKse4PAQg0xz2gEcTi9gKMEeQED1jA44NDEwPMMpw6qAUyqI\ngcEBuyT3jYzeB9il2Bj6gakXAFr6LczlCLDrAAAAAElFTkSuQmCC\n",
-       "prompt_number": 40,
-       "text": [
-        "    y\n",
-        "x - \u2500\n",
-        "    z"
-       ]
-      }
-     ],
-     "prompt_number": 40
-    },
-    {
-     "cell_type": "heading",
-     "level": 2,
-     "metadata": {},
-     "source": [
-      "Nested args"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "expr = x**2 - y*(2**(x + 3) + z)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 41
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Use nested `.args` calls to get the 3 in expr."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def nested_args():\n",
-      "    \"\"\"\n",
-      "    Get the 3 in the above expression.\n",
-      "\n",
-      "    >>> nested_args()\n",
-      "    3\n",
-      "    \"\"\"\n",
-      "    expr = x**2 - y*(2**(x + 3) + z)\n",
-      "    return expr.args[0].args[2].args[1].args[1].args[0]"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 42
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "nested_args()"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$3$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAAoAAAAOBAMAAADkjZCYAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAMom7VCKZRHbdzavv\nEGbh6M2uAAAATklEQVQIHWNgEFIyYWBgTWCob2Bg+sLAP4GBBUwyMIBEgGA1EDNqbQAxGXoKQCTP\nXwZWAQbmfwz3/4JI/gUMnF8ZOB4w1CswMLilLWEAAJ6qEfrOOFffAAAAAElFTkSuQmCC\n",
-       "prompt_number": 43,
-       "text": [
-        "3"
-       ]
-      }
-     ],
-     "prompt_number": 43
-    },
-    {
-     "cell_type": "heading",
-     "level": 2,
-     "metadata": {},
-     "source": [
-      "Traversal "
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Write a post-order traversal function that prints each node."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def post(expr):\n",
-      "    \"\"\"\n",
-      "    Post-order traversal\n",
-      "\n",
-      "    >>> expr = x**2 - y*(2**(x + 3) + z)\n",
-      "    >>> post(expr)\n",
-      "    -1\n",
-      "    y\n",
-      "    2\n",
-      "    3\n",
-      "    x\n",
-      "    x + 3\n",
-      "    2**(x + 3)\n",
-      "    z\n",
-      "    2**(x + 3) + z\n",
-      "    -y*(2**(x + 3) + z)\n",
-      "    x\n",
-      "    2\n",
-      "    x**2\n",
-      "    x**2 - y*(2**(x + 3) + z)\n",
-      "    \"\"\"\n",
-      "    for arg in expr.args:\n",
-      "        post(arg)\n",
-      "    display(expr)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 44
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "expr = x**2 - y*(2**(x + 3) + z)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 45
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "post(expr)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$-1$$"
-       ],
-       "metadata": {},
-       "output_type": "display_data",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAABgAAAAPBAMAAAAMihLoAAAAJ1BMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAilU6eAAAADHRSTlMAIs3dRLsQq3aZ72YDTSHvAAAALklE\nQVQIHWNggIMwOIuBIfUYgpNejsRh4CCTI2QMAiYMZBsAcxDnrEOzYWwwDQBP9Q53CSxxJQAAAABJ\nRU5ErkJggg==\n",
-       "text": [
-        "-1"
-       ]
-      },
-      {
-       "latex": [
-        "$$y$$"
-       ],
-       "metadata": {},
-       "output_type": "display_data",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAAsAAAANBAMAAACN24kIAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAEImZIkR2MlTdu+/N\nq2Z6CBlbAAAAWElEQVQIHWNgVFZg8BdgYGL9wJDPwFDBPIFhFQODAHcCwzcGBoZ+AfbvQMqGgW0D\nkDrMwHUBSNkyxD8AUlJp9g5AioFBE4h5JzDuAFKcClwKQIojzRRIAgDYaQ5MI2ffIgAAAABJRU5E\nrkJggg==\n",
-       "text": [
-        "y"
-       ]
-      },
-      {
-       "latex": [
-        "$$z$$"
-       ],
-       "metadata": {},
-       "output_type": "display_data",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAAoAAAAJBAMAAAD5iKAgAAAALVBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADAOrOgAAAADnRSTlMARO8idrtmmRCrVIkyzciQ\n8DMAAAA4SURBVAgdY2BgVBIwYWAwTSkPYGBoYOhsYGBgYJ4AJBjEQQTXBhC5moFhAgPPtbJcAQZ2\nhjwtBgDU0whkAL7DjgAAAABJRU5ErkJggg==\n",
-       "text": [
-        "z"
-       ]
-      },
-      {
-       "latex": [
-        "$$2$$"
-       ],
-       "metadata": {},
-       "output_type": "display_data",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAAkAAAAOBAMAAAAPuiubAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIpnNu0SrdlQQ3e8y\niWbzIQYJAAAAT0lEQVQIHWNgVDIJYGAQY2D/wcCQycCwnoFh9wSG/AAG+wkM+kAJoMgEIMHzF8Rk\ndgCRKiCCPQFENjEwCjDwKDDwCTBI3b2rBVT8//8vBgBR7Q/Fm5CwxAAAAABJRU5ErkJggg==\n",
-       "text": [
-        "2"
-       ]
-      },
-      {
-       "latex": [
-        "$$3$$"
-       ],
-       "metadata": {},
-       "output_type": "display_data",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAAoAAAAOBAMAAADkjZCYAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAMom7VCKZRHbdzavv\nEGbh6M2uAAAATklEQVQIHWNgEFIyYWBgTWCob2Bg+sLAP4GBBUwyMIBEgGA1EDNqbQAxGXoKQCTP\nXwZWAQbmfwz3/4JI/gUMnF8ZOB4w1CswMLilLWEAAJ6qEfrOOFffAAAAAElFTkSuQmCC\n",
-       "text": [
-        "3"
-       ]
-      },
-      {
-       "latex": [
-        "$$x$$"
-       ],
-       "metadata": {},
-       "output_type": "display_data",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAAsAAAAJBAMAAAAWSsseAAAAKlBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADmU0mKAAAADXRSTlMAIol2q1SZEGbd7zK78ZNZ0gAA\nAEJJREFUCB1jYBAyETUzYGBX4JjBNYGBiYH5AusGBnYGlgMMIMBlAKZkNzAUMHAI2DIwFzDENpxi\nEGZgqDEqUm5gAAAhlwo0cLKzVgAAAABJRU5ErkJggg==\n",
-       "text": [
-        "x"
-       ]
-      },
-      {
-       "latex": [
-        "$$x + 3$$"
-       ],
-       "metadata": {},
-       "output_type": "display_data",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAC8AAAAQBAMAAAB0JTvnAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIol2q1SZEGbd7zK7\nzUTvhYErAAAAvUlEQVQYGWNgwATcSjoBmKJAETEGvs8oEuwCEK5+AMNPFAlWAwg3HpcEA8QoIRNR\nM4hSmA4GBl4HBgZ2BY4ZXBPAZsAlNl0B8pkYmD+wbkCVYGBeB9TBwHIALMzAANfBwLC+ACjGBbaB\n7e7dm2vv3nUACkgzMJxvANLyGxhA8nAd7P8LQBIcAvYMzCgSDH8ZGOYLMMQ3nGIQBmuA22HBwPeJ\ngaHGqEi5AVWCNS03ACICJZFchSLOwAd2HlQMAHhUI/VdUwmwAAAAAElFTkSuQmCC\n",
-       "text": [
-        "x + 3"
-       ]
-      },
-      {
-       "latex": [
-        "$$2^{x + 3}$$"
-       ],
-       "metadata": {},
-       "output_type": "display_data",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAACcAAAAUBAMAAAD8YzkFAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIpnNu0SrdlQQ3e8y\niWbzIQYJAAAA1UlEQVQYGWNgQANzazNRRRqAXD0GZVRBByA3ieE9piADw2WoIG9ZeA6Q6QDicm4F\nkUBwk81hB5ByAGLOkgsMDIxKJgEMAcwPgHyISgYVBgYxBvYfDAz8Agxsxsabjc2BUvINDEBXrWdg\nOM1wAKKS8SuD/AOG3RMY8mM+XGYAmgTSzrmQ4fUEBvsJDPqR7k21EyCCDMdrE4EsoHaQAAg4gEkw\nwfMXxk6AMRgYmB0QbDgL6C4MwJ6AIcTA0MTAKIAuzKPAwIchKHX3rha6Qob1////QhcEANeKK2sF\nlvrRAAAAAElFTkSuQmCC\n",
-       "text": [
-        " x + 3\n",
-        "2     "
-       ]
-      },
-      {
-       "latex": [
-        "$$2^{x + 3} + z$$"
-       ],
-       "metadata": {},
-       "output_type": "display_data",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAEwAAAAWBAMAAACYrGeJAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIpnNu0SrdlQQ3e8y\niWbzIQYJAAABRElEQVQoFWNgQANzazPRRDC4DUARPQZlDHE0AQcgP4nhPZooBhekjIHhMpjERvCW\nhecAxR1AcpxbQSRWcJPNYQdQwgGIOUsuYFPCqGQSwBDA/AAk5wAiGFTAJBohxsD+g4GBX4CBzdh4\ns7E5UFa+AU0JiAsMpfUMDKcZDgDZDgwMjF8Z5B8AmUAwEUJByN0TGPJjPlxmALnIAei0hQyvJ0Bk\n2iEUhLSfwKAf6d5UC5JzAOLjtYkQCQYUZUCx9VDtUC9AVcGVse4OEAeK8fyFSSTAGGAaZprIcyUH\noAAziMACYMomMEwDWYc1nIDiMGUMjAlAHjuIwADKxsarjY3NwOJBILKJgVEAQxVIAGYaxwUgh0eB\ngQ+/sl4GhgQGqbt3tbAaBjONx07vcQDD+v//f+FVxsTwHpR6cAKY23AqgEiEI8kDANtZPfbhKwet\nAAAAAElFTkSuQmCC\n",
-       "text": [
-        " x + 3    \n",
-        "2      + z"
-       ]
-      },
-      {
-       "latex": [
-        "$$- y \\left(2^{x + 3} + z\\right)$$"
-       ],
-       "metadata": {},
-       "output_type": "display_data",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAHwAAAAcBAMAAABRxMbXAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIs3dRBCJmXYyVLvv\nq2aiBbi/AAACQ0lEQVQ4EZWTMWgUQRSG/93s3u7esZdDGyFKjhVBENSgCFbZRtTKrVIpWQKmPgx6\nhRCvuhQaCNhYKG5lLK+SNIIEC5EUJ6Ji5WElKOREI2hhfG9m5273dkjOV8y8/3vvn9mZuQPGiLn2\nuzG6tC0J0WXc0Na00AqzuEPiA7azSOWxSnLzo5xiO7CQY6nIN6bQPiaT0uqlj5QJu/0yLeYmt5WT\nUvg9OV/3O68pY7t9N5ZsZJwZ0SwPA0bzRIjQ7LGUH3+b00KsFgjQBI7A/QNM1uAHwWZwnJqmE00n\n5qMipWPSK88CD7FGVdrd+Inpnmy0a1nDREozzOsDWxE+Xe4vICZOdnsG3yLZUm7JWY4OFUfCfQGc\ninDnwsZ6mz3c8aD9Ju3K26v9FANzt2DskPLrAs2ylYPtw1B2ays8BFhskBFfgcuLVbqsvV+SAkIq\nAWWf+tKkdb3fquAlS6gQgdlgZHKqCWWPcC0Sd3rgDMdZG68w2SLDhLDr3xmD3WF0qdem502jvIPH\na5QLu8vFQjhBcHQzCETtIlfpRVU4ddzj3OTqOoyaKuRm9fHlmLExODuf+Tkjv0NX0kB1b/sTcafW\nd3aIcLrWX07c08DBxcUlSUfHdHfv5PLnEMi8u72xItay+vSL3d39MWqUOrU72OZ/Y6me6SrRvhTD\n82RqKlVnl9psKY63uJoI8X6ANInVysL54QWdwzNZuZ9t2Dv/Oiw/XQmlqCRDuE92XlM36hqoRdWG\nDtObjhdT2rZqosVFeLOI/pP8A3zcd135cM5RAAAAAElFTkSuQmCC\n",
-       "text": [
-        "   \u239b x + 3    \u239e\n",
-        "-y\u22c5\u239d2      + z\u23a0"
-       ]
-      },
-      {
-       "latex": [
-        "$$x$$"
-       ],
-       "metadata": {},
-       "output_type": "display_data",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAAsAAAAJBAMAAAAWSsseAAAAKlBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADmU0mKAAAADXRSTlMAIol2q1SZEGbd7zK78ZNZ0gAA\nAEJJREFUCB1jYBAyETUzYGBX4JjBNYGBiYH5AusGBnYGlgMMIMBlAKZkNzAUMHAI2DIwFzDENpxi\nEGZgqDEqUm5gAAAhlwo0cLKzVgAAAABJRU5ErkJggg==\n",
-       "text": [
-        "x"
-       ]
-      },
-      {
-       "latex": [
-        "$$2$$"
-       ],
-       "metadata": {},
-       "output_type": "display_data",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAAkAAAAOBAMAAAAPuiubAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIpnNu0SrdlQQ3e8y\niWbzIQYJAAAAT0lEQVQIHWNgVDIJYGAQY2D/wcCQycCwnoFh9wSG/AAG+wkM+kAJoMgEIMHzF8Rk\ndgCRKiCCPQFENjEwCjDwKDDwCTBI3b2rBVT8//8vBgBR7Q/Fm5CwxAAAAABJRU5ErkJggg==\n",
-       "text": [
-        "2"
-       ]
-      },
-      {
-       "latex": [
-        "$$x^{2}$$"
-       ],
-       "metadata": {},
-       "output_type": "display_data",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAABQAAAAUBAMAAAB/pwA+AAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIol2q1SZEGbd7zK7\nzUTvhYErAAAAgUlEQVQIHWNggAC1IwVQFlsB2wUok1OA8TeUyRXA/g/KZGBg/Q5n8irAmSpwFgdC\n8BHDbqgw99FQdyiT6///DwwMQiaiZgZgEXYFjhlcE8BMJgbmD6wbIKIMLAfADBDBBVEJYspvYCgA\n0QwcAvYMzBBmfMMpBmGwIEONUZFyA5gJAEICFuq4U3XkAAAAAElFTkSuQmCC\n",
-       "text": [
-        " 2\n",
-        "x "
-       ]
-      },
-      {
-       "latex": [
-        "$$x^{2} - y \\left(2^{x + 3} + z\\right)$$"
-       ],
-       "metadata": {},
-       "output_type": "display_data",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAJsAAAAcBAMAAACE+tDfAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIol2q1SZEGbd7zK7\nzUTvhYErAAACsUlEQVRIDY1US2gTURQ9k898MrXG7046mFJxIRRTC7ppdrpoJSiuG9Cl1VFXSsW4\nsLgzuJDqKhvpTrLRjUiCtCAiUlCKiiNBdy5MRKSi0HjvzJvJTPKmyYV579xzzju8efMBvJpYtQUa\nPGm58QFm1VbXB+eQI02XWh5kNrLKv7i4H2FhhJpUSW+HOYETXS5T1La6XQSZhXDLcUBCdisRY3oz\nvCqEb4pzyp2eqgFe3I1myBDAfICAHVaoCcNTXpOwZzNFEXftZdgQYCMbQIx3YQQpVWD/wluM4gPz\n3u7UBuPeShYCRrcCGAVqCUoBM7Sxn8Cc88lxJgHld9TkdVr3vL7iucwBZJpI2TDaMKsmOXh3Y03l\njzBfiSxa9jtz7dxJH0fnOiWuILVVT6zzm8Bx17P6ijCdjZgv+l2m02n7ODqfoKe0CXVr8dj5Q6Rw\nnJkf9w89GnePxN1T+6bpOHpKm7AwZhM55wqGfywcFyo/7vsThTJaNjRLX85UQg4PJkbbmGG46vZ1\ny53oixCzmESc8mqab7ReQwLJdroWNVH3VK3gDbMbrvTZHfsHEadB46Mfa0JDqhHYlI8PuZqAnZnE\nL+Yf8KA2aJCVf7PYy+qtIg20UFLztun+FNy4KYkBWHCcR47znrXREo+0OxpqsLmJ1gKSVWbYnS5h\nF+P+8nd3xpUoSc/OICmJ28BIgT2zdD0DbjPuLxGXttxn1Mpivvwae/p9uIBWmenj9EndPzhRkViI\nEnEvlu5+oY7eu8WjV3NliXcxfznLdAswOp3O9nEl/W+RvEckOQF12EU7awEhAf7ZedI7icOjUhXt\nsYtSVqyHhG9hUaN/TkwZ1ojlSmbMbUrW6Q0J6VHp/CWhrcV6egVj23MR7gO9q2L7pVglJNA7NVwp\njaF8d4Zy0YdtD2kc3vYf1SqGVaR9gp0AAAAASUVORK5CYII=\n",
-       "text": [
-        " 2     \u239b x + 3    \u239e\n",
-        "x  - y\u22c5\u239d2      + z\u23a0"
-       ]
-      }
-     ],
-     "prompt_number": 46
+     "output_type": "execute_result"
     }
    ],
-   "metadata": {}
+   "source": [
+    "explicit_classes1()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def explicit_classes2():\n",
+    "    \"\"\"\n",
+    "    Returns the expression x**(x**y), built using SymPy classes explicitly.\n",
+    "\n",
+    "    >>> explicit_classes2()\n",
+    "    x**(x**y)\n",
+    "    \"\"\"\n",
+    "    return Pow(x, Pow(x, y))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAUBAMAAABscEDKAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIol2q1SZEGbd7zK7\nRM2RoJmtAAAAlUlEQVQYGWNgQIBgBT4Eh4GhN2ELMpdlgwUyl5PhNIyr7Guygdl4AZTLVODDFSDB\nqgDl8jK8YGDY1gzlAamPCCaQxb2AG4m/n+kBExK3xjRZHcIVMhE1M4DLsCtwzOCaAOcyMTB/YN0A\n57IzsByAc0AMLoROEFd+A0MBiAYDDgF7BmYEN77hFIMwTI6BocaoSLkBzgUAQBUYbmElZeQAAAAA\nSUVORK5CYII=\n",
+      "text/latex": [
+       "$$x^{x^{y}}$$"
+      ],
+      "text/plain": [
+       " ⎛ y⎞\n",
+       " ⎝x ⎠\n",
+       "x    "
+      ]
+     },
+     "execution_count": 38,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "explicit_classes2()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def explicit_classes3():\n",
+    "    \"\"\"\n",
+    "    Returns the expression x - y/z, built using SymPy classes explicitly.\n",
+    "\n",
+    "    >>> explicit_classes3()\n",
+    "    x - y/z\n",
+    "    \"\"\"\n",
+    "    return Add(x, Mul(-1, Mul(y, Pow(z, -1))))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAADMAAAAlBAMAAAAdAMyfAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIol2q1SZEGbd7zK7\nzUTvhYErAAAA7UlEQVQoFWNgwALY1RQY5AuwSDAwMPF9YLDHKsOwlW0CwxnsUgVcBgyfsUsxxBdw\n/8YhlcvAvACH1DUGHgccUikM7xtwSNUY5wvgkGJg0MQhwzKBfSkOKU4FHgUcUqzGeThk4MJCJqJm\nBnAeMoNdgWMG1wRkETibiYH5A+sGOBeZwc7AcgDMl50JAvNA7P8g8AHIAMYALiC/gaEAqxyHgD0D\nM3ap+IZTDMJYNTHUGBUpN2CXGsyifKse4PAQg0xz2gEcTi9gKMEeQED1jA44NDEwPMMpw6qAUyqI\ngcEBuyT3jYzeB9il2Bj6gakXAFr6LczlCLDrAAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$$x - \\frac{y}{z}$$"
+      ],
+      "text/plain": [
+       "    y\n",
+       "x - ─\n",
+       "    z"
+      ]
+     },
+     "execution_count": 40,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "explicit_classes3()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Nested args"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "expr = x**2 - y*(2**(x + 3) + z)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Use nested `.args` calls to get the 3 in expr."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def nested_args():\n",
+    "    \"\"\"\n",
+    "    Get the 3 in the above expression.\n",
+    "\n",
+    "    >>> nested_args()\n",
+    "    3\n",
+    "    \"\"\"\n",
+    "    expr = x**2 - y*(2**(x + 3) + z)\n",
+    "    return expr.args[0].args[2].args[1].args[1].args[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAAoAAAAOBAMAAADkjZCYAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAMom7VCKZRHbdzavv\nEGbh6M2uAAAATklEQVQIHWNgEFIyYWBgTWCob2Bg+sLAP4GBBUwyMIBEgGA1EDNqbQAxGXoKQCTP\nXwZWAQbmfwz3/4JI/gUMnF8ZOB4w1CswMLilLWEAAJ6qEfrOOFffAAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$$3$$"
+      ],
+      "text/plain": [
+       "3"
+      ]
+     },
+     "execution_count": 43,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "nested_args()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Traversal "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Write a post-order traversal function that prints each node."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def post(expr):\n",
+    "    \"\"\"\n",
+    "    Post-order traversal\n",
+    "\n",
+    "    >>> expr = x**2 - y*(2**(x + 3) + z)\n",
+    "    >>> post(expr)\n",
+    "    -1\n",
+    "    y\n",
+    "    2\n",
+    "    3\n",
+    "    x\n",
+    "    x + 3\n",
+    "    2**(x + 3)\n",
+    "    z\n",
+    "    2**(x + 3) + z\n",
+    "    -y*(2**(x + 3) + z)\n",
+    "    x\n",
+    "    2\n",
+    "    x**2\n",
+    "    x**2 - y*(2**(x + 3) + z)\n",
+    "    \"\"\"\n",
+    "    for arg in expr.args:\n",
+    "        post(arg)\n",
+    "    display(expr)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "expr = x**2 - y*(2**(x + 3) + z)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 46,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABgAAAAPBAMAAAAMihLoAAAAJ1BMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAilU6eAAAADHRSTlMAIs3dRLsQq3aZ72YDTSHvAAAALklE\nQVQIHWNggIMwOIuBIfUYgpNejsRh4CCTI2QMAiYMZBsAcxDnrEOzYWwwDQBP9Q53CSxxJQAAAABJ\nRU5ErkJggg==\n",
+      "text/latex": [
+       "$$-1$$"
+      ],
+      "text/plain": [
+       "-1"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAAsAAAANBAMAAACN24kIAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAEImZIkR2MlTdu+/N\nq2Z6CBlbAAAAWElEQVQIHWNgVFZg8BdgYGL9wJDPwFDBPIFhFQODAHcCwzcGBoZ+AfbvQMqGgW0D\nkDrMwHUBSNkyxD8AUlJp9g5AioFBE4h5JzDuAFKcClwKQIojzRRIAgDYaQ5MI2ffIgAAAABJRU5E\nrkJggg==\n",
+      "text/latex": [
+       "$$y$$"
+      ],
+      "text/plain": [
+       "y"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAAoAAAAJBAMAAAD5iKAgAAAALVBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADAOrOgAAAADnRSTlMARO8idrtmmRCrVIkyzciQ\n8DMAAAA4SURBVAgdY2BgVBIwYWAwTSkPYGBoYOhsYGBgYJ4AJBjEQQTXBhC5moFhAgPPtbJcAQZ2\nhjwtBgDU0whkAL7DjgAAAABJRU5ErkJggg==\n",
+      "text/latex": [
+       "$$z$$"
+      ],
+      "text/plain": [
+       "z"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAAkAAAAOBAMAAAAPuiubAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIpnNu0SrdlQQ3e8y\niWbzIQYJAAAAT0lEQVQIHWNgVDIJYGAQY2D/wcCQycCwnoFh9wSG/AAG+wkM+kAJoMgEIMHzF8Rk\ndgCRKiCCPQFENjEwCjDwKDDwCTBI3b2rBVT8//8vBgBR7Q/Fm5CwxAAAAABJRU5ErkJggg==\n",
+      "text/latex": [
+       "$$2$$"
+      ],
+      "text/plain": [
+       "2"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAAoAAAAOBAMAAADkjZCYAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAMom7VCKZRHbdzavv\nEGbh6M2uAAAATklEQVQIHWNgEFIyYWBgTWCob2Bg+sLAP4GBBUwyMIBEgGA1EDNqbQAxGXoKQCTP\nXwZWAQbmfwz3/4JI/gUMnF8ZOB4w1CswMLilLWEAAJ6qEfrOOFffAAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$$3$$"
+      ],
+      "text/plain": [
+       "3"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAAsAAAAJBAMAAAAWSsseAAAAKlBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADmU0mKAAAADXRSTlMAIol2q1SZEGbd7zK78ZNZ0gAA\nAEJJREFUCB1jYBAyETUzYGBX4JjBNYGBiYH5AusGBnYGlgMMIMBlAKZkNzAUMHAI2DIwFzDENpxi\nEGZgqDEqUm5gAAAhlwo0cLKzVgAAAABJRU5ErkJggg==\n",
+      "text/latex": [
+       "$$x$$"
+      ],
+      "text/plain": [
+       "x"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAC8AAAAQBAMAAAB0JTvnAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIol2q1SZEGbd7zK7\nzUTvhYErAAAAvUlEQVQYGWNgwATcSjoBmKJAETEGvs8oEuwCEK5+AMNPFAlWAwg3HpcEA8QoIRNR\nM4hSmA4GBl4HBgZ2BY4ZXBPAZsAlNl0B8pkYmD+wbkCVYGBeB9TBwHIALMzAANfBwLC+ACjGBbaB\n7e7dm2vv3nUACkgzMJxvANLyGxhA8nAd7P8LQBIcAvYMzCgSDH8ZGOYLMMQ3nGIQBmuA22HBwPeJ\ngaHGqEi5AVWCNS03ACICJZFchSLOwAd2HlQMAHhUI/VdUwmwAAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$$x + 3$$"
+      ],
+      "text/plain": [
+       "x + 3"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAACcAAAAUBAMAAAD8YzkFAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIpnNu0SrdlQQ3e8y\niWbzIQYJAAAA1UlEQVQYGWNgQANzazNRRRqAXD0GZVRBByA3ieE9piADw2WoIG9ZeA6Q6QDicm4F\nkUBwk81hB5ByAGLOkgsMDIxKJgEMAcwPgHyISgYVBgYxBvYfDAz8Agxsxsabjc2BUvINDEBXrWdg\nOM1wAKKS8SuD/AOG3RMY8mM+XGYAmgTSzrmQ4fUEBvsJDPqR7k21EyCCDMdrE4EsoHaQAAg4gEkw\nwfMXxk6AMRgYmB0QbDgL6C4MwJ6AIcTA0MTAKIAuzKPAwIchKHX3rha6Qob1////QhcEANeKK2sF\nlvrRAAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$$2^{x + 3}$$"
+      ],
+      "text/plain": [
+       " x + 3\n",
+       "2     "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAEwAAAAWBAMAAACYrGeJAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIpnNu0SrdlQQ3e8y\niWbzIQYJAAABRElEQVQoFWNgQANzazPRRDC4DUARPQZlDHE0AQcgP4nhPZooBhekjIHhMpjERvCW\nhecAxR1AcpxbQSRWcJPNYQdQwgGIOUsuYFPCqGQSwBDA/AAk5wAiGFTAJBohxsD+g4GBX4CBzdh4\ns7E5UFa+AU0JiAsMpfUMDKcZDgDZDgwMjF8Z5B8AmUAwEUJByN0TGPJjPlxmALnIAei0hQyvJ0Bk\n2iEUhLSfwKAf6d5UC5JzAOLjtYkQCQYUZUCx9VDtUC9AVcGVse4OEAeK8fyFSSTAGGAaZprIcyUH\noAAziMACYMomMEwDWYc1nIDiMGUMjAlAHjuIwADKxsarjY3NwOJBILKJgVEAQxVIAGYaxwUgh0eB\ngQ+/sl4GhgQGqbt3tbAaBjONx07vcQDD+v//f+FVxsTwHpR6cAKY23AqgEiEI8kDANtZPfbhKwet\nAAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$$2^{x + 3} + z$$"
+      ],
+      "text/plain": [
+       " x + 3    \n",
+       "2      + z"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAHwAAAAcBAMAAABRxMbXAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIs3dRBCJmXYyVLvv\nq2aiBbi/AAACQ0lEQVQ4EZWTMWgUQRSG/93s3u7esZdDGyFKjhVBENSgCFbZRtTKrVIpWQKmPgx6\nhRCvuhQaCNhYKG5lLK+SNIIEC5EUJ6Ji5WElKOREI2hhfG9m5273dkjOV8y8/3vvn9mZuQPGiLn2\nuzG6tC0J0WXc0Na00AqzuEPiA7azSOWxSnLzo5xiO7CQY6nIN6bQPiaT0uqlj5QJu/0yLeYmt5WT\nUvg9OV/3O68pY7t9N5ZsZJwZ0SwPA0bzRIjQ7LGUH3+b00KsFgjQBI7A/QNM1uAHwWZwnJqmE00n\n5qMipWPSK88CD7FGVdrd+Inpnmy0a1nDREozzOsDWxE+Xe4vICZOdnsG3yLZUm7JWY4OFUfCfQGc\ninDnwsZ6mz3c8aD9Ju3K26v9FANzt2DskPLrAs2ylYPtw1B2ays8BFhskBFfgcuLVbqsvV+SAkIq\nAWWf+tKkdb3fquAlS6gQgdlgZHKqCWWPcC0Sd3rgDMdZG68w2SLDhLDr3xmD3WF0qdem502jvIPH\na5QLu8vFQjhBcHQzCETtIlfpRVU4ddzj3OTqOoyaKuRm9fHlmLExODuf+Tkjv0NX0kB1b/sTcafW\nd3aIcLrWX07c08DBxcUlSUfHdHfv5PLnEMi8u72xItay+vSL3d39MWqUOrU72OZ/Y6me6SrRvhTD\n82RqKlVnl9psKY63uJoI8X6ANInVysL54QWdwzNZuZ9t2Dv/Oiw/XQmlqCRDuE92XlM36hqoRdWG\nDtObjhdT2rZqosVFeLOI/pP8A3zcd135cM5RAAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$$- y \\left(2^{x + 3} + z\\right)$$"
+      ],
+      "text/plain": [
+       "   ⎛ x + 3    ⎞\n",
+       "-y⋅⎝2      + z⎠"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAAsAAAAJBAMAAAAWSsseAAAAKlBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADmU0mKAAAADXRSTlMAIol2q1SZEGbd7zK78ZNZ0gAA\nAEJJREFUCB1jYBAyETUzYGBX4JjBNYGBiYH5AusGBnYGlgMMIMBlAKZkNzAUMHAI2DIwFzDENpxi\nEGZgqDEqUm5gAAAhlwo0cLKzVgAAAABJRU5ErkJggg==\n",
+      "text/latex": [
+       "$$x$$"
+      ],
+      "text/plain": [
+       "x"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAAkAAAAOBAMAAAAPuiubAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIpnNu0SrdlQQ3e8y\niWbzIQYJAAAAT0lEQVQIHWNgVDIJYGAQY2D/wcCQycCwnoFh9wSG/AAG+wkM+kAJoMgEIMHzF8Rk\ndgCRKiCCPQFENjEwCjDwKDDwCTBI3b2rBVT8//8vBgBR7Q/Fm5CwxAAAAABJRU5ErkJggg==\n",
+      "text/latex": [
+       "$$2$$"
+      ],
+      "text/plain": [
+       "2"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABQAAAAUBAMAAAB/pwA+AAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIol2q1SZEGbd7zK7\nzUTvhYErAAAAgUlEQVQIHWNggAC1IwVQFlsB2wUok1OA8TeUyRXA/g/KZGBg/Q5n8irAmSpwFgdC\n8BHDbqgw99FQdyiT6///DwwMQiaiZgZgEXYFjhlcE8BMJgbmD6wbIKIMLAfADBDBBVEJYspvYCgA\n0QwcAvYMzBBmfMMpBmGwIEONUZFyA5gJAEICFuq4U3XkAAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$$x^{2}$$"
+      ],
+      "text/plain": [
+       " 2\n",
+       "x "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAJsAAAAcBAMAAACE+tDfAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIol2q1SZEGbd7zK7\nzUTvhYErAAACsUlEQVRIDY1US2gTURQ9k898MrXG7046mFJxIRRTC7ppdrpoJSiuG9Cl1VFXSsW4\nsLgzuJDqKhvpTrLRjUiCtCAiUlCKiiNBdy5MRKSi0HjvzJvJTPKmyYV579xzzju8efMBvJpYtQUa\nPGm58QFm1VbXB+eQI02XWh5kNrLKv7i4H2FhhJpUSW+HOYETXS5T1La6XQSZhXDLcUBCdisRY3oz\nvCqEb4pzyp2eqgFe3I1myBDAfICAHVaoCcNTXpOwZzNFEXftZdgQYCMbQIx3YQQpVWD/wluM4gPz\n3u7UBuPeShYCRrcCGAVqCUoBM7Sxn8Cc88lxJgHld9TkdVr3vL7iucwBZJpI2TDaMKsmOXh3Y03l\njzBfiSxa9jtz7dxJH0fnOiWuILVVT6zzm8Bx17P6ijCdjZgv+l2m02n7ODqfoKe0CXVr8dj5Q6Rw\nnJkf9w89GnePxN1T+6bpOHpKm7AwZhM55wqGfywcFyo/7vsThTJaNjRLX85UQg4PJkbbmGG46vZ1\ny53oixCzmESc8mqab7ReQwLJdroWNVH3VK3gDbMbrvTZHfsHEadB46Mfa0JDqhHYlI8PuZqAnZnE\nL+Yf8KA2aJCVf7PYy+qtIg20UFLztun+FNy4KYkBWHCcR47znrXREo+0OxpqsLmJ1gKSVWbYnS5h\nF+P+8nd3xpUoSc/OICmJ28BIgT2zdD0DbjPuLxGXttxn1Mpivvwae/p9uIBWmenj9EndPzhRkViI\nEnEvlu5+oY7eu8WjV3NliXcxfznLdAswOp3O9nEl/W+RvEckOQF12EU7awEhAf7ZedI7icOjUhXt\nsYtSVqyHhG9hUaN/TkwZ1ojlSmbMbUrW6Q0J6VHp/CWhrcV6egVj23MR7gO9q2L7pVglJNA7NVwp\njaF8d4Zy0YdtD2kc3vYf1SqGVaR9gp0AAAAASUVORK5CYII=\n",
+      "text/latex": [
+       "$$x^{2} - y \\left(2^{x + 3} + z\\right)$$"
+      ],
+      "text/plain": [
+       " 2     ⎛ x + 3    ⎞\n",
+       "x  - y⋅⎝2      + z⎠"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "post(expr)"
+   ]
   }
- ]
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 0
 }

--- a/tutorial_exercises/Advanced-Advanced Expression Manipulation.ipynb
+++ b/tutorial_exercises/Advanced-Advanced Expression Manipulation.ipynb
@@ -1,205 +1,201 @@
 {
- "metadata": {
-  "name": "",
-  "signature": "sha256:d5125a094772f2986705f9d9accd84b81e25c5a0fcac51a0ca9ff3bf7adbc1f2"
- },
- "nbformat": 3,
- "nbformat_minor": 0,
- "worksheets": [
+ "cells": [
   {
-   "cells": [
-    {
-     "cell_type": "heading",
-     "level": 1,
-     "metadata": {},
-     "source": [
-      "Advanced Expression Manipulation"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "from sympy import *\n",
-      "x, y, z = symbols('x y z')"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "For each exercise, fill in the function according to its docstring. "
-     ]
-    },
-    {
-     "cell_type": "heading",
-     "level": 2,
-     "metadata": {},
-     "source": [
-      "Creating expressions from classes"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Create the following objects without using any mathematical operators like `+`, `-`, `*`, `/`, or `**` by explicitly using the classes `Add`, `Mul`, and `Pow`.  You may use `x` instead of `Symbol('x')` and `4` instead of `Integer(4)`.\n",
-      "\n",
-      "$$x^2 + 4xyz$$\n",
-      "$$x^{(x^y)}$$\n",
-      "$$x - \\frac{y}{z}$$\n"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def explicit_classes1():\n",
-      "    \"\"\"\n",
-      "    Returns the expression x**2 + 4*x*y*z, built using SymPy classes explicitly.\n",
-      "\n",
-      "    >>> explicit_classes1()\n",
-      "    x**2 + 4*x*y*z\n",
-      "    \"\"\"\n"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def explicit_classes2():\n",
-      "    \"\"\"\n",
-      "    Returns the expression x**(x**y), built using SymPy classes explicitly.\n",
-      "\n",
-      "    >>> explicit_classes2()\n",
-      "    x**(x**y)\n",
-      "    \"\"\"\n"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def explicit_classes3():\n",
-      "    \"\"\"\n",
-      "    Returns the expression x - y/z, built using SymPy classes explicitly.\n",
-      "\n",
-      "    >>> explicit_classes3()\n",
-      "    x - y/z\n",
-      "    \"\"\"\n"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "heading",
-     "level": 2,
-     "metadata": {},
-     "source": [
-      "Nested args"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "expr = x**2 - y*(2**(x + 3) + z)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Use nested `.args` calls to get the 3 in expr."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def nested_args():\n",
-      "    \"\"\"\n",
-      "    Get the 3 in the above expression.\n",
-      "\n",
-      "    >>> nested_args()\n",
-      "    3\n",
-      "    \"\"\"\n"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "heading",
-     "level": 2,
-     "metadata": {},
-     "source": [
-      "Traversal "
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Write a post-order traversal function that prints each node."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def post(expr):\n",
-      "    \"\"\"\n",
-      "    Post-order traversal\n",
-      "\n",
-      "    >>> expr = x**2 - y*(2**(x + 3) + z)\n",
-      "    >>> post(expr)\n",
-      "    -1\n",
-      "    y\n",
-      "    2\n",
-      "    3\n",
-      "    x\n",
-      "    x + 3\n",
-      "    2**(x + 3)\n",
-      "    z\n",
-      "    2**(x + 3) + z\n",
-      "    -y*(2**(x + 3) + z)\n",
-      "    x\n",
-      "    2\n",
-      "    x**2\n",
-      "    x**2 - y*(2**(x + 3) + z)\n",
-      "    \"\"\"\n"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "for i in postorder_traversal(expr):\n",
-      "    print(i)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    }
-   ],
-   "metadata": {}
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Advanced Expression Manipulation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from sympy import *\n",
+    "x, y, z = symbols('x y z')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For each exercise, fill in the function according to its docstring. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Creating expressions from classes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Create the following objects without using any mathematical operators like `+`, `-`, `*`, `/`, or `**` by explicitly using the classes `Add`, `Mul`, and `Pow`.  You may use `x` instead of `Symbol('x')` and `4` instead of `Integer(4)`.\n",
+    "\n",
+    "$$x^2 + 4xyz$$\n",
+    "$$x^{(x^y)}$$\n",
+    "$$x - \\frac{y}{z}$$\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def explicit_classes1():\n",
+    "    \"\"\"\n",
+    "    Returns the expression x**2 + 4*x*y*z, built using SymPy classes explicitly.\n",
+    "\n",
+    "    >>> explicit_classes1()\n",
+    "    x**2 + 4*x*y*z\n",
+    "    \"\"\"\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def explicit_classes2():\n",
+    "    \"\"\"\n",
+    "    Returns the expression x**(x**y), built using SymPy classes explicitly.\n",
+    "\n",
+    "    >>> explicit_classes2()\n",
+    "    x**(x**y)\n",
+    "    \"\"\"\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def explicit_classes3():\n",
+    "    \"\"\"\n",
+    "    Returns the expression x - y/z, built using SymPy classes explicitly.\n",
+    "\n",
+    "    >>> explicit_classes3()\n",
+    "    x - y/z\n",
+    "    \"\"\"\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Nested args"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "expr = x**2 - y*(2**(x + 3) + z)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Use nested `.args` calls to get the 3 in expr."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def nested_args():\n",
+    "    \"\"\"\n",
+    "    Get the 3 in the above expression.\n",
+    "\n",
+    "    >>> nested_args()\n",
+    "    3\n",
+    "    \"\"\"\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Traversal "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Write a post-order traversal function that prints each node."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def post(expr):\n",
+    "    \"\"\"\n",
+    "    Post-order traversal\n",
+    "\n",
+    "    >>> expr = x**2 - y*(2**(x + 3) + z)\n",
+    "    >>> post(expr)\n",
+    "    -1\n",
+    "    y\n",
+    "    2\n",
+    "    3\n",
+    "    x\n",
+    "    x + 3\n",
+    "    2**(x + 3)\n",
+    "    z\n",
+    "    2**(x + 3) + z\n",
+    "    -y*(2**(x + 3) + z)\n",
+    "    x\n",
+    "    2\n",
+    "    x**2\n",
+    "    x**2 - y*(2**(x + 3) + z)\n",
+    "    \"\"\"\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "for i in postorder_traversal(expr):\n",
+    "    print(i)"
+   ]
   }
- ]
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 0
 }

--- a/tutorial_exercises/Advanced-Basic Operations Solutions.ipynb
+++ b/tutorial_exercises/Advanced-Basic Operations Solutions.ipynb
@@ -1,1013 +1,1052 @@
 {
- "metadata": {
-  "name": "",
-  "signature": "sha256:6df457da3dcbe607a894a72d85b091b46acbb5058e13449c37b3c7ac703ec11b"
- },
- "nbformat": 3,
- "nbformat_minor": 0,
- "worksheets": [
+ "cells": [
   {
-   "cells": [
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Basic Operations Solutions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from sympy import *\n",
+    "init_printing()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For each exercise, fill in the function according to its docstring. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Substitution"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Write a function that takes a list of expressions, a variable, and a point, and evaluates each expression in the list at that point."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def evaluate(exprs, x, x0):\n",
+    "    \"\"\"\n",
+    "    Evaluate each expression in exprs at the point x = x0.\n",
+    "\n",
+    "    >>> x, y = symbols('x y')\n",
+    "    >>> exprs = [x**2, cos(x), x*y]\n",
+    "    >>> evaluate(exprs, x, 1)\n",
+    "    [1, cos(1), y]\n",
+    "    >>> evaluate(exprs, y, 0)\n",
+    "    [x**2, cos(x), 0]\n",
+    "    \"\"\"\n",
+    "    return [expr.subs(x, x0) for expr in exprs]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "x, y = symbols('x y')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "exprs = [x**2, cos(x), x*y]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
     {
-     "cell_type": "heading",
-     "level": 1,
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAI4AAAAZBAMAAAAVsAvAAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAu90iEKt2me/NZkSJ\nVDK0ujvUAAAB/UlEQVQ4Ea2Vv0vDQBTHv6mxsaaNPxBcQ9FNMEtdGwfBQdBFJ5FOFRd1UfwFFuyo\n2M01swoKgriIQVAHUfofWJwEEQV/gIjiu4sXk9LTQvugd++9+77P5d6lLdqTFmo1PdkDs1YIr09V\nyzn0ttuR7PrD6ZAs+2ljhFxSaSWaK5jH6X+psBRKxWyAqwqhtB9wzsDov5ws4Kl2/dKQ4z1P9F9O\nnqq4ajBU7gdVcnR2HM5Rin5t0JFxUitXaJifLOJwe4r0mksD58Rng+WAeuEibUPCMT5wV7q1Ma62\nIkKFMYcGzkmUNTquP2EGMk6sFXuldSB934U4IZr2BUfPkRewB81Em5STdgH9E2iZ3RwrUVWLzzGe\nAhBy7aYM3qScEwdo/qD6wlDv658c3NjGl5Tz6AIJ9jwTFvaKdC76eP0pPxcWEc0FOSopfYsUAIf6\n83icgZYBFIeWeJ+bCwgpsQVlJMgZNkkqzPhE1Dqy0JnIQ7EAftvi3kNKzIE1gd+7tvC+hMFnAWFz\nav4axviZo59nLynUTXqHmAqx/TJlf3aVNvLeH1aJAz5KhjWRZ9+LMuUppQIcR0grzbsieU6OIwKa\nG011g6ZqOex3g5lKFxDiRFzFpdQvJ0qR3BroTpg1Ui9CykR2meV/OSz6w/q8tWmJpGqOpF6k68dJ\n1uX/q/sbt9B8wH311agAAAAASUVORK5CYII=\n",
+      "text/latex": [
+       "$$\\begin{bmatrix}1, & \\cos{\\left (1 \\right )}, & y\\end{bmatrix}$$"
+      ],
+      "text/plain": [
+       "[1, cos(1), y]"
+      ]
+     },
+     "execution_count": 5,
      "metadata": {},
-     "source": [
-      "Basic Operations Solutions"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "from sympy import *\n",
-      "init_printing()"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 1
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "For each exercise, fill in the function according to its docstring. "
-     ]
-    },
-    {
-     "cell_type": "heading",
-     "level": 2,
-     "metadata": {},
-     "source": [
-      "Substitution"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Write a function that takes a list of expressions, a variable, and a point, and evaluates each expression in the list at that point."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def evaluate(exprs, x, x0):\n",
-      "    \"\"\"\n",
-      "    Evaluate each expression in exprs at the point x = x0.\n",
-      "\n",
-      "    >>> x, y = symbols('x y')\n",
-      "    >>> exprs = [x**2, cos(x), x*y]\n",
-      "    >>> evaluate(exprs, x, 1)\n",
-      "    [1, cos(1), y]\n",
-      "    >>> evaluate(exprs, y, 0)\n",
-      "    [x**2, cos(x), 0]\n",
-      "    \"\"\"\n",
-      "    return [expr.subs(x, x0) for expr in exprs]"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 2
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "x, y = symbols('x y')"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 3
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "exprs = [x**2, cos(x), x*y]"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 4
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "evaluate(exprs, x, 1)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\begin{bmatrix}1, & \\cos{\\left (1 \\right )}, & y\\end{bmatrix}$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAI4AAAAZBAMAAAAVsAvAAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAu90iEKt2me/NZkSJ\nVDK0ujvUAAAB/UlEQVQ4Ea2Vv0vDQBTHv6mxsaaNPxBcQ9FNMEtdGwfBQdBFJ5FOFRd1UfwFFuyo\n2M01swoKgriIQVAHUfofWJwEEQV/gIjiu4sXk9LTQvugd++9+77P5d6lLdqTFmo1PdkDs1YIr09V\nyzn0ttuR7PrD6ZAs+2ljhFxSaSWaK5jH6X+psBRKxWyAqwqhtB9wzsDov5ws4Kl2/dKQ4z1P9F9O\nnqq4ajBU7gdVcnR2HM5Rin5t0JFxUitXaJifLOJwe4r0mksD58Rng+WAeuEibUPCMT5wV7q1Ma62\nIkKFMYcGzkmUNTquP2EGMk6sFXuldSB934U4IZr2BUfPkRewB81Em5STdgH9E2iZ3RwrUVWLzzGe\nAhBy7aYM3qScEwdo/qD6wlDv658c3NjGl5Tz6AIJ9jwTFvaKdC76eP0pPxcWEc0FOSopfYsUAIf6\n83icgZYBFIeWeJ+bCwgpsQVlJMgZNkkqzPhE1Dqy0JnIQ7EAftvi3kNKzIE1gd+7tvC+hMFnAWFz\nav4axviZo59nLynUTXqHmAqx/TJlf3aVNvLeH1aJAz5KhjWRZ9+LMuUppQIcR0grzbsieU6OIwKa\nG011g6ZqOex3g5lKFxDiRFzFpdQvJ0qR3BroTpg1Ui9CykR2meV/OSz6w/q8tWmJpGqOpF6k68dJ\n1uX/q/sbt9B8wH311agAAAAASUVORK5CYII=\n",
-       "prompt_number": 5,
-       "text": [
-        "[1, cos(1), y]"
-       ]
-      }
-     ],
-     "prompt_number": 5
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "evaluate(exprs, y, 0)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\begin{bmatrix}x^{2}, & \\cos{\\left (x \\right )}, & 0\\end{bmatrix}$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAJoAAAAaBAMAAAC9YVj8AAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAu90iiXarVJkQZu8y\nzUTTeIQ7AAACd0lEQVQ4Ea1VS2hTQRQ9TfKM+fQlCKLoJkRRdKFvoXGZtzB+QCQLK1WQVloXQhfd\nqJuWVmgWgkKULAoiPtSVIC2iFDfm6cKNYLJwowsRQVwUsfiFIq33dnIzmXysDV7I3DP3nDkzb97M\nCyARunxeYPd5Q9pRg6/gWvcuPNJOb0dKLLYh6wvuMme02xxuv1/Fxc4rQbSDsMENmCiu4vZC+KsC\nJE/3cclwey1cp/xGiF4Bkvfghm+6hQaF65Ct2oMCUdeUWClYVdPtnqlo7cXqOxGZNdnAIOxvhpvt\nxn1T09z7rAubNGSUmET8V80tmBu6UMCzSxfrcyttZuowgoX+UXy8f4YrU/Tbd/JAfx44ohTSZl3E\nf9TcSrjjPUR5eVlIleNLeOk/L2I4kkSAS2+BiBvdHUsB40oiLbt9r7m5GMCYEDr3JjHjPwKyr3Yh\nxOWnoGwthH1gXssYNboVcdYkVY8ksGk3EpPlcz6XlmhtWJdkWOFGB7vJkwKPNaHRF4+OAjkkqqW9\nP7lMGIjRrrW48VtYlHca/E2TtkTFBcK8thEHM6NEz7GELnOx5UnphITlhNy1FnCKlWBhPQJVwKN9\nq3zKY32eyltorc4ALBI9MKV0ekMptbbwYs9skNW0LV9XkmroBFnOvIPN4SfocahGx2LC24r9K9CQ\nYidu+sotsvHowdPKIFLmURKZwjHEhw95dq7vONc+ANdPlHIewXcwpdO5Eaoat576dqMb9Y2I1Um+\nWW2kzW5RY3hTR9/1UJ62sIml7prcUP8i3aKh/+BGc/4lMsINEWgjbV6byNvn2puH5bfn1+bW3kNX\n/7dbWv5P9RRdIju94w/Gx4QwEvm0agAAAABJRU5ErkJggg==\n",
-       "prompt_number": 6,
-       "text": [
-        "\u23a1 2           \u23a4\n",
-        "\u23a3x , cos(x), 0\u23a6"
-       ]
-      }
-     ],
-     "prompt_number": 6
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Write a function that computes \n",
-      "\n",
-      "$$\n",
-      "{\\underbrace{x^{{}^{.^{.^{.^x}}}}}_\\text{n copies of x}}\n",
-      "$$\n",
-      "\n",
-      "That is, `x**(x**(...x))`, with `n` copies of `x`.  In [Knuth up-arrow notation](http://en.wikipedia.org/wiki/Up_arrow_notation), $x\\uparrow\\uparrow n$."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def uparrow(x, n):\n",
-      "    \"\"\"\n",
-      "    Computes x**(x**(...x)), with n copies of x.\n",
-      "\n",
-      "    >>> x = symbols('x')\n",
-      "    >>> uparrow(x, 3)\n",
-      "    x**(x**x)\n",
-      "    >>> uparrow(x, 1)\n",
-      "    x\n",
-      "    >>> uparrow(x**x, 3)\n",
-      "    (x**x)**((x**x)**(x**x))\n",
-      "    \"\"\"\n",
-      "    expr = x\n",
-      "    for i in range(n - 1):\n",
-      "        expr = x**expr\n",
-      "    return expr"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 7
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "x = symbols('x')"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 8
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "uparrow(x, 3)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$x^{x^{x}}$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAB0AAAAUBAMAAACDsiv0AAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIol2q1SZEGbd7zK7\nRM2RoJmtAAAAjElEQVQYGWNgQIAdSj0IDpDVsIcJhc9gjMpVOM0BF1D2NdlwQqkbxmcq8OEKgHGA\nNC/DCyQeiPkRlc+9gBtZYD/TAxS7a0yT1aHyQiaiZgYItewKHDO4JiD4TAzMH1g3IPjsDCwHEDwQ\niwtJN4gvv4GhAERDAIeAPQMzEj++4RSDMEwSSNcYFSk3IPgAm1gXfwEYbXEAAAAASUVORK5CYII=\n",
-       "prompt_number": 9,
-       "text": [
-        " \u239b x\u239e\n",
-        " \u239dx \u23a0\n",
-        "x    "
-       ]
-      }
-     ],
-     "prompt_number": 9
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "uparrow(x, 1)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$x$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAAsAAAAJBAMAAAAWSsseAAAAKlBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADmU0mKAAAADXRSTlMAIol2q1SZEGbd7zK78ZNZ0gAA\nAEJJREFUCB1jYBAyETUzYGBX4JjBNYGBiYH5AusGBnYGlgMMIMBlAKZkNzAUMHAI2DIwFzDENpxi\nEGZgqDEqUm5gAAAhlwo0cLKzVgAAAABJRU5ErkJggg==\n",
-       "prompt_number": 10,
-       "text": [
-        "x"
-       ]
-      }
-     ],
-     "prompt_number": 10
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "uparrow(x**x, 3)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\left(x^{x}\\right)^{\\left(x^{x}\\right)^{x^{x}}}$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAFQAAAAfBAMAAACL2vddAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMARHYyq80Q75mJZlS7\n3SINk/qdAAABtklEQVQ4EY1SsUrDUBQ9bdqUpKUWUVwUgnSwdDCDIk6tdBWpi4NTFgehQ52d1Mkt\nFCzSKSAO3YoguBlcBAXp5OBU1EUcrD8g3pf3XpO0Tekdcs859yQ5uS/AVKW0W+5URkBXXHtKK+LG\ntE4tYzpjvR+e6uXrAKxn2i1znDXLY3n5NifnzIj7WT4th0k5b7jVy6dWEZmTbC/cyvNVEJWTuer0\n3vxshd+wzNv4q1IFmgn3mE/nAqaYIUhjK2/q9BWxMpBLOkJdF521NYE1azvVwRmQLpMy0xNy0Lon\ntBj2CSXpqS71DZhcX+SNXdnyRP1R122oXSj9C9hcbcspkLIkVuoKoNaBV6gPdwWhn8gxMC9hSatq\nhJ+BopRYr/rknOBX/nvFqBVPm4QvgZo/RdrwCX2Lautvqa6QbmkFjj9O+BBHdDSI99Om0BaoX/lz\n9iJZv/RUJFxJURqgEUBWWoMx0CdYvaP+MWEJMwsQUU+09t4q4paYX0f4SKbl3DuPeJcO4lG1RHss\nHDYcOd+VYLSneiGNHWxU0f8RLM0IsiEsf0IuHwxNQ/QzxHZCbIhkjYAQl+cb0CT8B+zTTgl2dwsa\nAAAAAElFTkSuQmCC\n",
-       "prompt_number": 11,
-       "text": [
-        "    \u239b    \u239b x\u239e\u239e\n",
-        "    \u239c    \u239dx \u23a0\u239f\n",
-        "    \u239c\u239b x\u239e    \u239f\n",
-        "    \u239d\u239dx \u23a0    \u23a0\n",
-        "\u239b x\u239e          \n",
-        "\u239dx \u23a0          "
-       ]
-      }
-     ],
-     "prompt_number": 11
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Write a function that takes a function and nests it within itself n times. \n",
-      "\n",
-      "For example, if we started with $x^x$, and $n=3$, we would end up with \n",
-      "\n",
-      "$$\\left(\\left(x^{x}\\right)^{\\left(x^{x}\\right)}\\right)^\\left({\\left(x^{x}\\right)^{\\left(x^{x}\\right)}}\\right)$$"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def nest(expr, x, n):\n",
-      "    \"\"\"\n",
-      "    Nests expr into itself (in the variable x) n times.\n",
-      "\n",
-      "    >>> x, y = symbols('x y')\n",
-      "    >>> nest(x**x, x, 3)\n",
-      "    ((x**x)**(x**x))**((x**x)**(x**x))\n",
-      "    >>> nest(sin(x)*cos(y), x, 2)\n",
-      "    sin(sin(x)*cos(y))*cos(y)\n",
-      "    >>> nest(sin(x)*cos(y), y, 2)\n",
-      "    sin(x)*cos(sin(x)*cos(y))\n",
-      "    >>> nest(x**2, x, 1)\n",
-      "    x**2\n",
-      "    \"\"\"\n",
-      "    origexpr = expr\n",
-      "    for i in range(n - 1):\n",
-      "        expr = expr.subs(x, origexpr)\n",
-      "    return expr"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 12
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "x, y = symbols('x y')"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 13
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "nest(x**x, x, 3)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\left(\\left(x^{x}\\right)^{x^{x}}\\right)^{\\left(x^{x}\\right)^{x^{x}}}$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAH8AAAAwBAMAAADKnbiZAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAdma7VN0Q7zKZRM0i\niau2leyDAAADCElEQVRIDaVVP2gTURj/0rteLpe7JGoRQawHUhQxGJ0UHNJNt0ziGOjQSRpFnRyC\nDg4iaQcXpxRHQYKbW9wEh6YFu0ghUpAiDrFIqaDg93333t17l8vpmTd83+/3+/68fHfvXgCmWI92\nzkxRjaX+Y2+6BnBkyvrBlZksHd5zMs9dByB/eedchgbugJN57mf/M78hNqO5vS5kn38xaMBzWz3I\nOD8WXwsaBHPvZZyfalsAm1/n20Eb/f3l/EBNttYX1u0eeM3dfD1Ieq3lHtPYGHnFijMEB97I4FMJ\nyJsNlY3jXI2zhmh/yajWYLkt5bi3q1tUzPs6iOyWLVJeqqlXVaLhGbs2QGGjj8ZqQMfryY+nquQ5\nBwqJwVyFhMKQ7E1YmlvbJoTrReDYFlcVokPPaPuouDz6nBrrKaTTV0gEvfn1PaO61SblLZklMmKZ\n/MsEeS5V3W+XavekcpGA6UsKUIogwB0m60KijeE8km7RFxLASp2g8unKR0Gyfch2SBYXb1xoIyr3\n0QRrdvJjAsiNKKnYDFLFxvSMnkBbaFBqSJTgDQ5GHwdvXAV79AkGMj3YRLKYn62R8CBUeeNlsC7d\nONWUosNjShbz5VUUnJ5QxcZGXcuyf2hUJysV5IUBHpfNb4trYmOPukbL+h7hMbTho0Sv7DYs+PdF\n2JS/SPDfwie5jo9qvgv4yE7DdZHhtAQQ7qdONdapIy13AZqwGwbsUQgZ/FMDeSapIlMDHwv4qnMP\nwaJqXFlG2KhggeEDXMDjcpyqcc1keIjlARbgazP3jZZLzWghV5e7r7IYzlOu08Cjt71zVMaKXYnY\npx6kYo1yHmoFsKxTM7yNdZ1ZoUVOvSSRbnIoNN4ohOPAPCAt/Jw5Af87tWXEuBa0+ENxh6pY6qsM\nz1lF5zrjGxPeqeIJlSCecO+KrLOx7AT6MUGLpJVuhCeguxP0QPZqqWEMmq3UDCvtvuLKWT+1AZxM\nDwMs/CVB+QdJzHRjx3Qsybo1JmlCsa7RBPKhnyBG0ucITkBud0KAZSs1Cn8Aj4KUD33G8usAAAAA\nSUVORK5CYII=\n",
-       "prompt_number": 14,
-       "text": [
-        "          \u239b    \u239b x\u239e\u239e\n",
-        "          \u239c    \u239dx \u23a0\u239f\n",
-        "          \u239c\u239b x\u239e    \u239f\n",
-        "          \u239d\u239dx \u23a0    \u23a0\n",
-        "\u239b    \u239b x\u239e\u239e          \n",
-        "\u239c    \u239dx \u23a0\u239f          \n",
-        "\u239c\u239b x\u239e    \u239f          \n",
-        "\u239d\u239dx \u23a0    \u23a0          "
-       ]
-      }
-     ],
-     "prompt_number": 14
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "nest(sin(x)*cos(y), x, 2)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\sin{\\left (\\sin{\\left (x \\right )} \\cos{\\left (y \\right )} \\right )} \\cos{\\left (y \\right )}$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAN8AAAAVBAMAAAA0pCbNAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMARHZmzRC73YnvqzIi\nVJlz8rUYAAADf0lEQVRIDcVVS2gTURQ9k2Ri0kliEKG66hBF6ocaPwt3RqQuJQspLS4sFsSKYkAL\n7hy7sasSha78BUVcKDa4cBGVBFdSUYOI4KpRBIsitn5AU2097715k9+4dmDy7r3nc+fdvEyA/36t\n6ngCw1alYLIDkgVXIeB/UAxbKbepBdZPN+BiFWRcduQiP0o6/KSDltVVAAL2p2iHRFEpjaWGQygr\n455ao9Svw5AOWlZXAQjYn+I5ZFylaiKTlCqZLsIlYOs46OioeXUVnCdhX0rDYVezUMVTHaWo9zhm\nvgNkwVMI2JfScBhSBrEHnpGRUeHTolda7UU40Qi9SCtYELAfpeEQrsJYtz0zU8f9q/c22OQnHGDV\njvWx6YI1+il1mBXM8X6y6VmfDUwyjN2dqOJ56rNUMheKwTnEfijYj0IHc9LBiywiNQwAORwD9qXN\nBcpDaZjDWIFwAaERHEqytJd0J3gqmgNeMS0nrUvWGLocqZQKOD0IzCvYj0KHiDGPrUA8g+4sHNFw\nFPhKu2gSxhgiomE4j5U2SxdIp1+cQ17LdB+Ci1EHsUWplAqr+gHhYQX7UejwKJHDEcDII1rfDNGQ\nmWi4knu6dr0oGw6rhty4iS76cXecqPjN9lSBJamUChMXJZWwL4UO2agt/K15mOeXC20NB8/W2xpy\nHzbNhJvxjetuPtZ3qVSPGP+BMgfgNuygsCFms9aibPgQwT9NDaNVWBXsroqRuju8Ilq9KCIrZybf\nSrPcYV0q+SiMExlsJEmMk3cHRTi8RyAvR/oSeNfUMJxG3EbCbmo4wp9zZSsCbLiTytNM+R1aC1IJ\nUIFQTVhI2I9CB+wXQ0MwgzdZHG9qyHMbn0K4QlTvkAd9Nj2Kx1SJM1+uYotxGeGaVPJA1bjDghyj\ngP0oovYRPXwyktekepOl5Zul5duvf1Fq5GCMp85Z0/WD0/VHJ6+S2g0M9A6Ok449vGN3e4soTdyQ\nSuZUwDzc99uF/Sh0wEDqS4WjSDJsvS63psyiFV3yfW9BKiKibV7dmu6tyuE88yGv5gWdr9fG+zhi\ne7SmgIpbGKpyXoR9KXToypni6Iw36dzQ+7NpQP06PKCDlpWKMzjKkoD9Kf1Y4YQd7j9DStsVK7QV\ngBlduaODlpWKl33iuxGwP2UG8dRbol0VfrRf4jS2XjFb5YFia11nrkLA/6BoB77U/gKKWQrvdJkP\n3wAAAABJRU5ErkJggg==\n",
-       "prompt_number": 15,
-       "text": [
-        "sin(sin(x)\u22c5cos(y))\u22c5cos(y)"
-       ]
-      }
-     ],
-     "prompt_number": 15
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "nest(sin(x)*cos(y), y, 2)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\sin{\\left (x \\right )} \\cos{\\left (\\sin{\\left (x \\right )} \\cos{\\left (y \\right )} \\right )}$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAOEAAAAVBAMAAABCnpRGAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMARHZmzRC73YnvqzIi\nVJlz8rUYAAACi0lEQVRIDcWVMWgTURjH/5f0zl7uEoMIdWtIUQoKjS46CB6IHeWmoquCoDhk0P0o\nSDOVKIiDVQKii1KKg0NUGhw7aOggiENrcRBBTK2DJtj4f+/uXi71ILksPnh5/+/L9/99dy93L8D/\nHweCSzgefyla4Z/8kA4BDKHWrx7FqgU6t9JLRlRd6uQOQABDqLbbQ465oXZC0beek1FyB21OMAVB\ndQGKIpbjVCiia6rgR8kdgADGQO8q/kWlIsKMtArSQzsEMIDaLxVTc5Q0mkr2xEFfJnfQJ4Cc2tQJ\nZ62NFw+fHykwm/MAe/7Z+hYwvsnYXq408bb4TdYx/oIRHPqih3euBBI6B5RxDZgt6dskjpWACzhZ\nugdkHcareeu+dRMZT9YBZzGCY1xrYcYHEjrhwhMdrwI/2MHMg/EMPvJeqoxnke6YHuyOrANuYwTH\n61wZV3wgoWb7KERHZkTH/ezo4gkVrBY3Vbypk01gV9YB3IfkDtcsCLgAcuoL3dqejsCdsKO2Q3WG\nV/FT1smOyR3YcK2O6vgK6T+Rjibvh3sI3d8EebZsMNeWdcADILkDn5Gqql1dB7YiHY0ScDrVwmEg\n7bD5Da78Ha1tWQdcBpI7cB5GzQcS+sHF9UhHPr3ZHaNqF4K3Y7WJY9oSjE1ZByxiBAe+YpJ3QraY\nh4rT+Xr3cb379P1vZrQy9Eu3KlPgi5Lnh708vYJ65ZGsYzyBERyYK35v+EAJJScylpSOP+Ua6vtQ\nDOVYYHXklAu9Yu0dtfPRdKjTXqjUOtiRKet84iCAMVD1b6U7ihkV/r9VNDPYsc8zPEAA46B2LaBl\nGoHoX9b6Q0aDHdniJ9YJYCz0TYDkURQ3xFO8ZwzpEEDOv750EDecmK+EAAAAAElFTkSuQmCC\n",
-       "prompt_number": 16,
-       "text": [
-        "sin(x)\u22c5cos(sin(x)\u22c5cos(y))"
-       ]
-      }
-     ],
-     "prompt_number": 16
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "nest(x**2, x, 1)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$x^{2}$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAABQAAAAUBAMAAAB/pwA+AAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIol2q1SZEGbd7zK7\nzUTvhYErAAAAgUlEQVQIHWNggAC1IwVQFlsB2wUok1OA8TeUyRXA/g/KZGBg/Q5n8irAmSpwFgdC\n8BHDbqgw99FQdyiT6///DwwMQiaiZgZgEXYFjhlcE8BMJgbmD6wbIKIMLAfADBDBBVEJYspvYCgA\n0QwcAvYMzBBmfMMpBmGwIEONUZFyA5gJAEICFuq4U3XkAAAAAElFTkSuQmCC\n",
-       "prompt_number": 17,
-       "text": [
-        " 2\n",
-        "x "
-       ]
-      }
-     ],
-     "prompt_number": 17
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Write a function that replaces all trig functions in terms of $\\sin(x)$ and $\\cos(x)$. You can assume that the trig function will be of the form $t(x)$, where $x$ is the variable.  The trig functions implemented in SymPy are\n",
-      "\n",
-      "$$\\tan(x) = \\frac{\\sin(x)}{\\cos(x)}$$\n",
-      "$$\\cot(x) = \\frac{\\cos(x)}{\\sin(x)}$$\n",
-      "$$\\sec(x) = \\frac{1}{\\cos(x)}$$\n",
-      "$$\\csc(x) = \\frac{1}{\\sin(x)}$$\n"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def trig_rewrite(expr, x):\n",
-      "    \"\"\"\n",
-      "    Rewrite all trig functions t(x) in terms of sin(x) and cos(x)\n",
-      "\n",
-      "    >>> x, y = symbols('x y')\n",
-      "    >>> trig_rewrite(tan(x), x)\n",
-      "    sin(x)/cos(x)\n",
-      "    >>> trig_rewrite(tan(x) + cos(x)*sec(x), x)\n",
-      "    sin(x)/cos(x) + 1\n",
-      "    >>> trig_rewrite(cot(x) + sin(x)*csc(x), x)\n",
-      "    1 + cos(x)/sin(x)\n",
-      "    >>> trig_rewrite(tan(x)*tan(y), x)\n",
-      "    sin(x)*tan(y)/cos(x)\n",
-      "    >>> trig_rewrite(tan(x)*tan(y), y)\n",
-      "    sin(y)*tan(x)/cos(y)\n",
-      "    \"\"\"\n",
-      "    return expr.subs([(tan(x), sin(x)/cos(x)), (sec(x), 1/cos(x)), (csc(x), 1/sin(x)), (cot(x), cos(x)/sin(x))])"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 18
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "x, y = symbols('x y')"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 19
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "trig_rewrite(tan(x), x)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\frac{\\sin{\\left (x \\right )}}{\\cos{\\left (x \\right )}}$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAADwAAAAyBAMAAADy2KUxAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMARHZmzRC73YnvqzIi\nVJlz8rUYAAACT0lEQVQ4EcWUT2gTQRTGv90k26a7m4QiSA/SJSqIQruioAehK+I9B5GKB0N76kEt\niGdjQBBFiULRg3+CBylYSDyJgmTxJBExiDcPhpwKvaR4ixT9XjYzWdMieOqD2fm99+283fnzBvhP\nM7xoQCKnBzZKGvFO4YYCTLc14qzCpAKkNMH0FCdKimJ9uqCcVEXRp7oi7NGEy4KTxw44taq9tJFf\nEHed7ePhzzMecJ+YKmIMVhXJRVySqZxhqJS4ll4GvtE1rmNcZKuCLEfgAeibXZefm6KL5y/qfbkY\nyZscjYmiKA15zN/ojchA2hNFZDvEXEuSD0Y/FeFLHYUouesh48XkRSARzsKkfJwvuiuwwpjM2fzw\nl/CBkkzMKOdv2rXexVrv/dVn9PcC5w/Nl33iabZRS4cqMlxUFWE/3IhxLxbWqDf0nA7FoamcNQV/\n9Y4XuSaXdXft9z9td/9t29cnB5Gj2xQJ2NVBOLPjqiZ5jCILFMT7vHZOaorBiuYLmoZgBJqtFrG5\nfg9OZ6YltUg3UwKc8trXDoupzR/dxNv6mwJW+7UIJH0WDk74j3jGA7pFzNUfszBeSy2yfnJACbP4\nzjNeYZjJjC0g25ZaZE+5gJck2F1g2ufhZVlmA6nFSAYeKlnuLFdGv5JaZHI2OL/kNpLkYwHg89uN\nfVKLgMVsp8wuDjIpJXsLZjgV4kq/FvuzcX9aFTnOMjE0O3dhr97xpRbpGstILdy6vZ+YzPExak90\nYKdFxXAjyvrFGOgNTQWxqEanOsCJUMfiIPeG2BG2P0Gmoa+aF1EhAAAAAElFTkSuQmCC\n",
-       "prompt_number": 20,
-       "text": [
-        "sin(x)\n",
-        "\u2500\u2500\u2500\u2500\u2500\u2500\n",
-        "cos(x)"
-       ]
-      }
-     ],
-     "prompt_number": 20
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "trig_rewrite(tan(x) + cos(x)*sec(x), x)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\frac{\\sin{\\left (x \\right )}}{\\cos{\\left (x \\right )}} + 1$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAGAAAAAyBAMAAABR8MP3AAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMARHZmzRC73YnvqzIi\nVJlz8rUYAAACg0lEQVRIDc1VP2gTURj/3V2SNl7+lCJIB+kRHMShBnRwa8S4OGWQUlQwWBw6qAVx\ncDJ2VJQ6FBz8E5yKComTKEgOJ4lIi7gbqkOliwVdAkW/L5fv3pl7fVFc+sHd93u/7/vde+949zvg\nv8Pygkc4Y4ZHtWqq+FrgpgBNnuwo8qTAhABNTirO9gQ7NUHGnK5IObkkKJ7fN0Nub4hwScEoGj9y\nINOou/ObhQtMb9D17tCHKQ+4y+NYJKsYQaqOxBzO84s8ASRrztX0AvAp1syEdQ2jLEgtIe/R+B5o\nbH/P0iInuB6Px0+aPUE1EGzRDNhT5b5WvJmZ2RvdAQGQ9riiF7g+ptd4Sf0ZHnLrahOVnZaU9ZDz\nIoI5wPEPwybBUdbGIruMlB8R0Lv8XJzHW2rUv1ZrsXDTbXTPNrpvrjyirn3AzMHZxSLB43QNj7Qv\nPbqjcVGKKqsjN+opto9mfsYoIDzep1XxXADPPNUJ2tL3XADwsQ9tnSDjBVWbDoeEUSBN0bzLBb+M\nwRv5Wi5fL5dPMdS+JS4Mxu7ddO7bjy+Dq6XxeJ+LuLHsQdMNuHWhlRvLM6TyR07QxxmEyY2lh3Ih\nxOrTCCkdWA5J3ScXFkNglUK4gxu3N+4gsz61BnJl6s3V6GZyY3cLr5ovK1jpuTKQIL8wunGiiunm\nfTK7F+zK5JJjQ9x4lZZgbQP5DrsyZRIY3XiSluCQZedL7MqBwOjG/MfN8gzP2JWplS6jG4+UgCLt\nobWfXRlI8YwmN3a3YfsTPi73XJk23Bnmxu3123BXbhXZlWkx1sK/uvEDUgXxd0cDx6QfGjcOaxGg\njnfEjSP1GMzUhYq4sVDazH8rjqgbBwzffwMEKbxiGjhYZAAAAABJRU5ErkJggg==\n",
-       "prompt_number": 21,
-       "text": [
-        "sin(x)    \n",
-        "\u2500\u2500\u2500\u2500\u2500\u2500 + 1\n",
-        "cos(x)    "
-       ]
-      }
-     ],
-     "prompt_number": 21
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "trig_rewrite(cot(x) + sin(x)*csc(x), x)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$1 + \\frac{\\cos{\\left (x \\right )}}{\\sin{\\left (x \\right )}}$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAGEAAAAyBAMAAAC+MqjJAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAuxCrdpnvzWYiVN1E\niTI89kC/AAACwElEQVRIDb1VTWgTQRT+skk22bBJ/aOopwRBT4WqFOxFVo1QD7E9iIigFFGkVqT1\nEkEPOQgiKgaqF0GMEPRmixc95iB6CGKQeJJAJF68mGCsLVIT38xmZhKzu83FPtiZb977vvnbt2+B\n/2KmZU8bLgw6fU0QzwqwXn9VEEICrNMHLEEIlwTy7vW4iGvTAnn371R4p4LdyBir5PAweRrmxM05\nCpyh5/GRR0ct4FM3T+F6IXYl9hL+UgJYIvc1QCuFX+uEnytWN5pHuKWXYLSKcbCjXgaiCDQiVeBt\nN09i4w/BDzlgWW8eZ941WgP+TQzWWdNn5iq57heAFe1ze5QwKQDdYq2zIsbWWMwBzW8I/yZ8iR48\nqSLutiu8AsJ0jthaHjhB5O00zk4iQIpbNHSweg7HzBn4pp7FsYPidKWLmWE8sKGDAMZYqopa5QDe\nJ1MFIhSBRGqknCF4gx5gC289Gj0rgnaWJH6IsVuv8i9qEWfXfqHQ5FT/SmW27+GRgFBE2ASOtiC8\n4xwMoDAsWxKoDqqw+bIdYA3JtcHGKYLp9PWL6TRL1aG2lzWAjdsV7cb9DfbeVfDkyinbM6hC6d0V\nbzqku4rMkajgfMA/3Q4hxm6QWbDKO+fGXFb+UFzgOQGceskCkjJ+TyJvcE6Gd0vUD4zv0meqvfhy\n0tsDWIFeaOLLha+HLAoES4BRHs9TIYpO9RDlgBforcB8RmPlMJQBRnAnM0svWS0n2QwUWYEmxTDw\nk4Z6ATSexAvAnIaj8QJNis22YogUcexl1FjDUQBeoHsVwHkvBS/QSqHniGy06I/guqs8K9BK4csA\ntwMNHKaC7XJyXqCVgq40suqbZiXI7XZZga6199XaB5/+ohdgLkHb9rEyQXsLFagZwGYkxytLJImA\nyr9yt9sDy2zXXA7epzVGOy5/ti/m4mD/M2b8X/0XQmDEFuSdDb8AAAAASUVORK5CYII=\n",
-       "prompt_number": 22,
-       "text": [
-        "    cos(x)\n",
-        "1 + \u2500\u2500\u2500\u2500\u2500\u2500\n",
-        "    sin(x)"
-       ]
-      }
-     ],
-     "prompt_number": 22
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "trig_rewrite(tan(x)*tan(y), x)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\frac{\\sin{\\left (x \\right )} \\tan{\\left (y \\right )}}{\\cos{\\left (x \\right )}}$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAHkAAAAyBAMAAACKS2nVAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMARHZmzRC73YnvqzIi\nVJlz8rUYAAADcUlEQVRIDd1WT0gUURz+Zndn/83uukSg0cFhxZCM3CKoQ+BE6TH2UGKnRCFQihaq\nS6dBCj2EbEEEZSKEXTJdOnTYEpeICKFcJIoocJIOkkSrdqjd0n7vzb7ZTVfXzU7+YOd9v9/3+96b\nmTcz3wL/N7blptu3xrSSahIWr/zIdyqDORyI54uFKLGSl5bytCMisMZBUKRibBJAE8BSACFRwyGO\nDCs3gU0VBZMXmTnetNJTDNkNKzeBx1qJ81T0PbFaJM2CzhTBHYaVm2C7lTNeqtmvTWTweODRLpWI\ngE6TdQ9PzQBug5YevfwQ9tAslM65UDvxmAXkPh2TEc63AFF0Ac1heZ5IRxhoxcHwLcCvUe4ygHfJ\ngAZHB04HqXCUppXSaDD5ygh0pu4EFoj0UIdO3Ac6qxjlLgNojEu/4IyhQgVwHRgLRHHG5D2ZejA1\npUxdQeoI7hOCkqaDy6BDVV0WzjZTTScY8aisl/Fyz/LgCjVwgyR59fMh5S81piNU4PxT2H8XqD0p\n0vmykK0zt+EYlOxJsfZd4j/DFjP5KWCmQO0MA4dtadTS/dao0WW45QX4szuFuoOKx+EcNPn3EZwt\nUNM2+RedMZ9q7hgCmhu34c5+FOo+Un9BNS3CdrQqVBdMLA8llh+8/UmpFIXcfrW3hnocQTrIXdfw\nYqb2Sv1oZuz8ABUq6dcS+pbM8ZQVRr+ViCfRKnDgSbKhh37F+Pyz383aVoVdhzcqs3tXjLfeUFlb\npeSFJrh0p07XVIz3DfIewJvMgRXDBPyhT1Qrzj/LddMjWDTYdrBYizfZLX5c3kSkt/i92cTlSaop\ntrMXtuwQroe5sqUkaBIihwBljDZVNNObXXbkXU+OlS1G3vVwrrTaN9KbwuvQV26P1E6uh5e7X+1V\nAfY5LRHjQeWOcglendsjdz1Zt1/wRIE3JaREN8Oe9ehkJ9weueu5YUv74+TlJdU+9geoOgUscXsE\nyPVkeNuYcJwd1g1pkejGIPCd2yNXky+rTFRazf98TdPaGW6PAPtyYzJOtryBM8dFsje6bmWe2yNA\nrmdPNsBG6gNsovVjPIU9Uj+cBrdHvk3T4U6w7/QGdsw3UhdHovcet0eSkOu11LV2hwkeWX/dYqzp\neoz5lyc1/2641WKzl6hZb+iJEo1F6QlRHRagnFG4ni2+WvUH/D4TjdV7Q1oAAAAASUVORK5CYII=\n",
-       "prompt_number": 23,
-       "text": [
-        "sin(x)\u22c5tan(y)\n",
-        "\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n",
-        "    cos(x)   "
-       ]
-      }
-     ],
-     "prompt_number": 23
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "trig_rewrite(tan(x)*tan(y), y)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\frac{\\sin{\\left (y \\right )} \\tan{\\left (x \\right )}}{\\cos{\\left (y \\right )}}$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAHkAAAAyBAMAAACKS2nVAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMARHZmzRC73YnvqzIi\nVJlz8rUYAAADMklEQVRIDeVVTWgTQRh9aX7auJsfetEepEuqoggxVkERsasHD55ykJKeLD2IipZe\nBA9S14AoirYUih6kBkEttodUULEqWTz20lBEEA+GIljw0lqK2lrjN9nZ3dmt2RX01oEw733ve5PZ\n2Z8H/N/RbCwXTNZZluvYberSdxMBUoHjL3ZNRJYeL/Jy4Jeth7Ich2pzwFYMZOlQTcl0EE+ZtaDG\nUNyk5mzp2G+WhHnYxOFBhg6Z1JwtHV28JL80NQRUC54jFBixqAEEPVImva1dnVrGs5En2xRqiGtA\nbg7yEnCL6IFvj8toT2sOXc6Pz8wCTRWgE+jDGeBoJrxA7aEMoLWiYR54SxT9QOwiPjn0HPZlblNd\nBTZmoTH3aeArdUeTkMqfEekGWogyd3AFrbqgU/8ufKBd08FEl3eCuU8a7kQSYQwhoQAl7kYgP1AU\ndGTxkEkS7S98tVpwuhFbQqlou+VjWaL26mQcMt2vEFwV3NEynZyKHSTznSshFaWnWe5mOuQV2mBt\n5zPArOCOZOjkKqyAvewP+qGdUPBxosjdTD9IZ7qVzkMF3mdxVnCz2xAvBBbJyO4YnbYWLWDgtc7d\npMcWI4OyYtyxTantycnqg8nq2LsfFdpOHx1FT/onGQ/TD52jutybyh0R9HDPlWttJIWSrME57jLa\nxNYYdAqc1fQaNp9UsY2e/UfoKtMKili2sP1u5K2aDegNvIBTxI/bNRFZb2hYFcscywXMpNkVjf9B\npBLpxtigc+CY3hisoeio2oTroEd0/Y7qP4z59XtsvlfOY69uLHouIBW4XCcWPc2wXiojFr2b16gp\ns2LEosn+crZir87HxnMZIfZYLPqNqbmbkGfTZTTv2UK9cc0Riz5uaQEvis+zGA13o5F63bHobQ91\no6N4B5ieOI8manXHord7WqOP+iqQqNy7zz5O7lj0drdmKGMoyRNq7tKy4XbEore7pFGus/8e09FR\npp3TT4xFb3ejCmToukubFcQVwB2L3m5pFQ16i47e2DAiupF1Yix6uzE1ewPS6PVMIJ+6TK3uWPRx\nu2W/WHT3O7lfLDq73cwvFt39Tu4Xi87uNcwjFn8DeSobC4RXkewAAAAASUVORK5CYII=\n",
-       "prompt_number": 24,
-       "text": [
-        "sin(y)\u22c5tan(x)\n",
-        "\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n",
-        "    cos(y)   "
-       ]
-      }
-     ],
-     "prompt_number": 24
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Suppose we are working with the series expansion of a function at $x=0$, like $a_0 + a_1x + a_2x^2 + \\cdots$.  In this expansion, the terms with higher powers are less significant to the calculation.  For example, if we had\n",
-      "\n",
-      "$$1 + x + \\frac{x^{2}}{2} + \\frac{x^{3}}{6} + \\frac{x^{4}}{24} + \\frac{x^{5}}{120} + \\frac{x^{6}}{720} + \\frac{x^{7}}{5040} + \\frac{x^{8}}{40320} + \\frac{x^{9}}{362880}$$\n",
-      "\n",
-      "We might only care about the terms with powers less than 5\n",
-      "\n",
-      "$$1 + x + \\frac{x^{2}}{2} + \\frac{x^{3}}{6} + \\frac{x^{4}}{24}$$\n",
-      "\n",
-      "We will see later that this is can be done automatically using the `O` class, but it can also be done using `subs`."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def series_reduce(expr, x, p):\n",
-      "    \"\"\"\n",
-      "    Remove all powers of x in expr with power greater than p.\n",
-      "\n",
-      "    You may assume that there are no powers of x greater than 10.\n",
-      "\n",
-      "    Bonus: which functions are represented by the series expansions below (you\n",
-      "    can use expr.series(x, 0, 10) to check if you are right)?\n",
-      "\n",
-      "    >>> x, y = symbols('x y')\n",
-      "    >>> series_reduce(1 - x**2/2 + x**4/24 - x**6/720 + x**8/40320, x, 5)\n",
-      "    x**4/24 - x**2/2 + 1\n",
-      "    >>> series_reduce(1 + x + x**2 + x**3 + x**4 + x**5 + x**6 + x**7 + x**8 + x**9 + x**10, x, 0)\n",
-      "    1\n",
-      "    >>> series_reduce(x*y + x**3*y**3/3 + 2*x**5*y**5/15 + 17*x**7*y**7/315 + 62*x**9*y**9/2835, x, 5)\n",
-      "    2*x**5*y**5/15 + x**3*y**3/3 + x*y\n",
-      "    \"\"\"\n",
-      "    return expr.subs([(x**i, 0) for i in range(11) if  i > p])"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 25
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "x, y = symbols('x y')"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 26
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "series_reduce(1 - x**2/2 + x**4/24 - x**6/720 + x**8/40320, x, 5)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\frac{x^{4}}{24} - \\frac{x^{2}}{2} + 1$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAG4AAAAwBAMAAAAC8VJPAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIol2q1SZEGbd7zK7\nzUTvhYErAAAB9klEQVRIDeWVsUvDQBTGXxvbpC2VoHZwkJYqrhYRBxc7VBzrYheHOhUVoUEdBesf\nIDjqYhcnQeji5JJBEZxcBYvFv6AIKiIa3zXX9JLcK21HfUPy3vf7voRe6B0Ar3i78d6nbwyvJM5F\ngoaN8IPo8/TqDJGL6IEvj1cclQMiF11Rf0Sjp7+icgChD49XHFN0Lp4Sje5e0+nclNvqmnaBzGkp\nl9M9FErlDbfiTC9w7fSSJkmsZ+x2dVliBxiZS8xnQMsv+WiLRC2r6SMoqCntJHrcH2HuICjNUE2W\nowlzqzBkylLdiO2PZuQ5AJqwRLIGhjxJEwBNXwRFmqMJe0uxcg+j0tfRhNn3Z3cmK9IcTaT2XsS7\nXkx+z363f6Tfruq2tpfrLxdqf2jlH+SsTrHVmjhldcbaDrDYiBviIOsSrtcfL+v1LHvAH1/P8NY3\nbraB0lMDf2ssixdvccZlZz1b8xgob9hETE7FG2dcGm5/h9aMu3EVmwWTU/HGmSg5/YUB+QYEjkxH\n6TQ268xi92xAuQHBuCmKvLeZBNhS1YBDaQ4xMqpir6BmiBwysjASBCJHyK1nbQOsUTlkVClZPMyI\nHDKyChBI5HL5c9dX5W5kOhGMreMZgWePKeGcSQjAeDq9iUCa40yaq1rWJx67+feKH9vMrw+u/AI7\nh46YdziClgAAAABJRU5ErkJggg==\n",
-       "prompt_number": 27,
-       "text": [
-        " 4    2    \n",
-        "x    x     \n",
-        "\u2500\u2500 - \u2500\u2500 + 1\n",
-        "24   2     "
-       ]
-      }
-     ],
-     "prompt_number": 27
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "series_reduce(1 + x + x**2 + x**3 + x**4 + x**5 + x**6 + x**7 + x**8 + x**9 + x**10, x, 0)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$1$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAAgAAAAPBAMAAAArJJMAAAAAHlBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAACGjDitAAAACXRSTlMAuxCrdpnvzWYiHG0BAAAAI0lEQVQIHWNgYBBiYGBQ\nnMTAoGwMJBhYSCVYw6ZHAPUxMAAAQGkI1Fjz0FgAAAAASUVORK5CYII=\n",
-       "prompt_number": 28,
-       "text": [
-        "1"
-       ]
-      }
-     ],
-     "prompt_number": 28
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "series_reduce(x*y + x**3*y**3/3 + 2*x**5*y**5/15 + 17*x**7*y**7/315 + 62*x**9*y**9/2835, x, 5)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\frac{2 x^{5}}{15} y^{5} + \\frac{x^{3} y^{3}}{3} + x y$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAK4AAAAwBAMAAAB6TlzuAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIpnNu0SrdlQQ3e8y\niWbzIQYJAAADoElEQVRYCbVWT0gUURz+Zv/P/nPzUh3CTcmosKSN6NDBQ2V/CEyIbu0G4aEuiweX\nkFLq4CVwAilIzL2HYSdTOiyduoSLgWYkroeIOhlRuSBub3bmzXvzZt64Cs3lfb/v+37fvJnd+c0A\n7AgefJFnlTtSlxY1Q2HI3cnYYO0PKyTIV/F1GhJDEqtFB7+mLCwDoXRy3dAYknkpH+yhyGtNmPsF\nGPLyA8HD/Zq3Q1fHrbMz5NbV3HbepJVUxNqLm7POPbtKJYYow69KDkPDlFA3KZKvvi6qMUQZbg1p\niK4btb+E35wigcoGFRiiDLfGZhEy02Il5SenuMKWHmXLEBhyNfqr8Jm5CS2cc/Vw5PNUctYoGeJk\nG4xWcWBgX38eKx02XijqnnhhMYWJDijVOhIs9nK+rJaTr2JFOytWnKecRdj8TUQXX59CgvgiJZ5z\nYuaJDx9FoMvpEBhfF1SEBF/v/m+CjXlUzKApL8jOckCnYoIvW8s5nJYnUsV8ySELRCSNPUBLCRov\n3LzGVwa2PGSkDTplgXkHrCVTQwjbcq8LLoDz+NO44NAFQplaWSiOVq5gr03oLRyx1QDn8eWC5sMh\neLgyWqvVimP3J5YqHAlyax7ZaoDzqN392z6YQjcrJ0sMO1Ci6KAaI86iqUfqvIPxYanoLbxFS8pw\nPHEap2ANYanH2VVnllH/WxM84nSM9AvX4uJxdtWZxELZVBrpacSjksQWjZ2ukR7ToyzdGjlsTDvW\nT1EiuI4hWpB1B7kT+FGZg2TavfcVcW53uWWyocfmtCOPhe2ARsbLX5dcm4sWps+8Jg23QWajZNqN\nanHrtdyWybzMZE5zp3FC3jNDZNm0a0N4muvewf2Fskm2K5t2JxHI7S53jbyd7kE27dqRrewqN7IV\nmFbykE27scKJ1K5y1e7llQfkh2PT7hLg/658ommfKdBXx/39sHKR1108dNqNVckLrlYzntxQUX3D\n993gC4KVNLJ5gbN5rGn3tI/k+tu/GOZoOWCcQOilZWIDTUVauK1s2oVJbohaIoVDFLquke1y2bSz\n5bqG2UnHfbDLVlXPLQz0WMQ2wPv5Y816bkBTG/j41XviH3Os1RPpueS462nixMEGr8zMXS1xvV4w\nZuzDy1LX9NzLwGpD21BKCGz7VWKcUs+dA2yPr3Qzk9Ud5aaBjDSLF5o6EW3wa0ffbzMir/l2KQ5X\nkC1LVV7wHft1HPHWvhRPyvHD1jNy8X8r/wBo+QwKWt9SIgAAAABJRU5ErkJggg==\n",
-       "prompt_number": 29,
-       "text": [
-        "   5  5    3  3      \n",
-        "2\u22c5x \u22c5y    x \u22c5y       \n",
-        "\u2500\u2500\u2500\u2500\u2500\u2500\u2500 + \u2500\u2500\u2500\u2500\u2500 + x\u22c5y\n",
-        "   15       3        "
-       ]
-      }
-     ],
-     "prompt_number": 29
-    },
-    {
-     "cell_type": "heading",
-     "level": 2,
-     "metadata": {},
-     "source": [
-      "Evalf"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "At the 762nd place in the decimal expansion of $\\pi$, there is `999999` (see the below comic ref: http://www.qwantz.com/index.php?comic=1013).  Note T-Rex is counting the digits like\n",
-      "\n",
-      "\n",
-      "        \u03c0: 3 . 1 4 1 5 9\n",
-      " \n",
-      "    digit:     1 2 3 4 5\n"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "from IPython.core.display import Image \n",
-      "Image(filename='../imgs/comic2-1040.png') "
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAt8AAAH0CAIAAABq69b7AAAABGdBTUEAALGPC/xhBQAA3JlJREFU\neF7tvT3ONElyoFnKEHuF4QEorTYH2A8LjLaDBaiRUksFLKjtagsQXRfYA7Q0pDA8APsApYzYF6BW\nZ+gL1Ea+lmmvpf2bu0eER6R/zC7mm+nhP+bmZo+beUT+9NP6tySwJLAksCSwJLAksCSwJLAksCSw\nJLAksCSwJLAksCQQS+D39W9J4C4SoOp+lzFdbxw4C9fr+urxksCSwHkS4LxyXk9Wy0sCgyWw6GSw\nQJuqW3TSJLZ10ZLAp0tg0cmna8CNx7/oZIbJHU4nW4WnjOvgdkFumZEmi2WqUsvsXX9zx8ZeWB1m\ntTzrbX5+rWGOsm+j6hk7HVtti06Gi3RVOIsEpl11swjokH4sOmkTc957dbrJsHt715/xvlIaUq86\n13t1mNXyw+kEK+zsyfB6Qo1KFlh0khTUKnY9CXRaq+sNeMoen+5FRklllA8Y1Z/DnMrAgfdURa8N\n6wkLyFmoXlItP3zehyvAPCOCoS062U9nVs0nS2DRyckT8G5iVGPquBz2Fe6e1c9DwwoFaCVW/VRo\nFK3a2mV2NjMjjt6qX/kylHTo9EEtTEXH5Bz2B2SueJpc0irUGWssUibW0FS9cqqt6qEUkSO0qn6i\ndiX1ik5Ehs8c5bFGUdI3v9uLTjLTuspcUgKLTmaYNmmtpIdTjSwWk1jQ4LSk3VeBxvL0eLnsqlpP\nxmuGs2MJivVBFdTAflpjr84jkko4cFZAbcj3ghmdccqoPczUycbo64ZaoU9LodKG6KmunZByfFVs\nWI8ZHVh0kpHSKnNJCSw6mWHaxtIJtf5Ji5n35b5rsSBgEjqR3SjJxwGCKoU47ZZkZflRhxR9zLU0\nIfTNeXp29FMuRhWFHda08C4p1VAfnHrUrmYgsscELTrpkd66dmoJLDqZYXp2pRNmv/yNo+OcVFVx\nvHK+XWxUyiGcHd+dUDdmbamH9PNcOqlSV7586K2T3pc70VfSKoSGPJ34pixsKANtKvpk1gWFyKq+\n+Utg0UloIlaBq0pg0ckMM7crneQHKLek6ibV2SOq5TMdyOw71XrydGK5lkz31BBFgxws+TQP3wpp\nOGKxKI3KIdPP0nRYcBBCQ5JOQgGGDbXRidVu83hL2ggq/favev0qvyQwrQQWncwwNT6dOBbQooc2\nSuikExiF5S/DLaBKAOHslOhEAkrSaWXoxPejTCyscOhcHTlkHGE4L5YYnX6GdJLUB38KjqcTfy4c\nffNVsW1dZPR/0UkopVXgkhJYdDLDtKl0Ij9EA4d2XzoP+ET9nHoL37U40ON0tbldNq6wn+ounwKE\n2kmLft6Me+I2GbU8il123lpitJPSseWF4Hh3X68cN5zRK2vhWONy5OxYoSSdyCgC654jJalO1tKT\ndOu3q46rqm8h1r9VOIM5W31YEhgiAccuDKl/VZKRgGMNM5d/cpmk1/lkEa2x5yVwOXVirJN6cHJe\nHKvkksCJElh0cqLw5XZ/hs5cqw+XcyfXEu+n9fZy6rTo5NNU9IPGu+hkhslesZPqLCyJVSW2ymck\nsOgkI6VVZkngCAksOjlCylEbVV87atbyhxuiERz9/ZxeZB55HiOfY1o5Wrfma88/l7POncw3Y6tH\nIyQwys+N6Mvn1lGik4EuwfKmA5vYaVLn7OGik52m+5Or9VV9ZXY+WTduPvZFJzNM8Fl0Yo19lO9X\nvXW1crV8tZJtpA2X7Kobo/ozSj4Ngx01hIamP+eSRSefM9drpG8SWHQyg0KodCKnhu+Tvv72+w8F\nZP3+vIfVJoXG6ET2P+w8uwTLW+MKB5sMb2Tqp1Ky5KnWU5WDA5E98mH9V0VHP0xqRdWkqMrvKIYj\nan8dUUJlYwmn0tEHS0TNcsDOZNY7L5NcmavYksD8EqguoflHdMUeqvRAByIdSXKYkg/YharLSfqh\nkC2ggOMJMqOwehjKpKddS25hnbKA1c8hQpbiRZln2mWOMJyvsM9hAR87Qn1w6lfHK7GjNEZVPkzm\nVpdC/bQWeLJ+OtHfZjyU4CqwJHAVCSw6mWGmdqUTxwg6vq1fLNSy+31IUk7SmmOxkCTynjI/Fr/R\nksdKTkGGL8P+Z1yspS1sXpoBJXMho8Zwrq3p2OnzsD/WnDpq44uFGvDH+6TSrGJLAvNLYNHJDHO0\n6CQPCpm9r5RnxrNm6CcknvnphPkzVZ7Uy6rlQ6DMO8oGEyQZhTtp4xcVMpSWkY9VT7PcFp3MYIdX\nH+aSQINpmGsAt+jNbHTSL1TLW1QpwSqf2fuGJJFHotCrJTfNtEt5/x2igCyQkY9DY9ZwSoqRGWCP\nQDLXJuWQoQ1VXNYYM2PP0HC4XvhCK83QKrwkMLMEFp3MMDu70olvxKtmNCmu5r1g6Gj92Ikz2NJI\n2e78SDqRgYFFJ6oEqnRCBcuubaaTJD2Hq6Z5vSw6CWW7ClxVAotOZpg5SSdg9azP830Gq6fWo7p5\n58Nqo6y89Ad5XKjSmyO6pO935OYvGcfNSE/mzHte2ur8+t5ODsGZC+b/QlRylM2CjLwVckpa/aT9\nsZRQ/ZyqSjitqormx9W83tmo17mT0sJZhaeWQGn9TD2SK3euatDzY80TQL7OTyh5rtzObf3G83s/\nwS46ubG6fvrQFp3MoAGLTmaYBdqHE93YiU3PNgvD+3M/2S46Ga4kq8JZJLDoZIaZWHQywyxMQiez\nieJO/Vl0cqfZXGO5uQQWncwwwVU6oRnxPfq/d/1Wn89qdw8Z7lpn6GX9AqPknK8n7PCu4uqvfNr+\nr9hJ/+SuGiaVwKKTGSZm0QnMQt7bzTBrJ/YhdJaLTsbOTijwsc3la1t0kpfVKnkxCSw6mWHCqnQy\nQ59XH06UQOgswwIHd362/jjDV7va0P+GSxomZdFJg9DWJdeQwA3o5BgrsOt0qnSiTo01X0wIoUyg\ngGzXrz/fT1p52BmnsNVP37vkYzBO/VIUo/wWDRSpE+fLGcTlK2R1fkfNl1UP7bAccpLOfflbleRN\nHPf0RMgZPcEZceoZbkYWnQwX6apwFgnkl+4sPRb9CC31tD2X5ox+knE/tAzKISMQ5r/lJaoLUbun\nOp5MH9QB5tsNpzXTByoH34NSJnBKhr2SBVhtoTzZ3Fli9DupUlFn5yU2SZ30Nc2fMlXDeyrMaCBF\nSX95jhJpaRYWnZTEtQpfSQL9dJKxlbtKJOOEdu1Af+U4C4xXnJrVUefnIrSkfgGLhOjnbfOSbDcj\n80wHrDJWN+BzlHOmibCrIRU5Xt+qvGF+28aSnC+UG+tw2E+1vC9/Js/quKyVpe4EnA+r7YZ64mDo\ntxlvq2VdtSQwoQR2ohPpbukWRK5btTz1BNKKjfUQ506NL67mHV4ebtQZyVheqj84I3nGkj1Mejt/\naJY8w+Zoz9XhD6QTden5VGR1LxxXOL90eZbWQnK+pG4wg5CcMkf+jimzWi+tLGs5WO0uOikp0iq8\nJMAl0EknuAKtpdjzObMpalsluzPt9PumWZWh9WHSJvpOZRNU3uuEUk12Cd1VhoqsRmlbmXaT+kl1\nDx2klFIoChUvnD5b6yscWnV+HZn7gyrpiex2OBDWOq53OgtsIpJzmlGhJK1mVDevG6WS1IA/3pcu\nPqtwv9Wmwz5rFOqewDflYVfHzmBVztXy4XA6C3TOsmU9rVVd+twyfKHl7ZTJ8Zf7Kq1qrGPoMxoe\nyrDkdUoOrFQ47Kf0XqGOZTyx065DDBnJS09Gr8rofMaGhHJzupofheSzsP9hx8LVp8rfkWFJHyzi\nDMcViiIcV1sBasAf79tqOfiqjAYnuzTPkIf0ZEglVONLFQ6cl+T0hc7Ad43h5dLawkJVqy19nrEI\nljUZIpzDKpGysgRlmdqq0Q/L+wWYM5C9DftvyTbfrlNDvnVn8Tq66uh8XmeYX7HqZKYGOhzanIb5\nbbMDsieq3JjCMEDMzxcduxzjKD1U16MFteo84mzCt3mtqJZkrWdbcjpd7cG55XcVbmloQ3oypJJS\nt5sLH9DVkl1gA+EL47UILUvU87lvlZolPMmFbY5hks6vbljI+AmSOcBGfYIYm8fYSCcqC/udsJAN\n+SsDYo6/sb7yjWMDHTO6r7pAH4GTphy67YsUh6auMfqtWo/TE38Ijptn0J0c7BDlrlbChKYKs4dI\nkvXfwD7uPcvVmV3lGyRwAz1co26QwLmXHEcnksEll+TXgEoVPub7TlrlLcvB+47fmVHLJzHiCXWC\nkRxDDVXUtM58/305y346A5TUEg6zs0AVHJP6w9YMvUptUS3vawJdGp1COP3yRSenT8HqQEkCS2NL\n4tqv8Ml0wpigmU4yTnEnOsn3WSKItfkO5zuz86bNOeX9/mcEq3IPzqxVf0luoUDUAs100tbcusqf\nBR/+QumFCpMp4DgeRvzVDUPY/6sXkPI5ZkRntbvf6EJF3a9pp+YJ5XwcnUhXgZMk34TTI72mukMF\nE+ObJN+5Mn6y/kwqnOPskzX4/cnULxty9LKTThxGKY031IdFJ20iOuAqufrapj68Kizg49GiE18Z\nzvJeZ7W739LIK+p+fZA1Tyjng+iEzocDJflpS3pNtd0MjjAIyDSX6XyGHjIaadWTqd/qp/p5ZuCO\nPPOizoy6WoYqd/XaVX6UBK5CJ6q9HiiEUVWteg6QQMaYZ7qRMarN9WQu3KnMKPlkgPjbjJcGk+/i\nnejEYsyMNDL0kJkC1gcJfIyu8E+nk8mF5A8zX39GXBlROGV66OSA7m0936+V/WquTopFJ/JzEIj6\nudUoLZwfslyGVmew3eQl1pbUGld+vNABXPjSArAhVMujNqrzFU5W2B9/ndKppzKvKgNthVnFZFV0\nRtigSvrp1EOnxtIrVQiyP6pUM/XTdh3llPPiy6dqHHahE9bFTJ/kJUx7SsZaWiKrS35X/XqYrlPT\nQP19Umn8S2RP2tazuj4tOgmNo9or5yprsfn1ZPSnoUw4ulDCDY2WLilN+gE179Ef6RXYemGG0gIC\n1fEzI54UkTVMqb24cFjNVp+tDlj676xW2SL1Osxayv5QY4UXqsOhdlja5FIP1bkLlcrRB0v+jleW\nfQjr91XLUshwXJZHy/THUsWMhlv1h3Wq1rttTjP9DMtQA/54H14wSYELdXUPibUNv+2qPfp/TJ2L\nTqpy3kNDVDpRfV5oPR1EsDxBxo357kfKpNpPx0s1+H4JEGp/nGJW/8PZdwpIPLKkGqJAKPAkAlqk\nFQ5zyHw5XJXRn0yZ4XLwG3WmuGpnkuUXnSQFNVexzAKTprzhqrmGXexNP51IzwqWy/K4+fLOUPLd\nVicUPsT/Qm1JW7mHhliykt6LG6Nos9Rswa1hygotCbOuhorpzFTSi8tJpJ/I/vjlM3QYYoRDdSX5\nhPOYVEurnrD+5EgPqMda+0kJqMvcWv6yTn+A9NtSf8LV4WDWmyI1V3TMhdLSHdPubK2UlONjhWYt\n9cxswrWq/VU/p+WdRR5OXFgg9CtQg9X/vAHKSClTRqpf0ouElTd4C4fSEOnYpIdGPOynrNn3ImqF\n0sdYXodV7lxolXS8RcaRl3TYEruq576ok3qV6Z5apkHfSvU47j/TZwcWk/qWNw6l/mQWiKXz1IZf\nJrPTPOB14edIoJNOQg6ghtVarlWLxqginCzGIpbHCj/33XbYDafAMXRSklt1sqqTmHHhGa/sa+AM\ndJLxvqHysLlrxkHm3al8HMfvs6ADSRkPnZGPOo89KmfJM6yzn05KyzCpGN9mPLxgFVgSuIoEdqKT\nN5x3kybggdTy4S4wY/vQw6FRyFCI49WSjZYUIE8nUlxhQ7TyfOerdKKSRFW7pBzYeEOVYAQpnbEq\nDcv5hfMSMpaj2yWdhx6q8qlCsyMBp34LUKSvrU66Oi4HAhy55fvvyNPvv9MxZwkwgMsvw/zqfnY7\nvADVJVxscqhSNKE4nEqkUKQyWcOx1pX6uRS3uuClq6Cy8qfQl0NyUlYxJoEGU4I1WDNirb3q55nJ\nyqxz1Hk0SapBp1VZ2pvpUkOZvFVtqHxdcgMJZPS8Z5h719/Ttz2uPXe8A1vn7jgpLNXYWZZdYlfo\nAxy/rl7r90cOqupLrPoZD6GHYOVVxnJ4ZeAEJyf0lsU+gU7o4nJWQaiB+ynAopP9ZHuPmvc2d3vX\nP9ssnDjesU0fQSdOj6XRlPDhkEGScvrpBH2A2mG2GaW7WPqebWrluFg9syn95fqzB52AJsiafSXP\n9yRfMr9S5PaAUbWzr+if9EUn/TK8dw1jXVre2t9VqnvL8zC5nU8nqq3P7AjzO8W8voYgtejkMNXs\nb6jB0/c3eokajrRfi04uoRIHdPJIraPDOavdNpFaOwertmr5aq/662+WfzudOEZHdeGqUJySaiDB\n8jf5FjGAoVZloRILe1jbVuiG9d8wdmJFaKr6tMrLWV4yoUrbbC8axHhdOum3y464fvrxE301CPZy\nlxypdYtORqlH/yponvd2OrEcNg17OGXUryiRqKCgIkupRb9Lvhzlt6w/lEtor6rjap7OURp5j3os\nlr3H6BpGcQoonNJog3DkJf12Wd+SfXHJL7//oK+bwYpqwRrMWsMl6jwO0YcTKxkih4H9L/WnVJhh\n5RsGJAdA23N8Nt2u6Qv1/XGQIXxY7fr9yetrM50AizA6kcNn9avjZTZxJxOZnOhLF1t0MsP0XZdO\n6KIeIklAEMYl6p8IK0PazVdiLZn8UnpzJy+TSPeEqj7ID516Mq6EtYhTKS2w2rRV3mnaH5fqJdkl\nqpB9eVqNhuOFAr5iVPtj1YZuUfoyX6/42JN67HjZjH6rXhnlpUoNR8jYCrWwZAStifGXhKphsj9W\nsYZxDbePyfm9R7G8Sb3HeOccRWlhTjgEaVLbOpnkkg1WWBzlMFJxrKJqdR05WLaOfu7YQ7mvC2Wu\n+hTqF9U61f6wGU96ccpD+baSpOX3Qbpja1y0Y+G4nFnIXytdmKUDqt9888ihEqwCSwJXkcCikxlm\n6up0MmSHkEeTjU7+6//8T05AZb85tThMOr+wD83k0dAWc6I4CpVXcA9M3zCwqPahSnWha1f9dJ4F\nrf5XxzWQTlS6Dfvzhiah1EKlXAWWBOaRwKKTGebiBnTSCSghmmw4Ql8STfBbiKzsOq2SUUIvIvtT\npRNrqZZcEhQu0Qnzf2H8IxnqwHoy9Wek58vBn6CQ0kJ1qtISq9ChJVU+lIreCoQdXQWWBK4igUUn\nM8zUPeikGVBCNIFgCcRLWOHtw+0T+BbzOwcACosr7E0ntP6Gtpgzw86HXrka87BWU7IeJxThu3M2\nHSHNXDR2oo5r0ckMNnz1YbwEFp2Ml2m9xtvQSRughHSCaOKclmUnUSiswFf1aQmu6CSGUuyksy06\nEpVIkt7aoocwflOlkyptVMtnxosRpozm7Bc78VtnkZXxWp4Z/CqzJLCHBBad7CHVap13opMqoKho\nQo+VOGhCv3q0u1HI9u+LRYBO2A3J1Xnxt6pyN1+dR1neiYswP8SAI+9KS3SCs8m66vRTFbKDL5lx\nJX2/I3+/wwz+UJghdVm4Bp/n9aFt3uXsLDrpX+OrhlkksOhkhpnIW7EZepvpQ8FZvjMEO+4qISMM\nn9Bcz3A6yYx9lbmNBPJ0ctaQV+zkLMmvdneXwKKT3UWcaOB+dJKPoDhpHTxNknz8CTt9woIuQC2J\n2VhFlgSeElh0slRhSeA0CSw6OU30pOGPpRP/xEkpcIIPQWEoQ+/0WXQyg7ZP3odrmcQVO5lcnVb3\n2iVwraXYPs65r7wlnYQiD9GkRCfO/cYTAkpy3e29d++sv5C/ix66KrVFPR8TKtWnFVh08mkz/kHj\nTVrJD5LIGUNddIIBDzh3gjka66lrmVyP9UyUqSIoPh900kOoy531n0InoxbLPepZdOIpeV5Bw6Wy\nChwvgUUnx8tc3SZ+2jqSgRM8JoKhjvBO4zZGWXSCGthJJ+raUetsaEiNndB6GupUB37pehadLDqZ\nwYXt0odFJ7uItVjpqG1csdkzi8tf+8MwCQ2cwL3BSQqhGRzKOng54k4noKirxvqQSlk6QvUTRNWM\n43TaVfWKftgQuYFLQgkw2mZXNWse63BGPhmEum49i04CXfq0bV/z0prwwsvRyS2V7dPoBChBPvWV\n5XQa8jsMUBjWQIuAO82PaMvEBtR9Pzh1ZgQcd5tUdVoDbdf6nMYPknSiVgX1hCPCYk4lecO46ETq\nzxug5EX5OSWTC+lzBHKVkS46mWGmPplO1CfTI0b4gKI+qC0EFNpiNYhiuXPLa4be1C8Q7umr7Yb9\nUeEJzXuGRUr0Vl19DHFC+Vj136aeNzRpFkd1Gq5VftHJteaL7Z8uNH0X6mpeJZJ00rzdz/fkmJIs\ndoK4ADfp/O2fHg97pb+tYz1gTaZy1E/kPcbNgDIhnTD/pIY0aEyFTnHozqDAPHSCncGONWssXXSh\nHJxWzq1n0UlKAW7pNlIjv3IhqtyXGMct1SxDJ+jRLzFNnjV/PRyWngLBwyX4HHoVKeAYCjuh4jAK\nRRyZ5aGNJqU6IZ2oPa/GVJwYA+WA02MnamgnOXc+YfRXAuR0cD2LTlICv6XbSI38yoUWncwwe0k6\nqaYhZhia7AOFEiAGevTVohMshgXaAif0hCyCTkmwqgfK0IBqIa0LacSiwa0290eZr5fHzQzc8tDO\nMJu1VNbZBgeXrmfRSVZ/FqBkJTVNuUUnM0xFSCfgv0tOdIZx6dv615FYiSnsea/sbh2QwEMIv/xr\niVGsW34wElOVrbpqrKXkR/7VaAQa0oy7Zf4JZB5CD42I+KqCVSXpBLmKlh9IJ9ZiqXqfe9Sz6CRr\n6Kr6ka13ldtNAteik7sqmE8nt8npPB0nuWEHz5dg+MSJneBtPgAoGUbxb0We8Bmyuy30j6g4A3MZ\nQVyonkUnmQl9lrmr/yiI4FJFF53MMF0hndwjaiLpBJ8Mi2EMdmCWhk8gwgGMAnSiMgqeNXEelILt\nLkCZQf+H9OFCSFEarz+uRScFYS46KQhrgqKLTiaYhO9nW8nO3Cmnw+hEHhyhERR69BVCIHh3MQOU\nP/z0028//zMEXf74xz/SamnsRIWVRScz6P/qQ7MEFp3URLcApSavU0svOjlV/G8RRz2v/+V0Z+jk\nkD7gWRMMhDA+APLAm4qRS/CNDJ/89uPHBigbl2z/GKBkHjK7ACU/s6PiE/kW+0v652b661drOExQ\ni05qM7jopCavU0tfiE5urFfmAb0bHYalgRO8VYdmYWjihj1J1s/vAJ1s4RMEFHoTkJPfebSy/Xvd\npZw8G+un4fKreVQ9+Rb7Sx7mdPu7ijUsOhkozDtUdWNHcofpIWNYdDLDhDp0cqfAySZqjJ0gf2Do\ngiIFO33CEjQAHHD65Ikm74DiB1Fozkje++MLnLrnHlc9qp6DtbdnyAd3dTidmItUe8bJYYJasZMW\nvVqA0iK1w69ZdHK4yJUGVcN3vxMnjE5k4IQ+Ho3GV+ST2fDbjU4AUCB8sjUBERQElO2Nld/Bgyz5\n8AnzOs1OaFQ9DdqrK9v7b/vRamn5zHgtk1I1NWp56MDxYSeVJjkZEExx+lkdly+3RScNS+D74cct\nF69rjpJA1WQc1S/ThZ/Ygf2aXnTC7tmhp1JoTIUdQ4FTJtu/B5q8Tp8goAAM4UkUiTjq89zysRNw\nk21acSKdyKAC+ns/3pDZcFoCqY7XKs/60Cz/0qzJVlRYkUhniVqVM9YZVq6y49OGlAb2yYUz2vzJ\n8plh7ItOppqFb7P1+qGZO2V2MK1D32AAA/M1NPMCmAJlEC/wT6QTmt/ZYIVGUCCIIhlFRZPw6Anz\nHM3ecVQ9PdrreEHVU2ZozLL5A+mE+eYeCSSvbaMTtZ8OdamdCX3oip0kJ5EXCyXbWO+6bJwErkIn\n99YlnAVGJ3dCE4hk0AfJ04fTQ5aHHoaljyRhgIJ0QtM323sZPoHICsCKPGLSEDvBMAO4mWY6GVhP\n1RioSz7pNZPjlat10QlME4cJ91cCvq3B12UOvnxXW9WGTy5/b6dyg5lddDLDJH4CnVA0oU99xeiI\nPB1CoykWoEBQBPgDz6AglMDn9B+No0g6qeJg0luHOjaqnlJDe8RO1ICBxLhwvGNpKRSLX2C/2Anl\nj7CTqtBW7CSUm1lg0Um77A65ctHJIWIOGvlAOqEHYOXJEjz0CuyyPf4EnoDCUjxAOQAfiCZWBEUy\nCj0MiwmmvD5IDxo6XWv7y5y644dkDSUbaxFJhgZKDTEiOSB2Uu1efqIbxpKRp0VyVscWnZSmLFV4\nV6VJ9WAVsiVwCTqRzvtmU/rhdIJpHXroFWIteOMSxDwYxwCaIKBgcocCCqoKO48Cn2O18CajV5Y2\nVg1dtR6r/uZ26YUOPdB+hvjl2JOqqVHLh/3MzGBbGccKKev3PRHDoFAOzRJsKDRa4PG+bWwfe1V1\n8XysoE4ZeKj9p/SKNXp7Fbo9nbC0DsUR+Apv0sHbjNnJWTV8ggRDyYOekJXaK8/MwidD/i3vMESM\nq5K8BBad5GWll7y9d+kV0HnXX4JOzhPPQS0vOqEPZ6MnZ+kjSSC2wfI7avhE3sJDJ5IelV1ocpCK\nr2b2kcCik165LjrpleBu1y862U20hYotOnk+EbVQ06RFZexEIogEFHo7Mb3Xl+Z3aPgEsOMP8GS2\nr6e0AaZMKpTVrSWBbgksOukW4apgVgksOplhZj6WTtgNO5jlUW8nhoOxMF8IKJJOfv3pBzDK9tVw\nQOnM3XReXtXV4dvCZP/72002xARyvDVr62d1Hp3yi04GCnNVNZcEjl/Pc41/jt7cm06cwAmlE/q8\nE3qvL0AJvhid4G07eDZ2oxMEFIijDAyfdHqjzsur2tpPCdL9Z/rQ326DoBouyYzFL3NKo7RLi076\nJ3HfGvLn7fftxwVrX3Qyw6RJOoHwwD0yO9aRWIkm9JEneL6Ekgq9rUaGTzah4W3DG6Agrwyc4k5v\n1Hm5OpA96rQk1tNW6dpS4SewnpHCO72fi04Gru5CVexmP7Z/on9aRpzVUGj7Y4ouOplhqh06uTqg\n+HfrqM+nl0dSEFBocgcADo/N4q3FwCgQPkFAGXX6FbyRPl+vT2W8AWMJoTPL1I+VcM/0/it0aifR\nkctvLVNAS2b679ecDKt0yoH2Ux1XqX7HRFj1MEGxYs7UVM3RopOqxLrKsxCufIIkFLA+p5lpWgY2\nanTv1dXLu1y86GSGmfwoOmEPs5c/zsfuN5ZZnrfI9hegAKbA6obwCdAJ/TdkoplzVb01c43YbsYx\nW/Wr3i4TM5A9tAhD7bZ080kx5tu1AkKOGKlI1ffWh1gnlXOzbJFTZXM9dSYlLEHzMajSxatwXgJI\nD5I8YAfJuISFfOFbpBCGJlh4AcqbcSd4kp+pVXKsBHw6uW74RN1FqKsbH3OCaEIfJgsPO2GBk6d1\nJuETWPs0ubMHnbDlIzXBcqvgzHzNsbxas7dzLnQGQr14OF4LL9jn4dg7+xOSIpV/BtFOma+qYSH2\n++tt9fpVPiMBx5BZwZI34PjzY17w4ZI0YozWsOFh1ZmeX7oMVe5LD+TSnVfp5GEcXzHCiyJ1nk7k\nT97gDcZ0Z6LKAfckdIHvETiR7kqGFuim3C+fceoZSvBdUp5OmJ97wp/9zNMSZmU8fZJO1H5a9Sdp\nD5vmzj5y98n6HWDtNFyLTjoFGFxuwQejChkBZk9qAsuFqWhp71b4RM7EopN9lTtXe0gnVwyf5NEE\nljYsT3yDt/BYp2LfnNlX3BQxZSc0cWjDcj9JOKDeUXXSB8dOwv6Eei2ZqbSxT3p9B2h8ukrGTqrD\n7KfJsEVWYNFJVWKF8qEJQ9vE6IQao9///JqjV5jXQRNM/Vx0P1oQbqLoopOEkHYv8sl0Ig/GsiXP\n9hvOssXkL76Bg7ED5y/jNR1SCT10pn4GSaXYSTLGoNIJCwv5Uu2nE1WMzmDVr5LytGgs1BwmE5VO\nrDJh5ZkCi04yUmopk0STsNjzwMrGKGQLRbdi6sk7jBi3dP0u19yDTnDeLzotFp08fAk5AD7W0e4q\nq3DN0sgoi5LSrQXN1SYzs/uhiRM7ga/U1UQnt5lOWP3WBlrOqeWzpcoN6b/v5h09lyOiQ6bfOv1U\nVdqaFEv/rfqtysN+qmpTQj1nqS462cWOhfYLjZE8RofkQePAGNe1jt1Znz/hZpdRzl7pDHQit7yl\nGQGfDZNLq5pd9KR/STq5UH4nXN3Wolajnm3TeiGYu5Curq5OJYFFJ+OnwzdeVjbHOolCjVcVTbD8\n1fffbZN0Lp2AzJupMby8TSbHX3UzOmlAE7rNWCfGjtfA1eJFJbDoZPDEhcYrpBMfQWhkBQ/cqcdW\n1HraNmqDZXRUdSfSSagGMhxCYyrh5Rc6YORHvNlI5w8JhFNTCpwwWJl/+Eet3dXOkgDPJ448Y/WZ\n0g2NVxud+FdJZKGJAGf7fu85OoVO/JiHOlP0tg7/ctiF0/KIKdNO5Z3oJFzddIKcEydWBGXRybRq\n7B+PGNhty2qNOswxsKt7V7ViJyMlnDRe9CR/c7KGhoudSugmW9rE0hmIkZI6pK6D6SQDFkgnsjAF\n0IwisXzBtI6tRCeTnz4J58Va2v59dpn7ig9ZMauRFgmEx4HzlTpVLTpZsZO8IiklQ+OFHqUHStjW\n2dmO01YAU6xzeV3DnvXiw+jE4RKLCGlmR26ycaZCPcH6F53srYaZ1e0fM8owyonzyLeqr6d1qZ9L\nP4qfsK/gT+Zcpa9VP6FzOhACmlVF7cPAjg2sSh1jtf5q+WbBWr19072xtX9UbZbxotspRITQ6zCw\nCO1assKPApQD6CQfL4EZlErCVEKdaD82Njmg+LGTh996PzsMApnQdOTpBAOWlDutpTfP0RPLFWU+\np2UkiDTTCau2ml6hwKTGHvImwkI3GBoOUJJZqP8wKFm/7LyDfWG7Tv9TZCCeq5scV89C5n3uqevD\nrw3pJIMm4bmEfkz5nJx33vSUVBeIJOQSGeJCDaE1gNNKuq5w9idM1YVWTC6cCekkjyZ49IRqSGmK\nzxp+hkLYSkHHLIMc1LlSF87eo29mb2Qxfx/PmpO1WfXX1r729HeVxtqaS46RAk2pIb9+KQq1vApJ\nJTEmCy86SQoqLgb2i0VK2DFGcELJOEdyx9xW4SekeEbRCYMJOBuRmUS5LX6jh+3nk75eYwEFN+5n\nOTnpwNRtKxa7H51QQEE9yQPoWRN3aTphMQz8U8Up6d1j+/5VouStG7x4lU7UbjvLbdFJcqLvVuww\nOnE20BmX6eSMzjKLO6lCJ53kAyRS7Opxk7ecxesHCpBOwrgIA9+wPFDU6dGUD4yd0APLyF4sfEKR\nd5LkDtuqfuPj+xeOv1cDITS+It+HsRMZRLHMBVYuIzqOKfDRORysRBYaxbFE6g8h+W2IMrLAopOd\nfM3s1Vp0InPPVYaQpyYXoGS0oZlOwqwNyl+dSisuBbjw6Dn+dtJXF0NAsRTGUgNZ/kRGaaCT2Y6e\nJENl6jqFa1n4jVWI38KEnjVZDbETNZxA3bNkC/YtFFC9uFqPs/CRMxid0HG1jZGCmuwAq1MOMGOs\nGKVZQRH6eQY1rL4lu6Q20VlnsmlFMfJXrpIcq0VmhzmJzLkTeUm4RfY9pUNCYATVXf49JreBTkIu\nodtinzJp6AWPEz2W3AYokNB5/aN0os4Ic3sZWJFloOnjw2MfSCfsyJEKN9aHqIHOTFHWGbhU2zy3\nvIrRAGMF6ekz3h3Jwx+vSgaLTny68oEvT2MDVRFZ7Q1bhzfwORX6GyyEAHA/pfBJElBKdT73c9vk\nC0A53oHtpCQlOslwSR5NfCgEOqEvJEU6HXh8gdJJdZZZeWSUnTycast81yIXzqVjJzIBJwcolY2W\ngeF/R9q+ZErni87pQOJ06ESNbVjbfZU2LIhxducNe3QrbqH2v2QfqINn+uz005FbJjrCN8Dixhmr\nEmdLEO4WZKNy/baJrmrnmfRmvJGvOqSzyqt0gptmSic+x1DTk+QSbCXvusCGgi+8K6Akl1CSSyia\nVPmSzcvTo7yOxEI0BX1SfhJHlRzo4e5HJ/nViiETxEq26jFrgxkcxhnw59biFuRCQGH66QRdzjJ9\nq90lgT0ksOhkmFTVLSCjE+QA3AnJVE4bnWQcldzVMXNJjekwuZxXUUgnbVySZMGQYDBeovqqzISO\nLbNTNMXfq1lM/yC2Of6V6IRNOttdqNsAGhjD3cIvW+xkIxTtSTBMbWQcZR7RzTGBqxdXlcCikzEz\n5wROwGChB6IGi/oDZshY6toKojT7Jycqcxvr5tNJ3utIH+NfS8urUZNqhaVZpkplXYgdUAtAHmHM\nwiBnHvUotHZvNkDzqA701JNXEho4ocARhj9ZjIROH20dPv/OL7zYhdkQ/LNn1OvaJYEZJLDoZMws\nOHSCZgs2RixBgIkVh1RCA4c7tnC/noGeSRxD/8Q4dJL3OpIkMqzgAAqE7h2GsK71kULtFfV8mW6z\njXj/FDxA5/VPSfoYj425Lp3IUGhm8YIybMESSOhgRJMqic92uPmBYgxlhsyjMn3ao8l2akttXT2z\ncnw/k93YSTLyUMhODVWr7RfLopOqzPXylrej3GDRCQIKmhjmvZw/22IqvsW8PZ00o0kS/uSxgzwZ\nqCE0K9kXVguqBf1xRm1xT+gdM4vnY+kkwyVYBgEF6QQ5wxcyi69kZmRUmX7309OTvFfeu5971x8o\nwJcgeiS507X9vVp0MmZqfDqh2IGxE/Rh6Dyoqfr9l39VX7/9/M/b64+vfxJc5M5b+tRPppMkmkgR\nhSigFoB6kteGaKKGvvKVJ0Mpqno0M6tFJz4tNTc3Zj2/IhBJ2TpT38AoLBASjmgIRIatHB+TaOiS\nHmHa2Xn3u2Hs9qiqRtXTMwX9fVh00iP/72ufW5+vI/fyJenEisOjM3tYZw1QGJ0ApWz9wP9SU9Vg\nGY+JCY8RelSLmtk5mE5oIs93dSHHOAWSAEQjKDDRVQ2JRK58/5l0UhIsLYyTUuWzrTwkhhrmaLsE\nfAkGJFhkQp1E6n6YK1KXntMxJ8CmUpGpVKRh1eXv0U8qukz9sgxKviQ33b5xl96oDyA9Z96tr6gK\ntakinbi30XRW97GXMzphLpDSiRVFB9dF61EB5Q8//QSAomIKMgpQi4yswOcsngzF4No7/ZOrN4km\n8mxQ0v33bLUz7BISTKkDACslP9oAr7oVc3+oCDp2uirmtaXtuMnYEGY/nUhAUclAen3mbpF10MPl\np1JW5TMN/Vb1+rQzO/VTkpw6cGzd6ieTW4/QSmLMNMRIVAVTp0ymCR9DH0Juq2VdhTFztFMSUHC3\nSpM7ql3DayWg/PbjxwYoklG2KcB0D75hHz60/wtE8MXiLjebR0YnJWczKrNTwgWncDLpU2pOheYM\nrJQY5aJ0UtKWGegEVnfzEpa+U3UH0i35Lr/qcUs+yHHzEkr262dIRQxWbkAnKhT609GgmdSALzpp\nEODzEkknEAhBs4VBdfzQ2gejz8BoCqZ4HlDy4we8KKBAJ1jghCZ9VF6R7NI+/imvfFPu3K8K0/na\nAwhK9OB0phpEUWM/NIyH6Jyhk9LBiAY66fGyozTxdDo5OIDk0wkDfXS3FsEwvxJOilp/5irVTUoa\n2LWfN6YTa94XnYTKOVEBlU4AUNAxYBn8xPcZMoLyHTh5BxQqCAkiFFwkkdDyEwl0RFe+l9Yd0cRP\nEcrdfAaMGhI94URJOgkd/+l0EvYQwp/5WFee+dgZlFC8owo4dCLjJdT9hzGJsIdW/aULt8I+JezX\nz7vSiT/vODtScxgdhvNoFVixk2bRvV1ISYLaLGrm1DKqj6HnQmgE5S1wQgDFOjIiz8yyVA5eeL9D\nJ2Ctnv8qdDJPTqfk0jLwEZYptUgTQ84qWnTSINVSdGqICWumEwcLkh07hk726ydoeN5bs8LNw5ct\nOp8gMahhJHWmeuiEySSpCazYopM2ufGrMI+jHjeBbZZM7oC38AEFyvxhm6gf32mdZ2bnBShW/IMx\nh/zzllBClyjod+iVaQGcrFJwotREmLJp9mfJblj7/uZ2nWjHLemkIXDyt3+qHUCeNrOj7pVl/IC6\nltDIMj8Ulrd252qjjvuvtquWh/qlnr9tkMQP+KH/tkSXFIKkLgoiauWlmqVIZZ3S5Fq9yjfNpPcG\ngKVaVmFKJwxQ4E/cDGEsRBo49gnzjgAoACJ49GT78Ekqv/124xxNm4LhukIKzDhvGrjynVCmtkyZ\nZiZQL0y2GBar9soCFGa1w6TJXdM6k9NJ2xI796p8GODcfk7V+oWEtmInYzSH0QlYdnSKmM5nx1Do\nn6q3YIACNwkjhWCiBwAF8zhjhnT9Wiid0BlxzmQwNGmgE+bUQwhojqNYNbf1WdZWpRNrr7/oZJNM\nA5ocHDu54nK/kKOdRLzXktiik2FqQ4+VII5g1MTK7NCSIaAAf8DmUjLKBiiLUeh0ZuiEUcuJdFLl\ngzz3hCUddGPJxxBZZOTjWnQC9y75EmsQ16KTYXY2+l3JgQ2tqs6VwKKTYfJnh17lHho2Q5jZQQsI\nBtHZ8tIIih8+wZt6AFOGje2aFTE6ceBPBjDCsFbo8ocUCGmgIVLS3LFMZ3w6CR0/xCBPVLdMD0OZ\nS0EtOgkPIuA5jM7Zz9czNpCQb7dzgKMurw6/Wr6/n4tO+mX4rAHtGlKINFIss0PNHDKKtH20ns18\nwwEUDJ+w/A69r+fDQyns3IlFJ/RzFjtpduRDLszQAMv9DWnXqSTTJYYXNHaS8f0n0smQwAmGS6ms\nFp0sOhnmaQZVVKWNavn+bi466ZehTicAGcyaszwOtYZQ3mIUWttWjEZQNhzBc7LsgSj457BBXqqi\nDJ3IMygAl2H0fgYOkKywR69AJ1EmIaDcmE5CrVBX/fZhSCdbAfYCPbzUggs6e7x78zs0W38Onuvq\n8Kvl+4ez6KRfhs8agC2QSDBMQq05yxcgkbBtVhhHYYACdMIYhcVUho3zOhVdkU5C3x8WGA4oD22E\nf7kf5bkonQwJnFh0Es6aWuBgOgH3Q2NduNapn4APVV/lOzCrflm5065jfqr10N6ynjtVyQ5U260O\nwZkXOl9sOP48shm0hkArWXRyHden9ZQldzBHw/IFmPoBlJEhFthFqYwCVUFDmN8BNKF0QtEEbz++\ntnDrvf8oOhkOJbTCEqBYdJJJ65xy7gSDQ6EMcUXLkvSrNhaRVx1PJ6rDlp6b+jbHx7MlC+uRkocs\nQD9pdodqh2W7WEw2lB+U0+GG/lvyt/qTYUR1mM5cZMrXjXHLFZSZ3lSnpbKPv4baX0wQ0GgKew82\nTkIMhIItQIFLEFDw5p0/fJ2E3f5rvT5tfuakk1Gui9UTetbOAk8Xvsk0iqBci05wzWbgyacTdSH3\nTPfxdKL6WsvZw+fo50Jn7EODjMcwD5o3XyU68dHEihKpnZHthjLJwI0vfzWW0zCPDr3BV6Wx5CfL\nKbnoZIgYn5VIA4eJauQJ/IRlecB5gA+gaPJQi68PmWWUERTAlF9/+gEvOJuyvfA5KJ/2QJR+OnG8\nUbOz73FXzrWZo6wNfaYe9yHPlyo6PemkkyPDJ3TBZugkFLKMg/ZM94fTCTrFql/M04laM3eK7495\n9b2pygrJ/lvtHkAnrGkVR5KjGOhQF50MFOYDI6T9wr0mfIt0wgInYJQxcUMZZesixFFUQMETslsx\nBihb+Y9FE9zVbSqe98roS3Au8teWSvY4LfVav3V5SbK3arrB7/xV6GQgmlgR0M5Znp9OMHyS2VtX\nYydOXMG32nk6Ubvd7IadCzN1WmUOoJNkKGiks0zUtegkIaR0EZVOMMVD6cTalLOwOUDJd8xNAArU\niQESpBN8g4Dy2+c96j4fO5Ex+b3pZOwmuyfGgx5U5ZUG/9pPJweET9hSxbWZhDbr3EmDuPJRqLQd\naiyY9IK0GL5v8L7ykk7vLnMTfgzA6nxmLBl3XqWrKp1YRJiZR7CNqnxUMdLyjepVv2zRSV1m9hXW\nbgxcHf2WRVDAHKvJnYcKpgEFwyc0xbNdjmgCb0aOeeK6MnQiQ1kYvvLddrMbw5jZWE/W2R+6+6dV\nNXRyfjqxkjhVyKNQu8e0ThI7oWHIjOezTEI1dkKdU8nMqNyDtVnel8FEQ+tygLLRMOoj2/XlpvbT\n6jztD6NMvx6LhErzUi286KQqMa+8uiGjzKH6ALRxNHCyvWfJHRpBURvCCAowChw9wTMojzt6XuGT\nkWOeuC6HTliwBP2xzOxIjuzkgAZ/71wic4Wd3etEE6Bw3dBHT4hnPd/PN1t00iY61JCxMyslOfFS\nm6trzcGPuYbx8b1ZdDJSBZjVo/ESDJ84+zMoL5M7LL/zDMeRLA82BJfjXTyUUZBORg547rpCOrEC\nJzJ8Ut1VV0+BVB0bhZLh/CRZrdS9UXSyU35nVOCEBkuG5+lQA+deYZP2btHJpBNT7Naik6LA3OLS\n8FGvBgwBn2BJVgCtEmUUlU4eobb3ezvxT2QUCJ8go1j37ED5kYKYoy6LTthm13LGlBRLu+oQZUrO\nXi3MQiYUUMLWk2Np7uRAOhkLKDCh1vDb5CYDJ85jYcMnxjKZ33JV7mcbqmmU/Xqyah4igUUnQ8T4\nrCRPJwxQ0DJS84TJHYceWKyF/smCKIAm3HN82eu7GkGfTsLACYa7QESUBcPQCMuPsPLNjp9RiMQs\nOagki6jF2vo5lk5gpXSqKM6gI41mOqGBE3gWgCO3EqB0jrrNtMGqabt27FWTdKNzUNYREFlt23jn\nma9OQakCeQOU4Q18VIUqnVAXgrETPIxC48OqUYNLrPAJzfLg5Rg7wTeY66H2Dk32XeeI0okao7LO\nWFAQkbwYYorFEJ0ZE9oT6hGdLA8bdZVUGuhEOtRv+1I8dyKPoTR4axovcQInIMMGdoGrqKAWnYyy\nJ23eelTrQ+opDaFUGLu36GTITN2/EtX80biIdGz0ktAZONaZbe63qhijMBbBdhss/lUmMk8nDEGc\niWABlXDKsIBFQvka8iUpBqnvk5iSb5GSMVOPUXSCQJ/UWIy4sJ1Acuz5YkxKIZ3kwyfz7x/aHGoy\nbDCq8hPtVWkIpcInDuqwpldmZ6SoLTqxnJ9qN62NOwCH3100Z+qbb9wmu9iwzpECOrauPegEZgEm\nlAm5wZfvdAkNyMn31ifSH1e7p+oSPQ3gRy/yQEAlT3WKfU4rzDTdEFyRIgrhI8z+oHaxaOjeq8fK\nQYDXpPNI/2SfP6O5pK7AZHEXxH+Ip79+icss8MDCD9Z4k1AlJSCHYA1Kyhk+sT5X66lOwd561Vz/\nopNm0SkXOnQC4V8oQKMp6CqYJVUZxc/vZEZCA93Ypfm3aJmhqbYD9JsJWcYzqBsIXTKdmoc//uVf\n4aUSYVgbK+Dz5fYtvSErU7nKIqoEZJQlUz8FNXWa9qATuViYYsusUCZrkyEYVk8DnWyXZABFWgCM\nBrUth/xVbBOvOm90gaHPzoQE1DLJdsP6aQE5NEoq1K/LATrXWrKt9k3tKpWDJSiHwPLzPlvJRScj\nZyRJJyzIT/0Hgsv2IRgjMGTsl3faOk27h14Q4zdba4eZv7b+V69C5VbphDpj6mLhPaCb9aLhE6QT\n9U1IG6yAWgkQyW8//zOca/ZfW5k8VfjsEtaDPbFuB5N7vgYCyMdUJDqw8CRdX7Lahr6pIgrDJxlA\noXQiaay6FkrlfTfsOHsVWUIPjeEB38ViPVVKsDps1WN1uNquNS46zAw5hQJs6FhJH84qvOhkpOQz\ndKIGTqQ7RHtEXREySkOnsW8YwmGQdL8ISolOEAczdAIyRKbxAaXz261jlE4QUzYdYO/hKcAWu5So\nJckl0CL9r7qTftv89Z2NbSAVuir3oBMVZDOAAowSErDa5103EvPTCfNbvj106EStx6EBi5CqsRPa\nrgzeMMhbdPIUV4PbW5d8q5dmeam3A5fGQugszE49n2q5HtmE4j8LTbB+rHNXq1fsdW9xRicyc0H9\nCgyczoXvoWnhh/Re+Z2xb7YeQshk+y+8CekEcAGIAf751BIGY9QCrH76J5s2nAV/mTRgR/ISn05Y\ntNLHF7XF5vBJUsGcYTaYgsyimp9OMqOgZWBEyRjD3nQyKpYTYk1VSrOVX7GTkTNSip346QbmLJkh\nq1olSie446deZ6QUpqnLohMWNKICQZT0Mzt4ya7hE0AT+soEURidqKRCwQUjH1BS/lNxB3HED5yA\nS6Cxk8cnh4dPVDBlCxCCZzDv8isrZ2TpSeZkST+dQJ+HL7hFJ45ImTL7wldBx4/lSOaoxk4khw3X\nEL/C/+N/+0m+Gvqw6KRBaOYlGTpRzRyzUzSt0x8+YWhyp+hIaBpAv63dJ5UtxUF0TlL4zBvtmt9h\naJIPomC8JEMqanZGfmgFSxro5ERAkaERGTvJ0IkKuGE6rFQAVSsMEQ0HlDydqPRJPww9K3XGnGLf\nHwrHnLqaHPGpQn7L/B8U8PvcTydMPtgcBnh8Oaij8Ic20smJuhQQ+euf6Ye///XP2ws/yXdmFzr5\nHP/HBG3RiWNf6Gadej4KKDSJAHmfkj3CHSFcm1eOq5eUsRPVObHYCd1ny1AK+3a//I5EExZEYbke\nYBfkEos5ZManSic+uDhWkn7VHD5pyLw4gRO5MP00kFpViTmShfNoAl36qHV9rl3K89a5/Tym9W/m\n+EIQfMHn9E/21bOA28vxdALL+zNXS5VO1JCJFSzBRMx3NiGhgDgdn4YmbxuUVyrBohMqJcYf1p+I\nknsAio8m6rcyTBKSCiug/skyOH6dqj7KzM5WDLQxjAoMLMC2AVbNNLnDtIXGVNj7JHPki1Xp5GNN\nbsIEjixSCpyMbHjWuvQkzitSQnlFfe8HVBadjJz2ZoObN1ssGRH2Hq3tB/Lit3ITOpEuBz0luAQf\nR2RibgY6ATXIJF/U8yIsOxNGU5CE2KGWPJ082HEHOnESN8mgC8WC0+mkCmcfuMZDAziqgArZoyq/\nQT00iGIFVBxYUUMpu9DJB27TQb16DO4egIL9+cwZoZkdmt6ShwYysRPn8MpYQCkFTiy7RrmBvacc\nk/zKD6v4ttUy68PDJ2p0hAY5ks6erhr1Epnva1u81lXw0MUkTrEe7gco1XMeUivOzYmssMcxDASc\n8R9/+f/gRd/jh/BGwsojGUT+DaaTT07rnEInPnYsOsFTsZROZIDEopOMP4Mp4DGt1huMtxZH0Qku\n8ySCyAiKFYwpmTln09lD83JqfHeed/ZhfnZvOmlGk/3OoAwBiyGVlHRPurrmy4dfeK40hg+HVUgz\nPv/+P37GFwMUiSk0iLLoZNg0NZha6SbbNmHWhmnRCdIJ7tTZDhv+7ImdwAGUUeGTIWji6DTLxTj8\nQb/CVE7DavFD4g2rxgli+cfPM6wJBzicDBGeN4La2hasf1UnnexxBqXqStXy1UoalO1Cl3yONNSz\nKfRDRJa3U7TkYQRPG9I5u7Cu9osudnZv18s77WyPmVMFTvvzmZNCMzsOnaCg6JkD5oR8xzYqfLI3\nmviQwXCELRb/W2dlhXSiZmSqoZEkeSSL+Wu5IXaSfHTsVjOkdZL9dIq1GWGZvuH716+/M9Mt5x0u\nVPWhlDZiHcA/rfrVyuUo6CfOJaX+O+P6HDoJ3S5NBlFAGR87aVsV4QDmL9BjU3rQBHf/b2HMH282\nbtEJ0onc+8LEYbKfBbSSfqI/fFLK6TQvBwcymvnD74xPJ5APTQIKOzCUnJqGYkk6yS/bPJ00B07U\nzpSsseX1ASlKKmfFThgBYJ3W52qjDp349eQHqNYDmgxdSnbYKVYVaUn+VyyMJ1Tw+Sgj6QTD41cU\nTX+fz6UT8I74gugu2uVFJzSDw/a+VuwEQ/cZ9ybp5+EYKqdPDgic9Ct5Qw0ZOkHnnRF1Zl4AMatL\nkmkC6wxiK+pPnk6gZMgozedhrZ7MRidvOyjN02dIyI+dqMQjkcIhjGT9tCGLxtTxqp1pWFk3u4Se\nn9UBpWfAn5zWgS1g3rZKw1e1dLK804GSkerRgamuRb+I8RIQ0Vg6oU6LTkGJTo4JnJwyOyGdwNqp\nAgoNccGcyshKdUmy6fPphC3AkDwygNIcRnKsR37t50MLoSKVvDXfIkdxmiQ9yD4kB2j1x4920MgK\n8geryoGVUKSfUIAByvbn278eESw6YeaMRjLCgwv9dEK378xS5y1UjwLMdm2GTphDAh9juSV1EulO\nmrnDPKDkAyezCTnsT4ZOGgDFohME0CqaAOLgVZYaWOs0SSfOMldzi+GGJ7Qb+bWfdN7hjFvxjyRV\nhPUn6wnpBPvpDLzKE8mMTzjGjy3gAUqPUBadUFPC3F5oK0MrkykgW/nMnA7bu2C8BKRh8QTu4NXI\nluUnrEgMZBYyyZ0bowk4ALmtVO0M0DzVcwcTHTqBr8IVJyeU8T1tguqMuhL76YSOPYQSmrQNLUMS\nUK5IJ1S1QsiweCW8MJ+LWXTSgxDbtYtOOgWoX+6HhcFcSmShe7XQymQKYIUYudlltFeoVMZOLDpB\nf4Y/LdsGKDJ8FQLKjXM6jBEzKkPjBwz7WPoG0QHe4J+dsRMZPsksuq1M548Ss4En6STZtySdUJRM\nOmxnTiWV+vRDY/ihqtDKsdqwz5JOnDCP7I96uSM09lXYvXDUH1KAPczteyJ6xv/JsRMZ0rfsC0ID\nvoGSSUMTFltQgjqMas224/RPdGYwCxg+YVtznKAwgsIAJaSTewdOSrGT74kjERRcHQ6dyI0BzEI1\nfIKK0bZn6Amf+EEjX+syNqHHsK9rlwSOlAALnyw66RW+EzhJWsnQxOQL5LdKvcOe+/oSnSTDJ3RD\nzw73SN+GxGPld/7w00+LTvJZHhZNwajJHnSClefXXXNJK2LkR1DyzS2DMLehWr17kwB7+P2ik179\nWHTSK8Edrg/phGbBaGrAun+ExWDU7E8pufPbjx9JQNlBPAdVKSP8+YYhoiAjizSUhViJLIhRlubY\nCUziYYDCAicybic5WF5iwcpCk7y+rZJMAtZjXncV1F508jwJuGvfp6xc9XPUXIYRlPxOKFNymSSa\nU7AyO4wpwSvARla9eYe5SYtOkoCyoQm8MoAypdanOtVDJ49JfD8ny7JylCkppjBkaTvGkSeAzJLE\nMiwBJAMnIZ2UOrZMQUpNV6EvCTAcsX5VWFLLQPktOukSJp7tgJVP/8QtF0UTNI7sWys1UDJ2auFl\nkprpxD99wg4JNYdPEE0ygNKlrGdf3EknDqDQ1cS2B7AoemInGD7pX4yyBjhCCy8VNfyDJnk6gfrP\nVoHV/tQSoKhh4Uj4OceajhEvOikLjyEItYbMlPhfoWVxdt79BnGZpJBOmOti8+KET2gEJRk+eUzH\n+3NjnyGTV/jEj6CUlXWmC/rpBABFnjmlThpmkyFFJ50cACglNJED9LkH6WcmdVh9mUgCzx8E/uuf\nQ/ioFngjnsqItwu3tuhPGQ87d3LvzA4Aytd/Hi/f9lnfwsVgVtC39eOIrGEBin/uBP2ZzA5g3CvM\n78g9Lk6EpB8KKN8hkwhQKkt7xrJD6AQGJn05A5SD6aT5Jh0nauKkdTAglDQXK3Ay43qYo0/7cYnk\nmGdbuYHvSydgIHI9uWQpZJRmOlGNizz6l7RBVrF7z0JGdVQ6oTF/KjoAa+obYL/uA4pDJyyzQMMn\nNK3zOHTiAkpmpDOXGUgnElAknYDY4fP+2IkfPmmjEz+nY9FJFU228h9CJ6BgMy+B2foGBHDwK8Mo\n2LG9Yif3Dp/gHq4NTZx08nA6uT0mhmveohOcO6QT62BQCCjqhDLowUgMxk4WnYRz5xSASVG9NULJ\ntHQSoomzJ6Fh18zWZdFJj5rd8tojQyYq/WDGh4mXdQzp5O2ndjqnBO3+XTfudFv2TPC8Mj3ohKo7\nNuASdtwyY33CMnedhaSW+nTCGAKmgIVPMidk/fAJ/RbDJ8qRWCN8khzpzMXGxk5we+ADCo2QWVsC\nf+Johs6JkZTCJ5jQkSkqfy2DqVFzW86FH0InD7Gs8ElkAk6JlzjhGf8o7r50cssICrMp8jBslUvA\nI4J92YNOPjx8otIJzBGNmrBY+n6AAnTC0EQeQKE3GEc25wLf70En4KdVQGG5njyaWMFL2pBEgSSd\nNHAJ3fzgNJewZtHJzMvDepRI83lSdbDfsYp0Kmcjg4OTPqw5HU36s3fUPd9v4472op9LkEXkmzAi\nUipwv1nIW5wMnVA0wfeSMtFFJb2dk9xR6YTdwoOAkh/stCV3ohMKKOy+XHThDbsFubhg6i0KCekk\nn8phsVh1QvN08lE37FwldlK9d7fnsSKdSZyzGIWeOHlL64ylk9uET9BqbOHVX7ad91eUleZxqkYQ\nPRwNmewUO/nk8ImkE5wplR4ondCAFuyq6R46ZBS1flgReTqZFjhKHduPThBQ2C0wACvw8meKhc0s\n7nfCJw61UC5RqSKDI0zUJTr5nJ3J5HSCkAGu14ma/Pv/+Hl7JRMi6jnThmAJbY5CCbw/ElM8NOmn\nE7AX9IxhyZBNW/hp6V5ogmYFs+Chu1KT3CqmlEIjmcKfY6S4KX85RnqGgFEgc2AWoGyfsw166Pas\n8AnSyR+//lknZLfwybTLodSxXelEAgoyAcxXOE20QBud0BbZe8YfDTiy6CSpbHMCCgYwkvkaWiyJ\nBYx1BiZlgBUGVuhXxdAEjxOhARlgEJlFuJNrBOMiV0toBFUTyfZt+8VOPjZ8wmIndJowNAIfqnOB\n+1Q8kcAARb2KEic93YLBtg1HgEs2RQrpBEsmbfSExfamEwAUCG/QqMkxdAJTLAHFshWdE7RiJ5YA\nJ6STJJFYI4LLj+QDSQ9Htk6Pmzy3/d9gMujYs3TVdwIUKxncGTtRXVomLpIsc/sp0OflPXbi04nM\nskleZBkElv1hOsCmRgYUGZqox2MBYi797wA6wRAmMgpiirMw5fQ1xE7wEpbH2WnKFp1ci0761eAs\nRsHAyTGAQtHkcXvR1z8GJwNiJ7CVoUbh9q5x/tjJZ4ZPrNgJDWmAZKzwCUZNqBMCF2idLLFAk9EJ\noglER/DPx3lY8uuAaN2uiymH0YlkFH9hJukEicdil2O4BEeX2ZB8zt06uEAmjJ30ownWAEGU5lRL\nG2HAEZntHEzb5fmUkMzpHEcncBhw4FTNVlUbnVjpnoz1aShz7ykoxU5YwgXppBQ+CQFFzhEFlM/J\n7xxMJ5RRQjrxw10wgxadsAMux6yvZOzkA+kEt9qzeYdR/cEgSgOjNOPFDelEhk/uDSiXoJMPDJ/Q\n2AnOkYx50K/kOWUnv0MBRT317CR3MBZC8zsy17OFUh4f/vbbip00WHlrYcrzQNapL5oqUk+/7nS+\nxMxfvH6iS6oW/WTRSYO2XOISxIU8o6hBlzyvQIv5QIha0m/u0NgJbl+YyT5me3G8ko2ik4aISOmS\nu8rfT0VvjILpG5apUbfOKqAwOeMBlAygYKPO0ROW32E38lCUuRymnBI7sUyQfz5MriaHTg7mEiez\nI5OJn7bSaSLgePt/cIsQRIGEC2MU6ubpe7gx+HGe4/VMtjydwIX58urRWv/hK/I87I6Zne9coLij\n75bLZhSdyFMOJfjIFL6l/PN0gkcN1N0zO4jA/qRBdesRWw7uyNogUkLvyrHOyW4DfJ5NuWAQ5Sp0\nkkeTU7jEohOqcjiEj1rmH3L0hFk5ySjWwRQemSCAkmSOtvAJtOtwCbSO3dt4C8/DnkMnkOK52eJZ\ndHLw7iHZnMzs+HQigxwUKVjKXwUUNb9DswY0fMLuFlbR5PtGni27c0E0wdMAQ56llJx3evTED5ao\nrp36ePX5JaVujC1MldBKJn5mWuejwieoVA6jsDiKGj5JpodY3CWT5fG5hELJVhK4hKEJNR1PSz52\nLakHUGBR3QlQLkQnH3X6RKUTGQaXAQ/ptFBp0XWxQ5HOUQbWIvy5sQguAXrPjvMk2cvldNgGaLht\nMWNmX/sfMDLNdII5HdhNTbKnQjpRxwVKuOjkME2bpCF8sAo8ahZejE7gk2d8gvzmThJQ8smdkEso\nmviPhNnljmI2Z5aNuA2g5I0g3hViGc1MdqazzG3EHpqGb+V+eSkqf8oTbF5YMeqf2NnDMIJCoy/0\nPdIJze844RP4IZ5wyBMWODizwxYj+9NagGpaZxIioXMKdOJbj89Z4FLb731fcbi6qbOXmIKf0AMo\nyArhg1x9QKEhkMwZWMz4ADbJwMkRsROMsqor6h4LaSCdDD96Au6TGt97yDxcqG/KTX6X2DkaQoMc\nGCx5TO7rhZgiA/4QJrSOs9DkDnqXrTweht0utw6dyBOy1wqizEMn7OhPmNbJ6NjBZUJT81HB0UUn\njvqppEIBhTFEeAaFPnNFHr+FqEyyEpaQUtHkODq5d4onNBnqyYNq+IRBRk8E5UMAhcVOLOcEuCC3\npJuUtog+QxOMnLPIP1K4AyjsK5rcseiE/XbxFSMoR9KJsxJvgCaOFaVg/SGr+2AuvHRzKqlImPCz\nPHjzjkQT/+gr5noohVDWmZdObnAGZSydOOGTUYDyIfZLpRPfgdFTqwxNrOA/TfMDslhnUHBmsQ84\nERg4UW8tpg+QvRygTEIn6hlSFtOa/NyGn9ahqntpV7o6v6sEMG6B0Y5kEMWiE8wTWdSiwsdcdOKD\n/6X95WF00hMv+cDkDqUTunW25ovmXCiabOETmrVRj56gArOSaiKJdgDyO86jY2X4BD5ht/zsatF6\nKj+MTpLLUB6LZstqWluUHGCy/5im7Jncde1FJQCMglENFjWxEjRQnp69pcdsKb6o9+BQWU1HJ3cF\nlKTVcGLLqg9TWWSFT/LmAP0iBi3wNIk8YoLb6Oe9Hu/HTeBDOSP0VCx2jJZUt+xwOAA7Ez7yxAKU\nS5yTPYtOwuVmra+kd8/r4aiSSTuTiUZvVeGtSPBOOcMx081Ko2S46mESsBhFBRSfTvCmZStTMzud\n3BJQklYjNJf+Mb1RgROoZ1oTPNB8ZOhEnjgBw73FS/AF5huExk4Zq3QCSu4cc2F0gkNmT7Vndxqz\n/A4+CmWgxPao6hg6YWvQSa45sZOZ78UFjbIOq8nPrQUOygzgARpOgyjfzELKzBZl2TRqD0X95DqR\nUWgQRQUUGTthdylbN+CoVARNnH/uhO4snQOhV/SaSTphO3hHCM7Rk1GMckU5V82HRSfP6MjXc0cY\nnaDtpmiCPAdUgYzCHnlCu4d0onoUSifs1uIwxSMZZfIsz8F0QheIs8SsMNi06yJvZJwDKFgJqDGg\nibTMiC9QrLru9i5/Ip2AMqsDtL46sbfVicDDs8glElAYneApFjx9AncmJzM7WNgRKRqQgxTRWWlX\n3NbnDUcmfAL+bBSFOPVMaHeqy8kvn6cT5A+QPN1BImdQ4GCMohpxB1Boc4BKG6P8+lP8VHuMlzBG\nAUAZK71RtZ1FJ+H5Enl+aOYVkTcylMlQM584Qoicneam9eMSGKUDUM+3m7F9fKbFU/w9wofaOn4o\nvz2ltxkxWmXwSIr6KBR6+w+SyttdOeRJ+U6Kh9LMRLETP7mz6AR323sDysy2uGd1fe8FX+ZQRq1o\n9AK/ZQaayp+iBn6OEGNlBPAq9fQJ3cjmn2rvPEx2iNCGV3IAnciJw6gYTfFYCwp/03H42AdWyMIe\njDasKBGqKCsAogC9ZdxD1Xtg/+mqZNWC/87riVPeqoSC0VuMk3yRHGzIH6zA5egE5AC5HgAU+qA2\nmdlhqRyKHX6WJwQUhrMHxU5uBij5bU0+drLCJ0lj4RSTsROaZ5FG2TLTgDK+b1Opmp6lVd0DtMge\nfLKNaPtkC4ewAInFJfj5Vr5faMNryHud5qZx4uj68ueLZeXmJ3WGERZ2JA+msOidam2wCfameZow\ngiLphLrw0J1jGMOqEFjH4SH1q7Bdp/+MeJw/O6V35OVAD+w+YUon+BULfjzTOl9BFAdQFp0cMZuL\nTo6Qcr0N9IvqWQQWPpGTyGInFqBYB2Oftsx4gCymkMCdUO9IszyIKQArIa9MCCh70wkLnMioicQU\nOmXzc8mbq3sPdbQxCqIJiE7FOCrV7f1Xs89Xp8SqsQe57jPBCUYnKnlk6glbZyQU/lk3Y6ddQW/6\nBRChqRwLTbC7CB/N+Z3TYid3Cp+U6MTf3GQ2f2MzPp225rSlk2iYxU5YfidPJ8AlIZ1YSUm8UIZP\nUHNgFvBRbHiIBEgFX2FM5cPpxD9rwqDkopqftzaqqUE0cWJLapzmF0IoicVnFtmVTqg/8yM0gBHs\nX2Zc1f4nQzKZpg8uo9IJDaVkjr7651798EnL9IySkbPMrnX6JG8vaGbBsR2Z/d8oRrmojc4ooaQT\nB1DYJMpDJ1age/scbzNWhUmxxgcUefqEogm8f9x1/NtvG4Vs1cpcz6fRibr01KWBh0surfBqsITB\nhGNYHDSh6q1Gm6jcemRY9e5h9AIrZPES1URkyvi2pb//Gds1QxlGJ/TPkEug/53hkzPpxAmf4Cqa\nYZLCPgykE3Cfi05CmWcKqHRCJYznQuQM0ug3GG4a3N7e41YSd+QOUufDJzguFjVhEZStLYijzA8o\nOAuZKauWsSaO+Vc8/lmtf7byqIcwcFA5fDmbH2czA5f7u52BT4Lp9+6gUTg1p9MJhGGgP9eNlFBV\nxxtzWKQE781JroskndCDtzQNNCmd4MJLSuHcYkk6oVkbJ7+z6GTUbFI6oQJnEyG3nmyLSdFkgxJ4\nYcikRCfSf1DlwS0poonKKHCKdougQBCFMgr8OUqAQ+rZj05QdFSq4b5/yKDOqoTSCegt7QlARhg7\nqYZdZUNtw2fORuJF0sEDAah6pTZBP2Q9t7okB8g9pSAkS88vxytwuEQGTpLxEhQd3vXjn43dytOS\nE9HJQ8lej/RWg95ty+Dgqy5NJ9dKopVmltGJ9GF4ItVKuIBwcHdK0QQ+zZ+vpNtThkqoP+Bs2KlY\nK7kDdAInVABKZuMSdDZss1uaRKewXHf3RhOwlpveARyrkkE1kzgeQsm3oqPGSwDSvPSoCV31nC4B\nAAWVTqp9y9MJAIoMtJwcO/Hp5BKOU+68rbhIeOgEEzpHZnYuIeTqwmB+kYajqGxVOgGB4AkVmF9w\nCfCSUIKfWD4D9Jy6B6oklE7wYCwMwcrvwOkTpJmZfxFwp9gJQxPV9Q7MR7Rp4PCrQBUdNZOaFkIJ\npoc2cYUd3hr/9Zf/HV87cWfYjVVgJwmMpRN8UEr+8fb0FO28dHKV5M6ik53WSX+1LHZCj8SiyWZO\njs0mFAN/8Cj52lOqe/TQF1JA8cMnwCUUTdif+GBZwBQMovQLbXgNu9KJkwYNp2P4SI+p0EeTJ5d/\nKarFJfS3okCx8z1fdJKX1RVLqnTi3BLsjBFiIfDfJJ1AEAV/eWfRSa8KDaETlnSoxk46f7i4ZJ56\n5XXg9ZJO5KFjSieMVOQsgMW37D7MQn/4hIVMMC7C4ihbQ8gleAcyYs2BYg6a2o9O8PxQGyzOI6Kd\negKmSb56bl9adLLTZE1S7Sg6gXoQNap0AoAyO53Mn3dQXZp1MC2T9JHbwQx8ZMo4e6lbAopFJyhh\nmlLx5xFFh7f5tHlERjZISwyS8OZh68EneGsxnJAF0wYcM1scZVc6UTn+Nnfo7OSxqvES2o1FJztN\nyiTVDqQTDJx8k0pikPT0yaKThMDsIvnAiXOTjsw4MJubJA/6cO5MspmW+Rw6oQdK/EmR38J0+wHz\nUJJqDQA9eA4m8+ATAJStM5RLZkOTrW970wmbjrsmdLrs1LiLF52Mk+WMNeGtOvSenYbMDk3rlG72\nQTpRwifHCyyzZw0t/vHdhhZH0QnuodXASZJO0Ew3YMq0Eu6ZWTV20kYnPpeA5JM/JmfxDf18ey+j\nJnhglt7FAyUhxTMhmuxKJ1YC9JbKnF8IIiC+1wfb2dh1KjY/L5coyejEf9KrM6JmOtnqNMMnx0vw\nunQCPc9ndsKdOubR0YOiz6vGQvBCSir0yRyswlsadIdOSrNGoxrORCTpBKBWrYcBCgRF8AAs/sme\nzMbQhN31c/yKZi3uFztZdCInd5P2L49T3N+3mG1/7vTaaWZP19hP7sAoOvn53/4NQiaP4yM/fpRE\naoZPSrUMKXwPOqHHWkMKSZ4+wR15A5rQ3XwmlPI5dAIzlacTWtJJ6+RjJxh1k9Mqwyc0xaPeXYwH\nTRBKZoug7OTDcF5UMQ4xTZerBNEEoho7QQmtdsVOLqckfocpndAYRtswO+nkeflOFiQzpIvSiXRa\nzVBiHaGldFJN7lSBZtGJOguIC/jt9ok1F/nYSSl8AotI3l2Mn8DB2GlvLd7JttAFCGfn8cDyLZU5\ntKWIJiDwIwEl7NsqcBUJ0BOs/XRSjZqAlFhW6DsxebwQF51Iv1hli/7ytzToMrODubNM7IRFShig\nqCmzkhir+R0rxfPh504QSiidlCbieKM3vEUaNWFPSzsmgjJ8RKvCUyTA6AR+AafhVGxP5y9DJ3AC\nYzZbw3yb3GF3xlFU2tg1fDKbhHuUG6+16AS32s40bQKx6AS8ILwoo8AnpZ6HgAJBEcolMo6C504g\np8Pu9yn1Z4/CB8ROQIwfSycsaoKxE8CUw1I8eyjPqvNgCbC7f/vDJw393xqFYyv8tp2GunouyWxh\nwVVX7X5Pr8JrT6GT/gCJU8NU4g3lnyzA6IQO31c8/FbSAwMaxBQglQYxSgwCbcfeAqDgkNUUD+WS\nTzt3ImMnIMCGuUjq1VTFnKjJd0j8qDMoU0lmdaZBAjPQydZtoJPtv1tu6LTMzhXpRO0zpgwyUZPw\nCK1/Y8gemHJLUy7pJHk7MZ1iK7zBZqF06ERaDdmKBShqKIWdjW2wSvtdsnfsBAWFmPI5dGKhCU3u\n7BFBodwj3++nS6vmvSUg6eSU5A4M80En9N/eg2f1LzppOHSyR4rnE+gERY3ROCsQIj/PEOHegAJB\nFPmgtjkTOrjSz6KTx56rmGg72Pp1NqcmdFDaJUDxaUN++4t7l/JOM94prnV5KAGGJlt5+OT4oyfQ\nVa544QDGFrgZnYRBkUxkhT7sxHKKwwHllnZcnjuhgMICJCzD0gwoPZJkfWABFbg3hy5AGjLpaXfs\nouY7kNc0jG0Fpw+kBPOFEtve3JtOVAqhJ05KwOHTRvO30Iex875q208Ckk4AUBadPIyL8yCQSYyv\ng1Ol5I6PKWBt/fzOWECZRLxjF16eTmjGh4qd3qeTCZ8MOSBFGYUBynY8FiIom6AwjiKpZawYO2vb\naScd0gmIsbPz819OKUTGS9gnW2F8wCu9sIE/SvSzGGV+RcJICbtDB5HlEUQ59t8FYidT3bbjB3sG\nxk4yEZSkv8wUu6Udd+hEnUd2HBXlxvblvjxHSRIZhQVU8FAFQAngy6hG9zA+x9MJWoyZxTJE1EAb\n+LKIgRYIC1exQy2PoxsSPil1aYhgP7MSK3ZyVnLnGnQCMdsZNOYYOgF3mKGKUWUmEe/YKR5FJzJx\n4Ie1BgoT+EMCCgWpgc2NlT/UtiudYGwJlwx+MrlYhoia0YkVO1G9ewZrMKZCc0YO38hB9dNJCU36\nmxsyL1eshD4llvb/xKMnl6GTGTaIfloneabET2DRb0eRR6aeW5pyVG4Z07JiJ1b4BGpgeRZVsG33\nFYfmzGGUzNxRyjk45bEHneD0bW8gxcnoZKqAazi5PQUaMjsqxDD+gD8ZnTBvIdNGw+lEogltQmWR\nBSht6oQUskVKaHJn0Yl36ITm/tvkPuqqJJ348ZVFJ6OmI6ynSifo0iyeywDKTnTyHSon0ZQ8l9CL\nYBSZa0MJZwocSSfb0BBWZtjPZOTTU4bFTqwwg5rZUQ+gsBr82IkMooylE3U4LGe0lbEaVb/qkfa9\nr8XYiTwDe8oz2WjY9akJB09AyZEfZk9VIYBBd87tUopqi6PILX4m7DGkzLmy3UnrLDoBv6XOEQjT\nj5GoeRachSMdv6OoGCx5h5lnkmgngev9eU3DqEbp3LHYicTHWyq2jB8wTJFRDdXTy+QOAw6VTmRV\n+EiVfjqhlVP/hO8lnTAKYd0bpXWfUI8TPtmQ5fg7d7imHTwHV6ET6GeSTvyS+djJkUdPbmnEUbmZ\nzDvpBAmGYcokXMIGC73a/nNW94bHTnAZwkTQzA4sPXo72y0Vm3po6xSIlb7xz6awgAqjE5hKp4Y2\nOqFO6Jdff8eXFQpq/vxg73a55pBONhCh+R2MnRwMKFeik7POxoZoghjBwicyFiLRhJYBa3v80ZO7\nWvAGOgmTOzJShVEKpJbjrRKSh8W+J07xWDphaIJ0QheOnBH8BN8cP0d7tOizAjXuGN4ID8Niye1y\nNXYy9lRsM2oMuXCPSbl0nRREgEXgBbftLDrxzqCcYmQzdAJebTidtIVPqo9COUWqB6xhlU5o5KM5\nueNk0w4WJrhbP5N47gmM4XSCQ8bYCSo8PRu7FWPTBDEkeB08TftpO4rXf9iJ6surmR1WyZBTsVCn\njJdsn+BXrIwVX8nHXbByOqL95uhCNTM6QUBBOmFnZncd2sViJ8eHT9D0Ux+gBkXYh1A+DJ/I2Mmo\n8An+fG54MOU2lpotFUkndFdtOfXM0RNfpHvLk0YCwhNO9EDMrqbEqnw4nWwbesALi06AQrb/MUx/\nzPjrdQ9AobETHx3U2IlKJ7QeP3Yy5FSsJA8rKELhg9KM+rks4MRaAFZOWR0TNirDJ8+QyVfsBHnl\ngJ5fj06OBBTqwBroBB0DuhAJKyybc0pyZ29veoAe++cxIXjANtNW1GFaOkEoCYmE6tuJ+SaYlOF0\nQtEEMjv06AkGSDbPKmd8++zb487xCKXO1QHilYETFVZYSdVhh5kdeVXPqVgHGvyvkoCyVYKRkh8/\nHrpj/euciDtdjtkcfA6bFVPZddQn08nDeEVxadUWH+BQWccydGKFT/DzJJ2oAZUwBNJWYO87YHdV\nX7/yb+V+7bOpLjl0wrxag2D30E+rw+FBJbjwrIk4l05k+OQb8k4Vy5DpQNqgdtx5nImKLBRH/Ht2\nLBJqphMLFHyMaAaazIVD5uUeldBDJ8+Ezlfs5PvRseRgyh5DXnSiSFV1A0gnMryB2W5JJ2H4xAqW\nyO1vg4/MXPIJdGIBrnXupJ9OIFozcMU6EE9zN+h66RsY5tj+5Ic2nE7UGBj9kIVP5GxCgXOhLS9A\np2QYNZFHQ/x7dpg/+I4zfX0Rco/sKlQYZv0y3ABREPZSP2QHUNRTJmqLQyblfpUgpkBmB17AK3ge\n5ed/+7ftNXbsV6UTsLbDDa61PWW+wTpNIj8Hy0gPoKjHStTtL4WeDGe0lflYOnFub2mTJLtqlHI6\nIRPGJX7Gh/LKWCOSjGD1N0qpArN1WK0ElM25wizA2DHJRT/s79W5NYTxDDTxcLewf8+OjJ2E3JCZ\n/VBEYSvHFAj7+ckF3p7JRgAF00DDAeXCdII7wlGY4iBIkk6sPbrM1LDQyFl0Ajn7UX50tqWLyp0/\nqCH32T2k0i9Ypnj5gciSGFGAsMFhkzUwdkJXujoEpBBEMTpMaSiOlMOuAqd2PB8dCe/ZYe6hYQhO\n4MSPCUFQZDiUsDqhDwNVtEFEV7kEKITeZkzvMaYPvx81osvTCVrhHkZRt6cUKXroBMI8Po4wX0Lz\nQcw7Vu8W9p3rjdGEGp2MU6fb6x4iGRhBcdAk7KFPJ0cCykDTn4SJO4VGGgy9QyosdkJPnPSDSENX\nSxmfzvpXKqdTgHD5RiFbjARYBDI7239/+vFjSOWskuFsuipcElgSWBJYElgSWBJYElgSWBJYElgS\nWBJYElgSWBJYElgSWBJYElgSWBJYElgSWBI4SAJ7ZI9WnZ8ggYHHCz5BXGuMSwIDJbBW30Bhrqom\nkQCHnkm6tbpxOQks+3i5KVsdvo0E1uq7zVSugaAEFp0sZRgjgWUfx8hx1bIkUJfAWn11ma0rZpfA\nvnSy1d4mgOYL25oLr5qtP2GHjy9wP/u4Jv14LdparIo9WR7085QRqY2O7c9VVt9OU7BTtf3aQv1r\nf22fVsOik9SMT6v9qd4fUugq9jEvjDXpeVkNLFkVe7L8WBroH+/Y/oxdfUmRNghhp5p3qrZhgNYl\n8/dw4GBHVZWik+aFlJkStUzmQiaChkvyQty18nw3Zi4p7SPXrZl2rhlJTjjp1lZMdU6s//jn5PNS\nFXu1/EWn3u+2Qydsug8YvmPS95ishnhbRghjy+w08IFj36+HzZJspBMYiWUTkWb8ATtWMlk/DLtq\nbWnleDlKMDT00uj7cghn3VnMbHS0k3TKwyaa9SN/oUonzk6ClQ8tmlqeahqtwZlEx46rvBsqOZuI\nfP3WCsrInA1WVYxMmUxbvhJa46WrUi4uaxExa6tWwuQWKr9TiZwC35hYValitIxYqZLqBKk6bHXP\nmbtku87ArdWkylzWk5/WpM6U5sjS+ba1wHoIPamqgSyf1FVmoKo636MJndfyATpaIq2/tIlOGauj\nlluybKtqiNXpd1qkhsO6Vu2A7G2ymD9P0lijBkvdkh0OV3KnlmQul5bO6VVGaFgGambzjh/SN76N\nU+txhpYpH2ppRnQl7WWK4SgkFaCqRcm+se7586LqbV6ZHZmrw2Hlq6vMmj7LKJXEGOrPwGUrV58z\nEaEB6eyYnKlQZywDmPEaVM4N9WR0IFxKDXNdMh3OjISTxRoKx5I3C3uXRK1+vsnTySiv2WwIqoro\nsFTYByjgeALpM0KlcSxdqEDNY99Pn6R9tCRgdb70uWMBLcFWhZYpb638qpxL2kJV0dFJOSO+x8p4\nAqdpS2nluvMBaz/l9yc09BYZfcgsaksgVZ1hbTEHSVuRX+VF0dYrNJjMcpbWuNP0WfU0t9spcGty\nVa/E5BYqdptZaFOM0lVowZ5v5qcT2mPHFmQ0W7WDav3hylc9gaNSx8u5pBYNhaUEmG5Jc6leIpeK\nurDl3LFF6FSeXI2OQbGUEIwFu9BXRVVzQvmrqqt6fdkZa14cOlEvSVrqHjoptZsXmqoAoRH3HYyz\noi19S+oJt9Ha+a2MFjkDrA4tKWpcC5a6ql3KiCWpe2FVTj0l3QsFKAtUl6FlW6wxqjbKEUgoq3DS\nhxfgmi+xa+wkhWvYNxz5BdZGJ1b98Llq6MMpSc66uoBHLcKwk/0FpH10lo3jCPvpxJ9Ey1mGmpmZ\noHzlTJ2SSiLrd3Qy4xIy856cR6u5HjpRuxd6glC7rkUnyTmCBegXHqUSYZewM8xyOnMX6g9tdJRh\nTNbTrMPhhaEk83bJko/jNB2RNnRs+CUxnagDyExqZrWoLl9+mHEM4cp0LHtYf8+qLnXMt7xWP/NN\nDFcgKlU240mvxrok1UaViRRFfhJV55S3ApnVnpmRTD0ZR2vVk/k8ow/JeQyHUzUamXaTRibEkQws\n+mtT1R9fJhklyUwQdD4jih47luwJipq2lWw3MwQ5lfSqUXOU0T2qM6Hpq3bMkXamqoa1P1AbS6ri\njxQV+/EmhCko45Sk6yQ5YLm0MvVLVW5eomwuqUTUxcCkpJZPdkZWpXprf7BJOY9SGrWecBJDoUm7\n5jgVae9Kkyh1OE8n1Bkwy1id9Le1l9j4WvWrn1uLiDWaUR61n765kIuCyU3VB0kJfj2ZecSGwg5b\nXaI15KcYTaVcvKpi9yzPUDEcAyIVIKMSYW/lCvUdB6pHWDM1FCjk4XNkrU1LIal6h8bEsiHW2NVG\n5ZBDG+vPbF63k3PUWYxbqs7q1uU9EhhiFHo60HPtKM2+tBB6BLiuvZkEjtTkUavv3Ck4UmJjAfH4\nnp87U8e0vujkGDnHrVgbrPjKOUoMsY9XF8IcU7F6MYUEjvRYQ1bfuVI7Ze2PmqNR9Zw7BbO1vujk\n/Bm5gWXxo5oZEd9DCJmRrjIfIoEjPdall8+JnR81R6Pq+ZClkRxmik5OoVp0eMmRlIpZaTw/vVdq\nYkj/x/an2v9S+RNNTKmfzYUPM0Btk37WIs3L0x/X3v3fr/7DFMMR9bmrbz/Z+trVtlJknWH/T5/i\n0zuQX+YDS34onaAErVkfog2h0ucnckh/rGU5xLQNqSQvkONL7jQFvsvJD3OgsuUbbSupSnLv/u9X\n//GK4SzkthnpvGo/2Y5aHRnKOaatNlGP0jGH58KvWM8PmPQUnbQJNHnVKLknm5MiVi88t1eq9Wkb\nYLgsaYGeUat00lPhHuPtqbNnLG3Xtl3VM8bqtW09zF+VL1nteVt5i6vaaht41cC9wa4btrFDHlhb\nyU6W2q3q8GE6xhoK5x0LIJeUhlYqDBIO6MTiKWhJLgnrc6swax5nPeQ4Bm6ldjP+mIqyQV2q/Vfl\n4/dTbcJROKdLVOylhcd6SCeFK5bxQzmyw2xmQTKWfKpydoSm2nf6IVOJpPI7cmiYdHV2wkFhQ0yY\n9HNpDphWsPEOHJfVf9U4DFyMjl5JOXfqs9rt5rXmdM//ytdha4z+2K2FE65Z1MaQDJhNkP3BcWVs\nhWq15ARZa9/qrWoQVB0Oa0jaFmfNZlRL2l5VeRw3ZC3Gkq1wuson2hGcnFSUDjVkTFGqA2blfQnS\nttjCC9uVnc9PQ97WqErP7L4/ZLWflliSn6uznB+UdTkzIpb1ocWsRqUZlUJzOpysli5vv35pH9Xy\nlhKGsrXWecbKqOqEHaZv0GGwN76OOfM1dlz+YrFWTdgH58LQaCTXZmbe8/0sTTrV4dDa9PTT77+0\nPGpbzroOR20Zt4xjcmx7aGClWfO7mumnU4NlCnrmLmPwYZh+58OhOUrSoP/YJaVneW/tu1t/hVeV\nXu1VKDXHUyZnLtTvUfVY2pmZDksO4QJrUB05raFyq4YglFt1UNZYnHpKSlWtx9K9UKOqk+L7A/gW\nyzhv2DT1WJyMMjvWI3N5XkolyxuqZUhLGaMUuuRkAbTjSWPr9C25fJIN+bqUnzu5iDK60T+JeZMV\n6kN+KmXJBpvjN5dc1NUl4zia0lyj2FGxH2+sISVXml+DuoT8Tiel4y82a+k6bkP2SlrzjLbJjr2J\n+z3fke9nm7JaqtOgN+r6kfVXLQgVTnK1JxuFuVaFXxVmtR5fzfKTHuobHYhUV/jE+tyx/nmzQKes\nYVzOorN8YUl1k8bEkXNGn6mErcUeTmW1gCVtR7cdQ5R36vlFqrr5zPSpNsFaU76u5nXSVxVLPmr9\nmTHSCg/QMb9LqhkpTR/IwefXjIZzS7sTneQH7A/JWWzqBDvtquK2Fptq1pPyDTWPrbSSdrJRZBZV\ndbVkhkl9fzheqwPWZFUHlanf6ST1LqFSZerJWNLMpIcToQqQDUeOrnm8w8eVt2hWn30R+YqUWReZ\naWrrWzi54dAyLiHTt+ryyfitUMcyfqdqB6y1WZpE302o/iLTT2c2S93LKG2VEvLO2m+9Uw7Up4Bu\n7xU7yQ94WjpBYZXsSHKGHPk0L35rQhsUOjPkpwKlf6pJ1mkJISPDhjIWiaqWlAozab5Lc5oxSeEs\nqC2y4cjRhZ4jbxakrpbGJQv7TVc12VeSTG2Z4VjyDKevp4C6+hg+ZnTYIk7n8+EGKkkVmbnI0EPY\nf8uQ9vTzLDppUHJHn/3aMjY5ydxP9c4wbJsG4/qRk20tLbUhWk/oYCR/JUHSUv3M7Fpai8vAGoL6\nubp42LhYiyhhqlglITcYSsc+shkPXQ6rytJyR1yWfFQldFYR7QktVq2H9kedLNUC9iibtCnwifW5\nVE5rcckV5Kzo0ricRSe/UmsOjZ2zNpPSlnqe0Z+G3pbWoL+6pUHwDWN+LWcsMDPj1ppyXI+60i1t\nqdYTGljH3yXXsjM7am/30zHVcLG1by1wajpYPepXcmjNcnheWFoSn1Y4ab98Ormr0Kqad1c5rHEd\nI4GGxXhMx05pJbn6ZhPabP05Ze5Wo0mgNDM7S4Jtu5/PWX5J+7gUaUmgXwJti7G/3WlrSK6+2czR\nbP2Zdn4/s2M8QvOZUvBHnVz5apTvc+TZIKXPEc4a6SgJLDVL5gKwmJoWGTUdDfXM1p+GIaxLjpHA\nopNj5Hz/Vqpu46zt712N41nj6p/Hs3ruxJMHLtdjwgPJ1cc6U527avmqGGfThGr/V/mxElh0Mlae\nn1tb0j6yLd3B8jrGVRw8qK25E8c10GOVRlEqXJqRsTWPrc0hqsxEzEwnQwTF/Flp3u9UmPt1+27c\n5hibY/CHTCWYtbd/d5qhNZYjJVClkyP7RlfgKe3u3egoc7B3P/36S6MoFZbtSvONFTbU7FzSUFvD\nLCRX3x6dGVXnkHokfjUIU/rFtkrmuSqUbVVutLysPGwuKZlFJ0lBrWKBBCz7SDUMqpCf4Of0W9ae\nWg8tA0sC/6u+sVhc7RKtQa5eOV6nvDVqSxSWrH1hJl2UI2RnjvebR4cdHfkMtIBS0ywRqZNuKVVJ\nmJ32xZl6+hUKzRcsfIurKaO9eEk4kOE67GhCs5LI9U611JK2ZUakcBrqr9oKZ1nJOXL6o06oX75Z\n7I7Nf2pkqF6rwJKAqt/hIlTdAFv2lFT8BaauEGpYmYWl1tbpCbPgYX/U8qwta7nSz8Ml7Vu0Np0M\nG1WHP3YefTqxvk32PBSLrIepsdpQ1ZrTbozqOatT5QOmYOpgrb6FFWZ0I1SVkhN1uhp63FATnDmy\n1mnz+rX0x9GNUlsNUqV2LJTVopNQRKvARBIAW1ZaQkkTn3HtSANyjYVdqlqKZPlwtSeHn3HPzQ4v\nc2FYJjmQznqSrVSXRMlhZ+Yi7IDq9cOr/AJy9YVUnSkQCodReDgKZxJD9UjSQwMzqWSDInUMSLjG\nkzhF61Hl0Kz8eamq47UmlMmkuXtJrX72LVSvVaBZAntYpebODL9Q2sdwYSR12qpHvVzaC8e4oCGj\nKzO0OKywVb65noxFYF4hFDWrs9kSqX3rnEfH5avzMsT9WI1KdysNsVzIVflDKw1XObqhVhhOjV9A\n9jDziWNbnOZK0rDW4CjdsPqZXPsMSvAqR9XlJVYlec3Ji1Qqeegg6KBCNQtrswzLm8DballXZSSQ\n16pMbbOVCVeg7HBSp601pl6OH8o30vH4tizZbmhxqvXsTSfMEoWKFNq4znkMBRj2sKdA6G4zihSK\nKDmnzQORq0/V7fxgraUR1uAPYSCdNMsqc6FDJ5YfDT931p2qP9V1GhpYZ+DJJby3GrP6OQtmZm6V\naZbAjQFFtY++1c4viczqhTIT0kmVipImoNl4NVy46zwuOmm2J1R0qm1hcx2yRbW8pdtH6nC/9EK/\nrhKqdKV+Pda6s5xCwzqlHSgRc94Uh7IaOB2LTgYKM67q0+gEjJcKLtKuhS5Q1kM/aaYT1smkJZLj\n8le4Kge2/EIFsoRZskTWeP3Wd51HaFr1naOGnPSXvlo682UpuWrN84VDlUDROU4Ov1IlLL1sqTxV\np0xvR02oPxeZnjhlMhMtBV5a49J2hdbSWYP90FCq3J/0qjly1ubbRHRO6ro8Y+JvKaXhBveWUlqD\nWhLYQwI7rb5RbmaPIa86by8BxojrVwD3nXFrf7Nvq4fUvpN9PKTvq5ElgWtLYKfVt+jk2mpx8d4v\nOjl0AhedHCru1diSwGdIYCCdVCP8nyHgNcoTJLDo5Gih3xVQBtrHzinxN3x7y/944773Btcf0d6t\ndyrDAZfPIIF5Vt8BAl9NfIgEFp0cPdF7e8ejx/Nqbx77eCKdnOKoDmtUbeiw1s9S7LBdSwLMtob1\n9BSYZ/X1jGJduyRAJXBtOrF2dcfvX/NategkL6uw5Gz+cm9Xfe54z209VIazCjh0wkztfj1cdLKf\nbFfNZ0ng2nSCUksaiLOkLHlwhp6M7YNqH/P4CDOI6MYYTtbDFZf8RDitiiqG0xlsmikSHVQmJGNt\nl9WmrX6q89IwXjqoJDb5WJ+sxNIrZ7x5PYFBSa9f1Z825e+Zx07p+R1edNI2oeuqmSUwF52odicj\nvkUnGSntWkbax+SkWH6FgYVKomoTkmzYwFUEkfVLsgkFaPVH3UPTfiZdV3W8lgwtAPL3+slOOnSC\nNTgr3SpjbUV69CecUEdzaD9DOXeKLuznLemELeRQCKvAzSRwGTpRdy2WwXI+9+s5ZnZvuepUOsl7\na+mTSp7McauyD45rpFtzv1jGwUMZq54Gj5WXp9OuQw9700lGaJbXD+mESTujP6X1npzHUN9KjSYL\nLzpJCmoVu5AErkQnPnOUDN+5M/QhdILeIkMDPp0wNfWpNKSKTH8avLu85HQ6seTWtlgacMrHHaoh\n1rZBLhZ1+tr0p2QHuK18JZiS6lRqq1r4lnQCC6pT66qSXOXnkcB0dKLa06q/cbZZM+j6LZecbx+p\n2Bu8S3K779OAv/mW34ZaJ3ulapdVT4Mq7lp/ON6GDifpJDSIO+lP2G5D/zulVOoSVdpbWpUFKG36\ncI+rpqMT1RxYuxZ/D+3sZU+xIMyU3EOBkvZxJ+9S8tY9dJI0/aX+NCjhrvVfkU5wXrDzzhuVJvOz\nYJUM5XbASvf3Bgd0YNcmkqtv1z6syo+XwGXoxBdN0nBkdkIHzMEtF5u0j1S3mFTlV75TYWrK5pHJ\nM/QWfgEGUtL/ORri6KEqnwZlC+tR+59UOWfKLNbPD8HhAHV+M/qDvWrTn6RYJILTC/PqlJdVteS9\n6WRFUKr6cI/yi05OmMeqTTyhi/UmP8E+1qWyrphdAg4zzd510r9PWH33mKkLKdXpXT2UTkKv7OxC\nnN2zs6uTFU6yjENRnK4Z1Q5MIthqt/Pll3HMy+oqJW8zp7dffSt8cpU1NbCfc9HJwIFNXtWik8kn\nCLrnZzouMYTVyU+QwCfQyacByjHofEwrbWvwODq5nz9ukzh1ez01zHbth9jH2cS++rMkQDH69tL4\nHD9yDDcc00qbWh5EJ5+jUslpuJ9AFp0kp34VWxIYLoGPWn13Mp7cAX/9jTvY4XoiK/x0OrmTMo1S\nl/vJ5KPs4yg1WPUsCQyRwEetvvsZT4h+MU2AT9SZVTPO1fKO4lUz2jup3+6xkxM1aWYqvF8OdScF\nHWK7VyVLAveWwKetvhPdyk6KpNIJ/TB8T2XCarOuVcfS4zd7rlXjOm+AMkr0Vfga1S6tZ6ykhvfw\nZgvs0+zjcH1YFS4JNEvgA1ff/eynGjvBD9GdWeRh+TuHVCw6aXadzRc6PflmieblISVb1R51YHRK\n1BXoYNBYSY2SDNW2yXtYGvJO9rGqRaU+r8JLAveQwE6rb3LhDDQOP/34aXu9bW6/PpGf7yQT6Qsc\nCnmLKETnVFjhpNMpydbxwj3i4j3vqav/Wofy6FcWRfrs2d+9sTWUpn9s03vUtpN9vJmU9pD8qnNJ\nYKfVN79ge+wDwsf25pfff2wvZBH8ZPvwv/7P/8TAZQ+xlOjEijSUPs+MIoMyqmvOVB6WuQad+BRp\nDTIj2VBA+xXoWVf79aq55v3s480E1SzhdeGSgGPrPnOZtI0aKASIZIMPeMGH8Aa+wtcBgLLoROr2\nXHSy9U+Ni/ixKUtBF50cac33oxPQisln80hRr7aWBGSceK0RRytomITBB0UTBBREFvpm1yxPnk7Q\nHjKT61hI5kD95UMLJxdaqf5knXKY/KamfEWjSlp0EtZ/Re91J4OyK50sQAn1fxX4ZAnsvfquK1sa\nJoHczQYcatTkIcNX7AShhEVQaPbnujK5Ss+ni52ofihDHpkys83KopPSjNxJXKWBr8JLAsn97hIU\nSoBxCSZxKHDQOIo8hsLyO+zCI8/Mfua0XoNOnFiWs2mYn1fu5G4P2L3dSVyfaW7oqOdfnheaowNW\n34Wk8fAX2tkRiIjQ0yQ0jqIeOqHlMXDCqGXXjM+1xD62t5PSydhBTlvbndztMfZxD4n99I/nJzSH\nqOhO2d8hfZOVLDoZKNhjVt/ADu9alYUmgBcyWYOfwLcOxNBbe2hteKj2gLt7dhXdYZVnTrdMRyd7\nuJ/DJF5t6E6DPcw+dgptYxH2+r/++n/CJ9Xpm7N8yevTWcMLWQ30T8umVD+HaOicArxirw5bfZcQ\njkMnTrJGfqWePqEoA+EW9lqhlFBJkmu/i07YQWj6Z9g/dS/V6XgaGj39ktsM+Uj72CY0QJCNRawX\npZbTFaO5A8mVz/iAitSnE+yYRTOygDqWfD+bRfE5Fx65+iaXqkQT9cRJBlModljlrdt8VhDF0ZPk\n2m+hE6SQzKGhyVX59O61OdrTu306XJbkxrjkz3/92WEUDKUgrEwo7f6VL6MXYezEohZrLvw5Slqo\nawn/rN4uOgHJq2gCdFLFEfWmYqsS6w7kpD5UQ49DQp6wAC3NUbtk9dMapizPgePr78zlbrkf34/1\nzdAJC38lJ+kDi5W87MzyOdg+JuXGuORv/vvfbPCx/RfeqC/49r/85b/AC2BlZsmzvuW9vkMbtE5K\nLcy4sGJq0w67XEiqk3f14NU3rTSsnE41oMJoI0M2GKFhj0gJZeW7Z7xc3TzQxWUtZ7YPYctZ1i/3\nLaUyamGrD75wOMrI0vK+rIZA2Qpz+XgYavD8BSa0j2oqx+cSwJHttb1BiNneXyiOsiudhHpotZ7v\nVdjEKkAl8PP/4u2AP0pWFoJYARWHOUqBE+ckSsbxJfFdpRPq9Rs2G9YmRFUbh36q5ZPWIKATDJOw\nY8zsaTZh3CwzSR+1kChgJqdqcvnMRif+ERM1aoLxEuQShBIMoswfR8mrEy1pbcKczVnGJFkbqcmV\n+Srd29Bk0QlMFrgY9WRrlU5UNAl9HH0WfjV8ApAh3b8aqmygkJ56mKuiVYWRD5V+WBzFqUShEzxy\nDJOK/8Un/rKH0vgHmylXXmXNH9lPC5yP7MOQtqaikzY0gSQOpH7Y6ROa5ZkWUFQbFFoQ1EAJK/CJ\n+jmjFnX2fUOWp6gh+nnLShadfPtO8YAT3EJn6MQiEvVgrOXy0EU20MmTscghDGuBNNBJZiOB1Sbb\nDReU1c92OsGJhHul2F05zvEihpaSNFf4JJzOSxeYh042egC8CE+/+hEU+JaGTyDdc6fbj63NzaVV\n8XM6v+gEAyfO/cDgyMKzIyGgNNRQ9XpsJxBSRU/Is0oP1e1EtX452PftFplCnCp2BtYJcFElgGJY\nGN5Up+pzrMwNRjoVnfi35DjnYfHQCURQEHQws4PX3o9RqtbnBkp76SE8cjq//v3K7Dz24saTYWn4\nxAeUEE0ymR1ZScblOSFGKxpKjW1PyNPZnKi9qkZnraElTQ253EWTJHtCxMW5NfzS5mB1PpMjPFdK\nfk5HQoZFKng8lvIKhFIwy8OyP+cOvK11P/nSVue66hgJYOAEQuV0G31MB+ZpRaUTiiaYc6GbbZag\nCQEFK1QdnHp5hk46xZj09J2tnHL5G504J0gydALBEgdQDpiqU4S4Gp3EPmKow2cOSTAyB6RSDqCJ\nzPjgJ0sTJpEAeG7rNUknO7ux6ISmdZiHwk0y+CN6IuThhn75V3pogR0TYecZ2K0h1vab0Qle1TnL\n4eUfQCdkCikYqmeCHIT06WQld0JVu26BGXZvPp3Q+24QX5yzKRJQrMAM3rp8oRuPr6tpas8ZiGwp\nD/76/fenO//KhkBC5Lr/aFpnkr3BWcJkd29Q94SHDVRA2RgFXhRH8MPtzR/f/1nUQgEID2tu0tiu\nPkAm96eTMKkWHgii9xhj+AR0gt3jc8CErSaOl8AkdIJ33MjwCUvWtJ1NoZUwskF2ud+RlOPVKdki\nQomCI1+A8h9/+l+3FxT7f397EAn4dTyxkWxotmID6QSc7mwDzPeH0gneZEpTOew5aeCeIILivH77\n+Z+3FwMUYA75j4ILflsYwutWnZ1QA6vtqb/n2rwoaMmnT9mJTtR7fC69Etqk/AlXTUInGzFYz1sb\nTicO36wgirQy/atAZmosKGGfqxdeN3wiAat59d0DTRBK4A3ekwGjQzfEPg/RBAAFXxALofChvh9F\nJ+wIqnr6lRGDpQbXphM6uziFTlrHOhYE2kDzO5J7Fp3ABu5mSfFm+9jvtLAG50gs3AxMeaIZVuip\nWFohDaXACZVpn4wyUOaZqoboBkYLMEGTRBNWbAulQEzluuETFjhpzuxg1CEziXOWweMm9I2kE+aw\n/PDJVphxyfYnDl+NndAPG3I6GXqwyqifS2qB/ifjH2qx5LVsW9KjNi+78X5HFjvgk0zrYPoNj8dK\nnQAM+ihAUSlEWkyeOO+Z1TOuHeKBOjse0gmGNJywh/Ooe7x/JyQbuBt5Aco3OJKdYMMsY7SgjUjk\nVZDxeXx+tX9qZqph9d0ATR7u9vXIUIkpeATECuGryR0fTSSjYDQFvtrprAkLnKgEYBFJScH9gI3F\nwVL9nHry/XlWYp2EVe+SYsyBSsBu+cEIG5Sn2nNROsl0uxp8vk1SvME+5tU0U3KjAXYQBP/EH8qB\nN+ymm7YDKJmrFp2wiaM2KzOnWKaTTr5Z5HVa9okm8Oel/i06efPNhE5oyATPwzI3hM7rG87eT59I\nOjldO2TQohQvaei/FTtxIAlaGUJIfEtTohNM1tCTR6gZdPqRSG5DJz6gUDTJb/LukRSfgU4kMcCv\nDeNzSgBNWOQDAiphOCSDI7LMSu5I41hlFPTHiPJ0yWy7VQkfmdWHtV0IUB6i+Kfvh7DJ0FTSFd0j\ncEJjJ/Q8LCZu6MZYPWMgwycsp5OU567FVDpRwxVMH5p7lcnsNJfJ90qJndC7b9TYCd6JQw8qy+wP\nnkiSsRPQpHwvJynpLGnMheM9Ahn7KPM7102Kz0YnmKCBAAY+hF7SCX2oGuIF/iIgfdMAKCt8Yi1e\nFvt11jhjEZb4l3D/iK7LO4rFJ99HT64TPrFuOCqtPjwoekUjzKNxr9gJOyVJzz5i+ITeQ0qDK3g8\n9g8//TQbnTiBE8yzqJDacEyE1qNuKt6iVu8/CaRqYE8fcHT8NwgcKKHxErxTXD2YgnQC0EqXxEXp\nhKI6m7zOyLN6cO9ap/ZK9nEP3JSZHYAJfCA9pnWsY614KsV6g6SSx5RFJ/5cZ9QG+AOg5Ld/+Rf8\nL8UU+Bz+UV55y+C8Awp+daGbdwbSyW3QhB5zpDtnvH+HJndoBAXPJCCd/PbjBwWUPcxUtU6fTmQy\nxSeMZOuluIiT7jmaTp5nWt+fY8MSQxgsYUSCR2JvRic08gyxE/nKbOZkmQvZzYybSa6NtmIqnWDg\nBMACD50goMiEzvNpJX/6y+9/+stffv7T1hl0e5RakqSy6KRtNulVkIIBKMEXwgrlEvqekgpmf0xY\n6e/l/jVYaPK9yyTbWTNk9brD9k50Qne/uH+mMXt6xgC9lQyfzEYnJUqwAhsNillq92g6ARqVL5al\nA1KR+TzUFXmOGgMq110bMr/j3B5cPSRLAQWvbVCv4y+ZgU7k7TaUTvCJriy5o3IGFP5/fnq8KKCo\npLK1S18s9HL8XNyvRaCTX18viilIJPAhTpCMptA9A1tol5DYQDq5rvl988HkVlPcCSNzYMwePvnb\nP5kpAvBrTzR5hU9mUAkr9mCd3BpohP1zLSxm42Rpe7r0du5EcgYAyrbggSoet32TE86MTmhWj3EJ\nvZ3HOb0xg0KEfaBDg8I08mxFm1nY2Qk4o90EY3SV8EmPFoYyzxRQH2NPszkADfQ8inrKhGZtJKOE\npLJdwg5GZDq/yoQSgJQNynYjFcYo1p9y6clTtPOvMpo7lr3Nrz7YT96PTuiOmqVycMgWoMB2eqMT\nABRI7oQKuQrsLYE3OlHv3EEu2Rb5Y9p+/KC/TYBEQslmUwJUCIq09ADKdZM7D2x8HcWC6WGRZ5od\nl6FmGXB2kj4XApS8fdxJp5E8aAQF6QTRxL89Jx9HoZiyjZ0RCf6502A/sFpcOBRTIJriYArsHGgB\n+IQCCqzfyUW66EROEMvX4B4YvQ+9gRRPmUg3B84IFAx83Pbf7f3kKnH77nl0AiGTh6/9+rmB7b/A\nlUgngKt4jw++YcoBf7LzSjegEzoEGnmWthJ4xUqKo620Airzm04I9MG/s9YMnilhdIJ3FAO+SDqR\nR08ko2z5HUz00HQPcAkMGawbvEFeOUsat2wXxQuAgqEUC1D+46eftpeSXf3lF1h0+IM7ky8xH03y\nqw/3ineKndBgtkzroJMCBwQ7Z3r0BM+pwPql+Z0FKOeaEZ1OEDNxC4hoAuGvbYI3TFFPnMC1qCV4\ncBoKs8/PHXxP6zI/xbZ06n7uuQBepIK8Ivdz8odCenq797Vb/2egE/mDw/R5J/hcEwAU/wEnFqDg\nikBGQdlSTAFG2VvsH1s/zgK82dRvAxTGKIgm8AZfD0//RSf0GMdH0cmd0IQdfVUPndAt9EYnFFDY\ntnlzbZRRcL/xsQvt3IErdAKpHLoR3LoIdAJoAnRCAyeIojSnw0IpSCc02nbu4HtaV+kkuaWTtx48\nmP1f/gUZ5XI378xAJ48d5Os5sHh2xKKTDKDA4VnKMY+gyNfhle3Nf/y3/wZrBI7Nrn9nSUAFFEYk\njE4omnw/k+2sASTaHRs7uT2dSF9DT8hagIJeD93cyu8kdHPHIm90AuDJ9iWwC3yeFXqhJSZrWIgM\noyZUGzB8gvfyIPDuOLKdq6bhRLp7ZtID7Ei+HtHmf/xHGnN+noqd+2wsmM7TYycOncDpExY7QUBJ\nxlGAeGB+sTYIkOCk76x0q3pFArAleEzEdiSOvFRAoVwCe4D5fw6Qool1TD65+uSe6roqxRI0NIhC\nT5ZgwB523fiSKR5GJ3gA5UQRjUqUj6rnYFE8tRpTOdTUouXFqMnTNIu0Dqbu6G07DEqwDGWU61K8\nSicweRRQMDvOws4qr2DMmR7ZA9s0c+R5Kjpht+QggsAb/C/cAAwnUdhjYTNPWsMpxlCKXDgHr+SP\nag7jJU/aeOcSZBSZ02Ge/nke9grrC4/IqBP9aXRC0QTv1mGehQbvfyE/xwNc8tjMkMdhILex5E71\nhGzb2bvvvPgrEEs/kXWq0w0Iwr5K1jMnvrw6L0ImdFMIdAIWAdI6lEIsNEHlwDgK9ei3CZ/4gKWG\nna1QCtDJ9qLHYxed5P0uPRiLh2HxOWyUTpBIAFAkoyQftsZCKXg7cb7Pfsk5rcao0bXVA5ES5BKY\nAhY4wU+wpOQS+qs9bT055qowrSN9ktWx28ROGugEoiaQ1qGAQk8a0PAJODuMoIBDDP9JzshcYs5X\nlDWm9oFCDLMbqhmZ37Y8hQk7v+0PhBKUFwZOEFAociKa4JQzvaEAi2uDRt6uHj5J9n+LnZTCJxh2\nnpxO0HQmd2/hWu0pQM+dMDqhjIKPt2ePTaN/soCKf4QWMz6PRfSVQuoZBb12fgsyaqTJejAY+VC8\nry0T2C6gE3iDkS2Zx4FUztvv/80dONlGN5xOLn2/JMQ8ZO6GPq6Cvkeng/kBTO5Y4RPUHzyAApiS\nVFEZrvBXsRNuCZc/o5MS5bSFeZJCGFLsKUmcD1YpJcfnNvGLQGlchOXzmN68hdd+/yHP0ia9+5DR\njq2kuhHZrAwAyu+//or/ZXEUTO7QpPjMmZ1Hh79+NHUeOoHkDqMTPOKKv/lHD71SFsGkD8IKDa5Y\neZ+thj//9fftVaUTZsuYiobmaaxKz18bAAegCQRRkEjwq+8y5Id1KJRkTnJMIopkV5Orz8lHTzLe\nTDesDTDeLiqj9Ygm9L5iaAs32/JO1c390c15HlCeNZO1HY5LZQVr+asRGsdW+F9Na2S+6QQDJyBH\nnBiYHtyjAIsgc0CIDHM9VnSE3ujF7kP+TDrZAIUyCjWscLsjjZ3Mf+hkfjrB4AfN/sDRE+uFBoVi\nioyp0E+aoyZJAwHF0JAldz/UdbHNlvRqtAlWGJtmvU26xtBAZwpsawHPsTIcUZ9q6EDJ20OZM22f\nUeZJ/18bAGeXkpyCG9CJiiZ49ISiBjuGwnbR1O9QsWBy59effsBr+z/qDXfVArmyZHNyVSIMlWIn\ntHDS/uw6dnWklMOewSsERkQTGjiht4/DHOPE06OvGCYBjUGCYXRy0TBj2zrfbA0ES4BO0LzShzHw\nQO7EkWfa1aR93FW/2R3FeNBkew4K3pgD75FL8E2mY5RjIFJCX81oAl4/1YEvKTNA8S+UOKLaMizG\niCf8/HgbR6FE/cVNP4hCIWb+24kxNrno5Km3WloHb8zBA5HswVrw57aP/uVrLw2v7+3H63gsC58A\nnTzStV/nMjdvmFmkPWUWnTB7wukE0QR/dwDzPixwgmiyRVDwsTaSXv1js59GJ5jceewCvx5kqTwt\n6nWvI+wUp42dXIJONhzBp7RRNMHTJwAxVZsiIy7VGhr8OmWFcMMUUojaAcs+Vu1mjzTy10oQgSWT\n+R2rtwMo+SaPLTk2swM7yUvfkcBiJyqOyHMn4GVYmP9N/1+AAmU2lwdcQt8804ijFYA6YCd+4Ljt\njCmQu0e/3dGjbKnvDU3AANHAyfYeJmn7HBASIx/IntsboBM691BMJgJl4OSiS6VtkePRE4QSh07A\nMM1OJ1vMebJzJ3A0BJhjewNEAoDCzsbiDcYNdNKy2uxr8rETZonCC6u0US3/cHjk31ixNNSWp5ML\nPUwoTEJJ32OJrs1wNUzEHpcwNKGnGOlXLIRP78rBXTTetoP9xOg+Aoqkkz0Gteo0dZXhCdDJ9oIZ\nwtAWoAmNi1A6YVxC0YSdn8Wv2OFZGme7xGy1LXKgE0kkED7ZhMxOnIABXbGTpEqwe3aQTpBRMNcD\nBLPo5Ns0kwctsF2aujOTURzAlORM5Yu9Hcl6/R44fijrQTrJhE/8dEm+kzuVZIdO+s+dPOboyrET\nSSfqTRj0xAm7YThDJzK/g8kd2Kivf8dIgMdOvm+m+u03GtSiag2TJ5ETiRUhlN2hQ8/GXppOelY4\nGFb1QZZIJ/iQqMnz4nNmduAALD10gpkdSicbmmyfA8G0JXcGLtGkX+/M7MBqz9MGBY5MTCU5iqTc\nYKX853/4hz/++iu8WB6HfoJ1bmX+/f/+T35yh4HLJeh/yLkTasavmFJP0gk9dIKxeUz3QLAfdtRM\nFdFzQQ1qciepvatYvwQUOvnti0tYvi3M2NFgGuYCVbAFDbv02dhOOmFost0bSQMniCaY1pnTerKN\nXT623K+1Vg2IGpROaFoHgiUQNYGMzx50QiEgHKwMXjqXNNAJEAZ2iQKEmpHJUAgLk5SGEAqEFUAi\n2TCF0vAzpvi6Z5iuEQQU9S4efHr95IGTTQ7s0MmQ2Ml1wydJNMETBcglMrSPgCK1EQuz/M5Oh04y\ni726ZOYs37B10WMn28RQOnHQBHRdoglmcKyDJhJcrpLcoYukoc8QOGGPtoSHN9C7iPnjYufTuG86\nmezcCYud0HuJJZrgeZTqc0p8s9KwFI+Z4Wk7Fg4fUjYUOBisyPCJpBMZU5kT/WEszyVGntpi9ba0\nN+i0YOFM7VQgTyeY2UHPBZ9gWgcdlrnP+Yqs4AsyOzuNy+zDDnnSg4dAm2uwPF7sBCMoIZ3gLOL0\n4w3oVl7QCqucKL5k0z1r+5m7IT8LAkKWx02uQSfEbpbsY1LU1WIsdoLPZKNvIGoC507oUVm8zbja\nqFq+FD4Z0mKykgYbkaz5gGIsXoLHWlkUBI+esJuH8UGxNHxyLTqxzsiXVl+PBTtglvUFJW4kVj0I\nvWmD5nTkqQN2PsFqlDIKlsEPR0lDXZWXXqpSMg3D0WMnePqEHoZVE3VbJ1QmRS3xszyXO33SubA3\nU/g4V2XQCd7ieIngMws7l+zjqFXN6sFTsfh0E7x/B5/xytCEPkMWMj6j+jYPoKgZnFHDPL4epnj4\nJ3IG0ok8GCs/mZ1OyAbAuYOvuvo67djxk14KnNBTsap7gg/z4RAsCU4QoiqWQywJhztgEi8Bd67O\nrJOTzZcv9RMKW5WH/YQC1Ra5cJ6d+MrsgPTxjUWXMlyGRFJCk0vcWty5qh+m8P33VOlJWNgYXSX4\nPNu5E3bDTuanhpFd6M/oTA4oDYu8ahSmKo/nTugbK8UDqEHphK2mRSdo4enNLFPNuLLtzgVO6F4X\nDTV9qgV1VVW2gPL0LMtAoVmxE/p5+J5uh1iF1rXNQ2AVqvU7ZZLtmnQScglqOU45TQBRPcCbijNZ\nnjzPJkc4sBjj92pXAUQwdkJzOvRnyS5GJ6+9XXX3NnBenqr4dfeNDJY4mEIfhUKvnRlQPopOkEjw\nnh28x56nPsnxWDgVC6/wvuLPjJ089rLE5VdN2fDF61eYCZzQFAy+l8md/NETdHDIJTQ9NFYCFp3Q\nVrCMRR6WZXBIpXkUDu6E/cw3qtMJ6G5SZVEV2MTTMygZLpmf5XvWM544wawZJtHpTTospzPzbQVT\nZXbYM+zDwAn7zWH6PNmx+R2MeebXZGCp6wHSUU3vXQ+yiGyInTiRIUaW3wFACQMnzl0wew82rP87\nNvn6kZ2BmZ0L0YmPJnIbTP1IJ53QeAnEYNgrnMRkgSqdMLf9BCnDMnAf32FAaFU4tCQtNWyrTDrJ\nilUchLYY5UI37zxN4bsIegIngCaQ1lGPwfo7vDm3d/PQSRVNLHYhR1IePzWcXAJhMRpxZYVhxWIB\nVlINR/m7lmQEy2o3YyXD8TYUoFkb9SkmW51AJPSpqUwDKcpj+AQvYW/wzzkXF4wXnsIsfxhISjg5\n72978fd0SXIv2jC5PZeEUZPQrVgRfRryV3tIc0PSqW3fbqwySmiZdWfFJCxKCD+vzotleS5PJ6XY\nyYmPCZJJ7u85NgKhzoYPr0UiUbM5FppMbkDnOXcif/wvjJ3QBBBCCTk5O5JOHCsguSS0U46RcsBF\nUpEEFHUH1rDjqVo9Vp6GSRg6MEBh9+wwcKGZHQtNZo+dvKPJfrGTE02ury0hnTieJeQS575iaJee\nm1QzR1enE2fjpBKwSjwZOik1RFt5C5+ULMs2N06kxIm5hadlR816aTjSSsIDoODFjlzB5gZe7EGW\nstFHmdedw7Dhw2ud1Pg16GSCcyc9sROW4nndaXwcnTAmSNKJLGbZCH1fKJ4Ya0HP8XSCYRLQfxbI\nlIAiH2oClyCdYH4HKmR/TgsoamRoyB3FT5V7j52U7mHpsav5a9vQJDxpEB49wXYpkVjxlVGuSka/\nnBX95rONpz+/xcneL2DuvzAjWj2Zfm5NNFgSNsxaNDtDJ1CmGjuZhOWpKaSAAhq5sQvFF7QmMpry\n/cm7tQUbKoPP647iwoIhh2GTIRNWTALKn/86BZ3QxRkaFL6S3eyyZBE17tJgUPITByVltBI+AYag\ngI5xlBBQkE5oJTJ8cg36f/3KJn1Uo7qvrW5Ppe8f5WirOmCVr9JJMlji00nP4cJRAz+yngPWePNw\njqAT9UavkFcOXipqTgetJKa0lWJfwQMajpZHWaEetgsE04x0ghs7ur2jwermOd7pQra3k+y/U7us\nWgic9IRPJNN8Pfz+CEBxKMFK02BGhsuhcthtBjrBuKMMEmyLgjKKXAU+oDA6YQuKLrTZT50feO5k\nkg3hN4UX7yLGNE0ynM9uNZXtHuyAjrGWPUbj+B6200kmcALRQnqIGvA2RJMjn31iWUmWfGFcwn71\n49vMGY+dxp0fnWO2R1SDKNMa0MeIiPU8hU4QSlQ6kQdK8sGVyelERkpLeyCfTqDyUoVVy7UpDz39\nikEOdpeN3B5gQw6gUDpRWf8SyR0JbbueO7kHnVTRBD0UJnHmv3W0utauW/5oOklyyWF0wphDtZIY\n4cBE+KbKaAFZ2pvZFBVKmIVl6fCr3FR8Fp3AD+LgCwInf/Pf/yZPHmpmR/LNwNt2zNi1ff4DEYFh\nnxVTscqrTc9AJ7g0aJhELkAaX6RnRJJ0Ig+d4PpimaPZjPjxdDLP0ZP8DpY6lAY0YftnrO14Uey9\nHxiu3rvuXqC3I+lEHkeih04w1pIHFNDR4WKlcEDpAZIv9DlOaCvRgIJ9xKAflG8DFGp22ZaR3UM4\n58E9Zj33jp0gjmwgAq8tNEIZpYdO8MeKaSXw4X7qN3PNu5oeK45Itwr0yAiNoNBrVf+NsUb6vBOM\nSqqhlDnDk0/6fz93AjkvqTkNq08SwPEu2aT2dHx9Dzo5RQ6LThytfqp33mIibagxMXramR1WytPJ\nKcFG1URi1ATfMMRht95Qu2mFT2hIhh06odu7J6nA8w9m+ncYnQCCWPDhfKvejyMDJ/CjPBJQPpZO\nzjKULJDJFog8xBrSCe4cGJ3I23xm2wB8o8n7TcWLTqT7gLsu8L8NERTprSY5dLLrJqHTmRzQNz12\ngrPlsK2EEkzHSAVqCJwcltyRY5RWkgWcZQEaXFFvcVRbwe0di52wGxam3tvtdkdxJi6iUkXmefaY\nCUI0oXSCv3X8abGThi14p42Dy2H5qCFDuvTYQlAjlzR2Au/p4qKYklynQwZYrcQCr0UnKp3gIyoa\n0OSUSAnVB+qD8XPumHNn3tWqWIqENsG6gfkUeonaVSig9raq6k55IYT3U6sUKr+7Ik62yqOv7D4d\nqj2l2MnB4RNpJWFTRU0kQxNq49TLrW0Z2FZ2z460p6z+gXPfU9Vzb0c2dkMcGztQQtHBeu8cOlHz\nNSx3Q6vdkIV2AC7/NEDp0Yq2azddghOybA8Af7LP2WqyAEVepR7nUgFlhiDl3nSiHuw43U8/vWMl\nrUMDJ/j8tCqjTBspKcUnrMLsc3nmjEIJcomEGIkj7MK25Z+jk3fmwBu05B03D83+KizLAEyAlrM3\nTI3yjHKY6mwWAe7EkVYSP8QYCZgw1YiYH77PA9JJdXs3p/VsoBN2vnX7k/3eTZJO1KSPH1bZLmGV\nywzRopPh5kZWKMOQeDsxLBD1nCzWg2VUztiulcfC1LSOcnTsgMHbTTzpX9xRPCp2cjM6oadZq2gy\nCZOxaESD47cSsg104sRUVGopUVR+Yb18yuvBvaC1iB0IGSwWQskDFZ2dL4FZp7qSJxLWXH48zSWt\nZI1qImFLB21Z8ZLQ3rGaMWoSW88JzqBIAqvSCR4lYff94udwaoTFMyTQqEdSrKMkNOmD8OGcXNm+\n+tjTJ81LqXShRG36SRJQ1DUowyp+Wudt3f3TV6bpvH/qDoeaHda18urT4hOT+GmVnJK+owFNJhl1\nP50g0Fg4ImMkVQpRy1vt9q+ep1ZjtAPQBDjjm5JegRAIjeALSm4fSC6xtIQdsU7q3N7hE8cSbU1j\nvISlwKUZ9cGCtYLxmJbt3QzW8/1ugpJ9BCCQoREVTXwtp5ewQyQSXCi1ON/SYhiD6V9sVg0yW6zu\nReBD/K+1Vdqvn8NrzhCAjGWqqVKMuPBM6Cv56KOJetNcpnvDZQIbHtWSLDrx/UUbmtyMTmTQZe/Y\niYMsnavjLXaCaKJWSrmEJm4wm5NRjiSOsGJ704kjRAB5ShJoyCRt+JyhlmeXZLd3GxmcGkHpiZ08\n0GT796ITiGdAjIT+OF/yzIeEDP8eH3g+Ck0hqfmj7Wls8EA2+Ha/h7OptkPNDVMu+d455I7LdZqJ\ncy9ngOIcEpdqCZ84d+zTk15s9Z1JJ+/oD0Ow0jrArHlatYITM/jp4wMnmCg4V8lHxU7a6IQqT4Zm\nLGUbm+J5oxMWMvF9tsz+7EcnB5+NfYPBVwg0YyJlMNnJ70CFWCA0oPPcYqDu7fL2Uc3OADHgcZD8\nWVQ1s6OeRMF2t4bwwCyiCT5GBd+wAM9OgOLbArQCKq+oFu10Izu8A8nwCbSrAooVjaBoopY5HlDe\nukHOnSw62SlwMjOdlLhThmDpHka1z/TDjIWxyueNf8k4PKv9sf3/x/+yqVZ6JDYDJVc5fSJlByOF\n8Im8AVgaLx9QWDJInviLD528P//geOv5dABib5dXUJU8KAr0o4l8dCzSDwAQhGrwaIt6ugXBBS7B\naEppgYWFF52EIgKV84/HYiUM+nFBOemSZ8bkfWW9XZjp4qAyaj/x9iWrkcLqs++IuW7spOqDZPkT\nw/ODFOeG1XzHTvKBwQfQvR93LSnHtZI7SCc0v0PjHCqgOAkaKA8QQ3HH4RJn53c8nah7u228Bfso\nHsAKOPKooXgHbzJwgrkePEQCsIKYAvWoKR76+R7hE4dO4Cv6Xxksye8oLm29IKkh14uq/3lAQeLx\ngisHnvF6dENwP2amnMVeWH0T00lzWqfkgNTCi04mtA+XoZOzkjuUTmQExUqBoyVVmWP7FumEPvLE\nOwpnbOzUE4L76ZmzAc3bRyVA9TqJUu15hk6e6PO6+wYuQRyhv2/s3MC8BVd2OoBi0QkFEVrGKV+V\n3uXKJwHFiV8yBf6OSRjr67HNOJhOtp68Awp00jl0ko//++7/9NhJM500P+mEkgoDlNJ2/XJL6RId\nprmqbGanJ3AC2mCFT5yvzqITCBTRDlMT6YR/AUFwc2Y994n+GoiFMvLzt9jMUdbze2P3/hgGMJ29\ndNL0izZJOsGoDJxHwcAJfVwbeywbIxVIFcGHkAYauLzpIqTVIogsOmGJG7asWFABl56zN8ATJ07U\n5Bki/dL2A4KUTk7HuVsHJJNcfb77Pzd+0IMml6YTa/nTmVXNQr8JUi1Mf7WjatiXTv72T2/PO/HR\nBDTMyfuctXjkslGxwwoyY5jEsZVWJkjNiPMN35F0om0x++nkYV7r/j6DJsAirCTSiRU4wUiJFU1p\n6O2oFbvqoasPFw5dfRib9BOsznGTN/o5hE4c9A8PnSw6UelE9T5ODkj6l4PDJ2qWVvZhYDJ30ckj\nWMJebbGTs8InKtTnAQVOmWQYRW6e5CdKLPpg6/kOKNif5O5toHNN0glFEIYjtAYAEbyl2cnyHPAE\nlIFSumVVFqAAo8Ba87Orz3CIQdvqKtsvfOIkTDNokqSTmdM6mcCJH3Tf4+jJDHSi5MHTN6+Ea/+j\n6WTTmFL4xI+dTEUnYP5k4sYxYcgo/gFYNFVyb+cc4rPahUbhFSqrVeBtY6eldbYCM9MJu8GY3tJs\n3XuMSRwLU4bnd5pn5zMvVFcfMAfuBKBM6T44XGJ89e32hCELTfAwbJjW+RA6ccLq/Wiinrk5l07C\nhC/MO0v6DLHDTtOsfhnIYWlo2R8okOnnvpkdS2nabtuBq07J74ThE2oEfQ4A0+lbzG+eMAIVSg0i\nvwNWL98xx8n5ezsYb0bbxvpRjHywZ+GrwEE/lLkeiS8WlOANyXscQMnL52C76XTMz5rnR9RQ0gEU\nOGyOW4gkoJhoAidV9zl98o3+2mLPoEly9U0bO4HnbIWPMzmeTlCwDcrZcImVspEIApWHZNDQB7Va\nrIeRh+yG1VVaLbNdTqJq0UlqBq3Fo0aYHSsGbj4DKGrkGcO8Kp3Qdi2eaIigPK2niIFDZ/BWglPo\nBHMxIZHk6YQ9hI1hCqUTOFSbUqDRheahE9VyjR6uXp+1+nCJlQDFQxOi/A0rKOB+8VN/9Blx/q06\nVPi+SmTc/ykbv4ff6kOTIUdirfuVjlxoJTrx0cSHDH95WkPOQJKKLwxiHIJhHbsknRy/ipz1kwcU\nSgwQHWkIO5tk8763c8LFJfP6ltMRezu0/snd20CntWEBnF2Fp+CX6EQ9Kou38+Cb8OjJOoBCJ9TZ\nAw2cd1aVs/row1HCtUZzps7aGRs+GZLTQdPfSSfHG9Vnz6PASXgvxQfSibrWuC/vO54i1cmq3yKS\nTPkwVPNWScaODLmj2DpiEh49OSW5k6cTK5MiLVEVUJSTetqZPqg2eLZbZprtXyPDjDjd2B0cO8kf\nibXAxakBHiML6BMySmf4xN+RSKnS5erELZjJUOuxmFJtIgTQU+hk65UKKADxLBxibQac41zmTf65\nFRRHTbTACfYnGTgJpyYTn5iTTkI0AX/RcO5kOxBJX86zXg4Ln4yNnXRr6KMCJxYidybJoEiyGNXq\np0XKDGnTYzm1Jf1AfVJTiSGgQJ4y09VRZfzYox9hBgPKzBykk/N5cQtNLOgJz7VkJGNRDuZ0JqGT\ntvwOUAs9s4L1IJ2EaNIfPnHoxDcNziLPfEVtbtIGOTDk74EyytZTRi5ASSew4iSgVNEEVlYpAKkO\nzUqYqugfCifcG4TZk4Mt6qjASTOd5B9mPyedyBW3x/YgaRmgWBI7ksXa6aTEIuodxT2PZYPwyZHL\nKVzbAaDYh1vxl9/9LI9DJyxh5NwqiciSsa3fOR3txAnN6TwNzctAhpZ0SIH+2ImMqcxGJ3J34nxi\n2RE/NiPnImOLVTu4h3FMqgpbfbCUAFD8CEobmjzWUd9DhkI0oSe6MkLw6SQ0X8cHpMGAhx0Ld6qw\nv+30R3C55VAyKyIzR2GZUuwErS6zCagJzevRqYF+lYEMtXzmQuZTnvWEEnwQTceP7CCU9NPJkSsq\nXEWqfVQDGCzwgAYUd3vyKkQTNWtDPwzTOklA8dEETCcLO4e7t4xq5csMoRMMnNCTKzKtgw9nw5Mu\nMqbSnN9J0oO0Nc4iZ6SSsRFM8qpF9g1fszXMT7pT0gqf4M07uNCAVzBEkV8ybwuzn07cR63kczqZ\nvUFovo60peBB8AbMzlt17kQnQxbCnSphhiuVLhlCJ+GTYX2tpfq993xk1vbWWyd8Qg/ho2vHB0bR\nux9xq4emECLS2+uPv/66vWCwFpGEphYDLX74pJTTydjH4XPURifhvcdqToc9OpYeRsGvTqeTh9Hv\niK+qE5SMx6jbuOEz7lcoUzkYO8H1RSMluKySNxsPPIASon81cAJT72zxkxbsmGg07UyyYyHB7Bo7\nQfEerNKruavSCcD+MU9ASS4hNdWNWzR60g2zOdKAAl5QRkEuATqhL2CIUuwkQyeh9VQ3difGThru\n2fEfwuYfhlW/bf75YhnnsGK2MryhfpIMnGZCHReiE0B2dgxWcgkUyGQ/U9TSFEGx0joNh2FRAa5C\nJ/1oInM9Q9DEyewsOjmLk86hE1XDqo9oY4q+kwSTaAK0JPM71FzKhAilE2ZYkTwklOAnwCX/+R/+\nYfsE31thj+/TfBBStg2rbz1lTues2Ak9DJsBFKfMFlNhwZjkeVj68Pue8AlufBEIQshQ8cL6UCZl\nLDpx0jdqhog6yJ3WYL5augBxcbE1mMIO+yfB+eVw5r3yT12hcvdSqXJM7GTv/A6zpfBn8mQJeodF\nJyXFCAs7IbfwWrn2M3ueUrVvNidzZX9mRx46adDRCelEbuCoZZR+3TegNGoC8PHT3/0dsAgDFPgW\nX8HtxC6dtKFJGFvO6FWpDKRg1JOtCBbwKBQGJRI7IN1DawtvJ7YOoDQDSmnsq7AjAVgFeFSLHYwd\njCawlCqAYm0eJqGT/QDF2uY1WH66jx0VOPFjJzcOn+xNJz28clrsBJUSbwkrxU6kTu+RNM0HTuiq\nViMomM1hhlUCCj24ikERjHxgsAS+opHqTMiaGkd1z+dbTytwcjydPFp8AUp4msR/VhuyCHJMPnAC\nz7OnT0ZZgDIDPMHSoLFJef8Orp0ByJJO8Tzpf3vMifi9KjwvXw3GhKuvZMd2AhS1Dz6aqN+yD+9N\nJz2u/chlaEV8QTObe3ImnbBb1TvpZPii6lnSElAsi2MZUAicQD3UetIIynA6eTOdmvV0biU4+NwJ\npZPqg2LD8iU6GXj/TvMyXhdKCchT5+zu4pF0kougWOhPT6dV79aBgQ85d4IWePhOry1wYtEJ3dne\ng07k9HHH3PFrf8AHfhN0+VjlaSV55siXlEt4XzpRf6B40yf8HO8HK6GJVXjgoqqiiWQjeoOAsxlS\n6YSiSUgnGFYJYydPw/fKqbNedZrOE+kkc+gkJBJaIPmUWHYvD2SR+p/PdifUyMeNe6yYJTG2uNgB\nFLayeiMoUfikc335WjGWTgbu9DZD6tjSztgJoInlZarg4ruPvCb3rF+2CpzDYdhKuHBYz2V52Sj9\nJPPeGXLYPf/aN0DJSLb/3AnVp4aDUQ7KwGLIjMITSvSrVGoH1HbDIK1qQGnuXBpNTO7QyAq+d4wg\n/+rdnmaspzOcg+kE0joZLknmfSiRsLtyMs+zZxGUld+he/rMeuyxYhk62fdsrEH82DEroSOfNRBa\nDHWww+kEAKXHlsLl/javh04QTY6hE4wcZJS5uUyGTjJlZCzEoRm/Qvy22i5agB5p7EUnjtLAg/CR\nbYcETmhYsnldhcvJB6OGaaB0gkf5ZEKHJXcAX3rp5PVAbqjqkQgX6XB2R/RUdEJ/TDgMjUhGoQdm\n1WOwWKD0sztQ1XbtPIAyyvGPqsfyrw3Lx78EFxeiSW+AJHEvjwxJvnG/tsp67iWmFGhutZu2W/i8\nhiqjUCs6nE4w3I7u4wZ0Qn2wAxZsrpMbwpAq8nTyxgq5AyU9RoM1l4o6ZGInvsbIb6XXr57lpnTS\nsK56uKTnsStgQNntxP5NNxiRLtGJGhp5cgm1ua3n9ZJLZZQHwiOxwCjwk8Uho6gFEE3gWxoFob9X\nLL9Vj6dADVU6Uc2T9SFNADNbxmaBL28jey0NYqkefzcvzZMzLnW/ZdnuUJfY4joATejp9W/od5mm\nH00sfXib1g5AycdRmBXN5Mcb8IWlbEI6CQtAhSGEgR6GWlctQOsMSQLmutREWGeeTkrt9hcu0AlG\n6kI6YaERmf/rpJNQ6WkB2m0mL/pVZ/wm1GxrqqgBzVhPIBI8YmKRipoP0j/U4iX0SbX0AI2jcGfR\nCQIHPLBE3kKsEgmgDL33GIsxWNk+RxJyTsvS+EoVUFRzY5kMZiKxmGOzQnPG7KNlLsN6MkERZ1xW\nKNgx35nYyeDTr4nwCTxPSHkNfXq9CqaWQEKbmTGAli21kjiZRqt0kvEmbWUyNnwPQFl0YiotwxPd\nvvx4pA9xyh06wd8urp5IKkVKQqW3CtDVFVaSWa79p9z3oBPzqdvCOL4ldNwfc4f7Myekky1lI7M2\nNOkDB0rwvl+HQthTT/DPzE8WSzrZ2s0kdyyXH3px5ssduxlSRdI+hvX004lsItz5OTpZXVyZ7UGh\nDFtQxjbgErETaQzDrR01sNK84yfgTfLGtsGzJA/PnkUnNPQlV7G668t4bVwX4QpKxk78fjqE0RxE\nCWInNFKXp5M2BcorqAMWVOnH3hDkdy+j2eokydS4vLOA3lwgYye0vGU6rROvSkZc+znlrYnwRseD\nYyePpfIVLIGXevQVGMVP98gL6cPZgGyQPNhNOhhKgbwSe54bXBUCyig6QVgJHTw1W3LWHFO1N52o\n9XMLVQlrVxdXgTzyEZR0WidcYp17g7H7sdBcY3PgDpwbLat0AjdS0Fcyd+ME9bevMjZ8j9hJs/O+\n/YUmnVAuQcXC/BzGSNibDJeoaZ2SgpboZOw9Qfm7dfKqI4+eOLc+4lkTH2KYnfXoRAuZsFsJwsAJ\nxer8wDtLssfFJu/NobCCl8gHxeInVlpHDajQwMxWIPPjO2PpRE2OWF5f3V2dSCegRUwr2pAIK6Gn\nztUHso0nEoYj9vrqf8yJBE2PYPqOnoQ4QguwwMlAOpGnYpOhEXqPj3Rbi046rfEel+t04rv/7dsk\nq6qw4tBJklEydAInuUorqrlwBrrD+LP8qXf1RgOMnah0Yj3CwaKT56/tGNs7flbXVcCDYyeYu4ET\nJP6RWDX748RUKKyoFAIhGSwmj6psLULgpBlQqpkdOjlhLJdxwDyZHQkou9LJ7mjy+tUIq6EhaZ3k\n3uAwe8hsr5PWwZJQJmn/Zexku7DHJcHlSTO+wid7gIhap0In4TGlHjpRdYjGZjKIEPYwU8nAMkm1\ntibV396xe4ktKHHumWQPYXszlPDIk4hOMjHnw+gE8zXsqIeT5fHDKkg2EmKsEyeQygnvEgI6SeZ3\n1CRLPvNCV7LUtHz2OkxCV62zGg7xxyX74I8uj/7nnJBNrK/MEuvM7Dwg5qgNG7WuIZ1g6sehE/qV\ntentAZS8Da/q/2G+/H4NiaxupL6Y3MkkcfJlaLzOOS+yVRgusDyADwGUvFqHNjR8eGUYOJHG10OT\nL6Np0QnFoIzpPIZO6DkSig4sfNKQ5cHDKzJwwm4zBtrAMyiZe4LC0yf3syxq2uiUYWLm9KBISfJI\nyq9/Pypwkoyd9NBJs1HNXIgHY3voJO9rZMl84ARFfYomf1qjhE5+BM/1oxEO0KeBr4F0MoQ5kpUA\nLfUrDT3rGj7sJB8++f7RPttihnSSQZO8feyRFTviShGBIoWFCxDtwBe7FRkfZ0JBR72FmJ5EsdJD\n9ERLw+NPeqQ027WdqZn+4SQX18HsQtEkucT6Yyc9gJI0iSxqkqQTdUeK12JwxTp00umJSnSyAKV/\nSSZreNFJFDJhOncMnaghwTB2UspfNiw5dvgrKWi/WN6AlsInSCdOVEalk2rg5AA6ARZhx05lbkXC\nhwUQEAL5Sr7we5L9HyvO0AlFn62hzOmTIYo0TyXHxNIy42VL5mAKyaRNr04nFoJk0ASOnqjnTg6j\nk+oOcyV3Muuuv8zThpSc9B7JHTV2oip3hk5Kw2kuXNXpJKD4x10lneBxWnlrMVg9P9fu08l39CXS\ntb29EQucYHqFPb+EnVS1np+Gh2oZuzDcoZfTX/iDVvyAzVa+dDY2EvD6/iGBtkhMhumPpBYWODmS\nToaHT1hgwz9xohrbRSdrbasSaKETCE6MDZ9IOlFDIP1oksT5EFnGosk2N/JsrPzBd/qcbOceH4yU\ntNFJQ+Bk79iJfGwJ0ol/OhUoRL6sgIpDJ87TTfxHqkCspfps+2WwLIPVIJnM4gpPfY3CF7a++tGk\nYfX1G9LMrQx5Y4v9UeMlu2Z2qmmdldlpWIBtl7TTyVhAScZO+hdVfsE4gDLquAmbs/zNO3CaFV7O\nUxwoneRvNp6NTiSa0LxJeOOMjw752IlKJ1bfMFsEERcAlE8+G9tmnuRVbbETlf5ZkHIUfIT1zEAn\nAyMoyaOs/n5Phk/wKAlsUxm1dB40oZcP32eOUvVVzyx0gnlH9obp9Ax0shOa+AbUPyorn+cG5Ut0\nAvjShiYNu7f82juSTtjNPpjBoSkePI0Lj5FV6QfrmTa5A24+vNMYpkllgmZQsBoN+9Oc2ZGLK48m\nUBL2ACF5hAX2QJO21YdA4HPDkO1cGIqG0yc0Xk5PojTQSfLu4obASd5wrZKdEngaiqoK5o+eJLUE\n9Y8yMtNpwALU44zGq2Wqg5UngjuFbl1OAyGhmaOPc1UjKPegEwdNAA7ysZOG24ytYyv0SbJObIb+\n1iBkl3bSHFptsiF2sg9RQ33eifptM51gb2kNmf70nEZsWFzsWa43oxMIn4TGkBUIy/eYZbr5PIZO\nVuDkAIvU3MQ3nTiHm6TCYWTMOX0S/lKxjM5JdmY3yMCfpQgKQ3L1OEtyRe0XNcH5wwfVZ+iEPctV\npniqsRO2oXwcmE3/2+NUrAofABkIJQ6+ZB6Y5hxAUX9VB599Ahf68ARlMLlzzNET6FJIQiqFyOAE\n4xLkg340YW1V+5NWzO+CpcUl44gmnbjPqqcLeafASVvs5BkVez0bwrKBVTopGWe58WOfyFB6Kafj\n741X4KRhER15CaeTJBqHdNKAJlTtJENg4KSZTuTBKxmbOf6sCZvs5JOj5H09ACIsxSNvVZDQgyab\n1Vk9rLcTnfinRjZSkXyQj6bQZ5zIhmTgBNEkfLwK1kZvTk5GNfrXfwZQqjRAM0E9GRbqSlns5C0C\n9PrBHaufDVJKLi7GJZjWUejE+Nlhuco606bhYHtWH+4wM5FmC1bQujI6SToUPFwiwyf03An1Ecmo\nvFNsBU5CvTq3gEInGX1ip4pKPJvRMJVOMHCS6SELulC4sS6Xn7NhHjNVmbsfJUkATOB/6ZNO5J3G\n8un40iKXAic9uzdLqk7WBn8QGOIomQCGSjny93Hk/cmUUVQ6wdblc1NoLgkfr3KMFiGgWEGUBjpB\nQOmhE4tIqv1pECPge/gwQ3Vx8XMnwCWVqEnPoa5wsD10gimejF3dm05UQ636lySdwLWy8AqchEp1\neoGT6STEGoQMXBWZXKk8S9tAJ9i3g/VYhkAse8puKkbLi7fzyAvVhNGQjV2nfZQrwWcOBAsIn+AJ\nj+QdOsgc1plW58QJYxrWT+gJcskpsZOHv3kd17XuFWqgAedsSj7R00MnPedONpnAo33kEfL8+vpe\nPmk0wcXFTrFU6d93Ff2rj+bonaCyQyfwlRr8yKfOwerScI7lI0p0IitZgZPT4SPsgE4nIUSzyW57\n9klSvUCzoUuouEl1p+EWNbNDR8reI3QfrMfUhjL+UG8exjKZfaFFJz0nTp4J7JeBDHUuU4AGJDJh\nD+qM1bQLow1WJ14CVBGiiXUqFk+60DeYPzr4pmIfUJyMCbq6PMHk6YRldhziQT2hrrfUkEyb4hOD\n1JUVrq/n8kmjiZU2HYsmQyKXsAejhp1aXblLxJLsLCA1s6EfkRiE1dJ7jK3YSdKDyMsP3nBmLN4q\no2xQYeXL+fPdfz+dVBWLoklJ6fFULF02DqnQoZ2ixEAnuMnLAAqwRWZTmKGT6omTXenEeR4JjX+w\nNJCPFwwXKM2w38fJ37MTHnaBqsLDqmONVBhBGdVcDzSM6kNYT2ZlqYACR0+el6fRBFfxrjmdsauP\nRVBwT6jSCQ1jy3MnYEhL28iqW6k6Ebrh3DoWKozqL52rOmN7DMcbunezS7zYiX/6uqpJzOtb8Trn\ncyf26KwBSScs9ogrkDV9CpqAekkzmkmWN9CJdbq2Qcv7Y8u00cxREvpoeXr6xCIMdqYEzqjS46sU\nU9QbdrbyLCWU6edZsZOn34pSPA1zzS65BJpYK0vSv7rWnnRSPG4Ce4z+wGQ4RwNX32Yeqdenh1LZ\nAVUa3hhCJ1g/i6A0OAvnkh7D7qv6opNQUUsFTDqB2XUARdIJ1ek2qk2iSQnJkWnUIIrVYo8GlyZA\nLYx0olo3i1SATraXgzIsdmKdrm0Ywkj7aDziDM9zsJ8DxAOnMoChBj8ol+CvBsLP4sANwCqa4CNf\n6bmT/M07GDs5K3wCGauDW29QpF0vYSsL0SSk/8cNO//0OFSrn4S1qYXRSVtgMpTJwNW3tcUAhUZB\n8D0YYWfvF3oQ6xahnn1vyDFg2P1kPc1sMsFeCMRDnZm/wDA6AZSBG4mHowlUTjUvHzBU6QTjJeqJ\nmXPRhMZOMDgcWk8MPufpZCCaPCzauHMnTkBCfaIa3leM9/JgRITeRwPFthe7uUbWaSV0ZOwkeQiX\nhnmO5wMqz87Wr26dKZ00nJDldIJQ4t68g4CyE5qMXX3PkNt7BAWhhAWww72fH4CXZlzihWqiQwqR\ngXD0TSGd0AyLGiaUts46qkWnJrN2RtUzP3lkehjTiRWokPoBTv0ANOmPnVh0kiHrjFg7y0gbmqET\nKOOHT6xnQ+GDZZt7PopOLDSBKIVKJ9tXFFB6HsLmH1hx6ETeTiwP3h58U/G3kX2PRfUASsbCNqvQ\nAReylVUFlLfL01keejPdTmMctfpo9wAsmD136ISGWGiOpgQoKnYMBBTojB878emELgG5HNgnzetl\nVD076dsx1QZ0gkGLDORiKG94+KQ5cAKKiB1jMRhaLfQ5qbV7z40MIGPWJjwkm6STzmevSQmMso8q\nnQA00Ltz8RP2tHi84yYZ1aDFwlt1gE7gv6z+8DH5eGEPHDQrHpWqn99hYW1179jcjdMvVFMz+cX1\nTSf1s7H7BU72iJ1gBMUHFGZdZQ7IPx6QTO7I2Hlb7KSEJiBVX/8zBdoARdJJWz2nr7ieDoynE5ri\nqepQHpyrmR11FTE6mQRNZGYH8zuWGZWoYcVaoCr2bX/gZJR9VNEEfkgPT3swhqBnTsHv0lMjeUZR\n0YTdXezQiWwID7JgJXh5z4ptu5YJNnymftIUQjEwIvSN30kKsmwnqsbMVe2iLaqmXB3Ck05EIiYJ\nKG+37aQfxQYRmuF3Eb/FOV6Ca1OPYL7eI+Jsr2gBChrzUuxEHoyle8s2h4I7T7z5OSmlDHxk8B0X\nSLJdFYzy6yvfyuQlU3QCibqSZsAl+SyPU1JtWt7hZvEK9AQqoVVNiyYWnbDbjJ1cjxM+kWjyfbdk\nn6oOiZ04aR0aO3GegAIEUAKUMGRCT43gj+bkuYfSSYgFfZPgXc1k64dw8nQiASVEEyxArbYkjOf2\n/YU++Kf/OfPZrDMys4O5zgz6t91UDHSy38yO2hs4PWTGXDWklo/I0AlN1uf3qBmXxNAkn9ZREcHS\nUqrSlhiTa4rpuaytVM+uWrd35Sk6ecrr5ebzpJIHFItO5DOCZHbTj6NYRIKfz5PQoZPtm9HMMRT/\neCw9pDLEdPbTCYQ91IwJy+xIMsCnqIH7Z4AS8oeMx/gHY9Xkjs8rGNc5JbPzMLXvp098TkpaQCwm\n3yRttHVh8+fNdEKfMOTcFuc9wN5O9wxZYh497Bk7QftPrXQeUMDAhg/QohtOB1DyO96tEjxHSFvP\nx8hHxU5C4CghSHJt7o0OB9RfoJO3ZZ+OpmSCKA6aDKQTdTnNiSabqB06yR/l88+g4G/xDNGzIXRi\nOXia2aFl2O8VI8QA6Fg3BldhhZaHmimdgNeXJ1HmORX7vbETx2MtVEpawDnpBFVRHUW4stg9wJRU\nlMRQ+radIavMYT4aiNqpLbrbtPI76s0yx9OJDJkgoBxJJ74q+rjJOLvfwO6kFftV20gnMpriB1RA\nrR0KUWHZQhMZBvSfxoZHYaAVvLdoWjR50om9FcMnw1oP5A6DK2PRBKKgPfYR3KR6RhU5wwlO0LOx\nEDjZKmRnUHqghB5AQUCB/jh0Yj2XZb/17Ncskzv3oxNKJCaduCvLeezy85EnX4e33p5qH51BuUHs\nREZQQkChN/EeGTtRQyYNdHLWOl3tYrTp4VOcBF6BNEnqB097wJuH9/p6g/rK3lTpBAGFJXrkGmDt\n4p/YsTlVwc9w46Pr1WS5jybIJWMtZj+dsLQOhYn8IQ+GIBDkyLzYAVjWuqwWe4sun4VP2I3NkNk5\nK63zXO0id2Z16ZjYCcVZ1mJzZqdAJxpS4NqBc6yM/jmdpO/cGbvW1ERAz96gZAOpGXcAhVr4Uuyk\n52CsEzKpHoktyWQV3kMCXbGThg6pgGKhiRM7KdEJojS0PjmXgFT9+DM7NZJ55CX9scA9bGU/neQR\nxCkpQYRGUBwEsQiGXkJTRQglFp1sF7LYySXohMaiQ0ZpyOywMBuDCalFVWqh9asOO7Oy8LlBklHa\nbireY8Wpkf8Gm9xwCd3ysffW/tMHFBoOD+nEagJtu7NlzW+2G8SyLhkrgaPphAVRnJgNUrBVhp2i\n8u/ZwdoupJ2OGUU6wTtu/Fsid4qXDLSP1t06eWRxAiSABZkISv6oCp7hTfZ8ztgJZKZOjOiEADTW\n3iW5H+mELhw4Zt52287N6ASzPLjbpDFplR4G0glk5+ULOhPeJNGgUUktpWQvbWO+3f4wmNWTfB9m\nKHkCnUjNVs+j0JylCih5OrlKvIQpRJ5OqA2F3R7b88GfuypcT+wEPb3KIv6Dzqo8AadShpyZBeJx\n6IT2fAY6eewNxG8YfRqd+ICCmR1gERZxfK4jJ6FjHECZefX1mAV6ho+9Z/Qwlk4YoAAbZR6C1bY7\nzdCJU6ZKG9Xyzgxmet6jALteexqdIKNQJaYUkqcTiAT6sZNdhbhT5c8bBOgRvNd7GjuhUWjJNwdw\nyXMqX3jSIA3Hwav3wshTIDQ0wp7PRm/kSUZQMlEWoA0oSftv3byDKNMgn4GXMFHj8eGBTYRVnb6x\nC7kf1pR6171y2w6sSvcMyl3pZJtr3Ps5CRco49BDc2YnzyU9504yPj5TJlwawzlj7171jCi89ptO\nnGxfWEtPAf+0rJPfobp+y0Tjtx0UGzJJJ5DZ6ZmIzms7YyfOvcTOrbmw71cL0BgJDQ/QYyhJCvFz\nRn74BE+fzEknH5jZecZOjCAHi51g5hQXl7JniH5wZ280eYTEOvYGnQsfLw8tuQUo0nrLYDkcv2Un\nbfFMbiZqUnoOGxOpfzqKHdWikQ8n16POmlpe1k+nzGd91nM51zPjy3NozpNw2kJhVY33NZudDA/v\n02l79k61zweUtzZ5Kp0c0B8f7dsCkk5aB7CAwgdwBotVQLE///V3eGHiBguzbkOLW8k8ndCzsezu\nYqzEPyKzNbq1eG4a5WEQtczOmU+wFT9lcoQa/9NXolOLdlh0QnvFV2V0586H0MkzhvqVZMkfPUEQ\nkbtNyijsRiHpERigqNH0/P0QEke+IYxobOj71auQS6xvoQC3WsZK8fvA6vH/PGLpVdrgdCIjKMfQ\nia/ZKp042RxGJ0cOoSL8uOyH0In062p+RIUSiiaIIyEENAAKQxn6eHtGUVY2CugE/hvP/T4l1MzO\nx9GJfU9cmU6iJ50c8Bj7SWInbxv6L0ZhmJI8GqL6IHZbA9RM8UWGT5iDwNYzjGJ5cce7+0GIKiUk\n6SSkjWq7+1idxloVOmHKcbxrV+MoyfCJRBZQyuNH0Tgh75dZR09uFjsBOsGn0cuQifqUNhYyqbp8\nIJhSBAU7Jg++UCLx6QTCPNXeDlGnF5P9jPLEnw0K+wNmTs0gOOFrv7y6R3xzctp+EQ2uFQYPa9gK\n+NzPzp2w4EfppuLnbT5D5s+uRJXzzm2mqgdjDjDRQycMKXroJHMAxaETqnU9sRNfS/N0YvXnueG3\nYzA+TqVmd+dCOp3A/AGZnuXXUa1Rs+WtPXlevjygvG/R2PPWDggdh3rYYx/Zhl49TcIeVcLyOKFz\ntfoPx0H6Xyyuo0aDAEqwreY+h3PhDBYfwYL3E8G5mbAzML9Yc/N7dmFoIqu72HA3iUNQAUXGTuTi\nKt1UfMza7Fl9zepUuhDsefKACDt3In0QRmVYyWT9oTtIal2Gg1VKCLU0Tyf+LDj1hEuvNL97FPbo\nBADlLDpR44TytJSfbmTrYYaxVGfx7Wzsi1HuRyf+bcMMTfBOE+tkSUnIbYDCugSV+I+JY3QCWFDq\namdheeikGjuRdJK04zTgkbfpMrgS1hPa/Tc6EUdG5HOWVbww79x5v8PumMAJSInhY6eq7HH5QDp5\nDFkkd5K5/mrshArW8ei+s/fVMsMiav0hYVhXhRfuoQDVOgM6CRmz2l5neZnfkXTi313c2YHjL/d3\nePSR9sf3jbmZNvsoT0Lg/l6GNIbgiBRUG6D4+R15J5Gkk2TcYsjMQlqH9gof+pKMnahUgX6ROUjn\n8xKdUEChJrVKRVKGGe638MK52//7J3h+/ftL3M8/RLvCSjDDzk6/qtEO9mgJdVe5K50w4GOKR3Vb\n8roqin46sRiULTTW+s3pZJLwCQhdTTcOROZwjR1fQNKJ3N6BQTwmhmxJoHn3Jjf06gNLMh60Z3by\ngIJRE/kgOBpB2aJB+IJLVDoBxNl7dI+1I+7WQTlnWk/SQGis87ENWdVYOtnqzywua1mFJ1fwwbIH\nLMzm1dezZPLX0hOpVTqxAt6wU82k+/Ggwm3u5cxLPoNKnbXtd3kcO5mKTgBQwvyOk328anKHRIwt\nOjkXUJrto+U1Zepkv2XwZN/Wc7L0KAnmdzY0wR8CxAO8DgPt+mA0X8hn0Uk+2CZLZmgprD9DJ7Cs\nzNMn4mGJ9HcEMY6yN6A0r7691xRYbIYF9FyjenaQ3Uts7ohety77DxOnz8tYgBIuigNUItnEJekk\nz8t4theV8op0QmPF9G4CtIOHGUFHq5rto3Sc9MDm8WdIt/7AkdvSUVmaJaF3xFDGcmInNB6TYYXk\n8v4OP7wCJ/J8TzJy48Q8rNhy+DkEqzNjUU2qGmCHOrG8X39IJyxNw7tqowmszeDyzMhzZZpXX676\nrlLNx00gNOJbbOt4rPpMLHmPcdfArnbxzEpixXgeffaPOs/m0TO3kznxw9mGk1Fy9kvu+JjteQCl\nTfUlmqh37R58Cy7wAd4WVCIVmtxhfMPohAWHsDA8XnYUo0A97BDMbD+eHC6BJMSE9bACz6AI+YGI\n6sqSgUz2yTGA0rb6quJqK78rnUBsRv2lNrk1ZZ8MdAQhKLcpcOYqLJMp3DaD1atG9SSOncxz5873\nRvDHA6jVaJ765MH9lLI6bc3lNzMKgEJt32b47kcn8sEnZz0gBPw6e6qKhSzs4Wzq0RmgHJbccX7F\nkN6a1KA5kkuQ/Ni544NvHaqOZddYNF1TcomF8Y9tYfqAsuikmU7CwAlVJItRWBCF/jmQTr59U+KJ\nrnn9z7j5RSdT3FcsdVFFZgjfqUqJkb099DKvc20lJaCA4ZsEUNp2b/6RWOq5z/KgeJdQPtGDg1Iv\noXRioQn7vBRKwQ6zO3TU8EkyrdOmsf1XtSlVtV0V/eWyss6e4+UIOnRhUjrZ72TYMYKqChYCG/TY\nh3UHg9xq4sNh841ubTmMIk+f7OEFLJ7IcIYcaeYqSSc0kJNUDCv2kxf+m3fOpWvDypXYCcwxvma7\nqZhFUNQfdLCecHxpOtkGngSUvY/gqVqVXAZvSizuccXNvTyuEary3gVoKMUnFYpc6k3R7ENgETy5\nAudqWRma7kH+UN/gUVz58BXglTnTOjvFxjNawZYV8oQKKNbjT2jchdVwQPikYfVlJNNfJqQTNQTe\ngCbULzi7Vti4Jo8hqjrpizpPJ6HCP9iuz83nL6cl2VWWEKo40gBAnE4AStjB5m06+9V0pxp8XpZn\no+4NKCcej22wj5tzpZ6SHdhE93zwoRNfUTOMQo+eSM5wbtuxTqJQaHMe+KZ+5VyLNzPvtDbbqs3b\n97b61asAUCSO5AOTPuLsDSgNq2+g9JyqGJ2w44A+mjTHNpyTKOyEpdNE6NrVAnntVYGAfRj2ITBW\nabjx6eSb/LSnRWc6mSmjho4eim2dim3Wj2NUX8ZRrMMo6gCvMjomTD+CctazTxrso3+b65x0AnOB\njKIemGV0oj5VNpMnYvkdFT7CZ+xaNOOgSZspUY1Lgx3I2/eGyp1LRgGKhTi77hwaVt9Y6Vm1AZ3I\n44C4b7R+zbize0lAsVxAZgn00ImMTzwNyztPZLrhoWE3nVj9xN4mewj6WZ3Tt9iJGjip1nhi+eTB\nqGRY78SBhE2rgMJuYjw4v9NgH5N0ctaJk3AW5K099NyrfFYseyxKBlBkGT92kjlrgrQkbwvCSVRn\nk34bbtpYVbS8X89ZdLL1EG7h6cELH3H2A5SG1Req95AClE7YAZQhZ038sE347IkGOhmivdZC82mg\nOiNyKTnthkteEkaVOdrKP3/Fl541geMm8KoK5cTyyYNR9wMUeRDvunRCYwZTpXVUxZa5Hhk7qYZP\nnBSP/Mo5aOLkepw7ljObwsxOKMMZqgHV5Vzfe7UZohBQ/JWlAsreO4cb0AncoTPW3Wy1hY/uVFts\nU91HVDV3z05nsaRiZxYpi9mU8KhKG2p8yI/9fDWxqcXXv+f1X1oCcDJWXZJi7SwGXc88QPCKo0Ph\nWHbwlOROg31UYycsnTFt4ISpKGWUkE7kfcVqHEW9o4fdq8xOuYanUjCh4wh2VzoJzV/ScHeaCP/y\nvQFl+M6hYfXtKkD0I/Ip8nuHTPjCFI4gefQkXAVhARYvdP7Er2idbb4/04qcetau2h8uWKSF4rah\nxEyo2N908mDAF6Bc139nUo/XHR3oigQUuksbbgQTnFuItFmZHfTK8wdOVEZR6aQaPrHyPhJHaDbH\nek+TSk7UxNnchFThmzxq794sjjBtM9AJrCw1xZNEf3/nMPzW4qvQiXUMdj87rHqB5PPsqaJaCmz5\n7PBzaxXQqcw7ctUy5y93Vrfaz6o1UCUZ8jFr+s21DI+zhb0ZXiBUzWnvl86LQibL8RFSV6STmQ/D\nJidlVzpheRwrrUM/p2gCj07xB5LZFGYMX6aeJNM89kvFLVpyspxiElBK6K8uzJ3W5uR04pw4KT1y\nrW1OpRdI0klbc+uqURLw6AQiKKNaOqueEFBuMEa51dvJCB4QO6Exg9CPnqVUgXf/esKsTLIw8Go7\nFctqDg+d0FROBk0sDqjulpL1zEwnsKyQUdjRriT6M8TZaWFelE4OQBNQMJnoX4Ayp/GkvQroZP4B\nZHpoAQo8++QedMIAZScjuDed3ABNHqYwopPkuRMnuROeL4FEEj6ubcuRJdHkac1fhsEyFpl1B4AC\n/xyjw6qaJLNDe0UBpRQ+gUoooNBH4yf5JiPqCelks6vshIdM6xxmexedZLRotjIfQScqO1/9sWyq\nJql2cKARXHSSXMDqkRrGXs2xk/BCCiXIJRcNRCUFvncxFVDyK0s9xZK/PBzdFenkMDQJwyfVnvjA\nHU5WWEDWH15yywI6nRyf4j1AuBY+V1XzgK72NLG3HbT6VrWP7EGx7FaUq7tS68AvPqUeDvyCEELa\nSBZgUJK5PadH0z7t2k7033VhVlffAXPHYicscHK81R1o/x16GOI6F508gZLhCQ3GDhH0Acsg2cRA\n7Uy2eEox9WaBgbu0/egEvGk1B3GKkMNGk3TyWG4jGAVYB34/md2eE3Z1FchLYFpAmY1OfDQ57LgJ\nndmS/W84ZYUONa9Oq6QvAR47kbByGwmWtPPSo6aAst/jKZmIqvZR+m/qVi8tf2AO62AsnAhhN0tj\n2AOiKQ0vWkN4z/CJ4qUW5sRutDXdTyfy13yG7Byqq69t+PmrZgucPJak8eATNYpj0UmovXJLbx29\nooEAFKxTv/qVQ1FhVy0DPk9UQsnsVEeVV9kTS8Ld0Vt0kf4XDm0dH2PcWw5AJ+z33Ic/YmEgndDs\nRunw5t6S7KnfOnqi0snbJu8rmlJ99XT1lGvnMYKl4fcDSv6XBfMdm5lOTjwM++31340//aXiEp1Q\njFBnx9Fq+hXN3aiX+MEb/NahqLzyQEnWverle5Q36eT3v/yZSnCPto+sk9IJEMkNHmbvCFANn+wK\nKFX7yJw3BE5ugyaP1f6PPzm/wHe5B80NX63XpZPO+MceB1Cqq2/4bPK9CjGwjE6OT+vIrWmGTvw0\ngqW9eTrxp6CfTkrry29ub22x6g9iJ/cAFBY1+TQ62ekmxp7YiZXWufphWBYCUZM7YezkLFtAt1BW\nODr/Odg7x2tK63mVqK2FF/BwFHj5O4fh4ZNp6eT0wAmiCQ2cI51YgfPQW+fpRNXqEB066QTXctgQ\nLTnbArRjJ788YyfJ4Z1rUgMO/fH9szsQNQFNvUFmhxpEZhb32KI5ci7ZRzVwAs/nmFmRqn1zzsZO\nO1K2IaHLX31vmVGnHhlJnja2rM64DExun/zx11+h8PZmezmYouaGNl7pOYBSWn1VNW4rjwb2xLt1\nAE1wd8osv5PWH0Un4fJxwgZvWx3xxCB1EanOOuPBM2Xa1KDnKpNOHt19AUpPA6dfSxUUoeQedALm\nDKwhvtDGXY5OpnXYzTrMzsZiKGVmDnNoQzWX1fJYSXJ32Cz8/S5kt8UBmlgvlTnk2vwoOjnmqN/W\nykYmeBhW7ktvRidsP2AtNHVdXIlONi7B15z9zpueUEePWSr5DidLqmhC923yVOwk504+Ia3z3NnY\nd+5Mi2J+LETGfgfSCdsqJRfCfsVYYJI2hHjhowkEUWQPP41OMJmOYYz9Zu3bK09AJ1tnVK0Ovaos\nIJcehk+QS/Aqq7Aj9tlWnxTdM1X8hiZfEZQDlGmnJm5JJxmbKHPbc9IJPtZ9Wofdo5nWnTvTDjZJ\nG2EIpBobn83IyCVGOQPwgpb56e/+bnv953/4BxlEYRcC9NDTYNvCvHfsBOiEnvzYe0/IQuZq1PyW\nN2z2GKvZrtUzOzejE1gYNOl46cwO2sTNFMJLNYhz0on01vAYsZmTHT2L9op0oibLLXrwYy1OeDnE\nlx6x91wL9KBmaoAzILODZViIRa5Hmmx97hB+/Xt8EBH+uODNzp089r6vQ36MTsD87gooULnM5lza\n8vdo9RWv5XTyjBG9Mjv452w7m7ys5Zntq5+KBbNIbaK6acPoMezMcKvXYwQzgUF/auR52HvTCVAX\nu7V4ZhSDlY52gc6mFftVw8hOPRiRZqoyQ2w5E5VEfIE3lDPgEwYoyDRQmF1yezrBmw/wV1eRTvYG\nFDyQS4/o3uN+iLwHvG5JETuBPM47nWBa64rjlIEToBO47f5ywT1EEzoX24cIKJRa6C8VU5O6xzyq\n/oy7H8NP3+9hJ29O/YJ00q8hV9zPhGjC7sdh2RkgD0knbC/BoiYfSCe4P9wCKDsBimr299uXNmg7\nPSPSv9wk6A+v8/gK9dgJ2wzdhk7wd4kpnVwLUJ7bNaEpCCX00fXUekLsxLq8X/MWnVgyhNgJvX9n\n/tjJEH3or+TgGtRkjUyewiKCeCSyBaIJpH7U17aFgAsloNzv3AkmVtTYCVjdvekEYyfQB/hzj9jJ\nXenk3HCmce7k919+//0XhJLr0gneTgY4cnU6cdAE7tBhVo/GkNH8nZLZgeeywy21NNOBR2Jv9qBY\nNXaCA595sA12VmWIUfUcBigUTVhgkgEK0gkNe2BQU+UPTO5AmnXRCYYxeg6gANyoL+QSZvbzdKLm\nK80dSP3GkUvETtgqPnhRe3SCgHIDOsE8DhI01dqrhE8cOqE7ubdf/nudv9sJSnC5WrET4BL4JR14\nTCqjE/zxvzs9xv66dDLQ/g4EiwNMkJozhUCInzaFqAmck2UxFfYbnNa3t7xn53m6iDz0EogBT8hS\nQGlQFUATgBO6C6UPf6NmnyX08zZfemhp62iZTPmG8ToLs60/1HTLylUQmYJOvjrxHT45uE89M8c4\nGkN58DmN7wGdYDRlp/Rnz1jktRZhgHFU92QYPjmFTtQ7dOgRURo7mTnf0TmPmNyBsc8cO/lkOnHW\n13NjQFmf3HdD06bWPgFWorpIP5xO2hbXw56/XpJO0BGAzVc3pUmb75PHE8JesRPpK53L2wb+tvOJ\nniHr+O7MuJy2+jsf1qDETh75QkInYRWTFAB1VDlaoglN9BxzgHxvKVn5bLZ7268bjN8hZMLuVWEf\nQtQEMj6fcDCWxo0uFygauEUZVdWoeiBAUkV/mTbFTYKVY7XQ5NPoBB98guGTql1Sd6E0m6PafDT7\npU1pxotDGR9N1ALVgbPyMk5DaclfIJlx+fGVzs6Hl3t0MnDxh/3oLABcAijNAAWCe/ChGjvBb5Mo\n3dnVnS6fhU6+oARDBQxH1JwOpZO7hk9g4IxOpgUUGShGw2p9JT9X7SY3N4lsPb2E2kpWVeey8unE\nD4fABgBqUB/QrN6k8wnPO3moDcns0GQ6hq5pePvpWb/2mf6EQgEImbDAyTOb49r8PehEdZcNCl/S\nZIdOLPetLihKTiFjlXrYU1ihk6/O/QJf9FR95LUY5WNo8jwDpWkqvRX+aznES+LIEYVtgTWkL9WG\nHhc7eZ17BSL5eorJzzJ2gqkNDJwgncBV4cCvWEDSySaHaelE3TAxg4DGwbGPdKZosTbDsqvRdPKe\nSeZwDp1k6KQz8apS4wwrxaITPH1Cj4lAwIOl4yWp4CcyobOhCW5HwaSraR2Ml2dOnziqy1bBriqq\nzqa/+vz+JFfuiVp0BzphUT6qspam0mUAmnohOqFEwu4fxufDyjed5i/YyryIxHo0Kg0bYB4HWQTv\n6LklndBbdSi0XY5OVNpI2rjJ6cRR7046YQdW9njYCWx859xPOnRCU+qUUdAgw6ZRWmZKJ9TaoyPA\nq9ihE7YjhfKh983TCY1APONA9R1+aR7D1WcVkF1FLQoFcliBm9AJDQlSFQT9A/2mn7PyqNaHyb2t\nIXisE/73+RtjJLDMoGSLM+OtBG0tJq+y4iUIIvRGYvWIyaMG+He78AnSCbzBkNK0Z2OpUVDjKE4c\nGK1hySxm1MzfCGZqaC7j3GuDaR2oXEY08RMrgtL5pBP0giWv1iyK6oU0egGBDcyq0Ht2VDr5hRx6\nddpl1lsafMQgTCdBGWdHqi4BJmqLWqTmO7XJcVXnMVyt+f5YTculV1WDtvIenUB+p63eI69i/CuV\nFSMlKiwzEj+y59W2Nku3PXoB/gtv6NE8TH4zE1ltpaH8ky3I+VbkEszgYJYHP2ENYSUNHZj2Ehos\nkcduIHwyFZDlbS4aayr8G9CJShjqr1bJtKm6Hv3MzpCgJtrx2RYC0AnAB9IJPfaxIchWhh1DoWGV\n6tYRy8vbHXCPSnets0mMov/BfZvN3et08mKoa9CJP4UUPsLJzgT6wkr2K6AeNLHiJft1Q6eKr7AH\nQsn2w37oejGyggXUpMZsfrpfgOzwDaMT+O1DjKBMwigOnahfWTESVtiqNi/kfOykuvvEPnCsJ/cP\nZ3KmGNfEgAo++X7XwAn4s+ZR56egWhJBAZ81Ip/jsMGJBSiAF1ujUCDZum/waRB9qzVfbbL1/mJn\nIcKM+sPxhGj5hN1tmPsJ9a9hFNsldI/lBJC/I8ltzdSvYvBB/8TKaOJm88qqJ57EPdcFoF+hHsFh\nz3pBQKGMcrocmE2gMRLVC9LyLI6CNkRCTNW8qFbb6U91HlnOVKZNIU/KXs/45dfypCzC/rToZEjg\nZHI6obfVsOQOzbDQyIrMwj/GmAOUsBgykxpKr6rNDcrPibZUqzmlwHe//+XrRwHXvyUBQwLfJ1tB\ng4xTI5i1ATQ53QHvOp8wQHa/Ek1ssSQXoAl76Mu9RbSr/NsqB87YCAPTpvJ3IeSuANqCC+FndCDl\n6tSDz78fcuIE2bFKe21SKl31SOu8H/uTR08wyQK3zxyJDotOSrN5fGE9dDKzxh8vo9WiIwFOJxrL\nIprcnkseTK9xCTzFX/7GED2dswHK9qLgsgDlsKUnsQNSOU6whPbNiWWqERc8rj5qgHNuf1U6ASaQ\nx2BL6ZthcsvFY0Y1t+opScBK7KzPlwTGSQDuN/6Ef+RhdPD4NXk6GEkFn8/GyuAjYb5zZJ8gulPH\nuOEF/vPTpplujq0t0+KkZbT7JZ9dfYVJnmdXt0/hk/VvSWBJYEngOAl8CJq8Elv0dDA79yqTPnBA\nWOWYZwjzc6R3nEaulg6RwItOIFiiwwclkkUnh0zLamRJYEngJYHP8a9fx24WnSzVXxJ4SGDRydKD\nJYElgSWB8yVAHigHsZDtCDCeAv7u3lekBB7Ltr3Y3To0iILHdD4lL3b+FK4ejJbAFg6BiMiKi4wW\n7afUVzqrsgovCSwJSAngMRH6E0Lbh/K3PPDkLALK9+Hir5Mr9Hkwn3CUeKnTXSUQ3t9714GvcY2S\nwLpneJQkVz1LAksCSwJLAksCSwJjJLDoZIwcVy1LAksCSwJLAksCSwKjJPBGJ798/XOqDguM6taH\n1ONL+0OEsIa5JLAksCSwJLAkwCTwTSfSUwKLSCLJ+FT1wq1tq0LWCm3aac7q4R7TTLuRkYDsgyrh\nPbq66lwSWBJYElgSWBKoSqDNtVVbSZZ/0knVcebHYDl1/Nz3+mEsB8epVgjf0q8kBlnMxCRIL2R9\nztSp8hbUY5FccgpXsSWBJYElgSWBOSWg+tb8h86g2ObcceLSxaiux3JS+SiAWpK1TptG96cOU6eT\nED7CAhIaKCUwYlALM7BQex+iD2tURRkHa2ijVMQ+WjkckySeOZfZ6tWSwJLAksCSQEkC0lmoDsL6\n0GpL+j61Ielx0LH6Xix0uLKASgVqPyWgnEAnrLsqTFiEYYGFSgyZhhDT8vTA2sIuhXSSnFpn7KUF\nsAovCSwJLAksCUwoAfTE1H3kP6zSiay55PicuEMYksjTCRISe8MGu2PsRPa1RCehLCi+WG2FwZU8\nH1AiWXQyoRVYXVoSWBJYEphNAnkQUUv208kQt1tyx3JXTykkE+OB8nudO0liFCUM531+hrAknWkJ\naD1BrTD0Yk1kEtdmW12rP0sCSwJLAksCzRJAl8F8BzopufWlJTH44Xt9WqzkpMItuuXN2edJpz+A\nTnCoTEx+KIbCAVwoB5D5MENqjGbCP9mIfHyRimhNoRym03lWOFSL5vWwLlwSWBJYElgSmEECqp3P\nf6jSieqgQydFOYnt5KXvRl+PbovVLz2dU9KBEstjencUZyIWM8y92gcVqqbt7erYksCSwJLAksCS\nQIMEkpv5hprPveSGT2NTYzbnSnm1viSwJLAksCSwJLCHBO5KJ/8/7d5FemD4AtYAAAAASUVORK5C\nYII=\n",
-       "prompt_number": 30,
-       "text": [
-        "<IPython.core.display.Image at 0x107ec2a58>"
-       ]
-      }
-     ],
-     "prompt_number": 30
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Write a function that takes a symbolic expression (like `pi`), and determines the first place where `999999` appears.  "
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Tip: Use the string representation of the number. You can take the part after the `.` by using `split('.', 2)[1]`."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "'1.2345'.split('.', 2)[1]"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 31,
-       "text": [
-        "'2345'"
-       ]
-      }
-     ],
-     "prompt_number": 31
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "And remember that Python starts counting at `0`, so if you use `str.find`, you'll need to add one."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "str(1.2345).split('.', 2)[1].find('345')"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$1$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAAgAAAAPBAMAAAArJJMAAAAAHlBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAACGjDitAAAACXRSTlMAuxCrdpnvzWYiHG0BAAAAI0lEQVQIHWNgYBBiYGBQ\nnMTAoGwMJBhYSCVYw6ZHAPUxMAAAQGkI1Fjz0FgAAAAASUVORK5CYII=\n",
-       "prompt_number": 32,
-       "text": [
-        "1"
-       ]
-      }
-     ],
-     "prompt_number": 32
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "str(1.2345).split('.', 2)[1].find('345') + 1"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$2$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAAkAAAAOBAMAAAAPuiubAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIpnNu0SrdlQQ3e8y\niWbzIQYJAAAAT0lEQVQIHWNgVDIJYGAQY2D/wcCQycCwnoFh9wSG/AAG+wkM+kAJoMgEIMHzF8Rk\ndgCRKiCCPQFENjEwCjDwKDDwCTBI3b2rBVT8//8vBgBR7Q/Fm5CwxAAAAABJRU5ErkJggg==\n",
-       "prompt_number": 33,
-       "text": [
-        "2"
-       ]
-      }
-     ],
-     "prompt_number": 33
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "And remember that `str.find` returns `-1` if it cannot find the string."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "'abcd'.find('def')"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$-1$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAABgAAAAPBAMAAAAMihLoAAAAJ1BMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAilU6eAAAADHRSTlMAIs3dRLsQq3aZ72YDTSHvAAAALklE\nQVQIHWNggIMwOIuBIfUYgpNejsRh4CCTI2QMAiYMZBsAcxDnrEOzYWwwDQBP9Q53CSxxJQAAAABJ\nRU5ErkJggg==\n",
-       "prompt_number": 34,
-       "text": [
-        "-1"
-       ]
-      }
-     ],
-     "prompt_number": 34
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def find_999999(expr, limit=100000):\n",
-      "    \"\"\"\n",
-      "    Find the first place in the decimal expr where 999999 appears.\n",
-      "\n",
-      "    Only checks up to limit digits. \n",
-      "\n",
-      "    Returns False when 999999 does not appear.\n",
-      "\n",
-      "    >>> find_999999(pi)\n",
-      "    762\n",
-      "    >>> find_999999(E)\n",
-      "    False\n",
-      "    >>> find_999999(E, 1000000) # This one will take a few seconds to compute\n",
-      "    384340\n",
-      "    \"\"\"\n",
-      "    found = str(expr.evalf(limit)).split('.', 2)[1].find('999999') + 1\n",
-      "    if found == 0:\n",
-      "        return False\n",
-      "    return found"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 35
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "find_999999(pi)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$762$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAB0AAAAOBAMAAAAh/woJAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAMt2ZiWarEER2u1TN\nIu/4jXmTAAAAu0lEQVQIHR2NMQ4BYRSEPxLWim10KlGod4MoKKxkEyU3IBqlLVQaewMSFxAnkDgA\ntQiicAOtiOhIfrOa9+Z7M5NHvhYEPpNaG6d6iKBvjBk4JYbcsD/QgTRJnyMjcMGHNv0QeISMI+3M\ngpMW55BWzFP4Fpab+OTGuSbWq0dZKvHWsJ5YBrqyciuxvZevvyo0hCQH6osX2FIw82D997c4F5iL\nd3E/4ZES78RZ37pzDYKK8sWeRr0e4Rrz4geOEjEwmFr2RQAAAABJRU5ErkJggg==\n",
-       "prompt_number": 36,
-       "text": [
-        "762"
-       ]
-      }
-     ],
-     "prompt_number": 36
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "find_999999(E)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 37,
-       "text": [
-        "False"
-       ]
-      }
-     ],
-     "prompt_number": 37
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "find_999999(E, 1000000)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$384340$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAADwAAAAPBAMAAABKPLFCAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAMom7VCKZRHbdzavv\nEGbh6M2uAAABHklEQVQYGX2RMUvDQBhAX2NaU4htcNQldBJd3XVycekv0AhSnMTdocHJwaGg4lqo\nmwh1EISO/QOlQ1EomMlVkBYEber3fSeO3vTeveSSu4Pl2iYMa4fIWMWp0ej8AIoJzZSEUib58leV\nuOElwptQbVUylloQ9J0aBS2CNr5mr2t5r+MUhMpdFqf6xWbqfw28FOKOU6NqQmGifgdb+RlU6pZF\nlfZjCp9QWO9CaX4Nz0g2VdL8oW9fnPC2Mt8m1myq9JfDWSXhfeZHLoeO3OLFiIU8HFDMh0g2NdJf\ny3mdSR7Lmke7vd73k6mRbMyfUm1TnoZ1eJRH+k6N5Fg8OZmMZuzf48duUtWIK8YR7DRu4bShV7Ix\nP3ZqNFp7kLl/xw+dmW1XxX384QAAAABJRU5ErkJggg==\n",
-       "prompt_number": 38,
-       "text": [
-        "384340"
-       ]
-      }
-     ],
-     "prompt_number": 38
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 38
+     "output_type": "execute_result"
     }
    ],
-   "metadata": {}
+   "source": [
+    "evaluate(exprs, x, 1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAJoAAAAaBAMAAAC9YVj8AAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAu90iiXarVJkQZu8y\nzUTTeIQ7AAACd0lEQVQ4Ea1VS2hTQRQ9TfKM+fQlCKLoJkRRdKFvoXGZtzB+QCQLK1WQVloXQhfd\nqJuWVmgWgkKULAoiPtSVIC2iFDfm6cKNYLJwowsRQVwUsfiFIq33dnIzmXysDV7I3DP3nDkzb97M\nCyARunxeYPd5Q9pRg6/gWvcuPNJOb0dKLLYh6wvuMme02xxuv1/Fxc4rQbSDsMENmCiu4vZC+KsC\nJE/3cclwey1cp/xGiF4Bkvfghm+6hQaF65Ct2oMCUdeUWClYVdPtnqlo7cXqOxGZNdnAIOxvhpvt\nxn1T09z7rAubNGSUmET8V80tmBu6UMCzSxfrcyttZuowgoX+UXy8f4YrU/Tbd/JAfx44ohTSZl3E\nf9TcSrjjPUR5eVlIleNLeOk/L2I4kkSAS2+BiBvdHUsB40oiLbt9r7m5GMCYEDr3JjHjPwKyr3Yh\nxOWnoGwthH1gXssYNboVcdYkVY8ksGk3EpPlcz6XlmhtWJdkWOFGB7vJkwKPNaHRF4+OAjkkqqW9\nP7lMGIjRrrW48VtYlHca/E2TtkTFBcK8thEHM6NEz7GELnOx5UnphITlhNy1FnCKlWBhPQJVwKN9\nq3zKY32eyltorc4ALBI9MKV0ekMptbbwYs9skNW0LV9XkmroBFnOvIPN4SfocahGx2LC24r9K9CQ\nYidu+sotsvHowdPKIFLmURKZwjHEhw95dq7vONc+ANdPlHIewXcwpdO5Eaoat576dqMb9Y2I1Um+\nWW2kzW5RY3hTR9/1UJ62sIml7prcUP8i3aKh/+BGc/4lMsINEWgjbV6byNvn2puH5bfn1+bW3kNX\n/7dbWv5P9RRdIju94w/Gx4QwEvm0agAAAABJRU5ErkJggg==\n",
+      "text/latex": [
+       "$$\\begin{bmatrix}x^{2}, & \\cos{\\left (x \\right )}, & 0\\end{bmatrix}$$"
+      ],
+      "text/plain": [
+       "⎡ 2           ⎤\n",
+       "⎣x , cos(x), 0⎦"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "evaluate(exprs, y, 0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Write a function that computes \n",
+    "\n",
+    "$$\n",
+    "{\\underbrace{x^{{}^{.^{.^{.^x}}}}}_\\text{n copies of x}}\n",
+    "$$\n",
+    "\n",
+    "That is, `x**(x**(...x))`, with `n` copies of `x`.  In [Knuth up-arrow notation](http://en.wikipedia.org/wiki/Up_arrow_notation), $x\\uparrow\\uparrow n$."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def uparrow(x, n):\n",
+    "    \"\"\"\n",
+    "    Computes x**(x**(...x)), with n copies of x.\n",
+    "\n",
+    "    >>> x = symbols('x')\n",
+    "    >>> uparrow(x, 3)\n",
+    "    x**(x**x)\n",
+    "    >>> uparrow(x, 1)\n",
+    "    x\n",
+    "    >>> uparrow(x**x, 3)\n",
+    "    (x**x)**((x**x)**(x**x))\n",
+    "    \"\"\"\n",
+    "    expr = x\n",
+    "    for i in range(n - 1):\n",
+    "        expr = x**expr\n",
+    "    return expr"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "x = symbols('x')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAB0AAAAUBAMAAACDsiv0AAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIol2q1SZEGbd7zK7\nRM2RoJmtAAAAjElEQVQYGWNgQIAdSj0IDpDVsIcJhc9gjMpVOM0BF1D2NdlwQqkbxmcq8OEKgHGA\nNC/DCyQeiPkRlc+9gBtZYD/TAxS7a0yT1aHyQiaiZgYItewKHDO4JiD4TAzMH1g3IPjsDCwHEDwQ\niwtJN4gvv4GhAERDAIeAPQMzEj++4RSDMEwSSNcYFSk3IPgAm1gXfwEYbXEAAAAASUVORK5CYII=\n",
+      "text/latex": [
+       "$$x^{x^{x}}$$"
+      ],
+      "text/plain": [
+       " ⎛ x⎞\n",
+       " ⎝x ⎠\n",
+       "x    "
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "uparrow(x, 3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAAsAAAAJBAMAAAAWSsseAAAAKlBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADmU0mKAAAADXRSTlMAIol2q1SZEGbd7zK78ZNZ0gAA\nAEJJREFUCB1jYBAyETUzYGBX4JjBNYGBiYH5AusGBnYGlgMMIMBlAKZkNzAUMHAI2DIwFzDENpxi\nEGZgqDEqUm5gAAAhlwo0cLKzVgAAAABJRU5ErkJggg==\n",
+      "text/latex": [
+       "$$x$$"
+      ],
+      "text/plain": [
+       "x"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "uparrow(x, 1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAFQAAAAfBAMAAACL2vddAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMARHYyq80Q75mJZlS7\n3SINk/qdAAABtklEQVQ4EY1SsUrDUBQ9bdqUpKUWUVwUgnSwdDCDIk6tdBWpi4NTFgehQ52d1Mkt\nFCzSKSAO3YoguBlcBAXp5OBU1EUcrD8g3pf3XpO0Tekdcs859yQ5uS/AVKW0W+5URkBXXHtKK+LG\ntE4tYzpjvR+e6uXrAKxn2i1znDXLY3n5NifnzIj7WT4th0k5b7jVy6dWEZmTbC/cyvNVEJWTuer0\n3vxshd+wzNv4q1IFmgn3mE/nAqaYIUhjK2/q9BWxMpBLOkJdF521NYE1azvVwRmQLpMy0xNy0Lon\ntBj2CSXpqS71DZhcX+SNXdnyRP1R122oXSj9C9hcbcspkLIkVuoKoNaBV6gPdwWhn8gxMC9hSatq\nhJ+BopRYr/rknOBX/nvFqBVPm4QvgZo/RdrwCX2Lautvqa6QbmkFjj9O+BBHdDSI99Om0BaoX/lz\n9iJZv/RUJFxJURqgEUBWWoMx0CdYvaP+MWEJMwsQUU+09t4q4paYX0f4SKbl3DuPeJcO4lG1RHss\nHDYcOd+VYLSneiGNHWxU0f8RLM0IsiEsf0IuHwxNQ/QzxHZCbIhkjYAQl+cb0CT8B+zTTgl2dwsa\nAAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$$\\left(x^{x}\\right)^{\\left(x^{x}\\right)^{x^{x}}}$$"
+      ],
+      "text/plain": [
+       "    ⎛    ⎛ x⎞⎞\n",
+       "    ⎜    ⎝x ⎠⎟\n",
+       "    ⎜⎛ x⎞    ⎟\n",
+       "    ⎝⎝x ⎠    ⎠\n",
+       "⎛ x⎞          \n",
+       "⎝x ⎠          "
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "uparrow(x**x, 3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Write a function that takes a function and nests it within itself n times. \n",
+    "\n",
+    "For example, if we started with $x^x$, and $n=3$, we would end up with \n",
+    "\n",
+    "$$\\left(\\left(x^{x}\\right)^{\\left(x^{x}\\right)}\\right)^\\left({\\left(x^{x}\\right)^{\\left(x^{x}\\right)}}\\right)$$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def nest(expr, x, n):\n",
+    "    \"\"\"\n",
+    "    Nests expr into itself (in the variable x) n times.\n",
+    "\n",
+    "    >>> x, y = symbols('x y')\n",
+    "    >>> nest(x**x, x, 3)\n",
+    "    ((x**x)**(x**x))**((x**x)**(x**x))\n",
+    "    >>> nest(sin(x)*cos(y), x, 2)\n",
+    "    sin(sin(x)*cos(y))*cos(y)\n",
+    "    >>> nest(sin(x)*cos(y), y, 2)\n",
+    "    sin(x)*cos(sin(x)*cos(y))\n",
+    "    >>> nest(x**2, x, 1)\n",
+    "    x**2\n",
+    "    \"\"\"\n",
+    "    origexpr = expr\n",
+    "    for i in range(n - 1):\n",
+    "        expr = expr.subs(x, origexpr)\n",
+    "    return expr"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "x, y = symbols('x y')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAH8AAAAwBAMAAADKnbiZAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAdma7VN0Q7zKZRM0i\niau2leyDAAADCElEQVRIDaVVP2gTURj/0rteLpe7JGoRQawHUhQxGJ0UHNJNt0ziGOjQSRpFnRyC\nDg4iaQcXpxRHQYKbW9wEh6YFu0ghUpAiDrFIqaDg93333t17l8vpmTd83+/3+/68fHfvXgCmWI92\nzkxRjaX+Y2+6BnBkyvrBlZksHd5zMs9dByB/eedchgbugJN57mf/M78hNqO5vS5kn38xaMBzWz3I\nOD8WXwsaBHPvZZyfalsAm1/n20Eb/f3l/EBNttYX1u0eeM3dfD1Ieq3lHtPYGHnFijMEB97I4FMJ\nyJsNlY3jXI2zhmh/yajWYLkt5bi3q1tUzPs6iOyWLVJeqqlXVaLhGbs2QGGjj8ZqQMfryY+nquQ5\nBwqJwVyFhMKQ7E1YmlvbJoTrReDYFlcVokPPaPuouDz6nBrrKaTTV0gEvfn1PaO61SblLZklMmKZ\n/MsEeS5V3W+XavekcpGA6UsKUIogwB0m60KijeE8km7RFxLASp2g8unKR0Gyfch2SBYXb1xoIyr3\n0QRrdvJjAsiNKKnYDFLFxvSMnkBbaFBqSJTgDQ5GHwdvXAV79AkGMj3YRLKYn62R8CBUeeNlsC7d\nONWUosNjShbz5VUUnJ5QxcZGXcuyf2hUJysV5IUBHpfNb4trYmOPukbL+h7hMbTho0Sv7DYs+PdF\n2JS/SPDfwie5jo9qvgv4yE7DdZHhtAQQ7qdONdapIy13AZqwGwbsUQgZ/FMDeSapIlMDHwv4qnMP\nwaJqXFlG2KhggeEDXMDjcpyqcc1keIjlARbgazP3jZZLzWghV5e7r7IYzlOu08Cjt71zVMaKXYnY\npx6kYo1yHmoFsKxTM7yNdZ1ZoUVOvSSRbnIoNN4ohOPAPCAt/Jw5Af87tWXEuBa0+ENxh6pY6qsM\nz1lF5zrjGxPeqeIJlSCecO+KrLOx7AT6MUGLpJVuhCeguxP0QPZqqWEMmq3UDCvtvuLKWT+1AZxM\nDwMs/CVB+QdJzHRjx3Qsybo1JmlCsa7RBPKhnyBG0ucITkBud0KAZSs1Cn8Aj4KUD33G8usAAAAA\nSUVORK5CYII=\n",
+      "text/latex": [
+       "$$\\left(\\left(x^{x}\\right)^{x^{x}}\\right)^{\\left(x^{x}\\right)^{x^{x}}}$$"
+      ],
+      "text/plain": [
+       "          ⎛    ⎛ x⎞⎞\n",
+       "          ⎜    ⎝x ⎠⎟\n",
+       "          ⎜⎛ x⎞    ⎟\n",
+       "          ⎝⎝x ⎠    ⎠\n",
+       "⎛    ⎛ x⎞⎞          \n",
+       "⎜    ⎝x ⎠⎟          \n",
+       "⎜⎛ x⎞    ⎟          \n",
+       "⎝⎝x ⎠    ⎠          "
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "nest(x**x, x, 3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAN8AAAAVBAMAAAA0pCbNAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMARHZmzRC73YnvqzIi\nVJlz8rUYAAADf0lEQVRIDcVVS2gTURQ9k2Ri0kliEKG66hBF6ocaPwt3RqQuJQspLS4sFsSKYkAL\n7hy7sasSha78BUVcKDa4cBGVBFdSUYOI4KpRBIsitn5AU2097715k9+4dmDy7r3nc+fdvEyA/36t\n6ngCw1alYLIDkgVXIeB/UAxbKbepBdZPN+BiFWRcduQiP0o6/KSDltVVAAL2p2iHRFEpjaWGQygr\n455ao9Svw5AOWlZXAQjYn+I5ZFylaiKTlCqZLsIlYOs46OioeXUVnCdhX0rDYVezUMVTHaWo9zhm\nvgNkwVMI2JfScBhSBrEHnpGRUeHTolda7UU40Qi9SCtYELAfpeEQrsJYtz0zU8f9q/c22OQnHGDV\njvWx6YI1+il1mBXM8X6y6VmfDUwyjN2dqOJ56rNUMheKwTnEfijYj0IHc9LBiywiNQwAORwD9qXN\nBcpDaZjDWIFwAaERHEqytJd0J3gqmgNeMS0nrUvWGLocqZQKOD0IzCvYj0KHiDGPrUA8g+4sHNFw\nFPhKu2gSxhgiomE4j5U2SxdIp1+cQ17LdB+Ci1EHsUWplAqr+gHhYQX7UejwKJHDEcDII1rfDNGQ\nmWi4knu6dr0oGw6rhty4iS76cXecqPjN9lSBJamUChMXJZWwL4UO2agt/K15mOeXC20NB8/W2xpy\nHzbNhJvxjetuPtZ3qVSPGP+BMgfgNuygsCFms9aibPgQwT9NDaNVWBXsroqRuju8Ilq9KCIrZybf\nSrPcYV0q+SiMExlsJEmMk3cHRTi8RyAvR/oSeNfUMJxG3EbCbmo4wp9zZSsCbLiTytNM+R1aC1IJ\nUIFQTVhI2I9CB+wXQ0MwgzdZHG9qyHMbn0K4QlTvkAd9Nj2Kx1SJM1+uYotxGeGaVPJA1bjDghyj\ngP0oovYRPXwyktekepOl5Zul5duvf1Fq5GCMp85Z0/WD0/VHJ6+S2g0M9A6Ok449vGN3e4soTdyQ\nSuZUwDzc99uF/Sh0wEDqS4WjSDJsvS63psyiFV3yfW9BKiKibV7dmu6tyuE88yGv5gWdr9fG+zhi\ne7SmgIpbGKpyXoR9KXToypni6Iw36dzQ+7NpQP06PKCDlpWKMzjKkoD9Kf1Y4YQd7j9DStsVK7QV\ngBlduaODlpWKl33iuxGwP2UG8dRbol0VfrRf4jS2XjFb5YFia11nrkLA/6BoB77U/gKKWQrvdJkP\n3wAAAABJRU5ErkJggg==\n",
+      "text/latex": [
+       "$$\\sin{\\left (\\sin{\\left (x \\right )} \\cos{\\left (y \\right )} \\right )} \\cos{\\left (y \\right )}$$"
+      ],
+      "text/plain": [
+       "sin(sin(x)⋅cos(y))⋅cos(y)"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "nest(sin(x)*cos(y), x, 2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAOEAAAAVBAMAAABCnpRGAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMARHZmzRC73YnvqzIi\nVJlz8rUYAAACi0lEQVRIDcWVMWgTURjH/5f0zl7uEoMIdWtIUQoKjS46CB6IHeWmoquCoDhk0P0o\nSDOVKIiDVQKii1KKg0NUGhw7aOggiENrcRBBTK2DJtj4f+/uXi71ILksPnh5/+/L9/99dy93L8D/\nHweCSzgefyla4Z/8kA4BDKHWrx7FqgU6t9JLRlRd6uQOQABDqLbbQ465oXZC0beek1FyB21OMAVB\ndQGKIpbjVCiia6rgR8kdgADGQO8q/kWlIsKMtArSQzsEMIDaLxVTc5Q0mkr2xEFfJnfQJ4Cc2tQJ\nZ62NFw+fHykwm/MAe/7Z+hYwvsnYXq408bb4TdYx/oIRHPqih3euBBI6B5RxDZgt6dskjpWACzhZ\nugdkHcareeu+dRMZT9YBZzGCY1xrYcYHEjrhwhMdrwI/2MHMg/EMPvJeqoxnke6YHuyOrANuYwTH\n61wZV3wgoWb7KERHZkTH/ezo4gkVrBY3Vbypk01gV9YB3IfkDtcsCLgAcuoL3dqejsCdsKO2Q3WG\nV/FT1smOyR3YcK2O6vgK6T+Rjibvh3sI3d8EebZsMNeWdcADILkDn5Gqql1dB7YiHY0ScDrVwmEg\n7bD5Da78Ha1tWQdcBpI7cB5GzQcS+sHF9UhHPr3ZHaNqF4K3Y7WJY9oSjE1ZByxiBAe+YpJ3QraY\nh4rT+Xr3cb379P1vZrQy9Eu3KlPgi5Lnh708vYJ65ZGsYzyBERyYK35v+EAJJScylpSOP+Ua6vtQ\nDOVYYHXklAu9Yu0dtfPRdKjTXqjUOtiRKet84iCAMVD1b6U7ihkV/r9VNDPYsc8zPEAA46B2LaBl\nGoHoX9b6Q0aDHdniJ9YJYCz0TYDkURQ3xFO8ZwzpEEDOv750EDecmK+EAAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$$\\sin{\\left (x \\right )} \\cos{\\left (\\sin{\\left (x \\right )} \\cos{\\left (y \\right )} \\right )}$$"
+      ],
+      "text/plain": [
+       "sin(x)⋅cos(sin(x)⋅cos(y))"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "nest(sin(x)*cos(y), y, 2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABQAAAAUBAMAAAB/pwA+AAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIol2q1SZEGbd7zK7\nzUTvhYErAAAAgUlEQVQIHWNggAC1IwVQFlsB2wUok1OA8TeUyRXA/g/KZGBg/Q5n8irAmSpwFgdC\n8BHDbqgw99FQdyiT6///DwwMQiaiZgZgEXYFjhlcE8BMJgbmD6wbIKIMLAfADBDBBVEJYspvYCgA\n0QwcAvYMzBBmfMMpBmGwIEONUZFyA5gJAEICFuq4U3XkAAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$$x^{2}$$"
+      ],
+      "text/plain": [
+       " 2\n",
+       "x "
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "nest(x**2, x, 1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Write a function that replaces all trig functions in terms of $\\sin(x)$ and $\\cos(x)$. You can assume that the trig function will be of the form $t(x)$, where $x$ is the variable.  The trig functions implemented in SymPy are\n",
+    "\n",
+    "$$\\tan(x) = \\frac{\\sin(x)}{\\cos(x)}$$\n",
+    "$$\\cot(x) = \\frac{\\cos(x)}{\\sin(x)}$$\n",
+    "$$\\sec(x) = \\frac{1}{\\cos(x)}$$\n",
+    "$$\\csc(x) = \\frac{1}{\\sin(x)}$$\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def trig_rewrite(expr, x):\n",
+    "    \"\"\"\n",
+    "    Rewrite all trig functions t(x) in terms of sin(x) and cos(x)\n",
+    "\n",
+    "    >>> x, y = symbols('x y')\n",
+    "    >>> trig_rewrite(tan(x), x)\n",
+    "    sin(x)/cos(x)\n",
+    "    >>> trig_rewrite(tan(x) + cos(x)*sec(x), x)\n",
+    "    sin(x)/cos(x) + 1\n",
+    "    >>> trig_rewrite(cot(x) + sin(x)*csc(x), x)\n",
+    "    1 + cos(x)/sin(x)\n",
+    "    >>> trig_rewrite(tan(x)*tan(y), x)\n",
+    "    sin(x)*tan(y)/cos(x)\n",
+    "    >>> trig_rewrite(tan(x)*tan(y), y)\n",
+    "    sin(y)*tan(x)/cos(y)\n",
+    "    \"\"\"\n",
+    "    return expr.subs([(tan(x), sin(x)/cos(x)), (sec(x), 1/cos(x)), (csc(x), 1/sin(x)), (cot(x), cos(x)/sin(x))])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "x, y = symbols('x y')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAADwAAAAyBAMAAADy2KUxAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMARHZmzRC73YnvqzIi\nVJlz8rUYAAACT0lEQVQ4EcWUT2gTQRTGv90k26a7m4QiSA/SJSqIQruioAehK+I9B5GKB0N76kEt\niGdjQBBFiULRg3+CBylYSDyJgmTxJBExiDcPhpwKvaR4ixT9XjYzWdMieOqD2fm99+283fnzBvhP\nM7xoQCKnBzZKGvFO4YYCTLc14qzCpAKkNMH0FCdKimJ9uqCcVEXRp7oi7NGEy4KTxw44taq9tJFf\nEHed7ePhzzMecJ+YKmIMVhXJRVySqZxhqJS4ll4GvtE1rmNcZKuCLEfgAeibXZefm6KL5y/qfbkY\nyZscjYmiKA15zN/ojchA2hNFZDvEXEuSD0Y/FeFLHYUouesh48XkRSARzsKkfJwvuiuwwpjM2fzw\nl/CBkkzMKOdv2rXexVrv/dVn9PcC5w/Nl33iabZRS4cqMlxUFWE/3IhxLxbWqDf0nA7FoamcNQV/\n9Y4XuSaXdXft9z9td/9t29cnB5Gj2xQJ2NVBOLPjqiZ5jCILFMT7vHZOaorBiuYLmoZgBJqtFrG5\nfg9OZ6YltUg3UwKc8trXDoupzR/dxNv6mwJW+7UIJH0WDk74j3jGA7pFzNUfszBeSy2yfnJACbP4\nzjNeYZjJjC0g25ZaZE+5gJck2F1g2ufhZVlmA6nFSAYeKlnuLFdGv5JaZHI2OL/kNpLkYwHg89uN\nfVKLgMVsp8wuDjIpJXsLZjgV4kq/FvuzcX9aFTnOMjE0O3dhr97xpRbpGstILdy6vZ+YzPExak90\nYKdFxXAjyvrFGOgNTQWxqEanOsCJUMfiIPeG2BG2P0Gmoa+aF1EhAAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$$\\frac{\\sin{\\left (x \\right )}}{\\cos{\\left (x \\right )}}$$"
+      ],
+      "text/plain": [
+       "sin(x)\n",
+       "──────\n",
+       "cos(x)"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "trig_rewrite(tan(x), x)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAGAAAAAyBAMAAABR8MP3AAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMARHZmzRC73YnvqzIi\nVJlz8rUYAAACg0lEQVRIDc1VP2gTURj/3V2SNl7+lCJIB+kRHMShBnRwa8S4OGWQUlQwWBw6qAVx\ncDJ2VJQ6FBz8E5yKComTKEgOJ4lIi7gbqkOliwVdAkW/L5fv3pl7fVFc+sHd93u/7/vde+949zvg\nv8Pygkc4Y4ZHtWqq+FrgpgBNnuwo8qTAhABNTirO9gQ7NUHGnK5IObkkKJ7fN0Nub4hwScEoGj9y\nINOou/ObhQtMb9D17tCHKQ+4y+NYJKsYQaqOxBzO84s8ASRrztX0AvAp1syEdQ2jLEgtIe/R+B5o\nbH/P0iInuB6Px0+aPUE1EGzRDNhT5b5WvJmZ2RvdAQGQ9riiF7g+ptd4Sf0ZHnLrahOVnZaU9ZDz\nIoI5wPEPwybBUdbGIruMlB8R0Lv8XJzHW2rUv1ZrsXDTbXTPNrpvrjyirn3AzMHZxSLB43QNj7Qv\nPbqjcVGKKqsjN+opto9mfsYoIDzep1XxXADPPNUJ2tL3XADwsQ9tnSDjBVWbDoeEUSBN0bzLBb+M\nwRv5Wi5fL5dPMdS+JS4Mxu7ddO7bjy+Dq6XxeJ+LuLHsQdMNuHWhlRvLM6TyR07QxxmEyY2lh3Ih\nxOrTCCkdWA5J3ScXFkNglUK4gxu3N+4gsz61BnJl6s3V6GZyY3cLr5ovK1jpuTKQIL8wunGiiunm\nfTK7F+zK5JJjQ9x4lZZgbQP5DrsyZRIY3XiSluCQZedL7MqBwOjG/MfN8gzP2JWplS6jG4+UgCLt\nobWfXRlI8YwmN3a3YfsTPi73XJk23Bnmxu3123BXbhXZlWkx1sK/uvEDUgXxd0cDx6QfGjcOaxGg\njnfEjSP1GMzUhYq4sVDazH8rjqgbBwzffwMEKbxiGjhYZAAAAABJRU5ErkJggg==\n",
+      "text/latex": [
+       "$$\\frac{\\sin{\\left (x \\right )}}{\\cos{\\left (x \\right )}} + 1$$"
+      ],
+      "text/plain": [
+       "sin(x)    \n",
+       "────── + 1\n",
+       "cos(x)    "
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "trig_rewrite(tan(x) + cos(x)*sec(x), x)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAGEAAAAyBAMAAAC+MqjJAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAuxCrdpnvzWYiVN1E\niTI89kC/AAACwElEQVRIDb1VTWgTQRT+skk22bBJ/aOopwRBT4WqFOxFVo1QD7E9iIigFFGkVqT1\nEkEPOQgiKgaqF0GMEPRmixc95iB6CGKQeJJAJF68mGCsLVIT38xmZhKzu83FPtiZb977vvnbt2+B\n/2KmZU8bLgw6fU0QzwqwXn9VEEICrNMHLEEIlwTy7vW4iGvTAnn371R4p4LdyBir5PAweRrmxM05\nCpyh5/GRR0ct4FM3T+F6IXYl9hL+UgJYIvc1QCuFX+uEnytWN5pHuKWXYLSKcbCjXgaiCDQiVeBt\nN09i4w/BDzlgWW8eZ941WgP+TQzWWdNn5iq57heAFe1ze5QwKQDdYq2zIsbWWMwBzW8I/yZ8iR48\nqSLutiu8AsJ0jthaHjhB5O00zk4iQIpbNHSweg7HzBn4pp7FsYPidKWLmWE8sKGDAMZYqopa5QDe\nJ1MFIhSBRGqknCF4gx5gC289Gj0rgnaWJH6IsVuv8i9qEWfXfqHQ5FT/SmW27+GRgFBE2ASOtiC8\n4xwMoDAsWxKoDqqw+bIdYA3JtcHGKYLp9PWL6TRL1aG2lzWAjdsV7cb9DfbeVfDkyinbM6hC6d0V\nbzqku4rMkajgfMA/3Q4hxm6QWbDKO+fGXFb+UFzgOQGceskCkjJ+TyJvcE6Gd0vUD4zv0meqvfhy\n0tsDWIFeaOLLha+HLAoES4BRHs9TIYpO9RDlgBforcB8RmPlMJQBRnAnM0svWS0n2QwUWYEmxTDw\nk4Z6ATSexAvAnIaj8QJNis22YogUcexl1FjDUQBeoHsVwHkvBS/QSqHniGy06I/guqs8K9BK4csA\ntwMNHKaC7XJyXqCVgq40suqbZiXI7XZZga6199XaB5/+ohdgLkHb9rEyQXsLFagZwGYkxytLJImA\nyr9yt9sDy2zXXA7epzVGOy5/ti/m4mD/M2b8X/0XQmDEFuSdDb8AAAAASUVORK5CYII=\n",
+      "text/latex": [
+       "$$1 + \\frac{\\cos{\\left (x \\right )}}{\\sin{\\left (x \\right )}}$$"
+      ],
+      "text/plain": [
+       "    cos(x)\n",
+       "1 + ──────\n",
+       "    sin(x)"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "trig_rewrite(cot(x) + sin(x)*csc(x), x)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAHkAAAAyBAMAAACKS2nVAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMARHZmzRC73YnvqzIi\nVJlz8rUYAAADcUlEQVRIDd1WT0gUURz+Zndn/83uukSg0cFhxZCM3CKoQ+BE6TH2UGKnRCFQihaq\nS6dBCj2EbEEEZSKEXTJdOnTYEpeICKFcJIoocJIOkkSrdqjd0n7vzb7ZTVfXzU7+YOd9v9/3+96b\nmTcz3wL/N7blptu3xrSSahIWr/zIdyqDORyI54uFKLGSl5bytCMisMZBUKRibBJAE8BSACFRwyGO\nDCs3gU0VBZMXmTnetNJTDNkNKzeBx1qJ81T0PbFaJM2CzhTBHYaVm2C7lTNeqtmvTWTweODRLpWI\ngE6TdQ9PzQBug5YevfwQ9tAslM65UDvxmAXkPh2TEc63AFF0Ac1heZ5IRxhoxcHwLcCvUe4ygHfJ\ngAZHB04HqXCUppXSaDD5ygh0pu4EFoj0UIdO3Ac6qxjlLgNojEu/4IyhQgVwHRgLRHHG5D2ZejA1\npUxdQeoI7hOCkqaDy6BDVV0WzjZTTScY8aisl/Fyz/LgCjVwgyR59fMh5S81piNU4PxT2H8XqD0p\n0vmykK0zt+EYlOxJsfZd4j/DFjP5KWCmQO0MA4dtadTS/dao0WW45QX4szuFuoOKx+EcNPn3EZwt\nUNM2+RedMZ9q7hgCmhu34c5+FOo+Un9BNS3CdrQqVBdMLA8llh+8/UmpFIXcfrW3hnocQTrIXdfw\nYqb2Sv1oZuz8ABUq6dcS+pbM8ZQVRr+ViCfRKnDgSbKhh37F+Pyz383aVoVdhzcqs3tXjLfeUFlb\npeSFJrh0p07XVIz3DfIewJvMgRXDBPyhT1Qrzj/LddMjWDTYdrBYizfZLX5c3kSkt/i92cTlSaop\ntrMXtuwQroe5sqUkaBIihwBljDZVNNObXXbkXU+OlS1G3vVwrrTaN9KbwuvQV26P1E6uh5e7X+1V\nAfY5LRHjQeWOcglendsjdz1Zt1/wRIE3JaREN8Oe9ehkJ9weueu5YUv74+TlJdU+9geoOgUscXsE\nyPVkeNuYcJwd1g1pkejGIPCd2yNXky+rTFRazf98TdPaGW6PAPtyYzJOtryBM8dFsje6bmWe2yNA\nrmdPNsBG6gNsovVjPIU9Uj+cBrdHvk3T4U6w7/QGdsw3UhdHovcet0eSkOu11LV2hwkeWX/dYqzp\neoz5lyc1/2641WKzl6hZb+iJEo1F6QlRHRagnFG4ni2+WvUH/D4TjdV7Q1oAAAAASUVORK5CYII=\n",
+      "text/latex": [
+       "$$\\frac{\\sin{\\left (x \\right )} \\tan{\\left (y \\right )}}{\\cos{\\left (x \\right )}}$$"
+      ],
+      "text/plain": [
+       "sin(x)⋅tan(y)\n",
+       "─────────────\n",
+       "    cos(x)   "
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "trig_rewrite(tan(x)*tan(y), x)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAHkAAAAyBAMAAACKS2nVAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMARHZmzRC73YnvqzIi\nVJlz8rUYAAADMklEQVRIDeVVTWgTQRh9aX7auJsfetEepEuqoggxVkERsasHD55ykJKeLD2IipZe\nBA9S14AoirYUih6kBkEttodUULEqWTz20lBEEA+GIljw0lqK2lrjN9nZ3dmt2RX01oEw733ve5PZ\n2Z8H/N/RbCwXTNZZluvYberSdxMBUoHjL3ZNRJYeL/Jy4Jeth7Ich2pzwFYMZOlQTcl0EE+ZtaDG\nUNyk5mzp2G+WhHnYxOFBhg6Z1JwtHV28JL80NQRUC54jFBixqAEEPVImva1dnVrGs5En2xRqiGtA\nbg7yEnCL6IFvj8toT2sOXc6Pz8wCTRWgE+jDGeBoJrxA7aEMoLWiYR54SxT9QOwiPjn0HPZlblNd\nBTZmoTH3aeArdUeTkMqfEekGWogyd3AFrbqgU/8ufKBd08FEl3eCuU8a7kQSYQwhoQAl7kYgP1AU\ndGTxkEkS7S98tVpwuhFbQqlou+VjWaL26mQcMt2vEFwV3NEynZyKHSTznSshFaWnWe5mOuQV2mBt\n5zPArOCOZOjkKqyAvewP+qGdUPBxosjdTD9IZ7qVzkMF3mdxVnCz2xAvBBbJyO4YnbYWLWDgtc7d\npMcWI4OyYtyxTantycnqg8nq2LsfFdpOHx1FT/onGQ/TD52jutybyh0R9HDPlWttJIWSrME57jLa\nxNYYdAqc1fQaNp9UsY2e/UfoKtMKili2sP1u5K2aDegNvIBTxI/bNRFZb2hYFcscywXMpNkVjf9B\npBLpxtigc+CY3hisoeio2oTroEd0/Y7qP4z59XtsvlfOY69uLHouIBW4XCcWPc2wXiojFr2b16gp\ns2LEosn+crZir87HxnMZIfZYLPqNqbmbkGfTZTTv2UK9cc0Riz5uaQEvis+zGA13o5F63bHobQ91\no6N4B5ieOI8manXHord7WqOP+iqQqNy7zz5O7lj0drdmKGMoyRNq7tKy4XbEore7pFGus/8e09FR\npp3TT4xFb3ejCmToukubFcQVwB2L3m5pFQ16i47e2DAiupF1Yix6uzE1ewPS6PVMIJ+6TK3uWPRx\nu2W/WHT3O7lfLDq73cwvFt39Tu4Xi87uNcwjFn8DeSobC4RXkewAAAAASUVORK5CYII=\n",
+      "text/latex": [
+       "$$\\frac{\\sin{\\left (y \\right )} \\tan{\\left (x \\right )}}{\\cos{\\left (y \\right )}}$$"
+      ],
+      "text/plain": [
+       "sin(y)⋅tan(x)\n",
+       "─────────────\n",
+       "    cos(y)   "
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "trig_rewrite(tan(x)*tan(y), y)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Suppose we are working with the series expansion of a function at $x=0$, like $a_0 + a_1x + a_2x^2 + \\cdots$.  In this expansion, the terms with higher powers are less significant to the calculation.  For example, if we had\n",
+    "\n",
+    "$$1 + x + \\frac{x^{2}}{2} + \\frac{x^{3}}{6} + \\frac{x^{4}}{24} + \\frac{x^{5}}{120} + \\frac{x^{6}}{720} + \\frac{x^{7}}{5040} + \\frac{x^{8}}{40320} + \\frac{x^{9}}{362880}$$\n",
+    "\n",
+    "We might only care about the terms with powers less than 5\n",
+    "\n",
+    "$$1 + x + \\frac{x^{2}}{2} + \\frac{x^{3}}{6} + \\frac{x^{4}}{24}$$\n",
+    "\n",
+    "We will see later that this is can be done automatically using the `O` class, but it can also be done using `subs`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def series_reduce(expr, x, p):\n",
+    "    \"\"\"\n",
+    "    Remove all powers of x in expr with power greater than p.\n",
+    "\n",
+    "    You may assume that there are no powers of x greater than 10.\n",
+    "\n",
+    "    Bonus: which functions are represented by the series expansions below (you\n",
+    "    can use expr.series(x, 0, 10) to check if you are right)?\n",
+    "\n",
+    "    >>> x, y = symbols('x y')\n",
+    "    >>> series_reduce(1 - x**2/2 + x**4/24 - x**6/720 + x**8/40320, x, 5)\n",
+    "    x**4/24 - x**2/2 + 1\n",
+    "    >>> series_reduce(1 + x + x**2 + x**3 + x**4 + x**5 + x**6 + x**7 + x**8 + x**9 + x**10, x, 0)\n",
+    "    1\n",
+    "    >>> series_reduce(x*y + x**3*y**3/3 + 2*x**5*y**5/15 + 17*x**7*y**7/315 + 62*x**9*y**9/2835, x, 5)\n",
+    "    2*x**5*y**5/15 + x**3*y**3/3 + x*y\n",
+    "    \"\"\"\n",
+    "    return expr.subs([(x**i, 0) for i in range(11) if  i > p])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "x, y = symbols('x y')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAG4AAAAwBAMAAAAC8VJPAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIol2q1SZEGbd7zK7\nzUTvhYErAAAB9klEQVRIDeWVsUvDQBTGXxvbpC2VoHZwkJYqrhYRBxc7VBzrYheHOhUVoUEdBesf\nIDjqYhcnQeji5JJBEZxcBYvFv6AIKiIa3zXX9JLcK21HfUPy3vf7voRe6B0Ar3i78d6nbwyvJM5F\ngoaN8IPo8/TqDJGL6IEvj1cclQMiF11Rf0Sjp7+icgChD49XHFN0Lp4Sje5e0+nclNvqmnaBzGkp\nl9M9FErlDbfiTC9w7fSSJkmsZ+x2dVliBxiZS8xnQMsv+WiLRC2r6SMoqCntJHrcH2HuICjNUE2W\nowlzqzBkylLdiO2PZuQ5AJqwRLIGhjxJEwBNXwRFmqMJe0uxcg+j0tfRhNn3Z3cmK9IcTaT2XsS7\nXkx+z363f6Tfruq2tpfrLxdqf2jlH+SsTrHVmjhldcbaDrDYiBviIOsSrtcfL+v1LHvAH1/P8NY3\nbraB0lMDf2ssixdvccZlZz1b8xgob9hETE7FG2dcGm5/h9aMu3EVmwWTU/HGmSg5/YUB+QYEjkxH\n6TQ268xi92xAuQHBuCmKvLeZBNhS1YBDaQ4xMqpir6BmiBwysjASBCJHyK1nbQOsUTlkVClZPMyI\nHDKyChBI5HL5c9dX5W5kOhGMreMZgWePKeGcSQjAeDq9iUCa40yaq1rWJx67+feKH9vMrw+u/AI7\nh46YdziClgAAAABJRU5ErkJggg==\n",
+      "text/latex": [
+       "$$\\frac{x^{4}}{24} - \\frac{x^{2}}{2} + 1$$"
+      ],
+      "text/plain": [
+       " 4    2    \n",
+       "x    x     \n",
+       "── - ── + 1\n",
+       "24   2     "
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "series_reduce(1 - x**2/2 + x**4/24 - x**6/720 + x**8/40320, x, 5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAAgAAAAPBAMAAAArJJMAAAAAHlBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAACGjDitAAAACXRSTlMAuxCrdpnvzWYiHG0BAAAAI0lEQVQIHWNgYBBiYGBQ\nnMTAoGwMJBhYSCVYw6ZHAPUxMAAAQGkI1Fjz0FgAAAAASUVORK5CYII=\n",
+      "text/latex": [
+       "$$1$$"
+      ],
+      "text/plain": [
+       "1"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "series_reduce(1 + x + x**2 + x**3 + x**4 + x**5 + x**6 + x**7 + x**8 + x**9 + x**10, x, 0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAK4AAAAwBAMAAAB6TlzuAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIpnNu0SrdlQQ3e8y\niWbzIQYJAAADoElEQVRYCbVWT0gUURz+Zv/P/nPzUh3CTcmosKSN6NDBQ2V/CEyIbu0G4aEuiweX\nkFLq4CVwAilIzL2HYSdTOiyduoSLgWYkroeIOhlRuSBub3bmzXvzZt64Cs3lfb/v+37fvJnd+c0A\n7AgefJFnlTtSlxY1Q2HI3cnYYO0PKyTIV/F1GhJDEqtFB7+mLCwDoXRy3dAYknkpH+yhyGtNmPsF\nGPLyA8HD/Zq3Q1fHrbMz5NbV3HbepJVUxNqLm7POPbtKJYYow69KDkPDlFA3KZKvvi6qMUQZbg1p\niK4btb+E35wigcoGFRiiDLfGZhEy02Il5SenuMKWHmXLEBhyNfqr8Jm5CS2cc/Vw5PNUctYoGeJk\nG4xWcWBgX38eKx02XijqnnhhMYWJDijVOhIs9nK+rJaTr2JFOytWnKecRdj8TUQXX59CgvgiJZ5z\nYuaJDx9FoMvpEBhfF1SEBF/v/m+CjXlUzKApL8jOckCnYoIvW8s5nJYnUsV8ySELRCSNPUBLCRov\n3LzGVwa2PGSkDTplgXkHrCVTQwjbcq8LLoDz+NO44NAFQplaWSiOVq5gr03oLRyx1QDn8eWC5sMh\neLgyWqvVimP3J5YqHAlyax7ZaoDzqN392z6YQjcrJ0sMO1Ci6KAaI86iqUfqvIPxYanoLbxFS8pw\nPHEap2ANYanH2VVnllH/WxM84nSM9AvX4uJxdtWZxELZVBrpacSjksQWjZ2ukR7ToyzdGjlsTDvW\nT1EiuI4hWpB1B7kT+FGZg2TavfcVcW53uWWyocfmtCOPhe2ARsbLX5dcm4sWps+8Jg23QWajZNqN\nanHrtdyWybzMZE5zp3FC3jNDZNm0a0N4muvewf2Fskm2K5t2JxHI7S53jbyd7kE27dqRrewqN7IV\nmFbykE27scKJ1K5y1e7llQfkh2PT7hLg/658ommfKdBXx/39sHKR1108dNqNVckLrlYzntxQUX3D\n993gC4KVNLJ5gbN5rGn3tI/k+tu/GOZoOWCcQOilZWIDTUVauK1s2oVJbohaIoVDFLquke1y2bSz\n5bqG2UnHfbDLVlXPLQz0WMQ2wPv5Y816bkBTG/j41XviH3Os1RPpueS462nixMEGr8zMXS1xvV4w\nZuzDy1LX9NzLwGpD21BKCGz7VWKcUs+dA2yPr3Qzk9Ud5aaBjDSLF5o6EW3wa0ffbzMir/l2KQ5X\nkC1LVV7wHft1HPHWvhRPyvHD1jNy8X8r/wBo+QwKWt9SIgAAAABJRU5ErkJggg==\n",
+      "text/latex": [
+       "$$\\frac{2 x^{5}}{15} y^{5} + \\frac{x^{3} y^{3}}{3} + x y$$"
+      ],
+      "text/plain": [
+       "   5  5    3  3      \n",
+       "2⋅x ⋅y    x ⋅y       \n",
+       "─────── + ───── + x⋅y\n",
+       "   15       3        "
+      ]
+     },
+     "execution_count": 29,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "series_reduce(x*y + x**3*y**3/3 + 2*x**5*y**5/15 + 17*x**7*y**7/315 + 62*x**9*y**9/2835, x, 5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Evalf"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "At the 762nd place in the decimal expansion of $\\pi$, there is `999999` (see the below comic ref: http://www.qwantz.com/index.php?comic=1013).  Note T-Rex is counting the digits like\n",
+    "\n",
+    "\n",
+    "        π: 3 . 1 4 1 5 9\n",
+    " \n",
+    "    digit:     1 2 3 4 5\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAt8AAAH0CAIAAABq69b7AAAABGdBTUEAALGPC/xhBQAA3JlJREFU\neF7tvT3ONElyoFnKEHuF4QEorTYH2A8LjLaDBaiRUksFLKjtagsQXRfYA7Q0pDA8APsApYzYF6BW\nZ+gL1Ea+lmmvpf2bu0eER6R/zC7mm+nhP+bmZo+beUT+9NP6tySwJLAksCSwJLAksCSwJLAksCSw\nJLAksCSwJLAksCQQS+D39W9J4C4SoOp+lzFdbxw4C9fr+urxksCSwHkS4LxyXk9Wy0sCgyWw6GSw\nQJuqW3TSJLZ10ZLAp0tg0cmna8CNx7/oZIbJHU4nW4WnjOvgdkFumZEmi2WqUsvsXX9zx8ZeWB1m\ntTzrbX5+rWGOsm+j6hk7HVtti06Gi3RVOIsEpl11swjokH4sOmkTc957dbrJsHt715/xvlIaUq86\n13t1mNXyw+kEK+zsyfB6Qo1KFlh0khTUKnY9CXRaq+sNeMoen+5FRklllA8Y1Z/DnMrAgfdURa8N\n6wkLyFmoXlItP3zehyvAPCOCoS062U9nVs0nS2DRyckT8G5iVGPquBz2Fe6e1c9DwwoFaCVW/VRo\nFK3a2mV2NjMjjt6qX/kylHTo9EEtTEXH5Bz2B2SueJpc0irUGWssUibW0FS9cqqt6qEUkSO0qn6i\ndiX1ik5Ehs8c5bFGUdI3v9uLTjLTuspcUgKLTmaYNmmtpIdTjSwWk1jQ4LSk3VeBxvL0eLnsqlpP\nxmuGs2MJivVBFdTAflpjr84jkko4cFZAbcj3ghmdccqoPczUycbo64ZaoU9LodKG6KmunZByfFVs\nWI8ZHVh0kpHSKnNJCSw6mWHaxtIJtf5Ji5n35b5rsSBgEjqR3SjJxwGCKoU47ZZkZflRhxR9zLU0\nIfTNeXp29FMuRhWFHda08C4p1VAfnHrUrmYgsscELTrpkd66dmoJLDqZYXp2pRNmv/yNo+OcVFVx\nvHK+XWxUyiGcHd+dUDdmbamH9PNcOqlSV7586K2T3pc70VfSKoSGPJ34pixsKANtKvpk1gWFyKq+\n+Utg0UloIlaBq0pg0ckMM7crneQHKLek6ibV2SOq5TMdyOw71XrydGK5lkz31BBFgxws+TQP3wpp\nOGKxKI3KIdPP0nRYcBBCQ5JOQgGGDbXRidVu83hL2ggq/favev0qvyQwrQQWncwwNT6dOBbQooc2\nSuikExiF5S/DLaBKAOHslOhEAkrSaWXoxPejTCyscOhcHTlkHGE4L5YYnX6GdJLUB38KjqcTfy4c\nffNVsW1dZPR/0UkopVXgkhJYdDLDtKl0Ij9EA4d2XzoP+ET9nHoL37U40ON0tbldNq6wn+ounwKE\n2kmLft6Me+I2GbU8il123lpitJPSseWF4Hh3X68cN5zRK2vhWONy5OxYoSSdyCgC654jJalO1tKT\ndOu3q46rqm8h1r9VOIM5W31YEhgiAccuDKl/VZKRgGMNM5d/cpmk1/lkEa2x5yVwOXVirJN6cHJe\nHKvkksCJElh0cqLw5XZ/hs5cqw+XcyfXEu+n9fZy6rTo5NNU9IPGu+hkhslesZPqLCyJVSW2ymck\nsOgkI6VVZkngCAksOjlCylEbVV87atbyhxuiERz9/ZxeZB55HiOfY1o5Wrfma88/l7POncw3Y6tH\nIyQwys+N6Mvn1lGik4EuwfKmA5vYaVLn7OGik52m+5Or9VV9ZXY+WTduPvZFJzNM8Fl0Yo19lO9X\nvXW1crV8tZJtpA2X7Kobo/ozSj4Ngx01hIamP+eSRSefM9drpG8SWHQyg0KodCKnhu+Tvv72+w8F\nZP3+vIfVJoXG6ET2P+w8uwTLW+MKB5sMb2Tqp1Ky5KnWU5WDA5E98mH9V0VHP0xqRdWkqMrvKIYj\nan8dUUJlYwmn0tEHS0TNcsDOZNY7L5NcmavYksD8EqguoflHdMUeqvRAByIdSXKYkg/YharLSfqh\nkC2ggOMJMqOwehjKpKddS25hnbKA1c8hQpbiRZln2mWOMJyvsM9hAR87Qn1w6lfHK7GjNEZVPkzm\nVpdC/bQWeLJ+OtHfZjyU4CqwJHAVCSw6mWGmdqUTxwg6vq1fLNSy+31IUk7SmmOxkCTynjI/Fr/R\nksdKTkGGL8P+Z1yspS1sXpoBJXMho8Zwrq3p2OnzsD/WnDpq44uFGvDH+6TSrGJLAvNLYNHJDHO0\n6CQPCpm9r5RnxrNm6CcknvnphPkzVZ7Uy6rlQ6DMO8oGEyQZhTtp4xcVMpSWkY9VT7PcFp3MYIdX\nH+aSQINpmGsAt+jNbHTSL1TLW1QpwSqf2fuGJJFHotCrJTfNtEt5/x2igCyQkY9DY9ZwSoqRGWCP\nQDLXJuWQoQ1VXNYYM2PP0HC4XvhCK83QKrwkMLMEFp3MMDu70olvxKtmNCmu5r1g6Gj92Ikz2NJI\n2e78SDqRgYFFJ6oEqnRCBcuubaaTJD2Hq6Z5vSw6CWW7ClxVAotOZpg5SSdg9azP830Gq6fWo7p5\n58Nqo6y89Ad5XKjSmyO6pO935OYvGcfNSE/mzHte2ur8+t5ODsGZC+b/QlRylM2CjLwVckpa/aT9\nsZRQ/ZyqSjitqormx9W83tmo17mT0sJZhaeWQGn9TD2SK3euatDzY80TQL7OTyh5rtzObf3G83s/\nwS46ubG6fvrQFp3MoAGLTmaYBdqHE93YiU3PNgvD+3M/2S46Ga4kq8JZJLDoZIaZWHQywyxMQiez\nieJO/Vl0cqfZXGO5uQQWncwwwVU6oRnxPfq/d/1Wn89qdw8Z7lpn6GX9AqPknK8n7PCu4uqvfNr+\nr9hJ/+SuGiaVwKKTGSZm0QnMQt7bzTBrJ/YhdJaLTsbOTijwsc3la1t0kpfVKnkxCSw6mWHCqnQy\nQ59XH06UQOgswwIHd362/jjDV7va0P+GSxomZdFJg9DWJdeQwA3o5BgrsOt0qnSiTo01X0wIoUyg\ngGzXrz/fT1p52BmnsNVP37vkYzBO/VIUo/wWDRSpE+fLGcTlK2R1fkfNl1UP7bAccpLOfflbleRN\nHPf0RMgZPcEZceoZbkYWnQwX6apwFgnkl+4sPRb9CC31tD2X5ox+knE/tAzKISMQ5r/lJaoLUbun\nOp5MH9QB5tsNpzXTByoH34NSJnBKhr2SBVhtoTzZ3Fli9DupUlFn5yU2SZ30Nc2fMlXDeyrMaCBF\nSX95jhJpaRYWnZTEtQpfSQL9dJKxlbtKJOOEdu1Af+U4C4xXnJrVUefnIrSkfgGLhOjnbfOSbDcj\n80wHrDJWN+BzlHOmibCrIRU5Xt+qvGF+28aSnC+UG+tw2E+1vC9/Js/quKyVpe4EnA+r7YZ64mDo\ntxlvq2VdtSQwoQR2ohPpbukWRK5btTz1BNKKjfUQ506NL67mHV4ebtQZyVheqj84I3nGkj1Mejt/\naJY8w+Zoz9XhD6QTden5VGR1LxxXOL90eZbWQnK+pG4wg5CcMkf+jimzWi+tLGs5WO0uOikp0iq8\nJMAl0EknuAKtpdjzObMpalsluzPt9PumWZWh9WHSJvpOZRNU3uuEUk12Cd1VhoqsRmlbmXaT+kl1\nDx2klFIoChUvnD5b6yscWnV+HZn7gyrpiex2OBDWOq53OgtsIpJzmlGhJK1mVDevG6WS1IA/3pcu\nPqtwv9Wmwz5rFOqewDflYVfHzmBVztXy4XA6C3TOsmU9rVVd+twyfKHl7ZTJ8Zf7Kq1qrGPoMxoe\nyrDkdUoOrFQ47Kf0XqGOZTyx065DDBnJS09Gr8rofMaGhHJzupofheSzsP9hx8LVp8rfkWFJHyzi\nDMcViiIcV1sBasAf79tqOfiqjAYnuzTPkIf0ZEglVONLFQ6cl+T0hc7Ad43h5dLawkJVqy19nrEI\nljUZIpzDKpGysgRlmdqq0Q/L+wWYM5C9DftvyTbfrlNDvnVn8Tq66uh8XmeYX7HqZKYGOhzanIb5\nbbMDsieq3JjCMEDMzxcduxzjKD1U16MFteo84mzCt3mtqJZkrWdbcjpd7cG55XcVbmloQ3oypJJS\nt5sLH9DVkl1gA+EL47UILUvU87lvlZolPMmFbY5hks6vbljI+AmSOcBGfYIYm8fYSCcqC/udsJAN\n+SsDYo6/sb7yjWMDHTO6r7pAH4GTphy67YsUh6auMfqtWo/TE38Ijptn0J0c7BDlrlbChKYKs4dI\nkvXfwD7uPcvVmV3lGyRwAz1co26QwLmXHEcnksEll+TXgEoVPub7TlrlLcvB+47fmVHLJzHiCXWC\nkRxDDVXUtM58/305y346A5TUEg6zs0AVHJP6w9YMvUptUS3vawJdGp1COP3yRSenT8HqQEkCS2NL\n4tqv8Ml0wpigmU4yTnEnOsn3WSKItfkO5zuz86bNOeX9/mcEq3IPzqxVf0luoUDUAs100tbcusqf\nBR/+QumFCpMp4DgeRvzVDUPY/6sXkPI5ZkRntbvf6EJF3a9pp+YJ5XwcnUhXgZMk34TTI72mukMF\nE+ObJN+5Mn6y/kwqnOPskzX4/cnULxty9LKTThxGKY031IdFJ20iOuAqufrapj68Kizg49GiE18Z\nzvJeZ7W739LIK+p+fZA1Tyjng+iEzocDJflpS3pNtd0MjjAIyDSX6XyGHjIaadWTqd/qp/p5ZuCO\nPPOizoy6WoYqd/XaVX6UBK5CJ6q9HiiEUVWteg6QQMaYZ7qRMarN9WQu3KnMKPlkgPjbjJcGk+/i\nnejEYsyMNDL0kJkC1gcJfIyu8E+nk8mF5A8zX39GXBlROGV66OSA7m0936+V/WquTopFJ/JzEIj6\nudUoLZwfslyGVmew3eQl1pbUGld+vNABXPjSArAhVMujNqrzFU5W2B9/ndKppzKvKgNthVnFZFV0\nRtigSvrp1EOnxtIrVQiyP6pUM/XTdh3llPPiy6dqHHahE9bFTJ/kJUx7SsZaWiKrS35X/XqYrlPT\nQP19Umn8S2RP2tazuj4tOgmNo9or5yprsfn1ZPSnoUw4ulDCDY2WLilN+gE179Ef6RXYemGG0gIC\n1fEzI54UkTVMqb24cFjNVp+tDlj676xW2SL1Osxayv5QY4UXqsOhdlja5FIP1bkLlcrRB0v+jleW\nfQjr91XLUshwXJZHy/THUsWMhlv1h3Wq1rttTjP9DMtQA/54H14wSYELdXUPibUNv+2qPfp/TJ2L\nTqpy3kNDVDpRfV5oPR1EsDxBxo357kfKpNpPx0s1+H4JEGp/nGJW/8PZdwpIPLKkGqJAKPAkAlqk\nFQ5zyHw5XJXRn0yZ4XLwG3WmuGpnkuUXnSQFNVexzAKTprzhqrmGXexNP51IzwqWy/K4+fLOUPLd\nVicUPsT/Qm1JW7mHhliykt6LG6Nos9Rswa1hygotCbOuhorpzFTSi8tJpJ/I/vjlM3QYYoRDdSX5\nhPOYVEurnrD+5EgPqMda+0kJqMvcWv6yTn+A9NtSf8LV4WDWmyI1V3TMhdLSHdPubK2UlONjhWYt\n9cxswrWq/VU/p+WdRR5OXFgg9CtQg9X/vAHKSClTRqpf0ouElTd4C4fSEOnYpIdGPOynrNn3ImqF\n0sdYXodV7lxolXS8RcaRl3TYEruq576ok3qV6Z5apkHfSvU47j/TZwcWk/qWNw6l/mQWiKXz1IZf\nJrPTPOB14edIoJNOQg6ghtVarlWLxqginCzGIpbHCj/33XbYDafAMXRSklt1sqqTmHHhGa/sa+AM\ndJLxvqHysLlrxkHm3al8HMfvs6ADSRkPnZGPOo89KmfJM6yzn05KyzCpGN9mPLxgFVgSuIoEdqKT\nN5x3kybggdTy4S4wY/vQw6FRyFCI49WSjZYUIE8nUlxhQ7TyfOerdKKSRFW7pBzYeEOVYAQpnbEq\nDcv5hfMSMpaj2yWdhx6q8qlCsyMBp34LUKSvrU66Oi4HAhy55fvvyNPvv9MxZwkwgMsvw/zqfnY7\nvADVJVxscqhSNKE4nEqkUKQyWcOx1pX6uRS3uuClq6Cy8qfQl0NyUlYxJoEGU4I1WDNirb3q55nJ\nyqxz1Hk0SapBp1VZ2pvpUkOZvFVtqHxdcgMJZPS8Z5h719/Ttz2uPXe8A1vn7jgpLNXYWZZdYlfo\nAxy/rl7r90cOqupLrPoZD6GHYOVVxnJ4ZeAEJyf0lsU+gU7o4nJWQaiB+ynAopP9ZHuPmvc2d3vX\nP9ssnDjesU0fQSdOj6XRlPDhkEGScvrpBH2A2mG2GaW7WPqebWrluFg9syn95fqzB52AJsiafSXP\n9yRfMr9S5PaAUbWzr+if9EUn/TK8dw1jXVre2t9VqnvL8zC5nU8nqq3P7AjzO8W8voYgtejkMNXs\nb6jB0/c3eokajrRfi04uoRIHdPJIraPDOavdNpFaOwertmr5aq/662+WfzudOEZHdeGqUJySaiDB\n8jf5FjGAoVZloRILe1jbVuiG9d8wdmJFaKr6tMrLWV4yoUrbbC8axHhdOum3y464fvrxE301CPZy\nlxypdYtORqlH/yponvd2OrEcNg17OGXUryiRqKCgIkupRb9Lvhzlt6w/lEtor6rjap7OURp5j3os\nlr3H6BpGcQoonNJog3DkJf12Wd+SfXHJL7//oK+bwYpqwRrMWsMl6jwO0YcTKxkih4H9L/WnVJhh\n5RsGJAdA23N8Nt2u6Qv1/XGQIXxY7fr9yetrM50AizA6kcNn9avjZTZxJxOZnOhLF1t0MsP0XZdO\n6KIeIklAEMYl6p8IK0PazVdiLZn8UnpzJy+TSPeEqj7ID516Mq6EtYhTKS2w2rRV3mnaH5fqJdkl\nqpB9eVqNhuOFAr5iVPtj1YZuUfoyX6/42JN67HjZjH6rXhnlpUoNR8jYCrWwZAStifGXhKphsj9W\nsYZxDbePyfm9R7G8Sb3HeOccRWlhTjgEaVLbOpnkkg1WWBzlMFJxrKJqdR05WLaOfu7YQ7mvC2Wu\n+hTqF9U61f6wGU96ccpD+baSpOX3Qbpja1y0Y+G4nFnIXytdmKUDqt9888ihEqwCSwJXkcCikxlm\n6up0MmSHkEeTjU7+6//8T05AZb85tThMOr+wD83k0dAWc6I4CpVXcA9M3zCwqPahSnWha1f9dJ4F\nrf5XxzWQTlS6Dfvzhiah1EKlXAWWBOaRwKKTGebiBnTSCSghmmw4Ql8STfBbiKzsOq2SUUIvIvtT\npRNrqZZcEhQu0Qnzf2H8IxnqwHoy9Wek58vBn6CQ0kJ1qtISq9ChJVU+lIreCoQdXQWWBK4igUUn\nM8zUPeikGVBCNIFgCcRLWOHtw+0T+BbzOwcACosr7E0ntP6Gtpgzw86HXrka87BWU7IeJxThu3M2\nHSHNXDR2oo5r0ckMNnz1YbwEFp2Ml2m9xtvQSRughHSCaOKclmUnUSiswFf1aQmu6CSGUuyksy06\nEpVIkt7aoocwflOlkyptVMtnxosRpozm7Bc78VtnkZXxWp4Z/CqzJLCHBBad7CHVap13opMqoKho\nQo+VOGhCv3q0u1HI9u+LRYBO2A3J1Xnxt6pyN1+dR1neiYswP8SAI+9KS3SCs8m66vRTFbKDL5lx\nJX2/I3+/wwz+UJghdVm4Bp/n9aFt3uXsLDrpX+OrhlkksOhkhpnIW7EZepvpQ8FZvjMEO+4qISMM\nn9Bcz3A6yYx9lbmNBPJ0ctaQV+zkLMmvdneXwKKT3UWcaOB+dJKPoDhpHTxNknz8CTt9woIuQC2J\n2VhFlgSeElh0slRhSeA0CSw6OU30pOGPpRP/xEkpcIIPQWEoQ+/0WXQyg7ZP3odrmcQVO5lcnVb3\n2iVwraXYPs65r7wlnYQiD9GkRCfO/cYTAkpy3e29d++sv5C/ix66KrVFPR8TKtWnFVh08mkz/kHj\nTVrJD5LIGUNddIIBDzh3gjka66lrmVyP9UyUqSIoPh900kOoy531n0InoxbLPepZdOIpeV5Bw6Wy\nChwvgUUnx8tc3SZ+2jqSgRM8JoKhjvBO4zZGWXSCGthJJ+raUetsaEiNndB6GupUB37pehadLDqZ\nwYXt0odFJ7uItVjpqG1csdkzi8tf+8MwCQ2cwL3BSQqhGRzKOng54k4noKirxvqQSlk6QvUTRNWM\n43TaVfWKftgQuYFLQgkw2mZXNWse63BGPhmEum49i04CXfq0bV/z0prwwsvRyS2V7dPoBChBPvWV\n5XQa8jsMUBjWQIuAO82PaMvEBtR9Pzh1ZgQcd5tUdVoDbdf6nMYPknSiVgX1hCPCYk4lecO46ETq\nzxug5EX5OSWTC+lzBHKVkS46mWGmPplO1CfTI0b4gKI+qC0EFNpiNYhiuXPLa4be1C8Q7umr7Yb9\nUeEJzXuGRUr0Vl19DHFC+Vj136aeNzRpFkd1Gq5VftHJteaL7Z8uNH0X6mpeJZJ00rzdz/fkmJIs\ndoK4ADfp/O2fHg97pb+tYz1gTaZy1E/kPcbNgDIhnTD/pIY0aEyFTnHozqDAPHSCncGONWssXXSh\nHJxWzq1n0UlKAW7pNlIjv3IhqtyXGMct1SxDJ+jRLzFNnjV/PRyWngLBwyX4HHoVKeAYCjuh4jAK\nRRyZ5aGNJqU6IZ2oPa/GVJwYA+WA02MnamgnOXc+YfRXAuR0cD2LTlICv6XbSI38yoUWncwwe0k6\nqaYhZhia7AOFEiAGevTVohMshgXaAif0hCyCTkmwqgfK0IBqIa0LacSiwa0290eZr5fHzQzc8tDO\nMJu1VNbZBgeXrmfRSVZ/FqBkJTVNuUUnM0xFSCfgv0tOdIZx6dv615FYiSnsea/sbh2QwEMIv/xr\niVGsW34wElOVrbpqrKXkR/7VaAQa0oy7Zf4JZB5CD42I+KqCVSXpBLmKlh9IJ9ZiqXqfe9Sz6CRr\n6Kr6ka13ldtNAteik7sqmE8nt8npPB0nuWEHz5dg+MSJneBtPgAoGUbxb0We8Bmyuy30j6g4A3MZ\nQVyonkUnmQl9lrmr/yiI4FJFF53MMF0hndwjaiLpBJ8Mi2EMdmCWhk8gwgGMAnSiMgqeNXEelILt\nLkCZQf+H9OFCSFEarz+uRScFYS46KQhrgqKLTiaYhO9nW8nO3Cmnw+hEHhyhERR69BVCIHh3MQOU\nP/z0028//zMEXf74xz/SamnsRIWVRScz6P/qQ7MEFp3URLcApSavU0svOjlV/G8RRz2v/+V0Z+jk\nkD7gWRMMhDA+APLAm4qRS/CNDJ/89uPHBigbl2z/GKBkHjK7ACU/s6PiE/kW+0v652b661drOExQ\ni05qM7jopCavU0tfiE5urFfmAb0bHYalgRO8VYdmYWjihj1J1s/vAJ1s4RMEFHoTkJPfebSy/Xvd\npZw8G+un4fKreVQ9+Rb7Sx7mdPu7ijUsOhkozDtUdWNHcofpIWNYdDLDhDp0cqfAySZqjJ0gf2Do\ngiIFO33CEjQAHHD65Ikm74DiB1Fozkje++MLnLrnHlc9qp6DtbdnyAd3dTidmItUe8bJYYJasZMW\nvVqA0iK1w69ZdHK4yJUGVcN3vxMnjE5k4IQ+Ho3GV+ST2fDbjU4AUCB8sjUBERQElO2Nld/Bgyz5\n8AnzOs1OaFQ9DdqrK9v7b/vRamn5zHgtk1I1NWp56MDxYSeVJjkZEExx+lkdly+3RScNS+D74cct\nF69rjpJA1WQc1S/ThZ/Ygf2aXnTC7tmhp1JoTIUdQ4FTJtu/B5q8Tp8goAAM4UkUiTjq89zysRNw\nk21acSKdyKAC+ns/3pDZcFoCqY7XKs/60Cz/0qzJVlRYkUhniVqVM9YZVq6y49OGlAb2yYUz2vzJ\n8plh7ItOppqFb7P1+qGZO2V2MK1D32AAA/M1NPMCmAJlEC/wT6QTmt/ZYIVGUCCIIhlFRZPw6Anz\nHM3ecVQ9PdrreEHVU2ZozLL5A+mE+eYeCSSvbaMTtZ8OdamdCX3oip0kJ5EXCyXbWO+6bJwErkIn\n99YlnAVGJ3dCE4hk0AfJ04fTQ5aHHoaljyRhgIJ0QtM323sZPoHICsCKPGLSEDvBMAO4mWY6GVhP\n1RioSz7pNZPjlat10QlME4cJ91cCvq3B12UOvnxXW9WGTy5/b6dyg5lddDLDJH4CnVA0oU99xeiI\nPB1CoykWoEBQBPgDz6AglMDn9B+No0g6qeJg0luHOjaqnlJDe8RO1ICBxLhwvGNpKRSLX2C/2Anl\nj7CTqtBW7CSUm1lg0Um77A65ctHJIWIOGvlAOqEHYOXJEjz0CuyyPf4EnoDCUjxAOQAfiCZWBEUy\nCj0MiwmmvD5IDxo6XWv7y5y644dkDSUbaxFJhgZKDTEiOSB2Uu1efqIbxpKRp0VyVscWnZSmLFV4\nV6VJ9WAVsiVwCTqRzvtmU/rhdIJpHXroFWIteOMSxDwYxwCaIKBgcocCCqoKO48Cn2O18CajV5Y2\nVg1dtR6r/uZ26YUOPdB+hvjl2JOqqVHLh/3MzGBbGccKKev3PRHDoFAOzRJsKDRa4PG+bWwfe1V1\n8XysoE4ZeKj9p/SKNXp7Fbo9nbC0DsUR+Apv0sHbjNnJWTV8ggRDyYOekJXaK8/MwidD/i3vMESM\nq5K8BBad5GWll7y9d+kV0HnXX4JOzhPPQS0vOqEPZ6MnZ+kjSSC2wfI7avhE3sJDJ5IelV1ocpCK\nr2b2kcCik165LjrpleBu1y862U20hYotOnk+EbVQ06RFZexEIogEFHo7Mb3Xl+Z3aPgEsOMP8GS2\nr6e0AaZMKpTVrSWBbgksOukW4apgVgksOplhZj6WTtgNO5jlUW8nhoOxMF8IKJJOfv3pBzDK9tVw\nQOnM3XReXtXV4dvCZP/72002xARyvDVr62d1Hp3yi04GCnNVNZcEjl/Pc41/jt7cm06cwAmlE/q8\nE3qvL0AJvhid4G07eDZ2oxMEFIijDAyfdHqjzsur2tpPCdL9Z/rQ326DoBouyYzFL3NKo7RLi076\nJ3HfGvLn7fftxwVrX3Qyw6RJOoHwwD0yO9aRWIkm9JEneL6Ekgq9rUaGTzah4W3DG6Agrwyc4k5v\n1Hm5OpA96rQk1tNW6dpS4SewnpHCO72fi04Gru5CVexmP7Z/on9aRpzVUGj7Y4ouOplhqh06uTqg\n+HfrqM+nl0dSEFBocgcADo/N4q3FwCgQPkFAGXX6FbyRPl+vT2W8AWMJoTPL1I+VcM/0/it0aifR\nkctvLVNAS2b679ecDKt0yoH2Ux1XqX7HRFj1MEGxYs7UVM3RopOqxLrKsxCufIIkFLA+p5lpWgY2\nanTv1dXLu1y86GSGmfwoOmEPs5c/zsfuN5ZZnrfI9hegAKbA6obwCdAJ/TdkoplzVb01c43YbsYx\nW/Wr3i4TM5A9tAhD7bZ080kx5tu1AkKOGKlI1ffWh1gnlXOzbJFTZXM9dSYlLEHzMajSxatwXgJI\nD5I8YAfJuISFfOFbpBCGJlh4AcqbcSd4kp+pVXKsBHw6uW74RN1FqKsbH3OCaEIfJgsPO2GBk6d1\nJuETWPs0ubMHnbDlIzXBcqvgzHzNsbxas7dzLnQGQr14OF4LL9jn4dg7+xOSIpV/BtFOma+qYSH2\n++tt9fpVPiMBx5BZwZI34PjzY17w4ZI0YozWsOFh1ZmeX7oMVe5LD+TSnVfp5GEcXzHCiyJ1nk7k\nT97gDcZ0Z6LKAfckdIHvETiR7kqGFuim3C+fceoZSvBdUp5OmJ97wp/9zNMSZmU8fZJO1H5a9Sdp\nD5vmzj5y98n6HWDtNFyLTjoFGFxuwQejChkBZk9qAsuFqWhp71b4RM7EopN9lTtXe0gnVwyf5NEE\nljYsT3yDt/BYp2LfnNlX3BQxZSc0cWjDcj9JOKDeUXXSB8dOwv6Eei2ZqbSxT3p9B2h8ukrGTqrD\n7KfJsEVWYNFJVWKF8qEJQ9vE6IQao9///JqjV5jXQRNM/Vx0P1oQbqLoopOEkHYv8sl0Ig/GsiXP\n9hvOssXkL76Bg7ED5y/jNR1SCT10pn4GSaXYSTLGoNIJCwv5Uu2nE1WMzmDVr5LytGgs1BwmE5VO\nrDJh5ZkCi04yUmopk0STsNjzwMrGKGQLRbdi6sk7jBi3dP0u19yDTnDeLzotFp08fAk5AD7W0e4q\nq3DN0sgoi5LSrQXN1SYzs/uhiRM7ga/U1UQnt5lOWP3WBlrOqeWzpcoN6b/v5h09lyOiQ6bfOv1U\nVdqaFEv/rfqtysN+qmpTQj1nqS462cWOhfYLjZE8RofkQePAGNe1jt1Znz/hZpdRzl7pDHQit7yl\nGQGfDZNLq5pd9KR/STq5UH4nXN3Wolajnm3TeiGYu5Curq5OJYFFJ+OnwzdeVjbHOolCjVcVTbD8\n1fffbZN0Lp2AzJupMby8TSbHX3UzOmlAE7rNWCfGjtfA1eJFJbDoZPDEhcYrpBMfQWhkBQ/cqcdW\n1HraNmqDZXRUdSfSSagGMhxCYyrh5Rc6YORHvNlI5w8JhFNTCpwwWJl/+Eet3dXOkgDPJ448Y/WZ\n0g2NVxud+FdJZKGJAGf7fu85OoVO/JiHOlP0tg7/ctiF0/KIKdNO5Z3oJFzddIKcEydWBGXRybRq\n7B+PGNhty2qNOswxsKt7V7ViJyMlnDRe9CR/c7KGhoudSugmW9rE0hmIkZI6pK6D6SQDFkgnsjAF\n0IwisXzBtI6tRCeTnz4J58Va2v59dpn7ig9ZMauRFgmEx4HzlTpVLTpZsZO8IiklQ+OFHqUHStjW\n2dmO01YAU6xzeV3DnvXiw+jE4RKLCGlmR26ycaZCPcH6F53srYaZ1e0fM8owyonzyLeqr6d1qZ9L\nP4qfsK/gT+Zcpa9VP6FzOhACmlVF7cPAjg2sSh1jtf5q+WbBWr19072xtX9UbZbxotspRITQ6zCw\nCO1assKPApQD6CQfL4EZlErCVEKdaD82Njmg+LGTh996PzsMApnQdOTpBAOWlDutpTfP0RPLFWU+\np2UkiDTTCau2ml6hwKTGHvImwkI3GBoOUJJZqP8wKFm/7LyDfWG7Tv9TZCCeq5scV89C5n3uqevD\nrw3pJIMm4bmEfkz5nJx33vSUVBeIJOQSGeJCDaE1gNNKuq5w9idM1YVWTC6cCekkjyZ49IRqSGmK\nzxp+hkLYSkHHLIMc1LlSF87eo29mb2Qxfx/PmpO1WfXX1r729HeVxtqaS46RAk2pIb9+KQq1vApJ\nJTEmCy86SQoqLgb2i0VK2DFGcELJOEdyx9xW4SekeEbRCYMJOBuRmUS5LX6jh+3nk75eYwEFN+5n\nOTnpwNRtKxa7H51QQEE9yQPoWRN3aTphMQz8U8Up6d1j+/5VouStG7x4lU7UbjvLbdFJcqLvVuww\nOnE20BmX6eSMzjKLO6lCJ53kAyRS7Opxk7ecxesHCpBOwrgIA9+wPFDU6dGUD4yd0APLyF4sfEKR\nd5LkDtuqfuPj+xeOv1cDITS+It+HsRMZRLHMBVYuIzqOKfDRORysRBYaxbFE6g8h+W2IMrLAopOd\nfM3s1Vp0InPPVYaQpyYXoGS0oZlOwqwNyl+dSisuBbjw6Dn+dtJXF0NAsRTGUgNZ/kRGaaCT2Y6e\nJENl6jqFa1n4jVWI38KEnjVZDbETNZxA3bNkC/YtFFC9uFqPs/CRMxid0HG1jZGCmuwAq1MOMGOs\nGKVZQRH6eQY1rL4lu6Q20VlnsmlFMfJXrpIcq0VmhzmJzLkTeUm4RfY9pUNCYATVXf49JreBTkIu\nodtinzJp6AWPEz2W3AYokNB5/aN0os4Ic3sZWJFloOnjw2MfSCfsyJEKN9aHqIHOTFHWGbhU2zy3\nvIrRAGMF6ekz3h3Jwx+vSgaLTny68oEvT2MDVRFZ7Q1bhzfwORX6GyyEAHA/pfBJElBKdT73c9vk\nC0A53oHtpCQlOslwSR5NfCgEOqEvJEU6HXh8gdJJdZZZeWSUnTycast81yIXzqVjJzIBJwcolY2W\ngeF/R9q+ZErni87pQOJ06ESNbVjbfZU2LIhxducNe3QrbqH2v2QfqINn+uz005FbJjrCN8Dixhmr\nEmdLEO4WZKNy/baJrmrnmfRmvJGvOqSzyqt0gptmSic+x1DTk+QSbCXvusCGgi+8K6Akl1CSSyia\nVPmSzcvTo7yOxEI0BX1SfhJHlRzo4e5HJ/nViiETxEq26jFrgxkcxhnw59biFuRCQGH66QRdzjJ9\nq90lgT0ksOhkmFTVLSCjE+QA3AnJVE4bnWQcldzVMXNJjekwuZxXUUgnbVySZMGQYDBeovqqzISO\nLbNTNMXfq1lM/yC2Of6V6IRNOttdqNsAGhjD3cIvW+xkIxTtSTBMbWQcZR7RzTGBqxdXlcCikzEz\n5wROwGChB6IGi/oDZshY6toKojT7Jycqcxvr5tNJ3utIH+NfS8urUZNqhaVZpkplXYgdUAtAHmHM\nwiBnHvUotHZvNkDzqA701JNXEho4ocARhj9ZjIROH20dPv/OL7zYhdkQ/LNn1OvaJYEZJLDoZMws\nOHSCZgs2RixBgIkVh1RCA4c7tnC/noGeSRxD/8Q4dJL3OpIkMqzgAAqE7h2GsK71kULtFfV8mW6z\njXj/FDxA5/VPSfoYj425Lp3IUGhm8YIybMESSOhgRJMqic92uPmBYgxlhsyjMn3ao8l2akttXT2z\ncnw/k93YSTLyUMhODVWr7RfLopOqzPXylrej3GDRCQIKmhjmvZw/22IqvsW8PZ00o0kS/uSxgzwZ\nqCE0K9kXVguqBf1xRm1xT+gdM4vnY+kkwyVYBgEF6QQ5wxcyi69kZmRUmX7309OTvFfeu5971x8o\nwJcgeiS507X9vVp0MmZqfDqh2IGxE/Rh6Dyoqfr9l39VX7/9/M/b64+vfxJc5M5b+tRPppMkmkgR\nhSigFoB6kteGaKKGvvKVJ0Mpqno0M6tFJz4tNTc3Zj2/IhBJ2TpT38AoLBASjmgIRIatHB+TaOiS\nHmHa2Xn3u2Hs9qiqRtXTMwX9fVh00iP/72ufW5+vI/fyJenEisOjM3tYZw1QGJ0ApWz9wP9SU9Vg\nGY+JCY8RelSLmtk5mE5oIs93dSHHOAWSAEQjKDDRVQ2JRK58/5l0UhIsLYyTUuWzrTwkhhrmaLsE\nfAkGJFhkQp1E6n6YK1KXntMxJ8CmUpGpVKRh1eXv0U8qukz9sgxKviQ33b5xl96oDyA9Z96tr6gK\ntakinbi30XRW97GXMzphLpDSiRVFB9dF61EB5Q8//QSAomIKMgpQi4yswOcsngzF4No7/ZOrN4km\n8mxQ0v33bLUz7BISTKkDACslP9oAr7oVc3+oCDp2uirmtaXtuMnYEGY/nUhAUclAen3mbpF10MPl\np1JW5TMN/Vb1+rQzO/VTkpw6cGzd6ieTW4/QSmLMNMRIVAVTp0ymCR9DH0Juq2VdhTFztFMSUHC3\nSpM7ql3DayWg/PbjxwYoklG2KcB0D75hHz60/wtE8MXiLjebR0YnJWczKrNTwgWncDLpU2pOheYM\nrJQY5aJ0UtKWGegEVnfzEpa+U3UH0i35Lr/qcUs+yHHzEkr262dIRQxWbkAnKhT609GgmdSALzpp\nEODzEkknEAhBs4VBdfzQ2gejz8BoCqZ4HlDy4we8KKBAJ1jghCZ9VF6R7NI+/imvfFPu3K8K0/na\nAwhK9OB0phpEUWM/NIyH6Jyhk9LBiAY66fGyozTxdDo5OIDk0wkDfXS3FsEwvxJOilp/5irVTUoa\n2LWfN6YTa94XnYTKOVEBlU4AUNAxYBn8xPcZMoLyHTh5BxQqCAkiFFwkkdDyEwl0RFe+l9Yd0cRP\nEcrdfAaMGhI94URJOgkd/+l0EvYQwp/5WFee+dgZlFC8owo4dCLjJdT9hzGJsIdW/aULt8I+JezX\nz7vSiT/vODtScxgdhvNoFVixk2bRvV1ISYLaLGrm1DKqj6HnQmgE5S1wQgDFOjIiz8yyVA5eeL9D\nJ2Ctnv8qdDJPTqfk0jLwEZYptUgTQ84qWnTSINVSdGqICWumEwcLkh07hk726ydoeN5bs8LNw5ct\nOp8gMahhJHWmeuiEySSpCazYopM2ufGrMI+jHjeBbZZM7oC38AEFyvxhm6gf32mdZ2bnBShW/IMx\nh/zzllBClyjod+iVaQGcrFJwotREmLJp9mfJblj7/uZ2nWjHLemkIXDyt3+qHUCeNrOj7pVl/IC6\nltDIMj8Ulrd252qjjvuvtquWh/qlnr9tkMQP+KH/tkSXFIKkLgoiauWlmqVIZZ3S5Fq9yjfNpPcG\ngKVaVmFKJwxQ4E/cDGEsRBo49gnzjgAoACJ49GT78Ekqv/124xxNm4LhukIKzDhvGrjynVCmtkyZ\nZiZQL0y2GBar9soCFGa1w6TJXdM6k9NJ2xI796p8GODcfk7V+oWEtmInYzSH0QlYdnSKmM5nx1Do\nn6q3YIACNwkjhWCiBwAF8zhjhnT9Wiid0BlxzmQwNGmgE+bUQwhojqNYNbf1WdZWpRNrr7/oZJNM\nA5ocHDu54nK/kKOdRLzXktiik2FqQ4+VII5g1MTK7NCSIaAAf8DmUjLKBiiLUeh0ZuiEUcuJdFLl\ngzz3hCUddGPJxxBZZOTjWnQC9y75EmsQ16KTYXY2+l3JgQ2tqs6VwKKTYfJnh17lHho2Q5jZQQsI\nBtHZ8tIIih8+wZt6AFOGje2aFTE6ceBPBjDCsFbo8ocUCGmgIVLS3LFMZ3w6CR0/xCBPVLdMD0OZ\nS0EtOgkPIuA5jM7Zz9czNpCQb7dzgKMurw6/Wr6/n4tO+mX4rAHtGlKINFIss0PNHDKKtH20ns18\nwwEUDJ+w/A69r+fDQyns3IlFJ/RzFjtpduRDLszQAMv9DWnXqSTTJYYXNHaS8f0n0smQwAmGS6ms\nFp0sOhnmaQZVVKWNavn+bi466ZehTicAGcyaszwOtYZQ3mIUWttWjEZQNhzBc7LsgSj457BBXqqi\nDJ3IMygAl2H0fgYOkKywR69AJ1EmIaDcmE5CrVBX/fZhSCdbAfYCPbzUggs6e7x78zs0W38Onuvq\n8Kvl+4ez6KRfhs8agC2QSDBMQq05yxcgkbBtVhhHYYACdMIYhcVUho3zOhVdkU5C3x8WGA4oD22E\nf7kf5bkonQwJnFh0Es6aWuBgOgH3Q2NduNapn4APVV/lOzCrflm5065jfqr10N6ynjtVyQ5U260O\nwZkXOl9sOP48shm0hkArWXRyHden9ZQldzBHw/IFmPoBlJEhFthFqYwCVUFDmN8BNKF0QtEEbz++\ntnDrvf8oOhkOJbTCEqBYdJJJ65xy7gSDQ6EMcUXLkvSrNhaRVx1PJ6rDlp6b+jbHx7MlC+uRkocs\nQD9pdodqh2W7WEw2lB+U0+GG/lvyt/qTYUR1mM5cZMrXjXHLFZSZ3lSnpbKPv4baX0wQ0GgKew82\nTkIMhIItQIFLEFDw5p0/fJ2E3f5rvT5tfuakk1Gui9UTetbOAk8Xvsk0iqBci05wzWbgyacTdSH3\nTPfxdKL6WsvZw+fo50Jn7EODjMcwD5o3XyU68dHEihKpnZHthjLJwI0vfzWW0zCPDr3BV6Wx5CfL\nKbnoZIgYn5VIA4eJauQJ/IRlecB5gA+gaPJQi68PmWWUERTAlF9/+gEvOJuyvfA5KJ/2QJR+OnG8\nUbOz73FXzrWZo6wNfaYe9yHPlyo6PemkkyPDJ3TBZugkFLKMg/ZM94fTCTrFql/M04laM3eK7495\n9b2pygrJ/lvtHkAnrGkVR5KjGOhQF50MFOYDI6T9wr0mfIt0wgInYJQxcUMZZesixFFUQMETslsx\nBihb+Y9FE9zVbSqe98roS3Au8teWSvY4LfVav3V5SbK3arrB7/xV6GQgmlgR0M5Znp9OMHyS2VtX\nYydOXMG32nk6Ubvd7IadCzN1WmUOoJNkKGiks0zUtegkIaR0EZVOMMVD6cTalLOwOUDJd8xNAArU\niQESpBN8g4Dy2+c96j4fO5Ex+b3pZOwmuyfGgx5U5ZUG/9pPJweET9hSxbWZhDbr3EmDuPJRqLQd\naiyY9IK0GL5v8L7ykk7vLnMTfgzA6nxmLBl3XqWrKp1YRJiZR7CNqnxUMdLyjepVv2zRSV1m9hXW\nbgxcHf2WRVDAHKvJnYcKpgEFwyc0xbNdjmgCb0aOeeK6MnQiQ1kYvvLddrMbw5jZWE/W2R+6+6dV\nNXRyfjqxkjhVyKNQu8e0ThI7oWHIjOezTEI1dkKdU8nMqNyDtVnel8FEQ+tygLLRMOoj2/XlpvbT\n6jztD6NMvx6LhErzUi286KQqMa+8uiGjzKH6ALRxNHCyvWfJHRpBURvCCAowChw9wTMojzt6XuGT\nkWOeuC6HTliwBP2xzOxIjuzkgAZ/71wic4Wd3etEE6Bw3dBHT4hnPd/PN1t00iY61JCxMyslOfFS\nm6trzcGPuYbx8b1ZdDJSBZjVo/ESDJ84+zMoL5M7LL/zDMeRLA82BJfjXTyUUZBORg547rpCOrEC\nJzJ8Ut1VV0+BVB0bhZLh/CRZrdS9UXSyU35nVOCEBkuG5+lQA+deYZP2btHJpBNT7Naik6LA3OLS\n8FGvBgwBn2BJVgCtEmUUlU4eobb3ezvxT2QUCJ8go1j37ED5kYKYoy6LTthm13LGlBRLu+oQZUrO\nXi3MQiYUUMLWk2Np7uRAOhkLKDCh1vDb5CYDJ85jYcMnxjKZ33JV7mcbqmmU/Xqyah4igUUnQ8T4\nrCRPJwxQ0DJS84TJHYceWKyF/smCKIAm3HN82eu7GkGfTsLACYa7QESUBcPQCMuPsPLNjp9RiMQs\nOagki6jF2vo5lk5gpXSqKM6gI41mOqGBE3gWgCO3EqB0jrrNtMGqabt27FWTdKNzUNYREFlt23jn\nma9OQakCeQOU4Q18VIUqnVAXgrETPIxC48OqUYNLrPAJzfLg5Rg7wTeY66H2Dk32XeeI0okao7LO\nWFAQkbwYYorFEJ0ZE9oT6hGdLA8bdZVUGuhEOtRv+1I8dyKPoTR4axovcQInIMMGdoGrqKAWnYyy\nJ23eelTrQ+opDaFUGLu36GTITN2/EtX80biIdGz0ktAZONaZbe63qhijMBbBdhss/lUmMk8nDEGc\niWABlXDKsIBFQvka8iUpBqnvk5iSb5GSMVOPUXSCQJ/UWIy4sJ1Acuz5YkxKIZ3kwyfz7x/aHGoy\nbDCq8hPtVWkIpcInDuqwpldmZ6SoLTqxnJ9qN62NOwCH3100Z+qbb9wmu9iwzpECOrauPegEZgEm\nlAm5wZfvdAkNyMn31ifSH1e7p+oSPQ3gRy/yQEAlT3WKfU4rzDTdEFyRIgrhI8z+oHaxaOjeq8fK\nQYDXpPNI/2SfP6O5pK7AZHEXxH+Ip79+icss8MDCD9Z4k1AlJSCHYA1Kyhk+sT5X66lOwd561Vz/\nopNm0SkXOnQC4V8oQKMp6CqYJVUZxc/vZEZCA93Ypfm3aJmhqbYD9JsJWcYzqBsIXTKdmoc//uVf\n4aUSYVgbK+Dz5fYtvSErU7nKIqoEZJQlUz8FNXWa9qATuViYYsusUCZrkyEYVk8DnWyXZABFWgCM\nBrUth/xVbBOvOm90gaHPzoQE1DLJdsP6aQE5NEoq1K/LATrXWrKt9k3tKpWDJSiHwPLzPlvJRScj\nZyRJJyzIT/0Hgsv2IRgjMGTsl3faOk27h14Q4zdba4eZv7b+V69C5VbphDpj6mLhPaCb9aLhE6QT\n9U1IG6yAWgkQyW8//zOca/ZfW5k8VfjsEtaDPbFuB5N7vgYCyMdUJDqw8CRdX7Lahr6pIgrDJxlA\noXQiaay6FkrlfTfsOHsVWUIPjeEB38ViPVVKsDps1WN1uNquNS46zAw5hQJs6FhJH84qvOhkpOQz\ndKIGTqQ7RHtEXREySkOnsW8YwmGQdL8ISolOEAczdAIyRKbxAaXz261jlE4QUzYdYO/hKcAWu5So\nJckl0CL9r7qTftv89Z2NbSAVuir3oBMVZDOAAowSErDa5103EvPTCfNbvj106EStx6EBi5CqsRPa\nrgzeMMhbdPIUV4PbW5d8q5dmeam3A5fGQugszE49n2q5HtmE4j8LTbB+rHNXq1fsdW9xRicyc0H9\nCgyczoXvoWnhh/Re+Z2xb7YeQshk+y+8CekEcAGIAf751BIGY9QCrH76J5s2nAV/mTRgR/ISn05Y\ntNLHF7XF5vBJUsGcYTaYgsyimp9OMqOgZWBEyRjD3nQyKpYTYk1VSrOVX7GTkTNSip346QbmLJkh\nq1olSie446deZ6QUpqnLohMWNKICQZT0Mzt4ya7hE0AT+soEURidqKRCwQUjH1BS/lNxB3HED5yA\nS6Cxk8cnh4dPVDBlCxCCZzDv8isrZ2TpSeZkST+dQJ+HL7hFJ45ImTL7wldBx4/lSOaoxk4khw3X\nEL/C/+N/+0m+Gvqw6KRBaOYlGTpRzRyzUzSt0x8+YWhyp+hIaBpAv63dJ5UtxUF0TlL4zBvtmt9h\naJIPomC8JEMqanZGfmgFSxro5ERAkaERGTvJ0IkKuGE6rFQAVSsMEQ0HlDydqPRJPww9K3XGnGLf\nHwrHnLqaHPGpQn7L/B8U8PvcTydMPtgcBnh8Oaij8Ic20smJuhQQ+euf6Ye///XP2ws/yXdmFzr5\nHP/HBG3RiWNf6Gadej4KKDSJAHmfkj3CHSFcm1eOq5eUsRPVObHYCd1ny1AK+3a//I5EExZEYbke\nYBfkEos5ZManSic+uDhWkn7VHD5pyLw4gRO5MP00kFpViTmShfNoAl36qHV9rl3K89a5/Tym9W/m\n+EIQfMHn9E/21bOA28vxdALL+zNXS5VO1JCJFSzBRMx3NiGhgDgdn4YmbxuUVyrBohMqJcYf1p+I\nknsAio8m6rcyTBKSCiug/skyOH6dqj7KzM5WDLQxjAoMLMC2AVbNNLnDtIXGVNj7JHPki1Xp5GNN\nbsIEjixSCpyMbHjWuvQkzitSQnlFfe8HVBadjJz2ZoObN1ssGRH2Hq3tB/Lit3ITOpEuBz0luAQf\nR2RibgY6ATXIJF/U8yIsOxNGU5CE2KGWPJ082HEHOnESN8mgC8WC0+mkCmcfuMZDAziqgArZoyq/\nQT00iGIFVBxYUUMpu9DJB27TQb16DO4egIL9+cwZoZkdmt6ShwYysRPn8MpYQCkFTiy7RrmBvacc\nk/zKD6v4ttUy68PDJ2p0hAY5ks6erhr1Epnva1u81lXw0MUkTrEe7gco1XMeUivOzYmssMcxDASc\n8R9/+f/gRd/jh/BGwsojGUT+DaaTT07rnEInPnYsOsFTsZROZIDEopOMP4Mp4DGt1huMtxZH0Qku\n8ySCyAiKFYwpmTln09lD83JqfHeed/ZhfnZvOmlGk/3OoAwBiyGVlHRPurrmy4dfeK40hg+HVUgz\nPv/+P37GFwMUiSk0iLLoZNg0NZha6SbbNmHWhmnRCdIJ7tTZDhv+7ImdwAGUUeGTIWji6DTLxTj8\nQb/CVE7DavFD4g2rxgli+cfPM6wJBzicDBGeN4La2hasf1UnnexxBqXqStXy1UoalO1Cl3yONNSz\nKfRDRJa3U7TkYQRPG9I5u7Cu9osudnZv18s77WyPmVMFTvvzmZNCMzsOnaCg6JkD5oR8xzYqfLI3\nmviQwXCELRb/W2dlhXSiZmSqoZEkeSSL+Wu5IXaSfHTsVjOkdZL9dIq1GWGZvuH716+/M9Mt5x0u\nVPWhlDZiHcA/rfrVyuUo6CfOJaX+O+P6HDoJ3S5NBlFAGR87aVsV4QDmL9BjU3rQBHf/b2HMH282\nbtEJ0onc+8LEYbKfBbSSfqI/fFLK6TQvBwcymvnD74xPJ5APTQIKOzCUnJqGYkk6yS/bPJ00B07U\nzpSsseX1ASlKKmfFThgBYJ3W52qjDp349eQHqNYDmgxdSnbYKVYVaUn+VyyMJ1Tw+Sgj6QTD41cU\nTX+fz6UT8I74gugu2uVFJzSDw/a+VuwEQ/cZ9ybp5+EYKqdPDgic9Ct5Qw0ZOkHnnRF1Zl4AMatL\nkmkC6wxiK+pPnk6gZMgozedhrZ7MRidvOyjN02dIyI+dqMQjkcIhjGT9tCGLxtTxqp1pWFk3u4Se\nn9UBpWfAn5zWgS1g3rZKw1e1dLK804GSkerRgamuRb+I8RIQ0Vg6oU6LTkGJTo4JnJwyOyGdwNqp\nAgoNccGcyshKdUmy6fPphC3AkDwygNIcRnKsR37t50MLoSKVvDXfIkdxmiQ9yD4kB2j1x4920MgK\n8geryoGVUKSfUIAByvbn278eESw6YeaMRjLCgwv9dEK378xS5y1UjwLMdm2GTphDAh9juSV1EulO\nmrnDPKDkAyezCTnsT4ZOGgDFohME0CqaAOLgVZYaWOs0SSfOMldzi+GGJ7Qb+bWfdN7hjFvxjyRV\nhPUn6wnpBPvpDLzKE8mMTzjGjy3gAUqPUBadUFPC3F5oK0MrkykgW/nMnA7bu2C8BKRh8QTu4NXI\nluUnrEgMZBYyyZ0bowk4ALmtVO0M0DzVcwcTHTqBr8IVJyeU8T1tguqMuhL76YSOPYQSmrQNLUMS\nUK5IJ1S1QsiweCW8MJ+LWXTSgxDbtYtOOgWoX+6HhcFcSmShe7XQymQKYIUYudlltFeoVMZOLDpB\nf4Y/LdsGKDJ8FQLKjXM6jBEzKkPjBwz7WPoG0QHe4J+dsRMZPsksuq1M548Ss4En6STZtySdUJRM\nOmxnTiWV+vRDY/ihqtDKsdqwz5JOnDCP7I96uSM09lXYvXDUH1KAPczteyJ6xv/JsRMZ0rfsC0ID\nvoGSSUMTFltQgjqMas224/RPdGYwCxg+YVtznKAwgsIAJaSTewdOSrGT74kjERRcHQ6dyI0BzEI1\nfIKK0bZn6Amf+EEjX+syNqHHsK9rlwSOlAALnyw66RW+EzhJWsnQxOQL5LdKvcOe+/oSnSTDJ3RD\nzw73SN+GxGPld/7w00+LTvJZHhZNwajJHnSClefXXXNJK2LkR1DyzS2DMLehWr17kwB7+P2ik179\nWHTSK8Edrg/phGbBaGrAun+ExWDU7E8pufPbjx9JQNlBPAdVKSP8+YYhoiAjizSUhViJLIhRlubY\nCUziYYDCAicybic5WF5iwcpCk7y+rZJMAtZjXncV1F508jwJuGvfp6xc9XPUXIYRlPxOKFNymSSa\nU7AyO4wpwSvARla9eYe5SYtOkoCyoQm8MoAypdanOtVDJ49JfD8ny7JylCkppjBkaTvGkSeAzJLE\nMiwBJAMnIZ2UOrZMQUpNV6EvCTAcsX5VWFLLQPktOukSJp7tgJVP/8QtF0UTNI7sWys1UDJ2auFl\nkprpxD99wg4JNYdPEE0ygNKlrGdf3EknDqDQ1cS2B7AoemInGD7pX4yyBjhCCy8VNfyDJnk6gfrP\nVoHV/tQSoKhh4Uj4OceajhEvOikLjyEItYbMlPhfoWVxdt79BnGZpJBOmOti8+KET2gEJRk+eUzH\n+3NjnyGTV/jEj6CUlXWmC/rpBABFnjmlThpmkyFFJ50cACglNJED9LkH6WcmdVh9mUgCzx8E/uuf\nQ/ioFngjnsqItwu3tuhPGQ87d3LvzA4Aytd/Hi/f9lnfwsVgVtC39eOIrGEBin/uBP2ZzA5g3CvM\n78g9Lk6EpB8KKN8hkwhQKkt7xrJD6AQGJn05A5SD6aT5Jh0nauKkdTAglDQXK3Ay43qYo0/7cYnk\nmGdbuYHvSydgIHI9uWQpZJRmOlGNizz6l7RBVrF7z0JGdVQ6oTF/KjoAa+obYL/uA4pDJyyzQMMn\nNK3zOHTiAkpmpDOXGUgnElAknYDY4fP+2IkfPmmjEz+nY9FJFU228h9CJ6BgMy+B2foGBHDwK8Mo\n2LG9Yif3Dp/gHq4NTZx08nA6uT0mhmveohOcO6QT62BQCCjqhDLowUgMxk4WnYRz5xSASVG9NULJ\ntHQSoomzJ6Fh18zWZdFJj5rd8tojQyYq/WDGh4mXdQzp5O2ndjqnBO3+XTfudFv2TPC8Mj3ohKo7\nNuASdtwyY33CMnedhaSW+nTCGAKmgIVPMidk/fAJ/RbDJ8qRWCN8khzpzMXGxk5we+ADCo2QWVsC\nf+Johs6JkZTCJ5jQkSkqfy2DqVFzW86FH0InD7Gs8ElkAk6JlzjhGf8o7r50cssICrMp8jBslUvA\nI4J92YNOPjx8otIJzBGNmrBY+n6AAnTC0EQeQKE3GEc25wLf70En4KdVQGG5njyaWMFL2pBEgSSd\nNHAJ3fzgNJewZtHJzMvDepRI83lSdbDfsYp0Kmcjg4OTPqw5HU36s3fUPd9v4472op9LkEXkmzAi\nUipwv1nIW5wMnVA0wfeSMtFFJb2dk9xR6YTdwoOAkh/stCV3ohMKKOy+XHThDbsFubhg6i0KCekk\nn8phsVh1QvN08lE37FwldlK9d7fnsSKdSZyzGIWeOHlL64ylk9uET9BqbOHVX7ad91eUleZxqkYQ\nPRwNmewUO/nk8ImkE5wplR4ondCAFuyq6R46ZBS1flgReTqZFjhKHduPThBQ2C0wACvw8meKhc0s\n7nfCJw61UC5RqSKDI0zUJTr5nJ3J5HSCkAGu14ma/Pv/+Hl7JRMi6jnThmAJbY5CCbw/ElM8NOmn\nE7AX9IxhyZBNW/hp6V5ogmYFs+Chu1KT3CqmlEIjmcKfY6S4KX85RnqGgFEgc2AWoGyfsw166Pas\n8AnSyR+//lknZLfwybTLodSxXelEAgoyAcxXOE20QBud0BbZe8YfDTiy6CSpbHMCCgYwkvkaWiyJ\nBYx1BiZlgBUGVuhXxdAEjxOhARlgEJlFuJNrBOMiV0toBFUTyfZt+8VOPjZ8wmIndJowNAIfqnOB\n+1Q8kcAARb2KEic93YLBtg1HgEs2RQrpBEsmbfSExfamEwAUCG/QqMkxdAJTLAHFshWdE7RiJ5YA\nJ6STJJFYI4LLj+QDSQ9Htk6Pmzy3/d9gMujYs3TVdwIUKxncGTtRXVomLpIsc/sp0OflPXbi04nM\nskleZBkElv1hOsCmRgYUGZqox2MBYi797wA6wRAmMgpiirMw5fQ1xE7wEpbH2WnKFp1ci0761eAs\nRsHAyTGAQtHkcXvR1z8GJwNiJ7CVoUbh9q5x/tjJZ4ZPrNgJDWmAZKzwCUZNqBMCF2idLLFAk9EJ\noglER/DPx3lY8uuAaN2uiymH0YlkFH9hJukEicdil2O4BEeX2ZB8zt06uEAmjJ30ownWAEGU5lRL\nG2HAEZntHEzb5fmUkMzpHEcncBhw4FTNVlUbnVjpnoz1aShz7ykoxU5YwgXppBQ+CQFFzhEFlM/J\n7xxMJ5RRQjrxw10wgxadsAMux6yvZOzkA+kEt9qzeYdR/cEgSgOjNOPFDelEhk/uDSiXoJMPDJ/Q\n2AnOkYx50K/kOWUnv0MBRT317CR3MBZC8zsy17OFUh4f/vbbip00WHlrYcrzQNapL5oqUk+/7nS+\nxMxfvH6iS6oW/WTRSYO2XOISxIU8o6hBlzyvQIv5QIha0m/u0NgJbl+YyT5me3G8ko2ik4aISOmS\nu8rfT0VvjILpG5apUbfOKqAwOeMBlAygYKPO0ROW32E38lCUuRymnBI7sUyQfz5MriaHTg7mEiez\nI5OJn7bSaSLgePt/cIsQRIGEC2MU6ubpe7gx+HGe4/VMtjydwIX58urRWv/hK/I87I6Zne9coLij\n75bLZhSdyFMOJfjIFL6l/PN0gkcN1N0zO4jA/qRBdesRWw7uyNogUkLvyrHOyW4DfJ5NuWAQ5Sp0\nkkeTU7jEohOqcjiEj1rmH3L0hFk5ySjWwRQemSCAkmSOtvAJtOtwCbSO3dt4C8/DnkMnkOK52eJZ\ndHLw7iHZnMzs+HQigxwUKVjKXwUUNb9DswY0fMLuFlbR5PtGni27c0E0wdMAQ56llJx3evTED5ao\nrp36ePX5JaVujC1MldBKJn5mWuejwieoVA6jsDiKGj5JpodY3CWT5fG5hELJVhK4hKEJNR1PSz52\nLakHUGBR3QlQLkQnH3X6RKUTGQaXAQ/ptFBp0XWxQ5HOUQbWIvy5sQguAXrPjvMk2cvldNgGaLht\nMWNmX/sfMDLNdII5HdhNTbKnQjpRxwVKuOjkME2bpCF8sAo8ahZejE7gk2d8gvzmThJQ8smdkEso\nmviPhNnljmI2Z5aNuA2g5I0g3hViGc1MdqazzG3EHpqGb+V+eSkqf8oTbF5YMeqf2NnDMIJCoy/0\nPdIJze844RP4IZ5wyBMWODizwxYj+9NagGpaZxIioXMKdOJbj89Z4FLb731fcbi6qbOXmIKf0AMo\nyArhg1x9QKEhkMwZWMz4ADbJwMkRsROMsqor6h4LaSCdDD96Au6TGt97yDxcqG/KTX6X2DkaQoMc\nGCx5TO7rhZgiA/4QJrSOs9DkDnqXrTweht0utw6dyBOy1wqizEMn7OhPmNbJ6NjBZUJT81HB0UUn\njvqppEIBhTFEeAaFPnNFHr+FqEyyEpaQUtHkODq5d4onNBnqyYNq+IRBRk8E5UMAhcVOLOcEuCC3\npJuUtog+QxOMnLPIP1K4AyjsK5rcseiE/XbxFSMoR9KJsxJvgCaOFaVg/SGr+2AuvHRzKqlImPCz\nPHjzjkQT/+gr5noohVDWmZdObnAGZSydOOGTUYDyIfZLpRPfgdFTqwxNrOA/TfMDslhnUHBmsQ84\nERg4UW8tpg+QvRygTEIn6hlSFtOa/NyGn9ahqntpV7o6v6sEMG6B0Y5kEMWiE8wTWdSiwsdcdOKD\n/6X95WF00hMv+cDkDqUTunW25ovmXCiabOETmrVRj56gArOSaiKJdgDyO86jY2X4BD5ht/zsatF6\nKj+MTpLLUB6LZstqWluUHGCy/5im7Jncde1FJQCMglENFjWxEjRQnp69pcdsKb6o9+BQWU1HJ3cF\nlKTVcGLLqg9TWWSFT/LmAP0iBi3wNIk8YoLb6Oe9Hu/HTeBDOSP0VCx2jJZUt+xwOAA7Ez7yxAKU\nS5yTPYtOwuVmra+kd8/r4aiSSTuTiUZvVeGtSPBOOcMx081Ko2S46mESsBhFBRSfTvCmZStTMzud\n3BJQklYjNJf+Mb1RgROoZ1oTPNB8ZOhEnjgBw73FS/AF5huExk4Zq3QCSu4cc2F0gkNmT7Vndxqz\n/A4+CmWgxPao6hg6YWvQSa45sZOZ78UFjbIOq8nPrQUOygzgARpOgyjfzELKzBZl2TRqD0X95DqR\nUWgQRQUUGTthdylbN+CoVARNnH/uhO4snQOhV/SaSTphO3hHCM7Rk1GMckU5V82HRSfP6MjXc0cY\nnaDtpmiCPAdUgYzCHnlCu4d0onoUSifs1uIwxSMZZfIsz8F0QheIs8SsMNi06yJvZJwDKFgJqDGg\nibTMiC9QrLru9i5/Ip2AMqsDtL46sbfVicDDs8glElAYneApFjx9AncmJzM7WNgRKRqQgxTRWWlX\n3NbnDUcmfAL+bBSFOPVMaHeqy8kvn6cT5A+QPN1BImdQ4GCMohpxB1Boc4BKG6P8+lP8VHuMlzBG\nAUAZK71RtZ1FJ+H5Enl+aOYVkTcylMlQM584Qoicneam9eMSGKUDUM+3m7F9fKbFU/w9wofaOn4o\nvz2ltxkxWmXwSIr6KBR6+w+SyttdOeRJ+U6Kh9LMRLETP7mz6AR323sDysy2uGd1fe8FX+ZQRq1o\n9AK/ZQaayp+iBn6OEGNlBPAq9fQJ3cjmn2rvPEx2iNCGV3IAnciJw6gYTfFYCwp/03H42AdWyMIe\njDasKBGqKCsAogC9ZdxD1Xtg/+mqZNWC/87riVPeqoSC0VuMk3yRHGzIH6zA5egE5AC5HgAU+qA2\nmdlhqRyKHX6WJwQUhrMHxU5uBij5bU0+drLCJ0lj4RSTsROaZ5FG2TLTgDK+b1Opmp6lVd0DtMge\nfLKNaPtkC4ewAInFJfj5Vr5faMNryHud5qZx4uj68ueLZeXmJ3WGERZ2JA+msOidam2wCfameZow\ngiLphLrw0J1jGMOqEFjH4SH1q7Bdp/+MeJw/O6V35OVAD+w+YUon+BULfjzTOl9BFAdQFp0cMZuL\nTo6Qcr0N9IvqWQQWPpGTyGInFqBYB2Oftsx4gCymkMCdUO9IszyIKQArIa9MCCh70wkLnMioicQU\nOmXzc8mbq3sPdbQxCqIJiE7FOCrV7f1Xs89Xp8SqsQe57jPBCUYnKnlk6glbZyQU/lk3Y6ddQW/6\nBRChqRwLTbC7CB/N+Z3TYid3Cp+U6MTf3GQ2f2MzPp225rSlk2iYxU5YfidPJ8AlIZ1YSUm8UIZP\nUHNgFvBRbHiIBEgFX2FM5cPpxD9rwqDkopqftzaqqUE0cWJLapzmF0IoicVnFtmVTqg/8yM0gBHs\nX2Zc1f4nQzKZpg8uo9IJDaVkjr7651798EnL9IySkbPMrnX6JG8vaGbBsR2Z/d8oRrmojc4ooaQT\nB1DYJMpDJ1age/scbzNWhUmxxgcUefqEogm8f9x1/NtvG4Vs1cpcz6fRibr01KWBh0surfBqsITB\nhGNYHDSh6q1Gm6jcemRY9e5h9AIrZPES1URkyvi2pb//Gds1QxlGJ/TPkEug/53hkzPpxAmf4Cqa\nYZLCPgykE3Cfi05CmWcKqHRCJYznQuQM0ug3GG4a3N7e41YSd+QOUufDJzguFjVhEZStLYijzA8o\nOAuZKauWsSaO+Vc8/lmtf7byqIcwcFA5fDmbH2czA5f7u52BT4Lp9+6gUTg1p9MJhGGgP9eNlFBV\nxxtzWKQE781JroskndCDtzQNNCmd4MJLSuHcYkk6oVkbJ7+z6GTUbFI6oQJnEyG3nmyLSdFkgxJ4\nYcikRCfSf1DlwS0poonKKHCKdougQBCFMgr8OUqAQ+rZj05QdFSq4b5/yKDOqoTSCegt7QlARhg7\nqYZdZUNtw2fORuJF0sEDAah6pTZBP2Q9t7okB8g9pSAkS88vxytwuEQGTpLxEhQd3vXjn43dytOS\nE9HJQ8lej/RWg95ty+Dgqy5NJ9dKopVmltGJ9GF4ItVKuIBwcHdK0QQ+zZ+vpNtThkqoP+Bs2KlY\nK7kDdAInVABKZuMSdDZss1uaRKewXHf3RhOwlpveARyrkkE1kzgeQsm3oqPGSwDSvPSoCV31nC4B\nAAWVTqp9y9MJAIoMtJwcO/Hp5BKOU+68rbhIeOgEEzpHZnYuIeTqwmB+kYajqGxVOgGB4AkVmF9w\nCfCSUIKfWD4D9Jy6B6oklE7wYCwMwcrvwOkTpJmZfxFwp9gJQxPV9Q7MR7Rp4PCrQBUdNZOaFkIJ\npoc2cYUd3hr/9Zf/HV87cWfYjVVgJwmMpRN8UEr+8fb0FO28dHKV5M6ik53WSX+1LHZCj8SiyWZO\njs0mFAN/8Cj52lOqe/TQF1JA8cMnwCUUTdif+GBZwBQMovQLbXgNu9KJkwYNp2P4SI+p0EeTJ5d/\nKarFJfS3okCx8z1fdJKX1RVLqnTi3BLsjBFiIfDfJJ1AEAV/eWfRSa8KDaETlnSoxk46f7i4ZJ56\n5XXg9ZJO5KFjSieMVOQsgMW37D7MQn/4hIVMMC7C4ihbQ8gleAcyYs2BYg6a2o9O8PxQGyzOI6Kd\negKmSb56bl9adLLTZE1S7Sg6gXoQNap0AoAyO53Mn3dQXZp1MC2T9JHbwQx8ZMo4e6lbAopFJyhh\nmlLx5xFFh7f5tHlERjZISwyS8OZh68EneGsxnJAF0wYcM1scZVc6UTn+Nnfo7OSxqvES2o1FJztN\nyiTVDqQTDJx8k0pikPT0yaKThMDsIvnAiXOTjsw4MJubJA/6cO5MspmW+Rw6oQdK/EmR38J0+wHz\nUJJqDQA9eA4m8+ATAJStM5RLZkOTrW970wmbjrsmdLrs1LiLF52Mk+WMNeGtOvSenYbMDk3rlG72\nQTpRwifHCyyzZw0t/vHdhhZH0QnuodXASZJO0Ew3YMq0Eu6ZWTV20kYnPpeA5JM/JmfxDf18ey+j\nJnhglt7FAyUhxTMhmuxKJ1YC9JbKnF8IIiC+1wfb2dh1KjY/L5coyejEf9KrM6JmOtnqNMMnx0vw\nunQCPc9ndsKdOubR0YOiz6vGQvBCSir0yRyswlsadIdOSrNGoxrORCTpBKBWrYcBCgRF8AAs/sme\nzMbQhN31c/yKZi3uFztZdCInd5P2L49T3N+3mG1/7vTaaWZP19hP7sAoOvn53/4NQiaP4yM/fpRE\naoZPSrUMKXwPOqHHWkMKSZ4+wR15A5rQ3XwmlPI5dAIzlacTWtJJ6+RjJxh1k9Mqwyc0xaPeXYwH\nTRBKZoug7OTDcF5UMQ4xTZerBNEEoho7QQmtdsVOLqckfocpndAYRtswO+nkeflOFiQzpIvSiXRa\nzVBiHaGldFJN7lSBZtGJOguIC/jt9ok1F/nYSSl8AotI3l2Mn8DB2GlvLd7JttAFCGfn8cDyLZU5\ntKWIJiDwIwEl7NsqcBUJ0BOs/XRSjZqAlFhW6DsxebwQF51Iv1hli/7ytzToMrODubNM7IRFShig\nqCmzkhir+R0rxfPh504QSiidlCbieKM3vEUaNWFPSzsmgjJ8RKvCUyTA6AR+AafhVGxP5y9DJ3AC\nYzZbw3yb3GF3xlFU2tg1fDKbhHuUG6+16AS32s40bQKx6AS8ILwoo8AnpZ6HgAJBEcolMo6C504g\np8Pu9yn1Z4/CB8ROQIwfSycsaoKxE8CUw1I8eyjPqvNgCbC7f/vDJw393xqFYyv8tp2GunouyWxh\nwVVX7X5Pr8JrT6GT/gCJU8NU4g3lnyzA6IQO31c8/FbSAwMaxBQglQYxSgwCbcfeAqDgkNUUD+WS\nTzt3ImMnIMCGuUjq1VTFnKjJd0j8qDMoU0lmdaZBAjPQydZtoJPtv1tu6LTMzhXpRO0zpgwyUZPw\nCK1/Y8gemHJLUy7pJHk7MZ1iK7zBZqF06ERaDdmKBShqKIWdjW2wSvtdsnfsBAWFmPI5dGKhCU3u\n7BFBodwj3++nS6vmvSUg6eSU5A4M80En9N/eg2f1LzppOHSyR4rnE+gERY3ROCsQIj/PEOHegAJB\nFPmgtjkTOrjSz6KTx56rmGg72Pp1NqcmdFDaJUDxaUN++4t7l/JOM94prnV5KAGGJlt5+OT4oyfQ\nVa544QDGFrgZnYRBkUxkhT7sxHKKwwHllnZcnjuhgMICJCzD0gwoPZJkfWABFbg3hy5AGjLpaXfs\nouY7kNc0jG0Fpw+kBPOFEtve3JtOVAqhJ05KwOHTRvO30Iex875q208Ckk4AUBadPIyL8yCQSYyv\ng1Ol5I6PKWBt/fzOWECZRLxjF16eTmjGh4qd3qeTCZ8MOSBFGYUBynY8FiIom6AwjiKpZawYO2vb\naScd0gmIsbPz819OKUTGS9gnW2F8wCu9sIE/SvSzGGV+RcJICbtDB5HlEUQ59t8FYidT3bbjB3sG\nxk4yEZSkv8wUu6Udd+hEnUd2HBXlxvblvjxHSRIZhQVU8FAFQAngy6hG9zA+x9MJWoyZxTJE1EAb\n+LKIgRYIC1exQy2PoxsSPil1aYhgP7MSK3ZyVnLnGnQCMdsZNOYYOgF3mKGKUWUmEe/YKR5FJzJx\n4Ie1BgoT+EMCCgWpgc2NlT/UtiudYGwJlwx+MrlYhoia0YkVO1G9ewZrMKZCc0YO38hB9dNJCU36\nmxsyL1eshD4llvb/xKMnl6GTGTaIfloneabET2DRb0eRR6aeW5pyVG4Z07JiJ1b4BGpgeRZVsG33\nFYfmzGGUzNxRyjk45bEHneD0bW8gxcnoZKqAazi5PQUaMjsqxDD+gD8ZnTBvIdNGw+lEogltQmWR\nBSht6oQUskVKaHJn0Yl36ITm/tvkPuqqJJ348ZVFJ6OmI6ynSifo0iyeywDKTnTyHSon0ZQ8l9CL\nYBSZa0MJZwocSSfb0BBWZtjPZOTTU4bFTqwwg5rZUQ+gsBr82IkMooylE3U4LGe0lbEaVb/qkfa9\nr8XYiTwDe8oz2WjY9akJB09AyZEfZk9VIYBBd87tUopqi6PILX4m7DGkzLmy3UnrLDoBv6XOEQjT\nj5GoeRachSMdv6OoGCx5h5lnkmgngev9eU3DqEbp3LHYicTHWyq2jB8wTJFRDdXTy+QOAw6VTmRV\n+EiVfjqhlVP/hO8lnTAKYd0bpXWfUI8TPtmQ5fg7d7imHTwHV6ET6GeSTvyS+djJkUdPbmnEUbmZ\nzDvpBAmGYcokXMIGC73a/nNW94bHTnAZwkTQzA4sPXo72y0Vm3po6xSIlb7xz6awgAqjE5hKp4Y2\nOqFO6Jdff8eXFQpq/vxg73a55pBONhCh+R2MnRwMKFeik7POxoZoghjBwicyFiLRhJYBa3v80ZO7\nWvAGOgmTOzJShVEKpJbjrRKSh8W+J07xWDphaIJ0QheOnBH8BN8cP0d7tOizAjXuGN4ID8Niye1y\nNXYy9lRsM2oMuXCPSbl0nRREgEXgBbftLDrxzqCcYmQzdAJebTidtIVPqo9COUWqB6xhlU5o5KM5\nueNk0w4WJrhbP5N47gmM4XSCQ8bYCSo8PRu7FWPTBDEkeB08TftpO4rXf9iJ6surmR1WyZBTsVCn\njJdsn+BXrIwVX8nHXbByOqL95uhCNTM6QUBBOmFnZncd2sViJ8eHT9D0Ux+gBkXYh1A+DJ/I2Mmo\n8An+fG54MOU2lpotFUkndFdtOfXM0RNfpHvLk0YCwhNO9EDMrqbEqnw4nWwbesALi06AQrb/MUx/\nzPjrdQ9AobETHx3U2IlKJ7QeP3Yy5FSsJA8rKELhg9KM+rks4MRaAFZOWR0TNirDJ8+QyVfsBHnl\ngJ5fj06OBBTqwBroBB0DuhAJKyybc0pyZ29veoAe++cxIXjANtNW1GFaOkEoCYmE6tuJ+SaYlOF0\nQtEEMjv06AkGSDbPKmd8++zb487xCKXO1QHilYETFVZYSdVhh5kdeVXPqVgHGvyvkoCyVYKRkh8/\nHrpj/euciDtdjtkcfA6bFVPZddQn08nDeEVxadUWH+BQWccydGKFT/DzJJ2oAZUwBNJWYO87YHdV\nX7/yb+V+7bOpLjl0wrxag2D30E+rw+FBJbjwrIk4l05k+OQb8k4Vy5DpQNqgdtx5nImKLBRH/Ht2\nLBJqphMLFHyMaAaazIVD5uUeldBDJ8+Ezlfs5PvRseRgyh5DXnSiSFV1A0gnMryB2W5JJ2H4xAqW\nyO1vg4/MXPIJdGIBrnXupJ9OIFozcMU6EE9zN+h66RsY5tj+5Ic2nE7UGBj9kIVP5GxCgXOhLS9A\np2QYNZFHQ/x7dpg/+I4zfX0Rco/sKlQYZv0y3ABREPZSP2QHUNRTJmqLQyblfpUgpkBmB17AK3ge\n5ed/+7ftNXbsV6UTsLbDDa61PWW+wTpNIj8Hy0gPoKjHStTtL4WeDGe0lflYOnFub2mTJLtqlHI6\nIRPGJX7Gh/LKWCOSjGD1N0qpArN1WK0ElM25wizA2DHJRT/s79W5NYTxDDTxcLewf8+OjJ2E3JCZ\n/VBEYSvHFAj7+ckF3p7JRgAF00DDAeXCdII7wlGY4iBIkk6sPbrM1LDQyFl0Ajn7UX50tqWLyp0/\nqCH32T2k0i9Ypnj5gciSGFGAsMFhkzUwdkJXujoEpBBEMTpMaSiOlMOuAqd2PB8dCe/ZYe6hYQhO\n4MSPCUFQZDiUsDqhDwNVtEFEV7kEKITeZkzvMaYPvx81osvTCVrhHkZRt6cUKXroBMI8Po4wX0Lz\nQcw7Vu8W9p3rjdGEGp2MU6fb6x4iGRhBcdAk7KFPJ0cCykDTn4SJO4VGGgy9QyosdkJPnPSDSENX\nSxmfzvpXKqdTgHD5RiFbjARYBDI7239/+vFjSOWskuFsuipcElgSWBJYElgSWBJYElgSWBJYElgS\nWBJYElgSWBJYElgSWBJYElgSWBJYElgSWBI4SAJ7ZI9WnZ8ggYHHCz5BXGuMSwIDJbBW30Bhrqom\nkQCHnkm6tbpxOQks+3i5KVsdvo0E1uq7zVSugaAEFp0sZRgjgWUfx8hx1bIkUJfAWn11ma0rZpfA\nvnSy1d4mgOYL25oLr5qtP2GHjy9wP/u4Jv14LdparIo9WR7085QRqY2O7c9VVt9OU7BTtf3aQv1r\nf22fVsOik9SMT6v9qd4fUugq9jEvjDXpeVkNLFkVe7L8WBroH+/Y/oxdfUmRNghhp5p3qrZhgNYl\n8/dw4GBHVZWik+aFlJkStUzmQiaChkvyQty18nw3Zi4p7SPXrZl2rhlJTjjp1lZMdU6s//jn5PNS\nFXu1/EWn3u+2Qydsug8YvmPS95ishnhbRghjy+w08IFj36+HzZJspBMYiWUTkWb8ATtWMlk/DLtq\nbWnleDlKMDT00uj7cghn3VnMbHS0k3TKwyaa9SN/oUonzk6ClQ8tmlqeahqtwZlEx46rvBsqOZuI\nfP3WCsrInA1WVYxMmUxbvhJa46WrUi4uaxExa6tWwuQWKr9TiZwC35hYValitIxYqZLqBKk6bHXP\nmbtku87ArdWkylzWk5/WpM6U5sjS+ba1wHoIPamqgSyf1FVmoKo636MJndfyATpaIq2/tIlOGauj\nlluybKtqiNXpd1qkhsO6Vu2A7G2ymD9P0lijBkvdkh0OV3KnlmQul5bO6VVGaFgGambzjh/SN76N\nU+txhpYpH2ppRnQl7WWK4SgkFaCqRcm+se7586LqbV6ZHZmrw2Hlq6vMmj7LKJXEGOrPwGUrV58z\nEaEB6eyYnKlQZywDmPEaVM4N9WR0IFxKDXNdMh3OjISTxRoKx5I3C3uXRK1+vsnTySiv2WwIqoro\nsFTYByjgeALpM0KlcSxdqEDNY99Pn6R9tCRgdb70uWMBLcFWhZYpb638qpxL2kJV0dFJOSO+x8p4\nAqdpS2nluvMBaz/l9yc09BYZfcgsaksgVZ1hbTEHSVuRX+VF0dYrNJjMcpbWuNP0WfU0t9spcGty\nVa/E5BYqdptZaFOM0lVowZ5v5qcT2mPHFmQ0W7WDav3hylc9gaNSx8u5pBYNhaUEmG5Jc6leIpeK\nurDl3LFF6FSeXI2OQbGUEIwFu9BXRVVzQvmrqqt6fdkZa14cOlEvSVrqHjoptZsXmqoAoRH3HYyz\noi19S+oJt9Ha+a2MFjkDrA4tKWpcC5a6ql3KiCWpe2FVTj0l3QsFKAtUl6FlW6wxqjbKEUgoq3DS\nhxfgmi+xa+wkhWvYNxz5BdZGJ1b98Llq6MMpSc66uoBHLcKwk/0FpH10lo3jCPvpxJ9Ey1mGmpmZ\noHzlTJ2SSiLrd3Qy4xIy856cR6u5HjpRuxd6glC7rkUnyTmCBegXHqUSYZewM8xyOnMX6g9tdJRh\nTNbTrMPhhaEk83bJko/jNB2RNnRs+CUxnagDyExqZrWoLl9+mHEM4cp0LHtYf8+qLnXMt7xWP/NN\nDFcgKlU240mvxrok1UaViRRFfhJV55S3ApnVnpmRTD0ZR2vVk/k8ow/JeQyHUzUamXaTRibEkQws\n+mtT1R9fJhklyUwQdD4jih47luwJipq2lWw3MwQ5lfSqUXOU0T2qM6Hpq3bMkXamqoa1P1AbS6ri\njxQV+/EmhCko45Sk6yQ5YLm0MvVLVW5eomwuqUTUxcCkpJZPdkZWpXprf7BJOY9SGrWecBJDoUm7\n5jgVae9Kkyh1OE8n1Bkwy1id9Le1l9j4WvWrn1uLiDWaUR61n765kIuCyU3VB0kJfj2ZecSGwg5b\nXaI15KcYTaVcvKpi9yzPUDEcAyIVIKMSYW/lCvUdB6pHWDM1FCjk4XNkrU1LIal6h8bEsiHW2NVG\n5ZBDG+vPbF63k3PUWYxbqs7q1uU9EhhiFHo60HPtKM2+tBB6BLiuvZkEjtTkUavv3Ck4UmJjAfH4\nnp87U8e0vujkGDnHrVgbrPjKOUoMsY9XF8IcU7F6MYUEjvRYQ1bfuVI7Ze2PmqNR9Zw7BbO1vujk\n/Bm5gWXxo5oZEd9DCJmRrjIfIoEjPdall8+JnR81R6Pq+ZClkRxmik5OoVp0eMmRlIpZaTw/vVdq\nYkj/x/an2v9S+RNNTKmfzYUPM0Btk37WIs3L0x/X3v3fr/7DFMMR9bmrbz/Z+trVtlJknWH/T5/i\n0zuQX+YDS34onaAErVkfog2h0ucnckh/rGU5xLQNqSQvkONL7jQFvsvJD3OgsuUbbSupSnLv/u9X\n//GK4SzkthnpvGo/2Y5aHRnKOaatNlGP0jGH58KvWM8PmPQUnbQJNHnVKLknm5MiVi88t1eq9Wkb\nYLgsaYGeUat00lPhHuPtqbNnLG3Xtl3VM8bqtW09zF+VL1nteVt5i6vaaht41cC9wa4btrFDHlhb\nyU6W2q3q8GE6xhoK5x0LIJeUhlYqDBIO6MTiKWhJLgnrc6swax5nPeQ4Bm6ldjP+mIqyQV2q/Vfl\n4/dTbcJROKdLVOylhcd6SCeFK5bxQzmyw2xmQTKWfKpydoSm2nf6IVOJpPI7cmiYdHV2wkFhQ0yY\n9HNpDphWsPEOHJfVf9U4DFyMjl5JOXfqs9rt5rXmdM//ytdha4z+2K2FE65Z1MaQDJhNkP3BcWVs\nhWq15ARZa9/qrWoQVB0Oa0jaFmfNZlRL2l5VeRw3ZC3Gkq1wuson2hGcnFSUDjVkTFGqA2blfQnS\nttjCC9uVnc9PQ97WqErP7L4/ZLWflliSn6uznB+UdTkzIpb1ocWsRqUZlUJzOpysli5vv35pH9Xy\nlhKGsrXWecbKqOqEHaZv0GGwN76OOfM1dlz+YrFWTdgH58LQaCTXZmbe8/0sTTrV4dDa9PTT77+0\nPGpbzroOR20Zt4xjcmx7aGClWfO7mumnU4NlCnrmLmPwYZh+58OhOUrSoP/YJaVneW/tu1t/hVeV\nXu1VKDXHUyZnLtTvUfVY2pmZDksO4QJrUB05raFyq4YglFt1UNZYnHpKSlWtx9K9UKOqk+L7A/gW\nyzhv2DT1WJyMMjvWI3N5XkolyxuqZUhLGaMUuuRkAbTjSWPr9C25fJIN+bqUnzu5iDK60T+JeZMV\n6kN+KmXJBpvjN5dc1NUl4zia0lyj2FGxH2+sISVXml+DuoT8Tiel4y82a+k6bkP2SlrzjLbJjr2J\n+z3fke9nm7JaqtOgN+r6kfVXLQgVTnK1JxuFuVaFXxVmtR5fzfKTHuobHYhUV/jE+tyx/nmzQKes\nYVzOorN8YUl1k8bEkXNGn6mErcUeTmW1gCVtR7cdQ5R36vlFqrr5zPSpNsFaU76u5nXSVxVLPmr9\nmTHSCg/QMb9LqhkpTR/IwefXjIZzS7sTneQH7A/JWWzqBDvtquK2Fptq1pPyDTWPrbSSdrJRZBZV\ndbVkhkl9fzheqwPWZFUHlanf6ST1LqFSZerJWNLMpIcToQqQDUeOrnm8w8eVt2hWn30R+YqUWReZ\naWrrWzi54dAyLiHTt+ryyfitUMcyfqdqB6y1WZpE302o/iLTT2c2S93LKG2VEvLO2m+9Uw7Up4Bu\n7xU7yQ94WjpBYZXsSHKGHPk0L35rQhsUOjPkpwKlf6pJ1mkJISPDhjIWiaqWlAozab5Lc5oxSeEs\nqC2y4cjRhZ4jbxakrpbGJQv7TVc12VeSTG2Z4VjyDKevp4C6+hg+ZnTYIk7n8+EGKkkVmbnI0EPY\nf8uQ9vTzLDppUHJHn/3aMjY5ydxP9c4wbJsG4/qRk20tLbUhWk/oYCR/JUHSUv3M7Fpai8vAGoL6\nubp42LhYiyhhqlglITcYSsc+shkPXQ6rytJyR1yWfFQldFYR7QktVq2H9kedLNUC9iibtCnwifW5\nVE5rcckV5Kzo0ricRSe/UmsOjZ2zNpPSlnqe0Z+G3pbWoL+6pUHwDWN+LWcsMDPj1ppyXI+60i1t\nqdYTGljH3yXXsjM7am/30zHVcLG1by1wajpYPepXcmjNcnheWFoSn1Y4ab98Ormr0Kqad1c5rHEd\nI4GGxXhMx05pJbn6ZhPabP05Ze5Wo0mgNDM7S4Jtu5/PWX5J+7gUaUmgXwJti7G/3WlrSK6+2czR\nbP2Zdn4/s2M8QvOZUvBHnVz5apTvc+TZIKXPEc4a6SgJLDVL5gKwmJoWGTUdDfXM1p+GIaxLjpHA\nopNj5Hz/Vqpu46zt712N41nj6p/Hs3ruxJMHLtdjwgPJ1cc6U527avmqGGfThGr/V/mxElh0Mlae\nn1tb0j6yLd3B8jrGVRw8qK25E8c10GOVRlEqXJqRsTWPrc0hqsxEzEwnQwTF/Flp3u9UmPt1+27c\n5hibY/CHTCWYtbd/d5qhNZYjJVClkyP7RlfgKe3u3egoc7B3P/36S6MoFZbtSvONFTbU7FzSUFvD\nLCRX3x6dGVXnkHokfjUIU/rFtkrmuSqUbVVutLysPGwuKZlFJ0lBrWKBBCz7SDUMqpCf4Of0W9ae\nWg8tA0sC/6u+sVhc7RKtQa5eOV6nvDVqSxSWrH1hJl2UI2RnjvebR4cdHfkMtIBS0ywRqZNuKVVJ\nmJ32xZl6+hUKzRcsfIurKaO9eEk4kOE67GhCs5LI9U611JK2ZUakcBrqr9oKZ1nJOXL6o06oX75Z\n7I7Nf2pkqF6rwJKAqt/hIlTdAFv2lFT8BaauEGpYmYWl1tbpCbPgYX/U8qwta7nSz8Ml7Vu0Np0M\nG1WHP3YefTqxvk32PBSLrIepsdpQ1ZrTbozqOatT5QOmYOpgrb6FFWZ0I1SVkhN1uhp63FATnDmy\n1mnz+rX0x9GNUlsNUqV2LJTVopNQRKvARBIAW1ZaQkkTn3HtSANyjYVdqlqKZPlwtSeHn3HPzQ4v\nc2FYJjmQznqSrVSXRMlhZ+Yi7IDq9cOr/AJy9YVUnSkQCodReDgKZxJD9UjSQwMzqWSDInUMSLjG\nkzhF61Hl0Kz8eamq47UmlMmkuXtJrX72LVSvVaBZAntYpebODL9Q2sdwYSR12qpHvVzaC8e4oCGj\nKzO0OKywVb65noxFYF4hFDWrs9kSqX3rnEfH5avzMsT9WI1KdysNsVzIVflDKw1XObqhVhhOjV9A\n9jDziWNbnOZK0rDW4CjdsPqZXPsMSvAqR9XlJVYlec3Ji1Qqeegg6KBCNQtrswzLm8DballXZSSQ\n16pMbbOVCVeg7HBSp601pl6OH8o30vH4tizZbmhxqvXsTSfMEoWKFNq4znkMBRj2sKdA6G4zihSK\nKDmnzQORq0/V7fxgraUR1uAPYSCdNMsqc6FDJ5YfDT931p2qP9V1GhpYZ+DJJby3GrP6OQtmZm6V\naZbAjQFFtY++1c4viczqhTIT0kmVipImoNl4NVy46zwuOmm2J1R0qm1hcx2yRbW8pdtH6nC/9EK/\nrhKqdKV+Pda6s5xCwzqlHSgRc94Uh7IaOB2LTgYKM67q0+gEjJcKLtKuhS5Q1kM/aaYT1smkJZLj\n8le4Kge2/EIFsoRZskTWeP3Wd51HaFr1naOGnPSXvlo682UpuWrN84VDlUDROU4Ov1IlLL1sqTxV\np0xvR02oPxeZnjhlMhMtBV5a49J2hdbSWYP90FCq3J/0qjly1ubbRHRO6ro8Y+JvKaXhBveWUlqD\nWhLYQwI7rb5RbmaPIa86by8BxojrVwD3nXFrf7Nvq4fUvpN9PKTvq5ElgWtLYKfVt+jk2mpx8d4v\nOjl0AhedHCru1diSwGdIYCCdVCP8nyHgNcoTJLDo5Gih3xVQBtrHzinxN3x7y/944773Btcf0d6t\ndyrDAZfPIIF5Vt8BAl9NfIgEFp0cPdF7e8ejx/Nqbx77eCKdnOKoDmtUbeiw1s9S7LBdSwLMtob1\n9BSYZ/X1jGJduyRAJXBtOrF2dcfvX/NategkL6uw5Gz+cm9Xfe54z209VIazCjh0wkztfj1cdLKf\nbFfNZ0ng2nSCUksaiLOkLHlwhp6M7YNqH/P4CDOI6MYYTtbDFZf8RDitiiqG0xlsmikSHVQmJGNt\nl9WmrX6q89IwXjqoJDb5WJ+sxNIrZ7x5PYFBSa9f1Z825e+Zx07p+R1edNI2oeuqmSUwF52odicj\nvkUnGSntWkbax+SkWH6FgYVKomoTkmzYwFUEkfVLsgkFaPVH3UPTfiZdV3W8lgwtAPL3+slOOnSC\nNTgr3SpjbUV69CecUEdzaD9DOXeKLuznLemELeRQCKvAzSRwGTpRdy2WwXI+9+s5ZnZvuepUOsl7\na+mTSp7McauyD45rpFtzv1jGwUMZq54Gj5WXp9OuQw9700lGaJbXD+mESTujP6X1npzHUN9KjSYL\nLzpJCmoVu5AErkQnPnOUDN+5M/QhdILeIkMDPp0wNfWpNKSKTH8avLu85HQ6seTWtlgacMrHHaoh\n1rZBLhZ1+tr0p2QHuK18JZiS6lRqq1r4lnQCC6pT66qSXOXnkcB0dKLa06q/cbZZM+j6LZecbx+p\n2Bu8S3K779OAv/mW34ZaJ3ulapdVT4Mq7lp/ON6GDifpJDSIO+lP2G5D/zulVOoSVdpbWpUFKG36\ncI+rpqMT1RxYuxZ/D+3sZU+xIMyU3EOBkvZxJ+9S8tY9dJI0/aX+NCjhrvVfkU5wXrDzzhuVJvOz\nYJUM5XbASvf3Bgd0YNcmkqtv1z6syo+XwGXoxBdN0nBkdkIHzMEtF5u0j1S3mFTlV75TYWrK5pHJ\nM/QWfgEGUtL/ORri6KEqnwZlC+tR+59UOWfKLNbPD8HhAHV+M/qDvWrTn6RYJILTC/PqlJdVteS9\n6WRFUKr6cI/yi05OmMeqTTyhi/UmP8E+1qWyrphdAg4zzd510r9PWH33mKkLKdXpXT2UTkKv7OxC\nnN2zs6uTFU6yjENRnK4Z1Q5MIthqt/Pll3HMy+oqJW8zp7dffSt8cpU1NbCfc9HJwIFNXtWik8kn\nCLrnZzouMYTVyU+QwCfQyacByjHofEwrbWvwODq5nz9ukzh1ez01zHbth9jH2cS++rMkQDH69tL4\nHD9yDDcc00qbWh5EJ5+jUslpuJ9AFp0kp34VWxIYLoGPWn13Mp7cAX/9jTvY4XoiK/x0OrmTMo1S\nl/vJ5KPs4yg1WPUsCQyRwEetvvsZT4h+MU2AT9SZVTPO1fKO4lUz2jup3+6xkxM1aWYqvF8OdScF\nHWK7VyVLAveWwKetvhPdyk6KpNIJ/TB8T2XCarOuVcfS4zd7rlXjOm+AMkr0Vfga1S6tZ6ykhvfw\nZgvs0+zjcH1YFS4JNEvgA1ff/eynGjvBD9GdWeRh+TuHVCw6aXadzRc6PflmieblISVb1R51YHRK\n1BXoYNBYSY2SDNW2yXtYGvJO9rGqRaU+r8JLAveQwE6rb3LhDDQOP/34aXu9bW6/PpGf7yQT6Qsc\nCnmLKETnVFjhpNMpydbxwj3i4j3vqav/Wofy6FcWRfrs2d+9sTWUpn9s03vUtpN9vJmU9pD8qnNJ\nYKfVN79ge+wDwsf25pfff2wvZBH8ZPvwv/7P/8TAZQ+xlOjEijSUPs+MIoMyqmvOVB6WuQad+BRp\nDTIj2VBA+xXoWVf79aq55v3s480E1SzhdeGSgGPrPnOZtI0aKASIZIMPeMGH8Aa+wtcBgLLoROr2\nXHSy9U+Ni/ixKUtBF50cac33oxPQisln80hRr7aWBGSceK0RRytomITBB0UTBBREFvpm1yxPnk7Q\nHjKT61hI5kD95UMLJxdaqf5knXKY/KamfEWjSlp0EtZ/Re91J4OyK50sQAn1fxX4ZAnsvfquK1sa\nJoHczQYcatTkIcNX7AShhEVQaPbnujK5Ss+ni52ofihDHpkys83KopPSjNxJXKWBr8JLAsn97hIU\nSoBxCSZxKHDQOIo8hsLyO+zCI8/Mfua0XoNOnFiWs2mYn1fu5G4P2L3dSVyfaW7oqOdfnheaowNW\n34Wk8fAX2tkRiIjQ0yQ0jqIeOqHlMXDCqGXXjM+1xD62t5PSydhBTlvbndztMfZxD4n99I/nJzSH\nqOhO2d8hfZOVLDoZKNhjVt/ADu9alYUmgBcyWYOfwLcOxNBbe2hteKj2gLt7dhXdYZVnTrdMRyd7\nuJ/DJF5t6E6DPcw+dgptYxH2+r/++n/CJ9Xpm7N8yevTWcMLWQ30T8umVD+HaOicArxirw5bfZcQ\njkMnTrJGfqWePqEoA+EW9lqhlFBJkmu/i07YQWj6Z9g/dS/V6XgaGj39ktsM+Uj72CY0QJCNRawX\npZbTFaO5A8mVz/iAitSnE+yYRTOygDqWfD+bRfE5Fx65+iaXqkQT9cRJBlModljlrdt8VhDF0ZPk\n2m+hE6SQzKGhyVX59O61OdrTu306XJbkxrjkz3/92WEUDKUgrEwo7f6VL6MXYezEohZrLvw5Slqo\nawn/rN4uOgHJq2gCdFLFEfWmYqsS6w7kpD5UQ49DQp6wAC3NUbtk9dMapizPgePr78zlbrkf34/1\nzdAJC38lJ+kDi5W87MzyOdg+JuXGuORv/vvfbPCx/RfeqC/49r/85b/AC2BlZsmzvuW9vkMbtE5K\nLcy4sGJq0w67XEiqk3f14NU3rTSsnE41oMJoI0M2GKFhj0gJZeW7Z7xc3TzQxWUtZ7YPYctZ1i/3\nLaUyamGrD75wOMrI0vK+rIZA2Qpz+XgYavD8BSa0j2oqx+cSwJHttb1BiNneXyiOsiudhHpotZ7v\nVdjEKkAl8PP/4u2AP0pWFoJYARWHOUqBE+ckSsbxJfFdpRPq9Rs2G9YmRFUbh36q5ZPWIKATDJOw\nY8zsaTZh3CwzSR+1kChgJqdqcvnMRif+ERM1aoLxEuQShBIMoswfR8mrEy1pbcKczVnGJFkbqcmV\n+Srd29Bk0QlMFrgY9WRrlU5UNAl9HH0WfjV8ApAh3b8aqmygkJ56mKuiVYWRD5V+WBzFqUShEzxy\nDJOK/8Un/rKH0vgHmylXXmXNH9lPC5yP7MOQtqaikzY0gSQOpH7Y6ROa5ZkWUFQbFFoQ1EAJK/CJ\n+jmjFnX2fUOWp6gh+nnLShadfPtO8YAT3EJn6MQiEvVgrOXy0EU20MmTscghDGuBNNBJZiOB1Sbb\nDReU1c92OsGJhHul2F05zvEihpaSNFf4JJzOSxeYh042egC8CE+/+hEU+JaGTyDdc6fbj63NzaVV\n8XM6v+gEAyfO/cDgyMKzIyGgNNRQ9XpsJxBSRU/Is0oP1e1EtX452PftFplCnCp2BtYJcFElgGJY\nGN5Up+pzrMwNRjoVnfi35DjnYfHQCURQEHQws4PX3o9RqtbnBkp76SE8cjq//v3K7Dz24saTYWn4\nxAeUEE0ymR1ZScblOSFGKxpKjW1PyNPZnKi9qkZnraElTQ253EWTJHtCxMW5NfzS5mB1PpMjPFdK\nfk5HQoZFKng8lvIKhFIwy8OyP+cOvK11P/nSVue66hgJYOAEQuV0G31MB+ZpRaUTiiaYc6GbbZag\nCQEFK1QdnHp5hk46xZj09J2tnHL5G504J0gydALBEgdQDpiqU4S4Gp3EPmKow2cOSTAyB6RSDqCJ\nzPjgJ0sTJpEAeG7rNUknO7ux6ISmdZiHwk0y+CN6IuThhn75V3pogR0TYecZ2K0h1vab0Qle1TnL\n4eUfQCdkCikYqmeCHIT06WQld0JVu26BGXZvPp3Q+24QX5yzKRJQrMAM3rp8oRuPr6tpas8ZiGwp\nD/76/fenO//KhkBC5Lr/aFpnkr3BWcJkd29Q94SHDVRA2RgFXhRH8MPtzR/f/1nUQgEID2tu0tiu\nPkAm96eTMKkWHgii9xhj+AR0gt3jc8CErSaOl8AkdIJ33MjwCUvWtJ1NoZUwskF2ud+RlOPVKdki\nQomCI1+A8h9/+l+3FxT7f397EAn4dTyxkWxotmID6QSc7mwDzPeH0gneZEpTOew5aeCeIILivH77\n+Z+3FwMUYA75j4ILflsYwutWnZ1QA6vtqb/n2rwoaMmnT9mJTtR7fC69Etqk/AlXTUInGzFYz1sb\nTicO36wgirQy/atAZmosKGGfqxdeN3wiAat59d0DTRBK4A3ekwGjQzfEPg/RBAAFXxALofChvh9F\nJ+wIqnr6lRGDpQbXphM6uziFTlrHOhYE2kDzO5J7Fp3ABu5mSfFm+9jvtLAG50gs3AxMeaIZVuip\nWFohDaXACZVpn4wyUOaZqoboBkYLMEGTRBNWbAulQEzluuETFjhpzuxg1CEziXOWweMm9I2kE+aw\n/PDJVphxyfYnDl+NndAPG3I6GXqwyqifS2qB/ifjH2qx5LVsW9KjNi+78X5HFjvgk0zrYPoNj8dK\nnQAM+ihAUSlEWkyeOO+Z1TOuHeKBOjse0gmGNJywh/Ooe7x/JyQbuBt5Aco3OJKdYMMsY7SgjUjk\nVZDxeXx+tX9qZqph9d0ATR7u9vXIUIkpeATECuGryR0fTSSjYDQFvtrprAkLnKgEYBFJScH9gI3F\nwVL9nHry/XlWYp2EVe+SYsyBSsBu+cEIG5Sn2nNROsl0uxp8vk1SvME+5tU0U3KjAXYQBP/EH8qB\nN+ymm7YDKJmrFp2wiaM2KzOnWKaTTr5Z5HVa9okm8Oel/i06efPNhE5oyATPwzI3hM7rG87eT59I\nOjldO2TQohQvaei/FTtxIAlaGUJIfEtTohNM1tCTR6gZdPqRSG5DJz6gUDTJb/LukRSfgU4kMcCv\nDeNzSgBNWOQDAiphOCSDI7LMSu5I41hlFPTHiPJ0yWy7VQkfmdWHtV0IUB6i+Kfvh7DJ0FTSFd0j\ncEJjJ/Q8LCZu6MZYPWMgwycsp5OU567FVDpRwxVMH5p7lcnsNJfJ90qJndC7b9TYCd6JQw8qy+wP\nnkiSsRPQpHwvJynpLGnMheM9Ahn7KPM7102Kz0YnmKCBAAY+hF7SCX2oGuIF/iIgfdMAKCt8Yi1e\nFvt11jhjEZb4l3D/iK7LO4rFJ99HT64TPrFuOCqtPjwoekUjzKNxr9gJOyVJzz5i+ITeQ0qDK3g8\n9g8//TQbnTiBE8yzqJDacEyE1qNuKt6iVu8/CaRqYE8fcHT8NwgcKKHxErxTXD2YgnQC0EqXxEXp\nhKI6m7zOyLN6cO9ap/ZK9nEP3JSZHYAJfCA9pnWsY614KsV6g6SSx5RFJ/5cZ9QG+AOg5Ld/+Rf8\nL8UU+Bz+UV55y+C8Awp+daGbdwbSyW3QhB5zpDtnvH+HJndoBAXPJCCd/PbjBwWUPcxUtU6fTmQy\nxSeMZOuluIiT7jmaTp5nWt+fY8MSQxgsYUSCR2JvRic08gyxE/nKbOZkmQvZzYybSa6NtmIqnWDg\nBMACD50goMiEzvNpJX/6y+9/+stffv7T1hl0e5RakqSy6KRtNulVkIIBKMEXwgrlEvqekgpmf0xY\n6e/l/jVYaPK9yyTbWTNk9brD9k50Qne/uH+mMXt6xgC9lQyfzEYnJUqwAhsNillq92g6ARqVL5al\nA1KR+TzUFXmOGgMq110bMr/j3B5cPSRLAQWvbVCv4y+ZgU7k7TaUTvCJriy5o3IGFP5/fnq8KKCo\npLK1S18s9HL8XNyvRaCTX18viilIJPAhTpCMptA9A1tol5DYQDq5rvl988HkVlPcCSNzYMwePvnb\nP5kpAvBrTzR5hU9mUAkr9mCd3BpohP1zLSxm42Rpe7r0du5EcgYAyrbggSoet32TE86MTmhWj3EJ\nvZ3HOb0xg0KEfaBDg8I08mxFm1nY2Qk4o90EY3SV8EmPFoYyzxRQH2NPszkADfQ8inrKhGZtJKOE\npLJdwg5GZDq/yoQSgJQNynYjFcYo1p9y6clTtPOvMpo7lr3Nrz7YT96PTuiOmqVycMgWoMB2eqMT\nABRI7oQKuQrsLYE3OlHv3EEu2Rb5Y9p+/KC/TYBEQslmUwJUCIq09ADKdZM7D2x8HcWC6WGRZ5od\nl6FmGXB2kj4XApS8fdxJp5E8aAQF6QTRxL89Jx9HoZiyjZ0RCf6502A/sFpcOBRTIJriYArsHGgB\n+IQCCqzfyUW66EROEMvX4B4YvQ+9gRRPmUg3B84IFAx83Pbf7f3kKnH77nl0AiGTh6/9+rmB7b/A\nlUgngKt4jw++YcoBf7LzSjegEzoEGnmWthJ4xUqKo620Airzm04I9MG/s9YMnilhdIJ3FAO+SDqR\nR08ko2z5HUz00HQPcAkMGawbvEFeOUsat2wXxQuAgqEUC1D+46eftpeSXf3lF1h0+IM7ky8xH03y\nqw/3ineKndBgtkzroJMCBwQ7Z3r0BM+pwPql+Z0FKOeaEZ1OEDNxC4hoAuGvbYI3TFFPnMC1qCV4\ncBoKs8/PHXxP6zI/xbZ06n7uuQBepIK8Ivdz8odCenq797Vb/2egE/mDw/R5J/hcEwAU/wEnFqDg\nikBGQdlSTAFG2VvsH1s/zgK82dRvAxTGKIgm8AZfD0//RSf0GMdH0cmd0IQdfVUPndAt9EYnFFDY\ntnlzbZRRcL/xsQvt3IErdAKpHLoR3LoIdAJoAnRCAyeIojSnw0IpSCc02nbu4HtaV+kkuaWTtx48\nmP1f/gUZ5XI378xAJ48d5Os5sHh2xKKTDKDA4VnKMY+gyNfhle3Nf/y3/wZrBI7Nrn9nSUAFFEYk\njE4omnw/k+2sASTaHRs7uT2dSF9DT8hagIJeD93cyu8kdHPHIm90AuDJ9iWwC3yeFXqhJSZrWIgM\noyZUGzB8gvfyIPDuOLKdq6bhRLp7ZtID7Ei+HtHmf/xHGnN+noqd+2wsmM7TYycOncDpExY7QUBJ\nxlGAeGB+sTYIkOCk76x0q3pFArAleEzEdiSOvFRAoVwCe4D5fw6Qool1TD65+uSe6roqxRI0NIhC\nT5ZgwB523fiSKR5GJ3gA5UQRjUqUj6rnYFE8tRpTOdTUouXFqMnTNIu0Dqbu6G07DEqwDGWU61K8\nSicweRRQMDvOws4qr2DMmR7ZA9s0c+R5Kjpht+QggsAb/C/cAAwnUdhjYTNPWsMpxlCKXDgHr+SP\nag7jJU/aeOcSZBSZ02Ge/nke9grrC4/IqBP9aXRC0QTv1mGehQbvfyE/xwNc8tjMkMdhILex5E71\nhGzb2bvvvPgrEEs/kXWq0w0Iwr5K1jMnvrw6L0ImdFMIdAIWAdI6lEIsNEHlwDgK9ei3CZ/4gKWG\nna1QCtDJ9qLHYxed5P0uPRiLh2HxOWyUTpBIAFAkoyQftsZCKXg7cb7Pfsk5rcao0bXVA5ES5BKY\nAhY4wU+wpOQS+qs9bT055qowrSN9ktWx28ROGugEoiaQ1qGAQk8a0PAJODuMoIBDDP9JzshcYs5X\nlDWm9oFCDLMbqhmZ37Y8hQk7v+0PhBKUFwZOEFAociKa4JQzvaEAi2uDRt6uHj5J9n+LnZTCJxh2\nnpxO0HQmd2/hWu0pQM+dMDqhjIKPt2ePTaN/soCKf4QWMz6PRfSVQuoZBb12fgsyaqTJejAY+VC8\nry0T2C6gE3iDkS2Zx4FUztvv/80dONlGN5xOLn2/JMQ8ZO6GPq6Cvkeng/kBTO5Y4RPUHzyAApiS\nVFEZrvBXsRNuCZc/o5MS5bSFeZJCGFLsKUmcD1YpJcfnNvGLQGlchOXzmN68hdd+/yHP0ia9+5DR\njq2kuhHZrAwAyu+//or/ZXEUTO7QpPjMmZ1Hh79+NHUeOoHkDqMTPOKKv/lHD71SFsGkD8IKDa5Y\neZ+thj//9fftVaUTZsuYiobmaaxKz18bAAegCQRRkEjwq+8y5Id1KJRkTnJMIopkV5Orz8lHTzLe\nTDesDTDeLiqj9Ygm9L5iaAs32/JO1c390c15HlCeNZO1HY5LZQVr+asRGsdW+F9Na2S+6QQDJyBH\nnBiYHtyjAIsgc0CIDHM9VnSE3ujF7kP+TDrZAIUyCjWscLsjjZ3Mf+hkfjrB4AfN/sDRE+uFBoVi\nioyp0E+aoyZJAwHF0JAldz/UdbHNlvRqtAlWGJtmvU26xtBAZwpsawHPsTIcUZ9q6EDJ20OZM22f\nUeZJ/18bAGeXkpyCG9CJiiZ49ISiBjuGwnbR1O9QsWBy59effsBr+z/qDXfVArmyZHNyVSIMlWIn\ntHDS/uw6dnWklMOewSsERkQTGjiht4/DHOPE06OvGCYBjUGCYXRy0TBj2zrfbA0ES4BO0LzShzHw\nQO7EkWfa1aR93FW/2R3FeNBkew4K3pgD75FL8E2mY5RjIFJCX81oAl4/1YEvKTNA8S+UOKLaMizG\niCf8/HgbR6FE/cVNP4hCIWb+24kxNrno5Km3WloHb8zBA5HswVrw57aP/uVrLw2v7+3H63gsC58A\nnTzStV/nMjdvmFmkPWUWnTB7wukE0QR/dwDzPixwgmiyRVDwsTaSXv1js59GJ5jceewCvx5kqTwt\n6nWvI+wUp42dXIJONhzBp7RRNMHTJwAxVZsiIy7VGhr8OmWFcMMUUojaAcs+Vu1mjzTy10oQgSWT\n+R2rtwMo+SaPLTk2swM7yUvfkcBiJyqOyHMn4GVYmP9N/1+AAmU2lwdcQt8804ijFYA6YCd+4Ljt\njCmQu0e/3dGjbKnvDU3AANHAyfYeJmn7HBASIx/IntsboBM691BMJgJl4OSiS6VtkePRE4QSh07A\nMM1OJ1vMebJzJ3A0BJhjewNEAoDCzsbiDcYNdNKy2uxr8rETZonCC6u0US3/cHjk31ixNNSWp5ML\nPUwoTEJJ32OJrs1wNUzEHpcwNKGnGOlXLIRP78rBXTTetoP9xOg+Aoqkkz0Gteo0dZXhCdDJ9oIZ\nwtAWoAmNi1A6YVxC0YSdn8Wv2OFZGme7xGy1LXKgE0kkED7ZhMxOnIABXbGTpEqwe3aQTpBRMNcD\nBLPo5Ns0kwctsF2aujOTURzAlORM5Yu9Hcl6/R44fijrQTrJhE/8dEm+kzuVZIdO+s+dPOboyrET\nSSfqTRj0xAm7YThDJzK/g8kd2Kivf8dIgMdOvm+m+u03GtSiag2TJ5ETiRUhlN2hQ8/GXppOelY4\nGFb1QZZIJ/iQqMnz4nNmduAALD10gpkdSicbmmyfA8G0JXcGLtGkX+/M7MBqz9MGBY5MTCU5iqTc\nYKX853/4hz/++iu8WB6HfoJ1bmX+/f/+T35yh4HLJeh/yLkTasavmFJP0gk9dIKxeUz3QLAfdtRM\nFdFzQQ1qciepvatYvwQUOvnti0tYvi3M2NFgGuYCVbAFDbv02dhOOmFost0bSQMniCaY1pnTerKN\nXT623K+1Vg2IGpROaFoHgiUQNYGMzx50QiEgHKwMXjqXNNAJEAZ2iQKEmpHJUAgLk5SGEAqEFUAi\n2TCF0vAzpvi6Z5iuEQQU9S4efHr95IGTTQ7s0MmQ2Ml1wydJNMETBcglMrSPgCK1EQuz/M5Oh04y\ni726ZOYs37B10WMn28RQOnHQBHRdoglmcKyDJhJcrpLcoYukoc8QOGGPtoSHN9C7iPnjYufTuG86\nmezcCYud0HuJJZrgeZTqc0p8s9KwFI+Z4Wk7Fg4fUjYUOBisyPCJpBMZU5kT/WEszyVGntpi9ba0\nN+i0YOFM7VQgTyeY2UHPBZ9gWgcdlrnP+Yqs4AsyOzuNy+zDDnnSg4dAm2uwPF7sBCMoIZ3gLOL0\n4w3oVl7QCqucKL5k0z1r+5m7IT8LAkKWx02uQSfEbpbsY1LU1WIsdoLPZKNvIGoC507oUVm8zbja\nqFq+FD4Z0mKykgYbkaz5gGIsXoLHWlkUBI+esJuH8UGxNHxyLTqxzsiXVl+PBTtglvUFJW4kVj0I\nvWmD5nTkqQN2PsFqlDIKlsEPR0lDXZWXXqpSMg3D0WMnePqEHoZVE3VbJ1QmRS3xszyXO33SubA3\nU/g4V2XQCd7ieIngMws7l+zjqFXN6sFTsfh0E7x/B5/xytCEPkMWMj6j+jYPoKgZnFHDPL4epnj4\nJ3IG0ok8GCs/mZ1OyAbAuYOvuvo67djxk14KnNBTsap7gg/z4RAsCU4QoiqWQywJhztgEi8Bd67O\nrJOTzZcv9RMKW5WH/YQC1Ra5cJ6d+MrsgPTxjUWXMlyGRFJCk0vcWty5qh+m8P33VOlJWNgYXSX4\nPNu5E3bDTuanhpFd6M/oTA4oDYu8ahSmKo/nTugbK8UDqEHphK2mRSdo4enNLFPNuLLtzgVO6F4X\nDTV9qgV1VVW2gPL0LMtAoVmxE/p5+J5uh1iF1rXNQ2AVqvU7ZZLtmnQScglqOU45TQBRPcCbijNZ\nnjzPJkc4sBjj92pXAUQwdkJzOvRnyS5GJ6+9XXX3NnBenqr4dfeNDJY4mEIfhUKvnRlQPopOkEjw\nnh28x56nPsnxWDgVC6/wvuLPjJ089rLE5VdN2fDF61eYCZzQFAy+l8md/NETdHDIJTQ9NFYCFp3Q\nVrCMRR6WZXBIpXkUDu6E/cw3qtMJ6G5SZVEV2MTTMygZLpmf5XvWM544wawZJtHpTTospzPzbQVT\nZXbYM+zDwAn7zWH6PNmx+R2MeebXZGCp6wHSUU3vXQ+yiGyInTiRIUaW3wFACQMnzl0wew82rP87\nNvn6kZ2BmZ0L0YmPJnIbTP1IJ53QeAnEYNgrnMRkgSqdMLf9BCnDMnAf32FAaFU4tCQtNWyrTDrJ\nilUchLYY5UI37zxN4bsIegIngCaQ1lGPwfo7vDm3d/PQSRVNLHYhR1IePzWcXAJhMRpxZYVhxWIB\nVlINR/m7lmQEy2o3YyXD8TYUoFkb9SkmW51AJPSpqUwDKcpj+AQvYW/wzzkXF4wXnsIsfxhISjg5\n72978fd0SXIv2jC5PZeEUZPQrVgRfRryV3tIc0PSqW3fbqwySmiZdWfFJCxKCD+vzotleS5PJ6XY\nyYmPCZJJ7u85NgKhzoYPr0UiUbM5FppMbkDnOXcif/wvjJ3QBBBCCTk5O5JOHCsguSS0U46RcsBF\nUpEEFHUH1rDjqVo9Vp6GSRg6MEBh9+wwcKGZHQtNZo+dvKPJfrGTE02ury0hnTieJeQS575iaJee\nm1QzR1enE2fjpBKwSjwZOik1RFt5C5+ULMs2N06kxIm5hadlR816aTjSSsIDoODFjlzB5gZe7EGW\nstFHmdedw7Dhw2ud1Pg16GSCcyc9sROW4nndaXwcnTAmSNKJLGbZCH1fKJ4Ya0HP8XSCYRLQfxbI\nlIAiH2oClyCdYH4HKmR/TgsoamRoyB3FT5V7j52U7mHpsav5a9vQJDxpEB49wXYpkVjxlVGuSka/\nnBX95rONpz+/xcneL2DuvzAjWj2Zfm5NNFgSNsxaNDtDJ1CmGjuZhOWpKaSAAhq5sQvFF7QmMpry\n/cm7tQUbKoPP647iwoIhh2GTIRNWTALKn/86BZ3QxRkaFL6S3eyyZBE17tJgUPITByVltBI+AYag\ngI5xlBBQkE5oJTJ8cg36f/3KJn1Uo7qvrW5Ppe8f5WirOmCVr9JJMlji00nP4cJRAz+yngPWePNw\njqAT9UavkFcOXipqTgetJKa0lWJfwQMajpZHWaEetgsE04x0ghs7ur2jwermOd7pQra3k+y/U7us\nWgic9IRPJNN8Pfz+CEBxKMFK02BGhsuhcthtBjrBuKMMEmyLgjKKXAU+oDA6YQuKLrTZT50feO5k\nkg3hN4UX7yLGNE0ynM9uNZXtHuyAjrGWPUbj+B6200kmcALRQnqIGvA2RJMjn31iWUmWfGFcwn71\n49vMGY+dxp0fnWO2R1SDKNMa0MeIiPU8hU4QSlQ6kQdK8sGVyelERkpLeyCfTqDyUoVVy7UpDz39\nikEOdpeN3B5gQw6gUDpRWf8SyR0JbbueO7kHnVTRBD0UJnHmv3W0utauW/5oOklyyWF0wphDtZIY\n4cBE+KbKaAFZ2pvZFBVKmIVl6fCr3FR8Fp3AD+LgCwInf/Pf/yZPHmpmR/LNwNt2zNi1ff4DEYFh\nnxVTscqrTc9AJ7g0aJhELkAaX6RnRJJ0Ig+d4PpimaPZjPjxdDLP0ZP8DpY6lAY0YftnrO14Uey9\nHxiu3rvuXqC3I+lEHkeih04w1pIHFNDR4WKlcEDpAZIv9DlOaCvRgIJ9xKAflG8DFGp22ZaR3UM4\n58E9Zj33jp0gjmwgAq8tNEIZpYdO8MeKaSXw4X7qN3PNu5oeK45Itwr0yAiNoNBrVf+NsUb6vBOM\nSqqhlDnDk0/6fz93AjkvqTkNq08SwPEu2aT2dHx9Dzo5RQ6LThytfqp33mIibagxMXramR1WytPJ\nKcFG1URi1ATfMMRht95Qu2mFT2hIhh06odu7J6nA8w9m+ncYnQCCWPDhfKvejyMDJ/CjPBJQPpZO\nzjKULJDJFog8xBrSCe4cGJ3I23xm2wB8o8n7TcWLTqT7gLsu8L8NERTprSY5dLLrJqHTmRzQNz12\ngrPlsK2EEkzHSAVqCJwcltyRY5RWkgWcZQEaXFFvcVRbwe0di52wGxam3tvtdkdxJi6iUkXmefaY\nCUI0oXSCv3X8abGThi14p42Dy2H5qCFDuvTYQlAjlzR2Au/p4qKYklynQwZYrcQCr0UnKp3gIyoa\n0OSUSAnVB+qD8XPumHNn3tWqWIqENsG6gfkUeonaVSig9raq6k55IYT3U6sUKr+7Ik62yqOv7D4d\nqj2l2MnB4RNpJWFTRU0kQxNq49TLrW0Z2FZ2z460p6z+gXPfU9Vzb0c2dkMcGztQQtHBeu8cOlHz\nNSx3Q6vdkIV2AC7/NEDp0Yq2azddghOybA8Af7LP2WqyAEVepR7nUgFlhiDl3nSiHuw43U8/vWMl\nrUMDJ/j8tCqjTBspKcUnrMLsc3nmjEIJcomEGIkj7MK25Z+jk3fmwBu05B03D83+KizLAEyAlrM3\nTI3yjHKY6mwWAe7EkVYSP8QYCZgw1YiYH77PA9JJdXs3p/VsoBN2vnX7k/3eTZJO1KSPH1bZLmGV\nywzRopPh5kZWKMOQeDsxLBD1nCzWg2VUztiulcfC1LSOcnTsgMHbTTzpX9xRPCp2cjM6oadZq2gy\nCZOxaESD47cSsg104sRUVGopUVR+Yb18yuvBvaC1iB0IGSwWQskDFZ2dL4FZp7qSJxLWXH48zSWt\nZI1qImFLB21Z8ZLQ3rGaMWoSW88JzqBIAqvSCR4lYff94udwaoTFMyTQqEdSrKMkNOmD8OGcXNm+\n+tjTJ81LqXShRG36SRJQ1DUowyp+Wudt3f3TV6bpvH/qDoeaHda18urT4hOT+GmVnJK+owFNJhl1\nP50g0Fg4ImMkVQpRy1vt9q+ep1ZjtAPQBDjjm5JegRAIjeALSm4fSC6xtIQdsU7q3N7hE8cSbU1j\nvISlwKUZ9cGCtYLxmJbt3QzW8/1ugpJ9BCCQoREVTXwtp5ewQyQSXCi1ON/SYhiD6V9sVg0yW6zu\nReBD/K+1Vdqvn8NrzhCAjGWqqVKMuPBM6Cv56KOJetNcpnvDZQIbHtWSLDrx/UUbmtyMTmTQZe/Y\niYMsnavjLXaCaKJWSrmEJm4wm5NRjiSOsGJ704kjRAB5ShJoyCRt+JyhlmeXZLd3GxmcGkHpiZ08\n0GT796ITiGdAjIT+OF/yzIeEDP8eH3g+Ck0hqfmj7Wls8EA2+Ha/h7OptkPNDVMu+d455I7LdZqJ\ncy9ngOIcEpdqCZ84d+zTk15s9Z1JJ+/oD0Ow0jrArHlatYITM/jp4wMnmCg4V8lHxU7a6IQqT4Zm\nLGUbm+J5oxMWMvF9tsz+7EcnB5+NfYPBVwg0YyJlMNnJ70CFWCA0oPPcYqDu7fL2Uc3OADHgcZD8\nWVQ1s6OeRMF2t4bwwCyiCT5GBd+wAM9OgOLbArQCKq+oFu10Izu8A8nwCbSrAooVjaBoopY5HlDe\nukHOnSw62SlwMjOdlLhThmDpHka1z/TDjIWxyueNf8k4PKv9sf3/x/+yqVZ6JDYDJVc5fSJlByOF\n8Im8AVgaLx9QWDJInviLD528P//geOv5dABib5dXUJU8KAr0o4l8dCzSDwAQhGrwaIt6ugXBBS7B\naEppgYWFF52EIgKV84/HYiUM+nFBOemSZ8bkfWW9XZjp4qAyaj/x9iWrkcLqs++IuW7spOqDZPkT\nw/ODFOeG1XzHTvKBwQfQvR93LSnHtZI7SCc0v0PjHCqgOAkaKA8QQ3HH4RJn53c8nah7u228Bfso\nHsAKOPKooXgHbzJwgrkePEQCsIKYAvWoKR76+R7hE4dO4Cv6Xxksye8oLm29IKkh14uq/3lAQeLx\ngisHnvF6dENwP2amnMVeWH0T00lzWqfkgNTCi04mtA+XoZOzkjuUTmQExUqBoyVVmWP7FumEPvLE\nOwpnbOzUE4L76ZmzAc3bRyVA9TqJUu15hk6e6PO6+wYuQRyhv2/s3MC8BVd2OoBi0QkFEVrGKV+V\n3uXKJwHFiV8yBf6OSRjr67HNOJhOtp68Awp00jl0ko//++7/9NhJM500P+mEkgoDlNJ2/XJL6RId\nprmqbGanJ3AC2mCFT5yvzqITCBTRDlMT6YR/AUFwc2Y994n+GoiFMvLzt9jMUdbze2P3/hgGMJ29\ndNL0izZJOsGoDJxHwcAJfVwbeywbIxVIFcGHkAYauLzpIqTVIogsOmGJG7asWFABl56zN8ATJ07U\n5Bki/dL2A4KUTk7HuVsHJJNcfb77Pzd+0IMml6YTa/nTmVXNQr8JUi1Mf7WjatiXTv72T2/PO/HR\nBDTMyfuctXjkslGxwwoyY5jEsZVWJkjNiPMN35F0om0x++nkYV7r/j6DJsAirCTSiRU4wUiJFU1p\n6O2oFbvqoasPFw5dfRib9BOsznGTN/o5hE4c9A8PnSw6UelE9T5ODkj6l4PDJ2qWVvZhYDJ30ckj\nWMJebbGTs8InKtTnAQVOmWQYRW6e5CdKLPpg6/kOKNif5O5toHNN0glFEIYjtAYAEbyl2cnyHPAE\nlIFSumVVFqAAo8Ba87Orz3CIQdvqKtsvfOIkTDNokqSTmdM6mcCJH3Tf4+jJDHSi5MHTN6+Ea/+j\n6WTTmFL4xI+dTEUnYP5k4sYxYcgo/gFYNFVyb+cc4rPahUbhFSqrVeBtY6eldbYCM9MJu8GY3tJs\n3XuMSRwLU4bnd5pn5zMvVFcfMAfuBKBM6T44XGJ89e32hCELTfAwbJjW+RA6ccLq/Wiinrk5l07C\nhC/MO0v6DLHDTtOsfhnIYWlo2R8okOnnvpkdS2nabtuBq07J74ThE2oEfQ4A0+lbzG+eMAIVSg0i\nvwNWL98xx8n5ezsYb0bbxvpRjHywZ+GrwEE/lLkeiS8WlOANyXscQMnL52C76XTMz5rnR9RQ0gEU\nOGyOW4gkoJhoAidV9zl98o3+2mLPoEly9U0bO4HnbIWPMzmeTlCwDcrZcImVspEIApWHZNDQB7Va\nrIeRh+yG1VVaLbNdTqJq0UlqBq3Fo0aYHSsGbj4DKGrkGcO8Kp3Qdi2eaIigPK2niIFDZ/BWglPo\nBHMxIZHk6YQ9hI1hCqUTOFSbUqDRheahE9VyjR6uXp+1+nCJlQDFQxOi/A0rKOB+8VN/9Blx/q06\nVPi+SmTc/ykbv4ff6kOTIUdirfuVjlxoJTrx0cSHDH95WkPOQJKKLwxiHIJhHbsknRy/ipz1kwcU\nSgwQHWkIO5tk8763c8LFJfP6ltMRezu0/snd20CntWEBnF2Fp+CX6EQ9Kou38+Cb8OjJOoBCJ9TZ\nAw2cd1aVs/row1HCtUZzps7aGRs+GZLTQdPfSSfHG9Vnz6PASXgvxQfSibrWuC/vO54i1cmq3yKS\nTPkwVPNWScaODLmj2DpiEh49OSW5k6cTK5MiLVEVUJSTetqZPqg2eLZbZprtXyPDjDjd2B0cO8kf\nibXAxakBHiML6BMySmf4xN+RSKnS5erELZjJUOuxmFJtIgTQU+hk65UKKADxLBxibQac41zmTf65\nFRRHTbTACfYnGTgJpyYTn5iTTkI0AX/RcO5kOxBJX86zXg4Ln4yNnXRr6KMCJxYidybJoEiyGNXq\np0XKDGnTYzm1Jf1AfVJTiSGgQJ4y09VRZfzYox9hBgPKzBykk/N5cQtNLOgJz7VkJGNRDuZ0JqGT\ntvwOUAs9s4L1IJ2EaNIfPnHoxDcNziLPfEVtbtIGOTDk74EyytZTRi5ASSew4iSgVNEEVlYpAKkO\nzUqYqugfCifcG4TZk4Mt6qjASTOd5B9mPyedyBW3x/YgaRmgWBI7ksXa6aTEIuodxT2PZYPwyZHL\nKVzbAaDYh1vxl9/9LI9DJyxh5NwqiciSsa3fOR3txAnN6TwNzctAhpZ0SIH+2ImMqcxGJ3J34nxi\n2RE/NiPnImOLVTu4h3FMqgpbfbCUAFD8CEobmjzWUd9DhkI0oSe6MkLw6SQ0X8cHpMGAhx0Ld6qw\nv+30R3C55VAyKyIzR2GZUuwErS6zCagJzevRqYF+lYEMtXzmQuZTnvWEEnwQTceP7CCU9NPJkSsq\nXEWqfVQDGCzwgAYUd3vyKkQTNWtDPwzTOklA8dEETCcLO4e7t4xq5csMoRMMnNCTKzKtgw9nw5Mu\nMqbSnN9J0oO0Nc4iZ6SSsRFM8qpF9g1fszXMT7pT0gqf4M07uNCAVzBEkV8ybwuzn07cR63kczqZ\nvUFovo60peBB8AbMzlt17kQnQxbCnSphhiuVLhlCJ+GTYX2tpfq993xk1vbWWyd8Qg/ho2vHB0bR\nux9xq4emECLS2+uPv/66vWCwFpGEphYDLX74pJTTydjH4XPURifhvcdqToc9OpYeRsGvTqeTh9Hv\niK+qE5SMx6jbuOEz7lcoUzkYO8H1RSMluKySNxsPPIASon81cAJT72zxkxbsmGg07UyyYyHB7Bo7\nQfEerNKruavSCcD+MU9ASS4hNdWNWzR60g2zOdKAAl5QRkEuATqhL2CIUuwkQyeh9VQ3difGThru\n2fEfwuYfhlW/bf75YhnnsGK2MryhfpIMnGZCHReiE0B2dgxWcgkUyGQ/U9TSFEGx0joNh2FRAa5C\nJ/1oInM9Q9DEyewsOjmLk86hE1XDqo9oY4q+kwSTaAK0JPM71FzKhAilE2ZYkTwklOAnwCX/+R/+\nYfsE31thj+/TfBBStg2rbz1lTues2Ak9DJsBFKfMFlNhwZjkeVj68Pue8AlufBEIQshQ8cL6UCZl\nLDpx0jdqhog6yJ3WYL5augBxcbE1mMIO+yfB+eVw5r3yT12hcvdSqXJM7GTv/A6zpfBn8mQJeodF\nJyXFCAs7IbfwWrn2M3ueUrVvNidzZX9mRx46adDRCelEbuCoZZR+3TegNGoC8PHT3/0dsAgDFPgW\nX8HtxC6dtKFJGFvO6FWpDKRg1JOtCBbwKBQGJRI7IN1DawtvJ7YOoDQDSmnsq7AjAVgFeFSLHYwd\njCawlCqAYm0eJqGT/QDF2uY1WH66jx0VOPFjJzcOn+xNJz28clrsBJUSbwkrxU6kTu+RNM0HTuiq\nViMomM1hhlUCCj24ikERjHxgsAS+opHqTMiaGkd1z+dbTytwcjydPFp8AUp4msR/VhuyCHJMPnAC\nz7OnT0ZZgDIDPMHSoLFJef8Orp0ByJJO8Tzpf3vMifi9KjwvXw3GhKuvZMd2AhS1Dz6aqN+yD+9N\nJz2u/chlaEV8QTObe3ImnbBb1TvpZPii6lnSElAsi2MZUAicQD3UetIIynA6eTOdmvV0biU4+NwJ\npZPqg2LD8iU6GXj/TvMyXhdKCchT5+zu4pF0kougWOhPT6dV79aBgQ85d4IWePhOry1wYtEJ3dne\ng07k9HHH3PFrf8AHfhN0+VjlaSV55siXlEt4XzpRf6B40yf8HO8HK6GJVXjgoqqiiWQjeoOAsxlS\n6YSiSUgnGFYJYydPw/fKqbNedZrOE+kkc+gkJBJaIPmUWHYvD2SR+p/PdifUyMeNe6yYJTG2uNgB\nFLayeiMoUfikc335WjGWTgbu9DZD6tjSztgJoInlZarg4ruPvCb3rF+2CpzDYdhKuHBYz2V52Sj9\nJPPeGXLYPf/aN0DJSLb/3AnVp4aDUQ7KwGLIjMITSvSrVGoH1HbDIK1qQGnuXBpNTO7QyAq+d4wg\n/+rdnmaspzOcg+kE0joZLknmfSiRsLtyMs+zZxGUld+he/rMeuyxYhk62fdsrEH82DEroSOfNRBa\nDHWww+kEAKXHlsLl/javh04QTY6hE4wcZJS5uUyGTjJlZCzEoRm/Qvy22i5agB5p7EUnjtLAg/CR\nbYcETmhYsnldhcvJB6OGaaB0gkf5ZEKHJXcAX3rp5PVAbqjqkQgX6XB2R/RUdEJ/TDgMjUhGoQdm\n1WOwWKD0sztQ1XbtPIAyyvGPqsfyrw3Lx78EFxeiSW+AJHEvjwxJvnG/tsp67iWmFGhutZu2W/i8\nhiqjUCs6nE4w3I7u4wZ0Qn2wAxZsrpMbwpAq8nTyxgq5AyU9RoM1l4o6ZGInvsbIb6XXr57lpnTS\nsK56uKTnsStgQNntxP5NNxiRLtGJGhp5cgm1ua3n9ZJLZZQHwiOxwCjwk8Uho6gFEE3gWxoFob9X\nLL9Vj6dADVU6Uc2T9SFNADNbxmaBL28jey0NYqkefzcvzZMzLnW/ZdnuUJfY4joATejp9W/od5mm\nH00sfXib1g5AycdRmBXN5Mcb8IWlbEI6CQtAhSGEgR6GWlctQOsMSQLmutREWGeeTkrt9hcu0AlG\n6kI6YaERmf/rpJNQ6WkB2m0mL/pVZ/wm1GxrqqgBzVhPIBI8YmKRipoP0j/U4iX0SbX0AI2jcGfR\nCQIHPLBE3kKsEgmgDL33GIsxWNk+RxJyTsvS+EoVUFRzY5kMZiKxmGOzQnPG7KNlLsN6MkERZ1xW\nKNgx35nYyeDTr4nwCTxPSHkNfXq9CqaWQEKbmTGAli21kjiZRqt0kvEmbWUyNnwPQFl0YiotwxPd\nvvx4pA9xyh06wd8urp5IKkVKQqW3CtDVFVaSWa79p9z3oBPzqdvCOL4ldNwfc4f7Myekky1lI7M2\nNOkDB0rwvl+HQthTT/DPzE8WSzrZ2s0kdyyXH3px5ssduxlSRdI+hvX004lsItz5OTpZXVyZ7UGh\nDFtQxjbgErETaQzDrR01sNK84yfgTfLGtsGzJA/PnkUnNPQlV7G668t4bVwX4QpKxk78fjqE0RxE\nCWInNFKXp5M2BcorqAMWVOnH3hDkdy+j2eokydS4vLOA3lwgYye0vGU6rROvSkZc+znlrYnwRseD\nYyePpfIVLIGXevQVGMVP98gL6cPZgGyQPNhNOhhKgbwSe54bXBUCyig6QVgJHTw1W3LWHFO1N52o\n9XMLVQlrVxdXgTzyEZR0WidcYp17g7H7sdBcY3PgDpwbLat0AjdS0Fcyd+ME9bevMjZ8j9hJs/O+\n/YUmnVAuQcXC/BzGSNibDJeoaZ2SgpboZOw9Qfm7dfKqI4+eOLc+4lkTH2KYnfXoRAuZsFsJwsAJ\nxer8wDtLssfFJu/NobCCl8gHxeInVlpHDajQwMxWIPPjO2PpRE2OWF5f3V2dSCegRUwr2pAIK6Gn\nztUHso0nEoYj9vrqf8yJBE2PYPqOnoQ4QguwwMlAOpGnYpOhEXqPj3Rbi046rfEel+t04rv/7dsk\nq6qw4tBJklEydAInuUorqrlwBrrD+LP8qXf1RgOMnah0Yj3CwaKT56/tGNs7flbXVcCDYyeYu4ET\nJP6RWDX748RUKKyoFAIhGSwmj6psLULgpBlQqpkdOjlhLJdxwDyZHQkou9LJ7mjy+tUIq6EhaZ3k\n3uAwe8hsr5PWwZJQJmn/Zexku7DHJcHlSTO+wid7gIhap0In4TGlHjpRdYjGZjKIEPYwU8nAMkm1\ntibV396xe4ktKHHumWQPYXszlPDIk4hOMjHnw+gE8zXsqIeT5fHDKkg2EmKsEyeQygnvEgI6SeZ3\n1CRLPvNCV7LUtHz2OkxCV62zGg7xxyX74I8uj/7nnJBNrK/MEuvM7Dwg5qgNG7WuIZ1g6sehE/qV\ntentAZS8Da/q/2G+/H4NiaxupL6Y3MkkcfJlaLzOOS+yVRgusDyADwGUvFqHNjR8eGUYOJHG10OT\nL6Np0QnFoIzpPIZO6DkSig4sfNKQ5cHDKzJwwm4zBtrAMyiZe4LC0yf3syxq2uiUYWLm9KBISfJI\nyq9/Pypwkoyd9NBJs1HNXIgHY3voJO9rZMl84ARFfYomf1qjhE5+BM/1oxEO0KeBr4F0MoQ5kpUA\nLfUrDT3rGj7sJB8++f7RPttihnSSQZO8feyRFTviShGBIoWFCxDtwBe7FRkfZ0JBR72FmJ5EsdJD\n9ERLw+NPeqQ027WdqZn+4SQX18HsQtEkucT6Yyc9gJI0iSxqkqQTdUeK12JwxTp00umJSnSyAKV/\nSSZreNFJFDJhOncMnaghwTB2UspfNiw5dvgrKWi/WN6AlsInSCdOVEalk2rg5AA6ARZhx05lbkXC\nhwUQEAL5Sr7we5L9HyvO0AlFn62hzOmTIYo0TyXHxNIy42VL5mAKyaRNr04nFoJk0ASOnqjnTg6j\nk+oOcyV3Muuuv8zThpSc9B7JHTV2oip3hk5Kw2kuXNXpJKD4x10lneBxWnlrMVg9P9fu08l39CXS\ntb29EQucYHqFPb+EnVS1np+Gh2oZuzDcoZfTX/iDVvyAzVa+dDY2EvD6/iGBtkhMhumPpBYWODmS\nToaHT1hgwz9xohrbRSdrbasSaKETCE6MDZ9IOlFDIP1oksT5EFnGosk2N/JsrPzBd/qcbOceH4yU\ntNFJQ+Bk79iJfGwJ0ol/OhUoRL6sgIpDJ87TTfxHqkCspfps+2WwLIPVIJnM4gpPfY3CF7a++tGk\nYfX1G9LMrQx5Y4v9UeMlu2Z2qmmdldlpWIBtl7TTyVhAScZO+hdVfsE4gDLquAmbs/zNO3CaFV7O\nUxwoneRvNp6NTiSa0LxJeOOMjw752IlKJ1bfMFsEERcAlE8+G9tmnuRVbbETlf5ZkHIUfIT1zEAn\nAyMoyaOs/n5Phk/wKAlsUxm1dB40oZcP32eOUvVVzyx0gnlH9obp9Ax0shOa+AbUPyorn+cG5Ut0\nAvjShiYNu7f82juSTtjNPpjBoSkePI0Lj5FV6QfrmTa5A24+vNMYpkllgmZQsBoN+9Oc2ZGLK48m\nUBL2ACF5hAX2QJO21YdA4HPDkO1cGIqG0yc0Xk5PojTQSfLu4obASd5wrZKdEngaiqoK5o+eJLUE\n9Y8yMtNpwALU44zGq2Wqg5UngjuFbl1OAyGhmaOPc1UjKPegEwdNAA7ysZOG24ytYyv0SbJObIb+\n1iBkl3bSHFptsiF2sg9RQ33eifptM51gb2kNmf70nEZsWFzsWa43oxMIn4TGkBUIy/eYZbr5PIZO\nVuDkAIvU3MQ3nTiHm6TCYWTMOX0S/lKxjM5JdmY3yMCfpQgKQ3L1OEtyRe0XNcH5wwfVZ+iEPctV\npniqsRO2oXwcmE3/2+NUrAofABkIJQ6+ZB6Y5hxAUX9VB599Ahf68ARlMLlzzNET6FJIQiqFyOAE\n4xLkg340YW1V+5NWzO+CpcUl44gmnbjPqqcLeafASVvs5BkVez0bwrKBVTopGWe58WOfyFB6Kafj\n741X4KRhER15CaeTJBqHdNKAJlTtJENg4KSZTuTBKxmbOf6sCZvs5JOj5H09ACIsxSNvVZDQgyab\n1Vk9rLcTnfinRjZSkXyQj6bQZ5zIhmTgBNEkfLwK1kZvTk5GNfrXfwZQqjRAM0E9GRbqSlns5C0C\n9PrBHaufDVJKLi7GJZjWUejE+Nlhuco606bhYHtWH+4wM5FmC1bQujI6SToUPFwiwyf03An1Ecmo\nvFNsBU5CvTq3gEInGX1ip4pKPJvRMJVOMHCS6SELulC4sS6Xn7NhHjNVmbsfJUkATOB/6ZNO5J3G\n8un40iKXAic9uzdLqk7WBn8QGOIomQCGSjny93Hk/cmUUVQ6wdblc1NoLgkfr3KMFiGgWEGUBjpB\nQOmhE4tIqv1pECPge/gwQ3Vx8XMnwCWVqEnPoa5wsD10gimejF3dm05UQ636lySdwLWy8AqchEp1\neoGT6STEGoQMXBWZXKk8S9tAJ9i3g/VYhkAse8puKkbLi7fzyAvVhNGQjV2nfZQrwWcOBAsIn+AJ\nj+QdOsgc1plW58QJYxrWT+gJcskpsZOHv3kd17XuFWqgAedsSj7R00MnPedONpnAo33kEfL8+vpe\nPmk0wcXFTrFU6d93Ff2rj+bonaCyQyfwlRr8yKfOwerScI7lI0p0IitZgZPT4SPsgE4nIUSzyW57\n9klSvUCzoUuouEl1p+EWNbNDR8reI3QfrMfUhjL+UG8exjKZfaFFJz0nTp4J7JeBDHUuU4AGJDJh\nD+qM1bQLow1WJ14CVBGiiXUqFk+60DeYPzr4pmIfUJyMCbq6PMHk6YRldhziQT2hrrfUkEyb4hOD\n1JUVrq/n8kmjiZU2HYsmQyKXsAejhp1aXblLxJLsLCA1s6EfkRiE1dJ7jK3YSdKDyMsP3nBmLN4q\no2xQYeXL+fPdfz+dVBWLoklJ6fFULF02DqnQoZ2ixEAnuMnLAAqwRWZTmKGT6omTXenEeR4JjX+w\nNJCPFwwXKM2w38fJ37MTHnaBqsLDqmONVBhBGdVcDzSM6kNYT2ZlqYACR0+el6fRBFfxrjmdsauP\nRVBwT6jSCQ1jy3MnYEhL28iqW6k6Ebrh3DoWKozqL52rOmN7DMcbunezS7zYiX/6uqpJzOtb8Trn\ncyf26KwBSScs9ogrkDV9CpqAekkzmkmWN9CJdbq2Qcv7Y8u00cxREvpoeXr6xCIMdqYEzqjS46sU\nU9QbdrbyLCWU6edZsZOn34pSPA1zzS65BJpYK0vSv7rWnnRSPG4Ce4z+wGQ4RwNX32Yeqdenh1LZ\nAVUa3hhCJ1g/i6A0OAvnkh7D7qv6opNQUUsFTDqB2XUARdIJ1ek2qk2iSQnJkWnUIIrVYo8GlyZA\nLYx0olo3i1SATraXgzIsdmKdrm0Ywkj7aDziDM9zsJ8DxAOnMoChBj8ol+CvBsLP4sANwCqa4CNf\n6bmT/M07GDs5K3wCGauDW29QpF0vYSsL0SSk/8cNO//0OFSrn4S1qYXRSVtgMpTJwNW3tcUAhUZB\n8D0YYWfvF3oQ6xahnn1vyDFg2P1kPc1sMsFeCMRDnZm/wDA6AZSBG4mHowlUTjUvHzBU6QTjJeqJ\nmXPRhMZOMDgcWk8MPufpZCCaPCzauHMnTkBCfaIa3leM9/JgRITeRwPFthe7uUbWaSV0ZOwkeQiX\nhnmO5wMqz87Wr26dKZ00nJDldIJQ4t68g4CyE5qMXX3PkNt7BAWhhAWww72fH4CXZlzihWqiQwqR\ngXD0TSGd0AyLGiaUts46qkWnJrN2RtUzP3lkehjTiRWokPoBTv0ANOmPnVh0kiHrjFg7y0gbmqET\nKOOHT6xnQ+GDZZt7PopOLDSBKIVKJ9tXFFB6HsLmH1hx6ETeTiwP3h58U/G3kX2PRfUASsbCNqvQ\nAReylVUFlLfL01keejPdTmMctfpo9wAsmD136ISGWGiOpgQoKnYMBBTojB878emELgG5HNgnzetl\nVD076dsx1QZ0gkGLDORiKG94+KQ5cAKKiB1jMRhaLfQ5qbV7z40MIGPWJjwkm6STzmevSQmMso8q\nnQA00Ltz8RP2tHi84yYZ1aDFwlt1gE7gv6z+8DH5eGEPHDQrHpWqn99hYW1179jcjdMvVFMz+cX1\nTSf1s7H7BU72iJ1gBMUHFGZdZQ7IPx6QTO7I2Hlb7KSEJiBVX/8zBdoARdJJWz2nr7ieDoynE5ri\nqepQHpyrmR11FTE6mQRNZGYH8zuWGZWoYcVaoCr2bX/gZJR9VNEEfkgPT3swhqBnTsHv0lMjeUZR\n0YTdXezQiWwID7JgJXh5z4ptu5YJNnymftIUQjEwIvSN30kKsmwnqsbMVe2iLaqmXB3Ck05EIiYJ\nKG+37aQfxQYRmuF3Eb/FOV6Ca1OPYL7eI+Jsr2gBChrzUuxEHoyle8s2h4I7T7z5OSmlDHxk8B0X\nSLJdFYzy6yvfyuQlU3QCibqSZsAl+SyPU1JtWt7hZvEK9AQqoVVNiyYWnbDbjJ1cjxM+kWjyfbdk\nn6oOiZ04aR0aO3GegAIEUAKUMGRCT43gj+bkuYfSSYgFfZPgXc1k64dw8nQiASVEEyxArbYkjOf2\n/YU++Kf/OfPZrDMys4O5zgz6t91UDHSy38yO2hs4PWTGXDWklo/I0AlN1uf3qBmXxNAkn9ZREcHS\nUqrSlhiTa4rpuaytVM+uWrd35Sk6ecrr5ebzpJIHFItO5DOCZHbTj6NYRIKfz5PQoZPtm9HMMRT/\neCw9pDLEdPbTCYQ91IwJy+xIMsCnqIH7Z4AS8oeMx/gHY9Xkjs8rGNc5JbPzMLXvp098TkpaQCwm\n3yRttHVh8+fNdEKfMOTcFuc9wN5O9wxZYh497Bk7QftPrXQeUMDAhg/QohtOB1DyO96tEjxHSFvP\nx8hHxU5C4CghSHJt7o0OB9RfoJO3ZZ+OpmSCKA6aDKQTdTnNiSabqB06yR/l88+g4G/xDNGzIXRi\nOXia2aFl2O8VI8QA6Fg3BldhhZaHmimdgNeXJ1HmORX7vbETx2MtVEpawDnpBFVRHUW4stg9wJRU\nlMRQ+radIavMYT4aiNqpLbrbtPI76s0yx9OJDJkgoBxJJ74q+rjJOLvfwO6kFftV20gnMpriB1RA\nrR0KUWHZQhMZBvSfxoZHYaAVvLdoWjR50om9FcMnw1oP5A6DK2PRBKKgPfYR3KR6RhU5wwlO0LOx\nEDjZKmRnUHqghB5AQUCB/jh0Yj2XZb/17Ncskzv3oxNKJCaduCvLeezy85EnX4e33p5qH51BuUHs\nREZQQkChN/EeGTtRQyYNdHLWOl3tYrTp4VOcBF6BNEnqB097wJuH9/p6g/rK3lTpBAGFJXrkGmDt\n4p/YsTlVwc9w46Pr1WS5jybIJWMtZj+dsLQOhYn8IQ+GIBDkyLzYAVjWuqwWe4sun4VP2I3NkNk5\nK63zXO0id2Z16ZjYCcVZ1mJzZqdAJxpS4NqBc6yM/jmdpO/cGbvW1ERAz96gZAOpGXcAhVr4Uuyk\n52CsEzKpHoktyWQV3kMCXbGThg6pgGKhiRM7KdEJojS0PjmXgFT9+DM7NZJ55CX9scA9bGU/neQR\nxCkpQYRGUBwEsQiGXkJTRQglFp1sF7LYySXohMaiQ0ZpyOywMBuDCalFVWqh9asOO7Oy8LlBklHa\nbireY8Wpkf8Gm9xwCd3ysffW/tMHFBoOD+nEagJtu7NlzW+2G8SyLhkrgaPphAVRnJgNUrBVhp2i\n8u/ZwdoupJ2OGUU6wTtu/Fsid4qXDLSP1t06eWRxAiSABZkISv6oCp7hTfZ8ztgJZKZOjOiEADTW\n3iW5H+mELhw4Zt52287N6ASzPLjbpDFplR4G0glk5+ULOhPeJNGgUUktpWQvbWO+3f4wmNWTfB9m\nKHkCnUjNVs+j0JylCih5OrlKvIQpRJ5OqA2F3R7b88GfuypcT+wEPb3KIv6Dzqo8AadShpyZBeJx\n6IT2fAY6eewNxG8YfRqd+ICCmR1gERZxfK4jJ6FjHECZefX1mAV6ho+9Z/Qwlk4YoAAbZR6C1bY7\nzdCJU6ZKG9Xyzgxmet6jALteexqdIKNQJaYUkqcTiAT6sZNdhbhT5c8bBOgRvNd7GjuhUWjJNwdw\nyXMqX3jSIA3Hwav3wshTIDQ0wp7PRm/kSUZQMlEWoA0oSftv3byDKNMgn4GXMFHj8eGBTYRVnb6x\nC7kf1pR6171y2w6sSvcMyl3pZJtr3Ps5CRco49BDc2YnzyU9504yPj5TJlwawzlj7171jCi89ptO\nnGxfWEtPAf+0rJPfobp+y0Tjtx0UGzJJJ5DZ6ZmIzms7YyfOvcTOrbmw71cL0BgJDQ/QYyhJCvFz\nRn74BE+fzEknH5jZecZOjCAHi51g5hQXl7JniH5wZ280eYTEOvYGnQsfLw8tuQUo0nrLYDkcv2Un\nbfFMbiZqUnoOGxOpfzqKHdWikQ8n16POmlpe1k+nzGd91nM51zPjy3NozpNw2kJhVY33NZudDA/v\n02l79k61zweUtzZ5Kp0c0B8f7dsCkk5aB7CAwgdwBotVQLE///V3eGHiBguzbkOLW8k8ndCzsezu\nYqzEPyKzNbq1eG4a5WEQtczOmU+wFT9lcoQa/9NXolOLdlh0QnvFV2V0586H0MkzhvqVZMkfPUEQ\nkbtNyijsRiHpERigqNH0/P0QEke+IYxobOj71auQS6xvoQC3WsZK8fvA6vH/PGLpVdrgdCIjKMfQ\nia/ZKp042RxGJ0cOoSL8uOyH0In062p+RIUSiiaIIyEENAAKQxn6eHtGUVY2CugE/hvP/T4l1MzO\nx9GJfU9cmU6iJ50c8Bj7SWInbxv6L0ZhmJI8GqL6IHZbA9RM8UWGT5iDwNYzjGJ5cce7+0GIKiUk\n6SSkjWq7+1idxloVOmHKcbxrV+MoyfCJRBZQyuNH0Tgh75dZR09uFjsBOsGn0cuQifqUNhYyqbp8\nIJhSBAU7Jg++UCLx6QTCPNXeDlGnF5P9jPLEnw0K+wNmTs0gOOFrv7y6R3xzctp+EQ2uFQYPa9gK\n+NzPzp2w4EfppuLnbT5D5s+uRJXzzm2mqgdjDjDRQycMKXroJHMAxaETqnU9sRNfS/N0YvXnueG3\nYzA+TqVmd+dCOp3A/AGZnuXXUa1Rs+WtPXlevjygvG/R2PPWDggdh3rYYx/Zhl49TcIeVcLyOKFz\ntfoPx0H6Xyyuo0aDAEqwreY+h3PhDBYfwYL3E8G5mbAzML9Yc/N7dmFoIqu72HA3iUNQAUXGTuTi\nKt1UfMza7Fl9zepUuhDsefKACDt3In0QRmVYyWT9oTtIal2Gg1VKCLU0Tyf+LDj1hEuvNL97FPbo\nBADlLDpR44TytJSfbmTrYYaxVGfx7Wzsi1HuRyf+bcMMTfBOE+tkSUnIbYDCugSV+I+JY3QCWFDq\namdheeikGjuRdJK04zTgkbfpMrgS1hPa/Tc6EUdG5HOWVbww79x5v8PumMAJSInhY6eq7HH5QDp5\nDFkkd5K5/mrshArW8ei+s/fVMsMiav0hYVhXhRfuoQDVOgM6CRmz2l5neZnfkXTi313c2YHjL/d3\nePSR9sf3jbmZNvsoT0Lg/l6GNIbgiBRUG6D4+R15J5Gkk2TcYsjMQlqH9gof+pKMnahUgX6ROUjn\n8xKdUEChJrVKRVKGGe638MK52//7J3h+/ftL3M8/RLvCSjDDzk6/qtEO9mgJdVe5K50w4GOKR3Vb\n8roqin46sRiULTTW+s3pZJLwCQhdTTcOROZwjR1fQNKJ3N6BQTwmhmxJoHn3Jjf06gNLMh60Z3by\ngIJRE/kgOBpB2aJB+IJLVDoBxNl7dI+1I+7WQTlnWk/SQGis87ENWdVYOtnqzywua1mFJ1fwwbIH\nLMzm1dezZPLX0hOpVTqxAt6wU82k+/Ggwm3u5cxLPoNKnbXtd3kcO5mKTgBQwvyOk328anKHRIwt\nOjkXUJrto+U1Zepkv2XwZN/Wc7L0KAnmdzY0wR8CxAO8DgPt+mA0X8hn0Uk+2CZLZmgprD9DJ7Cs\nzNMn4mGJ9HcEMY6yN6A0r7691xRYbIYF9FyjenaQ3Uts7ohety77DxOnz8tYgBIuigNUItnEJekk\nz8t4theV8op0QmPF9G4CtIOHGUFHq5rto3Sc9MDm8WdIt/7AkdvSUVmaJaF3xFDGcmInNB6TYYXk\n8v4OP7wCJ/J8TzJy48Q8rNhy+DkEqzNjUU2qGmCHOrG8X39IJyxNw7tqowmszeDyzMhzZZpXX676\nrlLNx00gNOJbbOt4rPpMLHmPcdfArnbxzEpixXgeffaPOs/m0TO3kznxw9mGk1Fy9kvu+JjteQCl\nTfUlmqh37R58Cy7wAd4WVCIVmtxhfMPohAWHsDA8XnYUo0A97BDMbD+eHC6BJMSE9bACz6AI+YGI\n6sqSgUz2yTGA0rb6quJqK78rnUBsRv2lNrk1ZZ8MdAQhKLcpcOYqLJMp3DaD1atG9SSOncxz5873\nRvDHA6jVaJ765MH9lLI6bc3lNzMKgEJt32b47kcn8sEnZz0gBPw6e6qKhSzs4Wzq0RmgHJbccX7F\nkN6a1KA5kkuQ/Ni544NvHaqOZddYNF1TcomF8Y9tYfqAsuikmU7CwAlVJItRWBCF/jmQTr59U+KJ\nrnn9z7j5RSdT3FcsdVFFZgjfqUqJkb099DKvc20lJaCA4ZsEUNp2b/6RWOq5z/KgeJdQPtGDg1Iv\noXRioQn7vBRKwQ6zO3TU8EkyrdOmsf1XtSlVtV0V/eWyss6e4+UIOnRhUjrZ72TYMYKqChYCG/TY\nh3UHg9xq4sNh841ubTmMIk+f7OEFLJ7IcIYcaeYqSSc0kJNUDCv2kxf+m3fOpWvDypXYCcwxvma7\nqZhFUNQfdLCecHxpOtkGngSUvY/gqVqVXAZvSizuccXNvTyuEary3gVoKMUnFYpc6k3R7ENgETy5\nAudqWRma7kH+UN/gUVz58BXglTnTOjvFxjNawZYV8oQKKNbjT2jchdVwQPikYfVlJNNfJqQTNQTe\ngCbULzi7Vti4Jo8hqjrpizpPJ6HCP9iuz83nL6cl2VWWEKo40gBAnE4AStjB5m06+9V0pxp8XpZn\no+4NKCcej22wj5tzpZ6SHdhE93zwoRNfUTOMQo+eSM5wbtuxTqJQaHMe+KZ+5VyLNzPvtDbbqs3b\n97b61asAUCSO5AOTPuLsDSgNq2+g9JyqGJ2w44A+mjTHNpyTKOyEpdNE6NrVAnntVYGAfRj2ITBW\nabjx6eSb/LSnRWc6mSmjho4eim2dim3Wj2NUX8ZRrMMo6gCvMjomTD+CctazTxrso3+b65x0AnOB\njKIemGV0oj5VNpMnYvkdFT7CZ+xaNOOgSZspUY1Lgx3I2/eGyp1LRgGKhTi77hwaVt9Y6Vm1AZ3I\n44C4b7R+zbize0lAsVxAZgn00ImMTzwNyztPZLrhoWE3nVj9xN4mewj6WZ3Tt9iJGjip1nhi+eTB\nqGRY78SBhE2rgMJuYjw4v9NgH5N0ctaJk3AW5K099NyrfFYseyxKBlBkGT92kjlrgrQkbwvCSVRn\nk34bbtpYVbS8X89ZdLL1EG7h6cELH3H2A5SG1Req95AClE7YAZQhZ038sE347IkGOhmivdZC82mg\nOiNyKTnthkteEkaVOdrKP3/Fl541geMm8KoK5cTyyYNR9wMUeRDvunRCYwZTpXVUxZa5Hhk7qYZP\nnBSP/Mo5aOLkepw7ljObwsxOKMMZqgHV5Vzfe7UZohBQ/JWlAsreO4cb0AncoTPW3Wy1hY/uVFts\nU91HVDV3z05nsaRiZxYpi9mU8KhKG2p8yI/9fDWxqcXXv+f1X1oCcDJWXZJi7SwGXc88QPCKo0Ph\nWHbwlOROg31UYycsnTFt4ISpKGWUkE7kfcVqHEW9o4fdq8xOuYanUjCh4wh2VzoJzV/ScHeaCP/y\nvQFl+M6hYfXtKkD0I/Ip8nuHTPjCFI4gefQkXAVhARYvdP7Er2idbb4/04qcetau2h8uWKSF4rah\nxEyo2N908mDAF6Bc139nUo/XHR3oigQUuksbbgQTnFuItFmZHfTK8wdOVEZR6aQaPrHyPhJHaDbH\nek+TSk7UxNnchFThmzxq794sjjBtM9AJrCw1xZNEf3/nMPzW4qvQiXUMdj87rHqB5PPsqaJaCmz5\n7PBzaxXQqcw7ctUy5y93Vrfaz6o1UCUZ8jFr+s21DI+zhb0ZXiBUzWnvl86LQibL8RFSV6STmQ/D\nJidlVzpheRwrrUM/p2gCj07xB5LZFGYMX6aeJNM89kvFLVpyspxiElBK6K8uzJ3W5uR04pw4KT1y\nrW1OpRdI0klbc+uqURLw6AQiKKNaOqueEFBuMEa51dvJCB4QO6Exg9CPnqVUgXf/esKsTLIw8Go7\nFctqDg+d0FROBk0sDqjulpL1zEwnsKyQUdjRriT6M8TZaWFelE4OQBNQMJnoX4Ayp/GkvQroZP4B\nZHpoAQo8++QedMIAZScjuDed3ABNHqYwopPkuRMnuROeL4FEEj6ubcuRJdHkac1fhsEyFpl1B4AC\n/xyjw6qaJLNDe0UBpRQ+gUoooNBH4yf5JiPqCelks6vshIdM6xxmexedZLRotjIfQScqO1/9sWyq\nJql2cKARXHSSXMDqkRrGXs2xk/BCCiXIJRcNRCUFvncxFVDyK0s9xZK/PBzdFenkMDQJwyfVnvjA\nHU5WWEDWH15yywI6nRyf4j1AuBY+V1XzgK72NLG3HbT6VrWP7EGx7FaUq7tS68AvPqUeDvyCEELa\nSBZgUJK5PadH0z7t2k7033VhVlffAXPHYicscHK81R1o/x16GOI6F508gZLhCQ3GDhH0Acsg2cRA\n7Uy2eEox9WaBgbu0/egEvGk1B3GKkMNGk3TyWG4jGAVYB34/md2eE3Z1FchLYFpAmY1OfDQ57LgJ\nndmS/W84ZYUONa9Oq6QvAR47kbByGwmWtPPSo6aAst/jKZmIqvZR+m/qVi8tf2AO62AsnAhhN0tj\n2AOiKQ0vWkN4z/CJ4qUW5sRutDXdTyfy13yG7Byqq69t+PmrZgucPJak8eATNYpj0UmovXJLbx29\nooEAFKxTv/qVQ1FhVy0DPk9UQsnsVEeVV9kTS8Ld0Vt0kf4XDm0dH2PcWw5AJ+z33Ic/YmEgndDs\nRunw5t6S7KnfOnqi0snbJu8rmlJ99XT1lGvnMYKl4fcDSv6XBfMdm5lOTjwM++31340//aXiEp1Q\njFBnx9Fq+hXN3aiX+MEb/NahqLzyQEnWverle5Q36eT3v/yZSnCPto+sk9IJEMkNHmbvCFANn+wK\nKFX7yJw3BE5ugyaP1f6PPzm/wHe5B80NX63XpZPO+MceB1Cqq2/4bPK9CjGwjE6OT+vIrWmGTvw0\ngqW9eTrxp6CfTkrry29ub22x6g9iJ/cAFBY1+TQ62ekmxp7YiZXWufphWBYCUZM7YezkLFtAt1BW\nODr/Odg7x2tK63mVqK2FF/BwFHj5O4fh4ZNp6eT0wAmiCQ2cI51YgfPQW+fpRNXqEB066QTXctgQ\nLTnbArRjJ788YyfJ4Z1rUgMO/fH9szsQNQFNvUFmhxpEZhb32KI5ci7ZRzVwAs/nmFmRqn1zzsZO\nO1K2IaHLX31vmVGnHhlJnja2rM64DExun/zx11+h8PZmezmYouaGNl7pOYBSWn1VNW4rjwb2xLt1\nAE1wd8osv5PWH0Un4fJxwgZvWx3xxCB1EanOOuPBM2Xa1KDnKpNOHt19AUpPA6dfSxUUoeQedALm\nDKwhvtDGXY5OpnXYzTrMzsZiKGVmDnNoQzWX1fJYSXJ32Cz8/S5kt8UBmlgvlTnk2vwoOjnmqN/W\nykYmeBhW7ktvRidsP2AtNHVdXIlONi7B15z9zpueUEePWSr5DidLqmhC923yVOwk504+Ia3z3NnY\nd+5Mi2J+LETGfgfSCdsqJRfCfsVYYJI2hHjhowkEUWQPP41OMJmOYYz9Zu3bK09AJ1tnVK0Ovaos\nIJcehk+QS/Aqq7Aj9tlWnxTdM1X8hiZfEZQDlGmnJm5JJxmbKHPbc9IJPtZ9Wofdo5nWnTvTDjZJ\nG2EIpBobn83IyCVGOQPwgpb56e/+bnv953/4BxlEYRcC9NDTYNvCvHfsBOiEnvzYe0/IQuZq1PyW\nN2z2GKvZrtUzOzejE1gYNOl46cwO2sTNFMJLNYhz0on01vAYsZmTHT2L9op0oibLLXrwYy1OeDnE\nlx6x91wL9KBmaoAzILODZViIRa5Hmmx97hB+/Xt8EBH+uODNzp089r6vQ36MTsD87gooULnM5lza\n8vdo9RWv5XTyjBG9Mjv452w7m7ys5Zntq5+KBbNIbaK6acPoMezMcKvXYwQzgUF/auR52HvTCVAX\nu7V4ZhSDlY52gc6mFftVw8hOPRiRZqoyQ2w5E5VEfIE3lDPgEwYoyDRQmF1yezrBmw/wV1eRTvYG\nFDyQS4/o3uN+iLwHvG5JETuBPM47nWBa64rjlIEToBO47f5ywT1EEzoX24cIKJRa6C8VU5O6xzyq\n/oy7H8NP3+9hJ29O/YJ00q8hV9zPhGjC7sdh2RkgD0knbC/BoiYfSCe4P9wCKDsBimr299uXNmg7\nPSPSv9wk6A+v8/gK9dgJ2wzdhk7wd4kpnVwLUJ7bNaEpCCX00fXUekLsxLq8X/MWnVgyhNgJvX9n\n/tjJEH3or+TgGtRkjUyewiKCeCSyBaIJpH7U17aFgAsloNzv3AkmVtTYCVjdvekEYyfQB/hzj9jJ\nXenk3HCmce7k919+//0XhJLr0gneTgY4cnU6cdAE7tBhVo/GkNH8nZLZgeeywy21NNOBR2Jv9qBY\nNXaCA595sA12VmWIUfUcBigUTVhgkgEK0gkNe2BQU+UPTO5AmnXRCYYxeg6gANyoL+QSZvbzdKLm\nK80dSP3GkUvETtgqPnhRe3SCgHIDOsE8DhI01dqrhE8cOqE7ubdf/nudv9sJSnC5WrET4BL4JR14\nTCqjE/zxvzs9xv66dDLQ/g4EiwNMkJozhUCInzaFqAmck2UxFfYbnNa3t7xn53m6iDz0EogBT8hS\nQGlQFUATgBO6C6UPf6NmnyX08zZfemhp62iZTPmG8ToLs60/1HTLylUQmYJOvjrxHT45uE89M8c4\nGkN58DmN7wGdYDRlp/Rnz1jktRZhgHFU92QYPjmFTtQ7dOgRURo7mTnf0TmPmNyBsc8cO/lkOnHW\n13NjQFmf3HdD06bWPgFWorpIP5xO2hbXw56/XpJO0BGAzVc3pUmb75PHE8JesRPpK53L2wb+tvOJ\nniHr+O7MuJy2+jsf1qDETh75QkInYRWTFAB1VDlaoglN9BxzgHxvKVn5bLZ7268bjN8hZMLuVWEf\nQtQEMj6fcDCWxo0uFygauEUZVdWoeiBAUkV/mTbFTYKVY7XQ5NPoBB98guGTql1Sd6E0m6PafDT7\npU1pxotDGR9N1ALVgbPyMk5DaclfIJlx+fGVzs6Hl3t0MnDxh/3oLABcAijNAAWCe/ChGjvBb5Mo\n3dnVnS6fhU6+oARDBQxH1JwOpZO7hk9g4IxOpgUUGShGw2p9JT9X7SY3N4lsPb2E2kpWVeey8unE\nD4fABgBqUB/QrN6k8wnPO3moDcns0GQ6hq5pePvpWb/2mf6EQgEImbDAyTOb49r8PehEdZcNCl/S\nZIdOLPetLihKTiFjlXrYU1ihk6/O/QJf9FR95LUY5WNo8jwDpWkqvRX+aznES+LIEYVtgTWkL9WG\nHhc7eZ17BSL5eorJzzJ2gqkNDJwgncBV4cCvWEDSySaHaelE3TAxg4DGwbGPdKZosTbDsqvRdPKe\nSeZwDp1k6KQz8apS4wwrxaITPH1Cj4lAwIOl4yWp4CcyobOhCW5HwaSraR2Ml2dOnziqy1bBriqq\nzqa/+vz+JFfuiVp0BzphUT6qspam0mUAmnohOqFEwu4fxufDyjed5i/YyryIxHo0Kg0bYB4HWQTv\n6LklndBbdSi0XY5OVNpI2rjJ6cRR7046YQdW9njYCWx859xPOnRCU+qUUdAgw6ZRWmZKJ9TaoyPA\nq9ihE7YjhfKh983TCY1APONA9R1+aR7D1WcVkF1FLQoFcliBm9AJDQlSFQT9A/2mn7PyqNaHyb2t\nIXisE/73+RtjJLDMoGSLM+OtBG0tJq+y4iUIIvRGYvWIyaMG+He78AnSCbzBkNK0Z2OpUVDjKE4c\nGK1hySxm1MzfCGZqaC7j3GuDaR2oXEY08RMrgtL5pBP0giWv1iyK6oU0egGBDcyq0Ht2VDr5hRx6\nddpl1lsafMQgTCdBGWdHqi4BJmqLWqTmO7XJcVXnMVyt+f5YTculV1WDtvIenUB+p63eI69i/CuV\nFSMlKiwzEj+y59W2Nku3PXoB/gtv6NE8TH4zE1ltpaH8ky3I+VbkEszgYJYHP2ENYSUNHZj2Ehos\nkcduIHwyFZDlbS4aayr8G9CJShjqr1bJtKm6Hv3MzpCgJtrx2RYC0AnAB9IJPfaxIchWhh1DoWGV\n6tYRy8vbHXCPSnets0mMov/BfZvN3et08mKoa9CJP4UUPsLJzgT6wkr2K6AeNLHiJft1Q6eKr7AH\nQsn2w37oejGyggXUpMZsfrpfgOzwDaMT+O1DjKBMwigOnahfWTESVtiqNi/kfOykuvvEPnCsJ/cP\nZ3KmGNfEgAo++X7XwAn4s+ZR56egWhJBAZ81Ip/jsMGJBSiAF1ujUCDZum/waRB9qzVfbbL1/mJn\nIcKM+sPxhGj5hN1tmPsJ9a9hFNsldI/lBJC/I8ltzdSvYvBB/8TKaOJm88qqJ57EPdcFoF+hHsFh\nz3pBQKGMcrocmE2gMRLVC9LyLI6CNkRCTNW8qFbb6U91HlnOVKZNIU/KXs/45dfypCzC/rToZEjg\nZHI6obfVsOQOzbDQyIrMwj/GmAOUsBgykxpKr6rNDcrPibZUqzmlwHe//+XrRwHXvyUBQwLfJ1tB\ng4xTI5i1ATQ53QHvOp8wQHa/Ek1ssSQXoAl76Mu9RbSr/NsqB87YCAPTpvJ3IeSuANqCC+FndCDl\n6tSDz78fcuIE2bFKe21SKl31SOu8H/uTR08wyQK3zxyJDotOSrN5fGE9dDKzxh8vo9WiIwFOJxrL\nIprcnkseTK9xCTzFX/7GED2dswHK9qLgsgDlsKUnsQNSOU6whPbNiWWqERc8rj5qgHNuf1U6ASaQ\nx2BL6ZthcsvFY0Y1t+opScBK7KzPlwTGSQDuN/6Ef+RhdPD4NXk6GEkFn8/GyuAjYb5zZJ8gulPH\nuOEF/vPTpplujq0t0+KkZbT7JZ9dfYVJnmdXt0/hk/VvSWBJYEngOAl8CJq8Elv0dDA79yqTPnBA\nWOWYZwjzc6R3nEaulg6RwItOIFiiwwclkkUnh0zLamRJYEngJYHP8a9fx24WnSzVXxJ4SGDRydKD\nJYElgSWB8yVAHigHsZDtCDCeAv7u3lekBB7Ltr3Y3To0iILHdD4lL3b+FK4ejJbAFg6BiMiKi4wW\n7afUVzqrsgovCSwJSAngMRH6E0Lbh/K3PPDkLALK9+Hir5Mr9Hkwn3CUeKnTXSUQ3t9714GvcY2S\nwLpneJQkVz1LAksCSwJLAksCSwJjJLDoZIwcVy1LAksCSwJLAksCSwKjJPBGJ798/XOqDguM6taH\n1ONL+0OEsIa5JLAksCSwJLAkwCTwTSfSUwKLSCLJ+FT1wq1tq0LWCm3aac7q4R7TTLuRkYDsgyrh\nPbq66lwSWBJYElgSWBKoSqDNtVVbSZZ/0knVcebHYDl1/Nz3+mEsB8epVgjf0q8kBlnMxCRIL2R9\nztSp8hbUY5FccgpXsSWBJYElgSWBOSWg+tb8h86g2ObcceLSxaiux3JS+SiAWpK1TptG96cOU6eT\nED7CAhIaKCUwYlALM7BQex+iD2tURRkHa2ijVMQ+WjkckySeOZfZ6tWSwJLAksCSQEkC0lmoDsL6\n0GpL+j61Ielx0LH6Xix0uLKASgVqPyWgnEAnrLsqTFiEYYGFSgyZhhDT8vTA2sIuhXSSnFpn7KUF\nsAovCSwJLAksCUwoAfTE1H3kP6zSiay55PicuEMYksjTCRISe8MGu2PsRPa1RCehLCi+WG2FwZU8\nH1AiWXQyoRVYXVoSWBJYEphNAnkQUUv208kQt1tyx3JXTykkE+OB8nudO0liFCUM531+hrAknWkJ\naD1BrTD0Yk1kEtdmW12rP0sCSwJLAksCzRJAl8F8BzopufWlJTH44Xt9WqzkpMItuuXN2edJpz+A\nTnCoTEx+KIbCAVwoB5D5MENqjGbCP9mIfHyRimhNoRym03lWOFSL5vWwLlwSWBJYElgSmEECqp3P\nf6jSieqgQydFOYnt5KXvRl+PbovVLz2dU9KBEstjencUZyIWM8y92gcVqqbt7erYksCSwJLAksCS\nQIMEkpv5hprPveSGT2NTYzbnSnm1viSwJLAksCSwJLCHBO5KJ/8/7d5FemD4AtYAAAAASUVORK5C\nYII=\n",
+      "text/plain": [
+       "<IPython.core.display.Image at 0x107ec2a58>"
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from IPython.core.display import Image \n",
+    "Image(filename='../imgs/comic2-1040.png') "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Write a function that takes a symbolic expression (like `pi`), and determines the first place where `999999` appears.  "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Tip: Use the string representation of the number. You can take the part after the `.` by using `split('.', 2)[1]`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'2345'"
+      ]
+     },
+     "execution_count": 31,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "'1.2345'.split('.', 2)[1]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And remember that Python starts counting at `0`, so if you use `str.find`, you'll need to add one."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAAgAAAAPBAMAAAArJJMAAAAAHlBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAACGjDitAAAACXRSTlMAuxCrdpnvzWYiHG0BAAAAI0lEQVQIHWNgYBBiYGBQ\nnMTAoGwMJBhYSCVYw6ZHAPUxMAAAQGkI1Fjz0FgAAAAASUVORK5CYII=\n",
+      "text/latex": [
+       "$$1$$"
+      ],
+      "text/plain": [
+       "1"
+      ]
+     },
+     "execution_count": 32,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "str(1.2345).split('.', 2)[1].find('345')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAAkAAAAOBAMAAAAPuiubAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIpnNu0SrdlQQ3e8y\niWbzIQYJAAAAT0lEQVQIHWNgVDIJYGAQY2D/wcCQycCwnoFh9wSG/AAG+wkM+kAJoMgEIMHzF8Rk\ndgCRKiCCPQFENjEwCjDwKDDwCTBI3b2rBVT8//8vBgBR7Q/Fm5CwxAAAAABJRU5ErkJggg==\n",
+      "text/latex": [
+       "$$2$$"
+      ],
+      "text/plain": [
+       "2"
+      ]
+     },
+     "execution_count": 33,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "str(1.2345).split('.', 2)[1].find('345') + 1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And remember that `str.find` returns `-1` if it cannot find the string."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABgAAAAPBAMAAAAMihLoAAAAJ1BMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAilU6eAAAADHRSTlMAIs3dRLsQq3aZ72YDTSHvAAAALklE\nQVQIHWNggIMwOIuBIfUYgpNejsRh4CCTI2QMAiYMZBsAcxDnrEOzYWwwDQBP9Q53CSxxJQAAAABJ\nRU5ErkJggg==\n",
+      "text/latex": [
+       "$$-1$$"
+      ],
+      "text/plain": [
+       "-1"
+      ]
+     },
+     "execution_count": 34,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "'abcd'.find('def')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def find_999999(expr, limit=100000):\n",
+    "    \"\"\"\n",
+    "    Find the first place in the decimal expr where 999999 appears.\n",
+    "\n",
+    "    Only checks up to limit digits. \n",
+    "\n",
+    "    Returns False when 999999 does not appear.\n",
+    "\n",
+    "    >>> find_999999(pi)\n",
+    "    762\n",
+    "    >>> find_999999(E)\n",
+    "    False\n",
+    "    >>> find_999999(E, 1000000) # This one will take a few seconds to compute\n",
+    "    384340\n",
+    "    \"\"\"\n",
+    "    found = str(expr.evalf(limit)).split('.', 2)[1].find('999999') + 1\n",
+    "    if found == 0:\n",
+    "        return False\n",
+    "    return found"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAB0AAAAOBAMAAAAh/woJAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAMt2ZiWarEER2u1TN\nIu/4jXmTAAAAu0lEQVQIHR2NMQ4BYRSEPxLWim10KlGod4MoKKxkEyU3IBqlLVQaewMSFxAnkDgA\ntQiicAOtiOhIfrOa9+Z7M5NHvhYEPpNaG6d6iKBvjBk4JYbcsD/QgTRJnyMjcMGHNv0QeISMI+3M\ngpMW55BWzFP4Fpab+OTGuSbWq0dZKvHWsJ5YBrqyciuxvZevvyo0hCQH6osX2FIw82D997c4F5iL\nd3E/4ZES78RZ37pzDYKK8sWeRr0e4Rrz4geOEjEwmFr2RQAAAABJRU5ErkJggg==\n",
+      "text/latex": [
+       "$$762$$"
+      ],
+      "text/plain": [
+       "762"
+      ]
+     },
+     "execution_count": 36,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "find_999999(pi)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "False"
+      ]
+     },
+     "execution_count": 37,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "find_999999(E)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAADwAAAAPBAMAAABKPLFCAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAMom7VCKZRHbdzavv\nEGbh6M2uAAABHklEQVQYGX2RMUvDQBhAX2NaU4htcNQldBJd3XVycekv0AhSnMTdocHJwaGg4lqo\nmwh1EISO/QOlQ1EomMlVkBYEber3fSeO3vTeveSSu4Pl2iYMa4fIWMWp0ej8AIoJzZSEUib58leV\nuOElwptQbVUylloQ9J0aBS2CNr5mr2t5r+MUhMpdFqf6xWbqfw28FOKOU6NqQmGifgdb+RlU6pZF\nlfZjCp9QWO9CaX4Nz0g2VdL8oW9fnPC2Mt8m1myq9JfDWSXhfeZHLoeO3OLFiIU8HFDMh0g2NdJf\ny3mdSR7Lmke7vd73k6mRbMyfUm1TnoZ1eJRH+k6N5Fg8OZmMZuzf48duUtWIK8YR7DRu4bShV7Ix\nP3ZqNFp7kLl/xw+dmW1XxX384QAAAABJRU5ErkJggg==\n",
+      "text/latex": [
+       "$$384340$$"
+      ],
+      "text/plain": [
+       "384340"
+      ]
+     },
+     "execution_count": 38,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "find_999999(E, 1000000)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": []
   }
- ]
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 0
 }

--- a/tutorial_exercises/Advanced-Basic Operations.ipynb
+++ b/tutorial_exercises/Advanced-Basic Operations.ipynb
@@ -1,686 +1,684 @@
 {
- "metadata": {
-  "name": "",
-  "signature": "sha256:0d4afd00f540ed45b9663382ea50b471519177b9c2907c22f2e7e30986df6a36"
- },
- "nbformat": 3,
- "nbformat_minor": 0,
- "worksheets": [
+ "cells": [
   {
-   "cells": [
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Basic Operations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from sympy import *\n",
+    "init_printing()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For each exercise, fill in the function according to its docstring."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Substitution"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Write a function that takes a list of expressions, a variable, and a point, and evaluates each expression in the list at that point."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def evaluate(exprs, x, x0):\n",
+    "    \"\"\"\n",
+    "    Evaluate each expression in exprs at the point x = x0.\n",
+    "\n",
+    "    >>> x, y = symbols('x y')\n",
+    "    >>> exprs = [x**2, cos(x), x*y]\n",
+    "    >>> evaluate(exprs, x, 1)\n",
+    "    [1, cos(1), y]\n",
+    "    >>> evaluate(exprs, y, 0)\n",
+    "    [x**2, cos(x), 0]\n",
+    "    \"\"\"\n",
+    "    ??? <- Write the answer here"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "x, y = symbols('x y')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "exprs = [x**2, cos(x), x*y]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "evaluate(exprs, x, 1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "evaluate(exprs, y, 0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Write a function that computes \n",
+    "\n",
+    "$$\n",
+    "{\\underbrace{x^{{}^{.^{.^{.^x}}}}}_\\text{n copies of x}}\n",
+    "$$\n",
+    "\n",
+    "That is, `x**(x**(...x))`, with `n` copies of `x`.  In [Knuth up-arrow notation](http://en.wikipedia.org/wiki/Up_arrow_notation), $x\\uparrow\\uparrow n$."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def uparrow(x, n):\n",
+    "    \"\"\"\n",
+    "    Computes x**(x**(...x)), with n copies of x.\n",
+    "\n",
+    "    >>> x = symbols('x')\n",
+    "    >>> uparrow(x, 3)\n",
+    "    x**(x**x)\n",
+    "    >>> uparrow(x, 1)\n",
+    "    x\n",
+    "    >>> uparrow(x**x, 3)\n",
+    "    (x**x)**((x**x)**(x**x))\n",
+    "    \"\"\"\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "x = symbols('x')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "uparrow(x, 3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "uparrow(x, 1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "uparrow(x**x, 3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Write a function that takes a function and nests it within itself n times. \n",
+    "\n",
+    "For example, if we started with $x^x$, and $n=3$, we would end up with \n",
+    "\n",
+    "$$\\left(\\left(x^{x}\\right)^{\\left(x^{x}\\right)}\\right)^\\left({\\left(x^{x}\\right)^{\\left(x^{x}\\right)}}\\right)$$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def nest(expr, x, n):\n",
+    "    \"\"\"\n",
+    "    Nests expr into itself (in the variable x) n times.\n",
+    "\n",
+    "    >>> x, y = symbols('x y')\n",
+    "    >>> nest(x**x, x, 3)\n",
+    "    ((x**x)**(x**x))**((x**x)**(x**x))\n",
+    "    >>> nest(sin(x)*cos(y), x, 2)\n",
+    "    sin(sin(x)*cos(y))*cos(y)\n",
+    "    >>> nest(sin(x)*cos(y), y, 2)\n",
+    "    sin(x)*cos(sin(x)*cos(y))\n",
+    "    >>> nest(x**2, x, 1)\n",
+    "    x**2\n",
+    "    \"\"\"\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "x, y = symbols('x y')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "nest(x**x, x, 3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "nest(sin(x)*cos(y), x, 2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "nest(sin(x)*cos(y), y, 2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "nest(x**2, x, 1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Write a function that replaces all trig functions in terms of $\\sin(x)$ and $\\cos(x)$. You can assume that the trig function will be of the form $t(x)$, where $x$ is the variable.  The trig functions implemented in SymPy are\n",
+    "\n",
+    "$$\\tan(x) = \\frac{\\sin(x)}{\\cos(x)}$$\n",
+    "$$\\cot(x) = \\frac{\\cos(x)}{\\sin(x)}$$\n",
+    "$$\\sec(x) = \\frac{1}{\\cos(x)}$$\n",
+    "$$\\csc(x) = \\frac{1}{\\sin(x)}$$\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def trig_rewrite(expr, x):\n",
+    "    \"\"\"\n",
+    "    Rewrite all trig functions t(x) in terms of sin(x) and cos(x)\n",
+    "\n",
+    "    >>> x, y = symbols('x y')\n",
+    "    >>> trig_rewrite(tan(x), x)\n",
+    "    sin(x)/cos(x)\n",
+    "    >>> trig_rewrite(tan(x) + cos(x)*sec(x), x)\n",
+    "    sin(x)/cos(x) + 1\n",
+    "    >>> trig_rewrite(cot(x) + sin(x)*csc(x), x)\n",
+    "    1 + cos(x)/sin(x)\n",
+    "    >>> trig_rewrite(tan(x)*tan(y), x)\n",
+    "    sin(x)*tan(y)/cos(x)\n",
+    "    >>> trig_rewrite(tan(x)*tan(y), y)\n",
+    "    sin(y)*tan(x)/cos(y)\n",
+    "    \"\"\"\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "x, y = symbols('x y')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "trig_rewrite(tan(x), x)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "trig_rewrite(tan(x) + cos(x)*sec(x), x)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "trig_rewrite(cot(x) + sin(x)*csc(x), x)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "trig_rewrite(tan(x)*tan(y), x)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "trig_rewrite(tan(x)*tan(y), y)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Suppose we are working with the series expansion of a function at $x=0$, like $a_0 + a_1x + a_2x^2 + \\cdots$.  In this expansion, the terms with higher powers are less significant to the calculation.  For example, if we had\n",
+    "\n",
+    "$$1 + x + \\frac{x^{2}}{2} + \\frac{x^{3}}{6} + \\frac{x^{4}}{24} + \\frac{x^{5}}{120} + \\frac{x^{6}}{720} + \\frac{x^{7}}{5040} + \\frac{x^{8}}{40320} + \\frac{x^{9}}{362880}$$\n",
+    "\n",
+    "We might only care about the terms with powers less than 5\n",
+    "\n",
+    "$$1 + x + \\frac{x^{2}}{2} + \\frac{x^{3}}{6} + \\frac{x^{4}}{24}$$\n",
+    "\n",
+    "We will see later that this is can be done automatically using the `O` class, but it can also be done using `subs`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def series_reduce(expr, x, p):\n",
+    "    \"\"\"\n",
+    "    Remove all powers of x in expr with power greater than p.\n",
+    "\n",
+    "    You may assume that there are no powers of x greater than 10.\n",
+    "\n",
+    "    Bonus: which functions are represented by the series expansions below (you\n",
+    "    can use expr.series(x, 0, 10) to check if you are right)?\n",
+    "\n",
+    "    >>> x, y = symbols('x y')\n",
+    "    >>> series_reduce(1 - x**2/2 + x**4/24 - x**6/720 + x**8/40320, x, 5)\n",
+    "    x**4/24 - x**2/2 + 1\n",
+    "    >>> series_reduce(1 + x + x**2 + x**3 + x**4 + x**5 + x**6 + x**7 + x**8 + x**9 + x**10, x, 0)\n",
+    "    1\n",
+    "    >>> series_reduce(x*y + x**3*y**3/3 + 2*x**5*y**5/15 + 17*x**7*y**7/315 + 62*x**9*y**9/2835, x, 5)\n",
+    "    2*x**5*y**5/15 + x**3*y**3/3 + x*y\n",
+    "    \"\"\"\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "x, y = symbols('x y')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "series_reduce(1 - x**2/2 + x**4/24 - x**6/720 + x**8/40320, x, 5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "series_reduce(1 + x + x**2 + x**3 + x**4 + x**5 + x**6 + x**7 + x**8 + x**9 + x**10, x, 0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "series_reduce(x*y + x**3*y**3/3 + 2*x**5*y**5/15 + 17*x**7*y**7/315 + 62*x**9*y**9/2835, x, 5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Evalf"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "At the 762rd place in the decimal expansion of $\\pi$, there is `999999` (see the below comic ref: http://www.qwantz.com/index.php?comic=1013).  Note T-Rex is counting the digits like\n",
+    "\n",
+    "\n",
+    "        π: 3 . 1 4 1 5 9\n",
+    " \n",
+    "    digit:     1 2 3 4 5 6\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
     {
-     "cell_type": "heading",
-     "level": 1,
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAt8AAAH0CAIAAABq69b7AAAABGdBTUEAALGPC/xhBQAA3JlJREFU\neF7tvT3ONElyoFnKEHuF4QEorTYH2A8LjLaDBaiRUksFLKjtagsQXRfYA7Q0pDA8APsApYzYF6BW\nZ+gL1Ea+lmmvpf2bu0eER6R/zC7mm+nhP+bmZo+beUT+9NP6tySwJLAksCSwJLAksCSwJLAksCSw\nJLAksCSwJLAksCQQS+D39W9J4C4SoOp+lzFdbxw4C9fr+urxksCSwHkS4LxyXk9Wy0sCgyWw6GSw\nQJuqW3TSJLZ10ZLAp0tg0cmna8CNx7/oZIbJHU4nW4WnjOvgdkFumZEmi2WqUsvsXX9zx8ZeWB1m\ntTzrbX5+rWGOsm+j6hk7HVtti06Gi3RVOIsEpl11swjokH4sOmkTc957dbrJsHt715/xvlIaUq86\n13t1mNXyw+kEK+zsyfB6Qo1KFlh0khTUKnY9CXRaq+sNeMoen+5FRklllA8Y1Z/DnMrAgfdURa8N\n6wkLyFmoXlItP3zehyvAPCOCoS062U9nVs0nS2DRyckT8G5iVGPquBz2Fe6e1c9DwwoFaCVW/VRo\nFK3a2mV2NjMjjt6qX/kylHTo9EEtTEXH5Bz2B2SueJpc0irUGWssUibW0FS9cqqt6qEUkSO0qn6i\ndiX1ik5Ehs8c5bFGUdI3v9uLTjLTuspcUgKLTmaYNmmtpIdTjSwWk1jQ4LSk3VeBxvL0eLnsqlpP\nxmuGs2MJivVBFdTAflpjr84jkko4cFZAbcj3ghmdccqoPczUycbo64ZaoU9LodKG6KmunZByfFVs\nWI8ZHVh0kpHSKnNJCSw6mWHaxtIJtf5Ji5n35b5rsSBgEjqR3SjJxwGCKoU47ZZkZflRhxR9zLU0\nIfTNeXp29FMuRhWFHda08C4p1VAfnHrUrmYgsscELTrpkd66dmoJLDqZYXp2pRNmv/yNo+OcVFVx\nvHK+XWxUyiGcHd+dUDdmbamH9PNcOqlSV7586K2T3pc70VfSKoSGPJ34pixsKANtKvpk1gWFyKq+\n+Utg0UloIlaBq0pg0ckMM7crneQHKLek6ibV2SOq5TMdyOw71XrydGK5lkz31BBFgxws+TQP3wpp\nOGKxKI3KIdPP0nRYcBBCQ5JOQgGGDbXRidVu83hL2ggq/favev0qvyQwrQQWncwwNT6dOBbQooc2\nSuikExiF5S/DLaBKAOHslOhEAkrSaWXoxPejTCyscOhcHTlkHGE4L5YYnX6GdJLUB38KjqcTfy4c\nffNVsW1dZPR/0UkopVXgkhJYdDLDtKl0Ij9EA4d2XzoP+ET9nHoL37U40ON0tbldNq6wn+ounwKE\n2kmLft6Me+I2GbU8il123lpitJPSseWF4Hh3X68cN5zRK2vhWONy5OxYoSSdyCgC654jJalO1tKT\ndOu3q46rqm8h1r9VOIM5W31YEhgiAccuDKl/VZKRgGMNM5d/cpmk1/lkEa2x5yVwOXVirJN6cHJe\nHKvkksCJElh0cqLw5XZ/hs5cqw+XcyfXEu+n9fZy6rTo5NNU9IPGu+hkhslesZPqLCyJVSW2ymck\nsOgkI6VVZkngCAksOjlCylEbVV87atbyhxuiERz9/ZxeZB55HiOfY1o5Wrfma88/l7POncw3Y6tH\nIyQwys+N6Mvn1lGik4EuwfKmA5vYaVLn7OGik52m+5Or9VV9ZXY+WTduPvZFJzNM8Fl0Yo19lO9X\nvXW1crV8tZJtpA2X7Kobo/ozSj4Ngx01hIamP+eSRSefM9drpG8SWHQyg0KodCKnhu+Tvv72+w8F\nZP3+vIfVJoXG6ET2P+w8uwTLW+MKB5sMb2Tqp1Ky5KnWU5WDA5E98mH9V0VHP0xqRdWkqMrvKIYj\nan8dUUJlYwmn0tEHS0TNcsDOZNY7L5NcmavYksD8EqguoflHdMUeqvRAByIdSXKYkg/YharLSfqh\nkC2ggOMJMqOwehjKpKddS25hnbKA1c8hQpbiRZln2mWOMJyvsM9hAR87Qn1w6lfHK7GjNEZVPkzm\nVpdC/bQWeLJ+OtHfZjyU4CqwJHAVCSw6mWGmdqUTxwg6vq1fLNSy+31IUk7SmmOxkCTynjI/Fr/R\nksdKTkGGL8P+Z1yspS1sXpoBJXMho8Zwrq3p2OnzsD/WnDpq44uFGvDH+6TSrGJLAvNLYNHJDHO0\n6CQPCpm9r5RnxrNm6CcknvnphPkzVZ7Uy6rlQ6DMO8oGEyQZhTtp4xcVMpSWkY9VT7PcFp3MYIdX\nH+aSQINpmGsAt+jNbHTSL1TLW1QpwSqf2fuGJJFHotCrJTfNtEt5/x2igCyQkY9DY9ZwSoqRGWCP\nQDLXJuWQoQ1VXNYYM2PP0HC4XvhCK83QKrwkMLMEFp3MMDu70olvxKtmNCmu5r1g6Gj92Ikz2NJI\n2e78SDqRgYFFJ6oEqnRCBcuubaaTJD2Hq6Z5vSw6CWW7ClxVAotOZpg5SSdg9azP830Gq6fWo7p5\n58Nqo6y89Ad5XKjSmyO6pO935OYvGcfNSE/mzHte2ur8+t5ODsGZC+b/QlRylM2CjLwVckpa/aT9\nsZRQ/ZyqSjitqormx9W83tmo17mT0sJZhaeWQGn9TD2SK3euatDzY80TQL7OTyh5rtzObf3G83s/\nwS46ubG6fvrQFp3MoAGLTmaYBdqHE93YiU3PNgvD+3M/2S46Ga4kq8JZJLDoZIaZWHQywyxMQiez\nieJO/Vl0cqfZXGO5uQQWncwwwVU6oRnxPfq/d/1Wn89qdw8Z7lpn6GX9AqPknK8n7PCu4uqvfNr+\nr9hJ/+SuGiaVwKKTGSZm0QnMQt7bzTBrJ/YhdJaLTsbOTijwsc3la1t0kpfVKnkxCSw6mWHCqnQy\nQ59XH06UQOgswwIHd362/jjDV7va0P+GSxomZdFJg9DWJdeQwA3o5BgrsOt0qnSiTo01X0wIoUyg\ngGzXrz/fT1p52BmnsNVP37vkYzBO/VIUo/wWDRSpE+fLGcTlK2R1fkfNl1UP7bAccpLOfflbleRN\nHPf0RMgZPcEZceoZbkYWnQwX6apwFgnkl+4sPRb9CC31tD2X5ox+knE/tAzKISMQ5r/lJaoLUbun\nOp5MH9QB5tsNpzXTByoH34NSJnBKhr2SBVhtoTzZ3Fli9DupUlFn5yU2SZ30Nc2fMlXDeyrMaCBF\nSX95jhJpaRYWnZTEtQpfSQL9dJKxlbtKJOOEdu1Af+U4C4xXnJrVUefnIrSkfgGLhOjnbfOSbDcj\n80wHrDJWN+BzlHOmibCrIRU5Xt+qvGF+28aSnC+UG+tw2E+1vC9/Js/quKyVpe4EnA+r7YZ64mDo\ntxlvq2VdtSQwoQR2ohPpbukWRK5btTz1BNKKjfUQ506NL67mHV4ebtQZyVheqj84I3nGkj1Mejt/\naJY8w+Zoz9XhD6QTden5VGR1LxxXOL90eZbWQnK+pG4wg5CcMkf+jimzWi+tLGs5WO0uOikp0iq8\nJMAl0EknuAKtpdjzObMpalsluzPt9PumWZWh9WHSJvpOZRNU3uuEUk12Cd1VhoqsRmlbmXaT+kl1\nDx2klFIoChUvnD5b6yscWnV+HZn7gyrpiex2OBDWOq53OgtsIpJzmlGhJK1mVDevG6WS1IA/3pcu\nPqtwv9Wmwz5rFOqewDflYVfHzmBVztXy4XA6C3TOsmU9rVVd+twyfKHl7ZTJ8Zf7Kq1qrGPoMxoe\nyrDkdUoOrFQ47Kf0XqGOZTyx065DDBnJS09Gr8rofMaGhHJzupofheSzsP9hx8LVp8rfkWFJHyzi\nDMcViiIcV1sBasAf79tqOfiqjAYnuzTPkIf0ZEglVONLFQ6cl+T0hc7Ad43h5dLawkJVqy19nrEI\nljUZIpzDKpGysgRlmdqq0Q/L+wWYM5C9DftvyTbfrlNDvnVn8Tq66uh8XmeYX7HqZKYGOhzanIb5\nbbMDsieq3JjCMEDMzxcduxzjKD1U16MFteo84mzCt3mtqJZkrWdbcjpd7cG55XcVbmloQ3oypJJS\nt5sLH9DVkl1gA+EL47UILUvU87lvlZolPMmFbY5hks6vbljI+AmSOcBGfYIYm8fYSCcqC/udsJAN\n+SsDYo6/sb7yjWMDHTO6r7pAH4GTphy67YsUh6auMfqtWo/TE38Ijptn0J0c7BDlrlbChKYKs4dI\nkvXfwD7uPcvVmV3lGyRwAz1co26QwLmXHEcnksEll+TXgEoVPub7TlrlLcvB+47fmVHLJzHiCXWC\nkRxDDVXUtM58/305y346A5TUEg6zs0AVHJP6w9YMvUptUS3vawJdGp1COP3yRSenT8HqQEkCS2NL\n4tqv8Ml0wpigmU4yTnEnOsn3WSKItfkO5zuz86bNOeX9/mcEq3IPzqxVf0luoUDUAs100tbcusqf\nBR/+QumFCpMp4DgeRvzVDUPY/6sXkPI5ZkRntbvf6EJF3a9pp+YJ5XwcnUhXgZMk34TTI72mukMF\nE+ObJN+5Mn6y/kwqnOPskzX4/cnULxty9LKTThxGKY031IdFJ20iOuAqufrapj68Kizg49GiE18Z\nzvJeZ7W739LIK+p+fZA1Tyjng+iEzocDJflpS3pNtd0MjjAIyDSX6XyGHjIaadWTqd/qp/p5ZuCO\nPPOizoy6WoYqd/XaVX6UBK5CJ6q9HiiEUVWteg6QQMaYZ7qRMarN9WQu3KnMKPlkgPjbjJcGk+/i\nnejEYsyMNDL0kJkC1gcJfIyu8E+nk8mF5A8zX39GXBlROGV66OSA7m0936+V/WquTopFJ/JzEIj6\nudUoLZwfslyGVmew3eQl1pbUGld+vNABXPjSArAhVMujNqrzFU5W2B9/ndKppzKvKgNthVnFZFV0\nRtigSvrp1EOnxtIrVQiyP6pUM/XTdh3llPPiy6dqHHahE9bFTJ/kJUx7SsZaWiKrS35X/XqYrlPT\nQP19Umn8S2RP2tazuj4tOgmNo9or5yprsfn1ZPSnoUw4ulDCDY2WLilN+gE179Ef6RXYemGG0gIC\n1fEzI54UkTVMqb24cFjNVp+tDlj676xW2SL1Osxayv5QY4UXqsOhdlja5FIP1bkLlcrRB0v+jleW\nfQjr91XLUshwXJZHy/THUsWMhlv1h3Wq1rttTjP9DMtQA/54H14wSYELdXUPibUNv+2qPfp/TJ2L\nTqpy3kNDVDpRfV5oPR1EsDxBxo357kfKpNpPx0s1+H4JEGp/nGJW/8PZdwpIPLKkGqJAKPAkAlqk\nFQ5zyHw5XJXRn0yZ4XLwG3WmuGpnkuUXnSQFNVexzAKTprzhqrmGXexNP51IzwqWy/K4+fLOUPLd\nVicUPsT/Qm1JW7mHhliykt6LG6Nos9Rswa1hygotCbOuhorpzFTSi8tJpJ/I/vjlM3QYYoRDdSX5\nhPOYVEurnrD+5EgPqMda+0kJqMvcWv6yTn+A9NtSf8LV4WDWmyI1V3TMhdLSHdPubK2UlONjhWYt\n9cxswrWq/VU/p+WdRR5OXFgg9CtQg9X/vAHKSClTRqpf0ouElTd4C4fSEOnYpIdGPOynrNn3ImqF\n0sdYXodV7lxolXS8RcaRl3TYEruq576ok3qV6Z5apkHfSvU47j/TZwcWk/qWNw6l/mQWiKXz1IZf\nJrPTPOB14edIoJNOQg6ghtVarlWLxqginCzGIpbHCj/33XbYDafAMXRSklt1sqqTmHHhGa/sa+AM\ndJLxvqHysLlrxkHm3al8HMfvs6ADSRkPnZGPOo89KmfJM6yzn05KyzCpGN9mPLxgFVgSuIoEdqKT\nN5x3kybggdTy4S4wY/vQw6FRyFCI49WSjZYUIE8nUlxhQ7TyfOerdKKSRFW7pBzYeEOVYAQpnbEq\nDcv5hfMSMpaj2yWdhx6q8qlCsyMBp34LUKSvrU66Oi4HAhy55fvvyNPvv9MxZwkwgMsvw/zqfnY7\nvADVJVxscqhSNKE4nEqkUKQyWcOx1pX6uRS3uuClq6Cy8qfQl0NyUlYxJoEGU4I1WDNirb3q55nJ\nyqxz1Hk0SapBp1VZ2pvpUkOZvFVtqHxdcgMJZPS8Z5h719/Ttz2uPXe8A1vn7jgpLNXYWZZdYlfo\nAxy/rl7r90cOqupLrPoZD6GHYOVVxnJ4ZeAEJyf0lsU+gU7o4nJWQaiB+ynAopP9ZHuPmvc2d3vX\nP9ssnDjesU0fQSdOj6XRlPDhkEGScvrpBH2A2mG2GaW7WPqebWrluFg9syn95fqzB52AJsiafSXP\n9yRfMr9S5PaAUbWzr+if9EUn/TK8dw1jXVre2t9VqnvL8zC5nU8nqq3P7AjzO8W8voYgtejkMNXs\nb6jB0/c3eokajrRfi04uoRIHdPJIraPDOavdNpFaOwertmr5aq/662+WfzudOEZHdeGqUJySaiDB\n8jf5FjGAoVZloRILe1jbVuiG9d8wdmJFaKr6tMrLWV4yoUrbbC8axHhdOum3y464fvrxE301CPZy\nlxypdYtORqlH/yponvd2OrEcNg17OGXUryiRqKCgIkupRb9Lvhzlt6w/lEtor6rjap7OURp5j3os\nlr3H6BpGcQoonNJog3DkJf12Wd+SfXHJL7//oK+bwYpqwRrMWsMl6jwO0YcTKxkih4H9L/WnVJhh\n5RsGJAdA23N8Nt2u6Qv1/XGQIXxY7fr9yetrM50AizA6kcNn9avjZTZxJxOZnOhLF1t0MsP0XZdO\n6KIeIklAEMYl6p8IK0PazVdiLZn8UnpzJy+TSPeEqj7ID516Mq6EtYhTKS2w2rRV3mnaH5fqJdkl\nqpB9eVqNhuOFAr5iVPtj1YZuUfoyX6/42JN67HjZjH6rXhnlpUoNR8jYCrWwZAStifGXhKphsj9W\nsYZxDbePyfm9R7G8Sb3HeOccRWlhTjgEaVLbOpnkkg1WWBzlMFJxrKJqdR05WLaOfu7YQ7mvC2Wu\n+hTqF9U61f6wGU96ccpD+baSpOX3Qbpja1y0Y+G4nFnIXytdmKUDqt9888ihEqwCSwJXkcCikxlm\n6up0MmSHkEeTjU7+6//8T05AZb85tThMOr+wD83k0dAWc6I4CpVXcA9M3zCwqPahSnWha1f9dJ4F\nrf5XxzWQTlS6Dfvzhiah1EKlXAWWBOaRwKKTGebiBnTSCSghmmw4Ql8STfBbiKzsOq2SUUIvIvtT\npRNrqZZcEhQu0Qnzf2H8IxnqwHoy9Wek58vBn6CQ0kJ1qtISq9ChJVU+lIreCoQdXQWWBK4igUUn\nM8zUPeikGVBCNIFgCcRLWOHtw+0T+BbzOwcACosr7E0ntP6Gtpgzw86HXrka87BWU7IeJxThu3M2\nHSHNXDR2oo5r0ckMNnz1YbwEFp2Ml2m9xtvQSRughHSCaOKclmUnUSiswFf1aQmu6CSGUuyksy06\nEpVIkt7aoocwflOlkyptVMtnxosRpozm7Bc78VtnkZXxWp4Z/CqzJLCHBBad7CHVap13opMqoKho\nQo+VOGhCv3q0u1HI9u+LRYBO2A3J1Xnxt6pyN1+dR1neiYswP8SAI+9KS3SCs8m66vRTFbKDL5lx\nJX2/I3+/wwz+UJghdVm4Bp/n9aFt3uXsLDrpX+OrhlkksOhkhpnIW7EZepvpQ8FZvjMEO+4qISMM\nn9Bcz3A6yYx9lbmNBPJ0ctaQV+zkLMmvdneXwKKT3UWcaOB+dJKPoDhpHTxNknz8CTt9woIuQC2J\n2VhFlgSeElh0slRhSeA0CSw6OU30pOGPpRP/xEkpcIIPQWEoQ+/0WXQyg7ZP3odrmcQVO5lcnVb3\n2iVwraXYPs65r7wlnYQiD9GkRCfO/cYTAkpy3e29d++sv5C/ix66KrVFPR8TKtWnFVh08mkz/kHj\nTVrJD5LIGUNddIIBDzh3gjka66lrmVyP9UyUqSIoPh900kOoy531n0InoxbLPepZdOIpeV5Bw6Wy\nChwvgUUnx8tc3SZ+2jqSgRM8JoKhjvBO4zZGWXSCGthJJ+raUetsaEiNndB6GupUB37pehadLDqZ\nwYXt0odFJ7uItVjpqG1csdkzi8tf+8MwCQ2cwL3BSQqhGRzKOng54k4noKirxvqQSlk6QvUTRNWM\n43TaVfWKftgQuYFLQgkw2mZXNWse63BGPhmEum49i04CXfq0bV/z0prwwsvRyS2V7dPoBChBPvWV\n5XQa8jsMUBjWQIuAO82PaMvEBtR9Pzh1ZgQcd5tUdVoDbdf6nMYPknSiVgX1hCPCYk4lecO46ETq\nzxug5EX5OSWTC+lzBHKVkS46mWGmPplO1CfTI0b4gKI+qC0EFNpiNYhiuXPLa4be1C8Q7umr7Yb9\nUeEJzXuGRUr0Vl19DHFC+Vj136aeNzRpFkd1Gq5VftHJteaL7Z8uNH0X6mpeJZJ00rzdz/fkmJIs\ndoK4ADfp/O2fHg97pb+tYz1gTaZy1E/kPcbNgDIhnTD/pIY0aEyFTnHozqDAPHSCncGONWssXXSh\nHJxWzq1n0UlKAW7pNlIjv3IhqtyXGMct1SxDJ+jRLzFNnjV/PRyWngLBwyX4HHoVKeAYCjuh4jAK\nRRyZ5aGNJqU6IZ2oPa/GVJwYA+WA02MnamgnOXc+YfRXAuR0cD2LTlICv6XbSI38yoUWncwwe0k6\nqaYhZhia7AOFEiAGevTVohMshgXaAif0hCyCTkmwqgfK0IBqIa0LacSiwa0290eZr5fHzQzc8tDO\nMJu1VNbZBgeXrmfRSVZ/FqBkJTVNuUUnM0xFSCfgv0tOdIZx6dv615FYiSnsea/sbh2QwEMIv/xr\niVGsW34wElOVrbpqrKXkR/7VaAQa0oy7Zf4JZB5CD42I+KqCVSXpBLmKlh9IJ9ZiqXqfe9Sz6CRr\n6Kr6ka13ldtNAteik7sqmE8nt8npPB0nuWEHz5dg+MSJneBtPgAoGUbxb0We8Bmyuy30j6g4A3MZ\nQVyonkUnmQl9lrmr/yiI4FJFF53MMF0hndwjaiLpBJ8Mi2EMdmCWhk8gwgGMAnSiMgqeNXEelILt\nLkCZQf+H9OFCSFEarz+uRScFYS46KQhrgqKLTiaYhO9nW8nO3Cmnw+hEHhyhERR69BVCIHh3MQOU\nP/z0028//zMEXf74xz/SamnsRIWVRScz6P/qQ7MEFp3URLcApSavU0svOjlV/G8RRz2v/+V0Z+jk\nkD7gWRMMhDA+APLAm4qRS/CNDJ/89uPHBigbl2z/GKBkHjK7ACU/s6PiE/kW+0v652b661drOExQ\ni05qM7jopCavU0tfiE5urFfmAb0bHYalgRO8VYdmYWjihj1J1s/vAJ1s4RMEFHoTkJPfebSy/Xvd\npZw8G+un4fKreVQ9+Rb7Sx7mdPu7ijUsOhkozDtUdWNHcofpIWNYdDLDhDp0cqfAySZqjJ0gf2Do\ngiIFO33CEjQAHHD65Ikm74DiB1Fozkje++MLnLrnHlc9qp6DtbdnyAd3dTidmItUe8bJYYJasZMW\nvVqA0iK1w69ZdHK4yJUGVcN3vxMnjE5k4IQ+Ho3GV+ST2fDbjU4AUCB8sjUBERQElO2Nld/Bgyz5\n8AnzOs1OaFQ9DdqrK9v7b/vRamn5zHgtk1I1NWp56MDxYSeVJjkZEExx+lkdly+3RScNS+D74cct\nF69rjpJA1WQc1S/ThZ/Ygf2aXnTC7tmhp1JoTIUdQ4FTJtu/B5q8Tp8goAAM4UkUiTjq89zysRNw\nk21acSKdyKAC+ns/3pDZcFoCqY7XKs/60Cz/0qzJVlRYkUhniVqVM9YZVq6y49OGlAb2yYUz2vzJ\n8plh7ItOppqFb7P1+qGZO2V2MK1D32AAA/M1NPMCmAJlEC/wT6QTmt/ZYIVGUCCIIhlFRZPw6Anz\nHM3ecVQ9PdrreEHVU2ZozLL5A+mE+eYeCSSvbaMTtZ8OdamdCX3oip0kJ5EXCyXbWO+6bJwErkIn\n99YlnAVGJ3dCE4hk0AfJ04fTQ5aHHoaljyRhgIJ0QtM323sZPoHICsCKPGLSEDvBMAO4mWY6GVhP\n1RioSz7pNZPjlat10QlME4cJ91cCvq3B12UOvnxXW9WGTy5/b6dyg5lddDLDJH4CnVA0oU99xeiI\nPB1CoykWoEBQBPgDz6AglMDn9B+No0g6qeJg0luHOjaqnlJDe8RO1ICBxLhwvGNpKRSLX2C/2Anl\nj7CTqtBW7CSUm1lg0Um77A65ctHJIWIOGvlAOqEHYOXJEjz0CuyyPf4EnoDCUjxAOQAfiCZWBEUy\nCj0MiwmmvD5IDxo6XWv7y5y644dkDSUbaxFJhgZKDTEiOSB2Uu1efqIbxpKRp0VyVscWnZSmLFV4\nV6VJ9WAVsiVwCTqRzvtmU/rhdIJpHXroFWIteOMSxDwYxwCaIKBgcocCCqoKO48Cn2O18CajV5Y2\nVg1dtR6r/uZ26YUOPdB+hvjl2JOqqVHLh/3MzGBbGccKKev3PRHDoFAOzRJsKDRa4PG+bWwfe1V1\n8XysoE4ZeKj9p/SKNXp7Fbo9nbC0DsUR+Apv0sHbjNnJWTV8ggRDyYOekJXaK8/MwidD/i3vMESM\nq5K8BBad5GWll7y9d+kV0HnXX4JOzhPPQS0vOqEPZ6MnZ+kjSSC2wfI7avhE3sJDJ5IelV1ocpCK\nr2b2kcCik165LjrpleBu1y862U20hYotOnk+EbVQ06RFZexEIogEFHo7Mb3Xl+Z3aPgEsOMP8GS2\nr6e0AaZMKpTVrSWBbgksOukW4apgVgksOplhZj6WTtgNO5jlUW8nhoOxMF8IKJJOfv3pBzDK9tVw\nQOnM3XReXtXV4dvCZP/72002xARyvDVr62d1Hp3yi04GCnNVNZcEjl/Pc41/jt7cm06cwAmlE/q8\nE3qvL0AJvhid4G07eDZ2oxMEFIijDAyfdHqjzsur2tpPCdL9Z/rQ326DoBouyYzFL3NKo7RLi076\nJ3HfGvLn7fftxwVrX3Qyw6RJOoHwwD0yO9aRWIkm9JEneL6Ekgq9rUaGTzah4W3DG6Agrwyc4k5v\n1Hm5OpA96rQk1tNW6dpS4SewnpHCO72fi04Gru5CVexmP7Z/on9aRpzVUGj7Y4ouOplhqh06uTqg\n+HfrqM+nl0dSEFBocgcADo/N4q3FwCgQPkFAGXX6FbyRPl+vT2W8AWMJoTPL1I+VcM/0/it0aifR\nkctvLVNAS2b679ecDKt0yoH2Ux1XqX7HRFj1MEGxYs7UVM3RopOqxLrKsxCufIIkFLA+p5lpWgY2\nanTv1dXLu1y86GSGmfwoOmEPs5c/zsfuN5ZZnrfI9hegAKbA6obwCdAJ/TdkoplzVb01c43YbsYx\nW/Wr3i4TM5A9tAhD7bZ080kx5tu1AkKOGKlI1ffWh1gnlXOzbJFTZXM9dSYlLEHzMajSxatwXgJI\nD5I8YAfJuISFfOFbpBCGJlh4AcqbcSd4kp+pVXKsBHw6uW74RN1FqKsbH3OCaEIfJgsPO2GBk6d1\nJuETWPs0ubMHnbDlIzXBcqvgzHzNsbxas7dzLnQGQr14OF4LL9jn4dg7+xOSIpV/BtFOma+qYSH2\n++tt9fpVPiMBx5BZwZI34PjzY17w4ZI0YozWsOFh1ZmeX7oMVe5LD+TSnVfp5GEcXzHCiyJ1nk7k\nT97gDcZ0Z6LKAfckdIHvETiR7kqGFuim3C+fceoZSvBdUp5OmJ97wp/9zNMSZmU8fZJO1H5a9Sdp\nD5vmzj5y98n6HWDtNFyLTjoFGFxuwQejChkBZk9qAsuFqWhp71b4RM7EopN9lTtXe0gnVwyf5NEE\nljYsT3yDt/BYp2LfnNlX3BQxZSc0cWjDcj9JOKDeUXXSB8dOwv6Eei2ZqbSxT3p9B2h8ukrGTqrD\n7KfJsEVWYNFJVWKF8qEJQ9vE6IQao9///JqjV5jXQRNM/Vx0P1oQbqLoopOEkHYv8sl0Ig/GsiXP\n9hvOssXkL76Bg7ED5y/jNR1SCT10pn4GSaXYSTLGoNIJCwv5Uu2nE1WMzmDVr5LytGgs1BwmE5VO\nrDJh5ZkCi04yUmopk0STsNjzwMrGKGQLRbdi6sk7jBi3dP0u19yDTnDeLzotFp08fAk5AD7W0e4q\nq3DN0sgoi5LSrQXN1SYzs/uhiRM7ga/U1UQnt5lOWP3WBlrOqeWzpcoN6b/v5h09lyOiQ6bfOv1U\nVdqaFEv/rfqtysN+qmpTQj1nqS462cWOhfYLjZE8RofkQePAGNe1jt1Znz/hZpdRzl7pDHQit7yl\nGQGfDZNLq5pd9KR/STq5UH4nXN3Wolajnm3TeiGYu5Curq5OJYFFJ+OnwzdeVjbHOolCjVcVTbD8\n1fffbZN0Lp2AzJupMby8TSbHX3UzOmlAE7rNWCfGjtfA1eJFJbDoZPDEhcYrpBMfQWhkBQ/cqcdW\n1HraNmqDZXRUdSfSSagGMhxCYyrh5Rc6YORHvNlI5w8JhFNTCpwwWJl/+Eet3dXOkgDPJ448Y/WZ\n0g2NVxud+FdJZKGJAGf7fu85OoVO/JiHOlP0tg7/ctiF0/KIKdNO5Z3oJFzddIKcEydWBGXRybRq\n7B+PGNhty2qNOswxsKt7V7ViJyMlnDRe9CR/c7KGhoudSugmW9rE0hmIkZI6pK6D6SQDFkgnsjAF\n0IwisXzBtI6tRCeTnz4J58Va2v59dpn7ig9ZMauRFgmEx4HzlTpVLTpZsZO8IiklQ+OFHqUHStjW\n2dmO01YAU6xzeV3DnvXiw+jE4RKLCGlmR26ycaZCPcH6F53srYaZ1e0fM8owyonzyLeqr6d1qZ9L\nP4qfsK/gT+Zcpa9VP6FzOhACmlVF7cPAjg2sSh1jtf5q+WbBWr19072xtX9UbZbxotspRITQ6zCw\nCO1assKPApQD6CQfL4EZlErCVEKdaD82Njmg+LGTh996PzsMApnQdOTpBAOWlDutpTfP0RPLFWU+\np2UkiDTTCau2ml6hwKTGHvImwkI3GBoOUJJZqP8wKFm/7LyDfWG7Tv9TZCCeq5scV89C5n3uqevD\nrw3pJIMm4bmEfkz5nJx33vSUVBeIJOQSGeJCDaE1gNNKuq5w9idM1YVWTC6cCekkjyZ49IRqSGmK\nzxp+hkLYSkHHLIMc1LlSF87eo29mb2Qxfx/PmpO1WfXX1r729HeVxtqaS46RAk2pIb9+KQq1vApJ\nJTEmCy86SQoqLgb2i0VK2DFGcELJOEdyx9xW4SekeEbRCYMJOBuRmUS5LX6jh+3nk75eYwEFN+5n\nOTnpwNRtKxa7H51QQEE9yQPoWRN3aTphMQz8U8Up6d1j+/5VouStG7x4lU7UbjvLbdFJcqLvVuww\nOnE20BmX6eSMzjKLO6lCJ53kAyRS7Opxk7ecxesHCpBOwrgIA9+wPFDU6dGUD4yd0APLyF4sfEKR\nd5LkDtuqfuPj+xeOv1cDITS+It+HsRMZRLHMBVYuIzqOKfDRORysRBYaxbFE6g8h+W2IMrLAopOd\nfM3s1Vp0InPPVYaQpyYXoGS0oZlOwqwNyl+dSisuBbjw6Dn+dtJXF0NAsRTGUgNZ/kRGaaCT2Y6e\nJENl6jqFa1n4jVWI38KEnjVZDbETNZxA3bNkC/YtFFC9uFqPs/CRMxid0HG1jZGCmuwAq1MOMGOs\nGKVZQRH6eQY1rL4lu6Q20VlnsmlFMfJXrpIcq0VmhzmJzLkTeUm4RfY9pUNCYATVXf49JreBTkIu\nodtinzJp6AWPEz2W3AYokNB5/aN0os4Ic3sZWJFloOnjw2MfSCfsyJEKN9aHqIHOTFHWGbhU2zy3\nvIrRAGMF6ekz3h3Jwx+vSgaLTny68oEvT2MDVRFZ7Q1bhzfwORX6GyyEAHA/pfBJElBKdT73c9vk\nC0A53oHtpCQlOslwSR5NfCgEOqEvJEU6HXh8gdJJdZZZeWSUnTycast81yIXzqVjJzIBJwcolY2W\ngeF/R9q+ZErni87pQOJ06ESNbVjbfZU2LIhxducNe3QrbqH2v2QfqINn+uz005FbJjrCN8Dixhmr\nEmdLEO4WZKNy/baJrmrnmfRmvJGvOqSzyqt0gptmSic+x1DTk+QSbCXvusCGgi+8K6Akl1CSSyia\nVPmSzcvTo7yOxEI0BX1SfhJHlRzo4e5HJ/nViiETxEq26jFrgxkcxhnw59biFuRCQGH66QRdzjJ9\nq90lgT0ksOhkmFTVLSCjE+QA3AnJVE4bnWQcldzVMXNJjekwuZxXUUgnbVySZMGQYDBeovqqzISO\nLbNTNMXfq1lM/yC2Of6V6IRNOttdqNsAGhjD3cIvW+xkIxTtSTBMbWQcZR7RzTGBqxdXlcCikzEz\n5wROwGChB6IGi/oDZshY6toKojT7Jycqcxvr5tNJ3utIH+NfS8urUZNqhaVZpkplXYgdUAtAHmHM\nwiBnHvUotHZvNkDzqA701JNXEho4ocARhj9ZjIROH20dPv/OL7zYhdkQ/LNn1OvaJYEZJLDoZMws\nOHSCZgs2RixBgIkVh1RCA4c7tnC/noGeSRxD/8Q4dJL3OpIkMqzgAAqE7h2GsK71kULtFfV8mW6z\njXj/FDxA5/VPSfoYj425Lp3IUGhm8YIybMESSOhgRJMqic92uPmBYgxlhsyjMn3ao8l2akttXT2z\ncnw/k93YSTLyUMhODVWr7RfLopOqzPXylrej3GDRCQIKmhjmvZw/22IqvsW8PZ00o0kS/uSxgzwZ\nqCE0K9kXVguqBf1xRm1xT+gdM4vnY+kkwyVYBgEF6QQ5wxcyi69kZmRUmX7309OTvFfeu5971x8o\nwJcgeiS507X9vVp0MmZqfDqh2IGxE/Rh6Dyoqfr9l39VX7/9/M/b64+vfxJc5M5b+tRPppMkmkgR\nhSigFoB6kteGaKKGvvKVJ0Mpqno0M6tFJz4tNTc3Zj2/IhBJ2TpT38AoLBASjmgIRIatHB+TaOiS\nHmHa2Xn3u2Hs9qiqRtXTMwX9fVh00iP/72ufW5+vI/fyJenEisOjM3tYZw1QGJ0ApWz9wP9SU9Vg\nGY+JCY8RelSLmtk5mE5oIs93dSHHOAWSAEQjKDDRVQ2JRK58/5l0UhIsLYyTUuWzrTwkhhrmaLsE\nfAkGJFhkQp1E6n6YK1KXntMxJ8CmUpGpVKRh1eXv0U8qukz9sgxKviQ33b5xl96oDyA9Z96tr6gK\ntakinbi30XRW97GXMzphLpDSiRVFB9dF61EB5Q8//QSAomIKMgpQi4yswOcsngzF4No7/ZOrN4km\n8mxQ0v33bLUz7BISTKkDACslP9oAr7oVc3+oCDp2uirmtaXtuMnYEGY/nUhAUclAen3mbpF10MPl\np1JW5TMN/Vb1+rQzO/VTkpw6cGzd6ieTW4/QSmLMNMRIVAVTp0ymCR9DH0Juq2VdhTFztFMSUHC3\nSpM7ql3DayWg/PbjxwYoklG2KcB0D75hHz60/wtE8MXiLjebR0YnJWczKrNTwgWncDLpU2pOheYM\nrJQY5aJ0UtKWGegEVnfzEpa+U3UH0i35Lr/qcUs+yHHzEkr262dIRQxWbkAnKhT609GgmdSALzpp\nEODzEkknEAhBs4VBdfzQ2gejz8BoCqZ4HlDy4we8KKBAJ1jghCZ9VF6R7NI+/imvfFPu3K8K0/na\nAwhK9OB0phpEUWM/NIyH6Jyhk9LBiAY66fGyozTxdDo5OIDk0wkDfXS3FsEwvxJOilp/5irVTUoa\n2LWfN6YTa94XnYTKOVEBlU4AUNAxYBn8xPcZMoLyHTh5BxQqCAkiFFwkkdDyEwl0RFe+l9Yd0cRP\nEcrdfAaMGhI94URJOgkd/+l0EvYQwp/5WFee+dgZlFC8owo4dCLjJdT9hzGJsIdW/aULt8I+JezX\nz7vSiT/vODtScxgdhvNoFVixk2bRvV1ISYLaLGrm1DKqj6HnQmgE5S1wQgDFOjIiz8yyVA5eeL9D\nJ2Ctnv8qdDJPTqfk0jLwEZYptUgTQ84qWnTSINVSdGqICWumEwcLkh07hk726ydoeN5bs8LNw5ct\nOp8gMahhJHWmeuiEySSpCazYopM2ufGrMI+jHjeBbZZM7oC38AEFyvxhm6gf32mdZ2bnBShW/IMx\nh/zzllBClyjod+iVaQGcrFJwotREmLJp9mfJblj7/uZ2nWjHLemkIXDyt3+qHUCeNrOj7pVl/IC6\nltDIMj8Ulrd252qjjvuvtquWh/qlnr9tkMQP+KH/tkSXFIKkLgoiauWlmqVIZZ3S5Fq9yjfNpPcG\ngKVaVmFKJwxQ4E/cDGEsRBo49gnzjgAoACJ49GT78Ekqv/124xxNm4LhukIKzDhvGrjynVCmtkyZ\nZiZQL0y2GBar9soCFGa1w6TJXdM6k9NJ2xI796p8GODcfk7V+oWEtmInYzSH0QlYdnSKmM5nx1Do\nn6q3YIACNwkjhWCiBwAF8zhjhnT9Wiid0BlxzmQwNGmgE+bUQwhojqNYNbf1WdZWpRNrr7/oZJNM\nA5ocHDu54nK/kKOdRLzXktiik2FqQ4+VII5g1MTK7NCSIaAAf8DmUjLKBiiLUeh0ZuiEUcuJdFLl\ngzz3hCUddGPJxxBZZOTjWnQC9y75EmsQ16KTYXY2+l3JgQ2tqs6VwKKTYfJnh17lHho2Q5jZQQsI\nBtHZ8tIIih8+wZt6AFOGje2aFTE6ceBPBjDCsFbo8ocUCGmgIVLS3LFMZ3w6CR0/xCBPVLdMD0OZ\nS0EtOgkPIuA5jM7Zz9czNpCQb7dzgKMurw6/Wr6/n4tO+mX4rAHtGlKINFIss0PNHDKKtH20ns18\nwwEUDJ+w/A69r+fDQyns3IlFJ/RzFjtpduRDLszQAMv9DWnXqSTTJYYXNHaS8f0n0smQwAmGS6ms\nFp0sOhnmaQZVVKWNavn+bi466ZehTicAGcyaszwOtYZQ3mIUWttWjEZQNhzBc7LsgSj457BBXqqi\nDJ3IMygAl2H0fgYOkKywR69AJ1EmIaDcmE5CrVBX/fZhSCdbAfYCPbzUggs6e7x78zs0W38Onuvq\n8Kvl+4ez6KRfhs8agC2QSDBMQq05yxcgkbBtVhhHYYACdMIYhcVUho3zOhVdkU5C3x8WGA4oD22E\nf7kf5bkonQwJnFh0Es6aWuBgOgH3Q2NduNapn4APVV/lOzCrflm5065jfqr10N6ynjtVyQ5U260O\nwZkXOl9sOP48shm0hkArWXRyHden9ZQldzBHw/IFmPoBlJEhFthFqYwCVUFDmN8BNKF0QtEEbz++\ntnDrvf8oOhkOJbTCEqBYdJJJ65xy7gSDQ6EMcUXLkvSrNhaRVx1PJ6rDlp6b+jbHx7MlC+uRkocs\nQD9pdodqh2W7WEw2lB+U0+GG/lvyt/qTYUR1mM5cZMrXjXHLFZSZ3lSnpbKPv4baX0wQ0GgKew82\nTkIMhIItQIFLEFDw5p0/fJ2E3f5rvT5tfuakk1Gui9UTetbOAk8Xvsk0iqBci05wzWbgyacTdSH3\nTPfxdKL6WsvZw+fo50Jn7EODjMcwD5o3XyU68dHEihKpnZHthjLJwI0vfzWW0zCPDr3BV6Wx5CfL\nKbnoZIgYn5VIA4eJauQJ/IRlecB5gA+gaPJQi68PmWWUERTAlF9/+gEvOJuyvfA5KJ/2QJR+OnG8\nUbOz73FXzrWZo6wNfaYe9yHPlyo6PemkkyPDJ3TBZugkFLKMg/ZM94fTCTrFql/M04laM3eK7495\n9b2pygrJ/lvtHkAnrGkVR5KjGOhQF50MFOYDI6T9wr0mfIt0wgInYJQxcUMZZesixFFUQMETslsx\nBihb+Y9FE9zVbSqe98roS3Au8teWSvY4LfVav3V5SbK3arrB7/xV6GQgmlgR0M5Znp9OMHyS2VtX\nYydOXMG32nk6Ubvd7IadCzN1WmUOoJNkKGiks0zUtegkIaR0EZVOMMVD6cTalLOwOUDJd8xNAArU\niQESpBN8g4Dy2+c96j4fO5Ex+b3pZOwmuyfGgx5U5ZUG/9pPJweET9hSxbWZhDbr3EmDuPJRqLQd\naiyY9IK0GL5v8L7ykk7vLnMTfgzA6nxmLBl3XqWrKp1YRJiZR7CNqnxUMdLyjepVv2zRSV1m9hXW\nbgxcHf2WRVDAHKvJnYcKpgEFwyc0xbNdjmgCb0aOeeK6MnQiQ1kYvvLddrMbw5jZWE/W2R+6+6dV\nNXRyfjqxkjhVyKNQu8e0ThI7oWHIjOezTEI1dkKdU8nMqNyDtVnel8FEQ+tygLLRMOoj2/XlpvbT\n6jztD6NMvx6LhErzUi286KQqMa+8uiGjzKH6ALRxNHCyvWfJHRpBURvCCAowChw9wTMojzt6XuGT\nkWOeuC6HTliwBP2xzOxIjuzkgAZ/71wic4Wd3etEE6Bw3dBHT4hnPd/PN1t00iY61JCxMyslOfFS\nm6trzcGPuYbx8b1ZdDJSBZjVo/ESDJ84+zMoL5M7LL/zDMeRLA82BJfjXTyUUZBORg547rpCOrEC\nJzJ8Ut1VV0+BVB0bhZLh/CRZrdS9UXSyU35nVOCEBkuG5+lQA+deYZP2btHJpBNT7Naik6LA3OLS\n8FGvBgwBn2BJVgCtEmUUlU4eobb3ezvxT2QUCJ8go1j37ED5kYKYoy6LTthm13LGlBRLu+oQZUrO\nXi3MQiYUUMLWk2Np7uRAOhkLKDCh1vDb5CYDJ85jYcMnxjKZ33JV7mcbqmmU/Xqyah4igUUnQ8T4\nrCRPJwxQ0DJS84TJHYceWKyF/smCKIAm3HN82eu7GkGfTsLACYa7QESUBcPQCMuPsPLNjp9RiMQs\nOagki6jF2vo5lk5gpXSqKM6gI41mOqGBE3gWgCO3EqB0jrrNtMGqabt27FWTdKNzUNYREFlt23jn\nma9OQakCeQOU4Q18VIUqnVAXgrETPIxC48OqUYNLrPAJzfLg5Rg7wTeY66H2Dk32XeeI0okao7LO\nWFAQkbwYYorFEJ0ZE9oT6hGdLA8bdZVUGuhEOtRv+1I8dyKPoTR4axovcQInIMMGdoGrqKAWnYyy\nJ23eelTrQ+opDaFUGLu36GTITN2/EtX80biIdGz0ktAZONaZbe63qhijMBbBdhss/lUmMk8nDEGc\niWABlXDKsIBFQvka8iUpBqnvk5iSb5GSMVOPUXSCQJ/UWIy4sJ1Acuz5YkxKIZ3kwyfz7x/aHGoy\nbDCq8hPtVWkIpcInDuqwpldmZ6SoLTqxnJ9qN62NOwCH3100Z+qbb9wmu9iwzpECOrauPegEZgEm\nlAm5wZfvdAkNyMn31ifSH1e7p+oSPQ3gRy/yQEAlT3WKfU4rzDTdEFyRIgrhI8z+oHaxaOjeq8fK\nQYDXpPNI/2SfP6O5pK7AZHEXxH+Ip79+icss8MDCD9Z4k1AlJSCHYA1Kyhk+sT5X66lOwd561Vz/\nopNm0SkXOnQC4V8oQKMp6CqYJVUZxc/vZEZCA93Ypfm3aJmhqbYD9JsJWcYzqBsIXTKdmoc//uVf\n4aUSYVgbK+Dz5fYtvSErU7nKIqoEZJQlUz8FNXWa9qATuViYYsusUCZrkyEYVk8DnWyXZABFWgCM\nBrUth/xVbBOvOm90gaHPzoQE1DLJdsP6aQE5NEoq1K/LATrXWrKt9k3tKpWDJSiHwPLzPlvJRScj\nZyRJJyzIT/0Hgsv2IRgjMGTsl3faOk27h14Q4zdba4eZv7b+V69C5VbphDpj6mLhPaCb9aLhE6QT\n9U1IG6yAWgkQyW8//zOca/ZfW5k8VfjsEtaDPbFuB5N7vgYCyMdUJDqw8CRdX7Lahr6pIgrDJxlA\noXQiaay6FkrlfTfsOHsVWUIPjeEB38ViPVVKsDps1WN1uNquNS46zAw5hQJs6FhJH84qvOhkpOQz\ndKIGTqQ7RHtEXREySkOnsW8YwmGQdL8ISolOEAczdAIyRKbxAaXz261jlE4QUzYdYO/hKcAWu5So\nJckl0CL9r7qTftv89Z2NbSAVuir3oBMVZDOAAowSErDa5103EvPTCfNbvj106EStx6EBi5CqsRPa\nrgzeMMhbdPIUV4PbW5d8q5dmeam3A5fGQugszE49n2q5HtmE4j8LTbB+rHNXq1fsdW9xRicyc0H9\nCgyczoXvoWnhh/Re+Z2xb7YeQshk+y+8CekEcAGIAf751BIGY9QCrH76J5s2nAV/mTRgR/ISn05Y\ntNLHF7XF5vBJUsGcYTaYgsyimp9OMqOgZWBEyRjD3nQyKpYTYk1VSrOVX7GTkTNSip346QbmLJkh\nq1olSie446deZ6QUpqnLohMWNKICQZT0Mzt4ya7hE0AT+soEURidqKRCwQUjH1BS/lNxB3HED5yA\nS6Cxk8cnh4dPVDBlCxCCZzDv8isrZ2TpSeZkST+dQJ+HL7hFJ45ImTL7wldBx4/lSOaoxk4khw3X\nEL/C/+N/+0m+Gvqw6KRBaOYlGTpRzRyzUzSt0x8+YWhyp+hIaBpAv63dJ5UtxUF0TlL4zBvtmt9h\naJIPomC8JEMqanZGfmgFSxro5ERAkaERGTvJ0IkKuGE6rFQAVSsMEQ0HlDydqPRJPww9K3XGnGLf\nHwrHnLqaHPGpQn7L/B8U8PvcTydMPtgcBnh8Oaij8Ic20smJuhQQ+euf6Ye///XP2ws/yXdmFzr5\nHP/HBG3RiWNf6Gadej4KKDSJAHmfkj3CHSFcm1eOq5eUsRPVObHYCd1ny1AK+3a//I5EExZEYbke\nYBfkEos5ZManSic+uDhWkn7VHD5pyLw4gRO5MP00kFpViTmShfNoAl36qHV9rl3K89a5/Tym9W/m\n+EIQfMHn9E/21bOA28vxdALL+zNXS5VO1JCJFSzBRMx3NiGhgDgdn4YmbxuUVyrBohMqJcYf1p+I\nknsAio8m6rcyTBKSCiug/skyOH6dqj7KzM5WDLQxjAoMLMC2AVbNNLnDtIXGVNj7JHPki1Xp5GNN\nbsIEjixSCpyMbHjWuvQkzitSQnlFfe8HVBadjJz2ZoObN1ssGRH2Hq3tB/Lit3ITOpEuBz0luAQf\nR2RibgY6ATXIJF/U8yIsOxNGU5CE2KGWPJ082HEHOnESN8mgC8WC0+mkCmcfuMZDAziqgArZoyq/\nQT00iGIFVBxYUUMpu9DJB27TQb16DO4egIL9+cwZoZkdmt6ShwYysRPn8MpYQCkFTiy7RrmBvacc\nk/zKD6v4ttUy68PDJ2p0hAY5ks6erhr1Epnva1u81lXw0MUkTrEe7gco1XMeUivOzYmssMcxDASc\n8R9/+f/gRd/jh/BGwsojGUT+DaaTT07rnEInPnYsOsFTsZROZIDEopOMP4Mp4DGt1huMtxZH0Qku\n8ySCyAiKFYwpmTln09lD83JqfHeed/ZhfnZvOmlGk/3OoAwBiyGVlHRPurrmy4dfeK40hg+HVUgz\nPv/+P37GFwMUiSk0iLLoZNg0NZha6SbbNmHWhmnRCdIJ7tTZDhv+7ImdwAGUUeGTIWji6DTLxTj8\nQb/CVE7DavFD4g2rxgli+cfPM6wJBzicDBGeN4La2hasf1UnnexxBqXqStXy1UoalO1Cl3yONNSz\nKfRDRJa3U7TkYQRPG9I5u7Cu9osudnZv18s77WyPmVMFTvvzmZNCMzsOnaCg6JkD5oR8xzYqfLI3\nmviQwXCELRb/W2dlhXSiZmSqoZEkeSSL+Wu5IXaSfHTsVjOkdZL9dIq1GWGZvuH716+/M9Mt5x0u\nVPWhlDZiHcA/rfrVyuUo6CfOJaX+O+P6HDoJ3S5NBlFAGR87aVsV4QDmL9BjU3rQBHf/b2HMH282\nbtEJ0onc+8LEYbKfBbSSfqI/fFLK6TQvBwcymvnD74xPJ5APTQIKOzCUnJqGYkk6yS/bPJ00B07U\nzpSsseX1ASlKKmfFThgBYJ3W52qjDp349eQHqNYDmgxdSnbYKVYVaUn+VyyMJ1Tw+Sgj6QTD41cU\nTX+fz6UT8I74gugu2uVFJzSDw/a+VuwEQ/cZ9ybp5+EYKqdPDgic9Ct5Qw0ZOkHnnRF1Zl4AMatL\nkmkC6wxiK+pPnk6gZMgozedhrZ7MRidvOyjN02dIyI+dqMQjkcIhjGT9tCGLxtTxqp1pWFk3u4Se\nn9UBpWfAn5zWgS1g3rZKw1e1dLK804GSkerRgamuRb+I8RIQ0Vg6oU6LTkGJTo4JnJwyOyGdwNqp\nAgoNccGcyshKdUmy6fPphC3AkDwygNIcRnKsR37t50MLoSKVvDXfIkdxmiQ9yD4kB2j1x4920MgK\n8geryoGVUKSfUIAByvbn278eESw6YeaMRjLCgwv9dEK378xS5y1UjwLMdm2GTphDAh9juSV1EulO\nmrnDPKDkAyezCTnsT4ZOGgDFohME0CqaAOLgVZYaWOs0SSfOMldzi+GGJ7Qb+bWfdN7hjFvxjyRV\nhPUn6wnpBPvpDLzKE8mMTzjGjy3gAUqPUBadUFPC3F5oK0MrkykgW/nMnA7bu2C8BKRh8QTu4NXI\nluUnrEgMZBYyyZ0bowk4ALmtVO0M0DzVcwcTHTqBr8IVJyeU8T1tguqMuhL76YSOPYQSmrQNLUMS\nUK5IJ1S1QsiweCW8MJ+LWXTSgxDbtYtOOgWoX+6HhcFcSmShe7XQymQKYIUYudlltFeoVMZOLDpB\nf4Y/LdsGKDJ8FQLKjXM6jBEzKkPjBwz7WPoG0QHe4J+dsRMZPsksuq1M548Ss4En6STZtySdUJRM\nOmxnTiWV+vRDY/ihqtDKsdqwz5JOnDCP7I96uSM09lXYvXDUH1KAPczteyJ6xv/JsRMZ0rfsC0ID\nvoGSSUMTFltQgjqMas224/RPdGYwCxg+YVtznKAwgsIAJaSTewdOSrGT74kjERRcHQ6dyI0BzEI1\nfIKK0bZn6Amf+EEjX+syNqHHsK9rlwSOlAALnyw66RW+EzhJWsnQxOQL5LdKvcOe+/oSnSTDJ3RD\nzw73SN+GxGPld/7w00+LTvJZHhZNwajJHnSClefXXXNJK2LkR1DyzS2DMLehWr17kwB7+P2ik179\nWHTSK8Edrg/phGbBaGrAun+ExWDU7E8pufPbjx9JQNlBPAdVKSP8+YYhoiAjizSUhViJLIhRlubY\nCUziYYDCAicybic5WF5iwcpCk7y+rZJMAtZjXncV1F508jwJuGvfp6xc9XPUXIYRlPxOKFNymSSa\nU7AyO4wpwSvARla9eYe5SYtOkoCyoQm8MoAypdanOtVDJ49JfD8ny7JylCkppjBkaTvGkSeAzJLE\nMiwBJAMnIZ2UOrZMQUpNV6EvCTAcsX5VWFLLQPktOukSJp7tgJVP/8QtF0UTNI7sWys1UDJ2auFl\nkprpxD99wg4JNYdPEE0ygNKlrGdf3EknDqDQ1cS2B7AoemInGD7pX4yyBjhCCy8VNfyDJnk6gfrP\nVoHV/tQSoKhh4Uj4OceajhEvOikLjyEItYbMlPhfoWVxdt79BnGZpJBOmOti8+KET2gEJRk+eUzH\n+3NjnyGTV/jEj6CUlXWmC/rpBABFnjmlThpmkyFFJ50cACglNJED9LkH6WcmdVh9mUgCzx8E/uuf\nQ/ioFngjnsqItwu3tuhPGQ87d3LvzA4Aytd/Hi/f9lnfwsVgVtC39eOIrGEBin/uBP2ZzA5g3CvM\n78g9Lk6EpB8KKN8hkwhQKkt7xrJD6AQGJn05A5SD6aT5Jh0nauKkdTAglDQXK3Ay43qYo0/7cYnk\nmGdbuYHvSydgIHI9uWQpZJRmOlGNizz6l7RBVrF7z0JGdVQ6oTF/KjoAa+obYL/uA4pDJyyzQMMn\nNK3zOHTiAkpmpDOXGUgnElAknYDY4fP+2IkfPmmjEz+nY9FJFU228h9CJ6BgMy+B2foGBHDwK8Mo\n2LG9Yif3Dp/gHq4NTZx08nA6uT0mhmveohOcO6QT62BQCCjqhDLowUgMxk4WnYRz5xSASVG9NULJ\ntHQSoomzJ6Fh18zWZdFJj5rd8tojQyYq/WDGh4mXdQzp5O2ndjqnBO3+XTfudFv2TPC8Mj3ohKo7\nNuASdtwyY33CMnedhaSW+nTCGAKmgIVPMidk/fAJ/RbDJ8qRWCN8khzpzMXGxk5we+ADCo2QWVsC\nf+Johs6JkZTCJ5jQkSkqfy2DqVFzW86FH0InD7Gs8ElkAk6JlzjhGf8o7r50cssICrMp8jBslUvA\nI4J92YNOPjx8otIJzBGNmrBY+n6AAnTC0EQeQKE3GEc25wLf70En4KdVQGG5njyaWMFL2pBEgSSd\nNHAJ3fzgNJewZtHJzMvDepRI83lSdbDfsYp0Kmcjg4OTPqw5HU36s3fUPd9v4472op9LkEXkmzAi\nUipwv1nIW5wMnVA0wfeSMtFFJb2dk9xR6YTdwoOAkh/stCV3ohMKKOy+XHThDbsFubhg6i0KCekk\nn8phsVh1QvN08lE37FwldlK9d7fnsSKdSZyzGIWeOHlL64ylk9uET9BqbOHVX7ad91eUleZxqkYQ\nPRwNmewUO/nk8ImkE5wplR4ondCAFuyq6R46ZBS1flgReTqZFjhKHduPThBQ2C0wACvw8meKhc0s\n7nfCJw61UC5RqSKDI0zUJTr5nJ3J5HSCkAGu14ma/Pv/+Hl7JRMi6jnThmAJbY5CCbw/ElM8NOmn\nE7AX9IxhyZBNW/hp6V5ogmYFs+Chu1KT3CqmlEIjmcKfY6S4KX85RnqGgFEgc2AWoGyfsw166Pas\n8AnSyR+//lknZLfwybTLodSxXelEAgoyAcxXOE20QBud0BbZe8YfDTiy6CSpbHMCCgYwkvkaWiyJ\nBYx1BiZlgBUGVuhXxdAEjxOhARlgEJlFuJNrBOMiV0toBFUTyfZt+8VOPjZ8wmIndJowNAIfqnOB\n+1Q8kcAARb2KEic93YLBtg1HgEs2RQrpBEsmbfSExfamEwAUCG/QqMkxdAJTLAHFshWdE7RiJ5YA\nJ6STJJFYI4LLj+QDSQ9Htk6Pmzy3/d9gMujYs3TVdwIUKxncGTtRXVomLpIsc/sp0OflPXbi04nM\nskleZBkElv1hOsCmRgYUGZqox2MBYi797wA6wRAmMgpiirMw5fQ1xE7wEpbH2WnKFp1ci0761eAs\nRsHAyTGAQtHkcXvR1z8GJwNiJ7CVoUbh9q5x/tjJZ4ZPrNgJDWmAZKzwCUZNqBMCF2idLLFAk9EJ\noglER/DPx3lY8uuAaN2uiymH0YlkFH9hJukEicdil2O4BEeX2ZB8zt06uEAmjJ30ownWAEGU5lRL\nG2HAEZntHEzb5fmUkMzpHEcncBhw4FTNVlUbnVjpnoz1aShz7ykoxU5YwgXppBQ+CQFFzhEFlM/J\n7xxMJ5RRQjrxw10wgxadsAMux6yvZOzkA+kEt9qzeYdR/cEgSgOjNOPFDelEhk/uDSiXoJMPDJ/Q\n2AnOkYx50K/kOWUnv0MBRT317CR3MBZC8zsy17OFUh4f/vbbip00WHlrYcrzQNapL5oqUk+/7nS+\nxMxfvH6iS6oW/WTRSYO2XOISxIU8o6hBlzyvQIv5QIha0m/u0NgJbl+YyT5me3G8ko2ik4aISOmS\nu8rfT0VvjILpG5apUbfOKqAwOeMBlAygYKPO0ROW32E38lCUuRymnBI7sUyQfz5MriaHTg7mEiez\nI5OJn7bSaSLgePt/cIsQRIGEC2MU6ubpe7gx+HGe4/VMtjydwIX58urRWv/hK/I87I6Zne9coLij\n75bLZhSdyFMOJfjIFL6l/PN0gkcN1N0zO4jA/qRBdesRWw7uyNogUkLvyrHOyW4DfJ5NuWAQ5Sp0\nkkeTU7jEohOqcjiEj1rmH3L0hFk5ySjWwRQemSCAkmSOtvAJtOtwCbSO3dt4C8/DnkMnkOK52eJZ\ndHLw7iHZnMzs+HQigxwUKVjKXwUUNb9DswY0fMLuFlbR5PtGni27c0E0wdMAQ56llJx3evTED5ao\nrp36ePX5JaVujC1MldBKJn5mWuejwieoVA6jsDiKGj5JpodY3CWT5fG5hELJVhK4hKEJNR1PSz52\nLakHUGBR3QlQLkQnH3X6RKUTGQaXAQ/ptFBp0XWxQ5HOUQbWIvy5sQguAXrPjvMk2cvldNgGaLht\nMWNmX/sfMDLNdII5HdhNTbKnQjpRxwVKuOjkME2bpCF8sAo8ahZejE7gk2d8gvzmThJQ8smdkEso\nmviPhNnljmI2Z5aNuA2g5I0g3hViGc1MdqazzG3EHpqGb+V+eSkqf8oTbF5YMeqf2NnDMIJCoy/0\nPdIJze844RP4IZ5wyBMWODizwxYj+9NagGpaZxIioXMKdOJbj89Z4FLb731fcbi6qbOXmIKf0AMo\nyArhg1x9QKEhkMwZWMz4ADbJwMkRsROMsqor6h4LaSCdDD96Au6TGt97yDxcqG/KTX6X2DkaQoMc\nGCx5TO7rhZgiA/4QJrSOs9DkDnqXrTweht0utw6dyBOy1wqizEMn7OhPmNbJ6NjBZUJT81HB0UUn\njvqppEIBhTFEeAaFPnNFHr+FqEyyEpaQUtHkODq5d4onNBnqyYNq+IRBRk8E5UMAhcVOLOcEuCC3\npJuUtog+QxOMnLPIP1K4AyjsK5rcseiE/XbxFSMoR9KJsxJvgCaOFaVg/SGr+2AuvHRzKqlImPCz\nPHjzjkQT/+gr5noohVDWmZdObnAGZSydOOGTUYDyIfZLpRPfgdFTqwxNrOA/TfMDslhnUHBmsQ84\nERg4UW8tpg+QvRygTEIn6hlSFtOa/NyGn9ahqntpV7o6v6sEMG6B0Y5kEMWiE8wTWdSiwsdcdOKD\n/6X95WF00hMv+cDkDqUTunW25ovmXCiabOETmrVRj56gArOSaiKJdgDyO86jY2X4BD5ht/zsatF6\nKj+MTpLLUB6LZstqWluUHGCy/5im7Jncde1FJQCMglENFjWxEjRQnp69pcdsKb6o9+BQWU1HJ3cF\nlKTVcGLLqg9TWWSFT/LmAP0iBi3wNIk8YoLb6Oe9Hu/HTeBDOSP0VCx2jJZUt+xwOAA7Ez7yxAKU\nS5yTPYtOwuVmra+kd8/r4aiSSTuTiUZvVeGtSPBOOcMx081Ko2S46mESsBhFBRSfTvCmZStTMzud\n3BJQklYjNJf+Mb1RgROoZ1oTPNB8ZOhEnjgBw73FS/AF5huExk4Zq3QCSu4cc2F0gkNmT7Vndxqz\n/A4+CmWgxPao6hg6YWvQSa45sZOZ78UFjbIOq8nPrQUOygzgARpOgyjfzELKzBZl2TRqD0X95DqR\nUWgQRQUUGTthdylbN+CoVARNnH/uhO4snQOhV/SaSTphO3hHCM7Rk1GMckU5V82HRSfP6MjXc0cY\nnaDtpmiCPAdUgYzCHnlCu4d0onoUSifs1uIwxSMZZfIsz8F0QheIs8SsMNi06yJvZJwDKFgJqDGg\nibTMiC9QrLru9i5/Ip2AMqsDtL46sbfVicDDs8glElAYneApFjx9AncmJzM7WNgRKRqQgxTRWWlX\n3NbnDUcmfAL+bBSFOPVMaHeqy8kvn6cT5A+QPN1BImdQ4GCMohpxB1Boc4BKG6P8+lP8VHuMlzBG\nAUAZK71RtZ1FJ+H5Enl+aOYVkTcylMlQM584Qoicneam9eMSGKUDUM+3m7F9fKbFU/w9wofaOn4o\nvz2ltxkxWmXwSIr6KBR6+w+SyttdOeRJ+U6Kh9LMRLETP7mz6AR323sDysy2uGd1fe8FX+ZQRq1o\n9AK/ZQaayp+iBn6OEGNlBPAq9fQJ3cjmn2rvPEx2iNCGV3IAnciJw6gYTfFYCwp/03H42AdWyMIe\njDasKBGqKCsAogC9ZdxD1Xtg/+mqZNWC/87riVPeqoSC0VuMk3yRHGzIH6zA5egE5AC5HgAU+qA2\nmdlhqRyKHX6WJwQUhrMHxU5uBij5bU0+drLCJ0lj4RSTsROaZ5FG2TLTgDK+b1Opmp6lVd0DtMge\nfLKNaPtkC4ewAInFJfj5Vr5faMNryHud5qZx4uj68ueLZeXmJ3WGERZ2JA+msOidam2wCfameZow\ngiLphLrw0J1jGMOqEFjH4SH1q7Bdp/+MeJw/O6V35OVAD+w+YUon+BULfjzTOl9BFAdQFp0cMZuL\nTo6Qcr0N9IvqWQQWPpGTyGInFqBYB2Oftsx4gCymkMCdUO9IszyIKQArIa9MCCh70wkLnMioicQU\nOmXzc8mbq3sPdbQxCqIJiE7FOCrV7f1Xs89Xp8SqsQe57jPBCUYnKnlk6glbZyQU/lk3Y6ddQW/6\nBRChqRwLTbC7CB/N+Z3TYid3Cp+U6MTf3GQ2f2MzPp225rSlk2iYxU5YfidPJ8AlIZ1YSUm8UIZP\nUHNgFvBRbHiIBEgFX2FM5cPpxD9rwqDkopqftzaqqUE0cWJLapzmF0IoicVnFtmVTqg/8yM0gBHs\nX2Zc1f4nQzKZpg8uo9IJDaVkjr7651798EnL9IySkbPMrnX6JG8vaGbBsR2Z/d8oRrmojc4ooaQT\nB1DYJMpDJ1age/scbzNWhUmxxgcUefqEogm8f9x1/NtvG4Vs1cpcz6fRibr01KWBh0surfBqsITB\nhGNYHDSh6q1Gm6jcemRY9e5h9AIrZPES1URkyvi2pb//Gds1QxlGJ/TPkEug/53hkzPpxAmf4Cqa\nYZLCPgykE3Cfi05CmWcKqHRCJYznQuQM0ug3GG4a3N7e41YSd+QOUufDJzguFjVhEZStLYijzA8o\nOAuZKauWsSaO+Vc8/lmtf7byqIcwcFA5fDmbH2czA5f7u52BT4Lp9+6gUTg1p9MJhGGgP9eNlFBV\nxxtzWKQE781JroskndCDtzQNNCmd4MJLSuHcYkk6oVkbJ7+z6GTUbFI6oQJnEyG3nmyLSdFkgxJ4\nYcikRCfSf1DlwS0poonKKHCKdougQBCFMgr8OUqAQ+rZj05QdFSq4b5/yKDOqoTSCegt7QlARhg7\nqYZdZUNtw2fORuJF0sEDAah6pTZBP2Q9t7okB8g9pSAkS88vxytwuEQGTpLxEhQd3vXjn43dytOS\nE9HJQ8lej/RWg95ty+Dgqy5NJ9dKopVmltGJ9GF4ItVKuIBwcHdK0QQ+zZ+vpNtThkqoP+Bs2KlY\nK7kDdAInVABKZuMSdDZss1uaRKewXHf3RhOwlpveARyrkkE1kzgeQsm3oqPGSwDSvPSoCV31nC4B\nAAWVTqp9y9MJAIoMtJwcO/Hp5BKOU+68rbhIeOgEEzpHZnYuIeTqwmB+kYajqGxVOgGB4AkVmF9w\nCfCSUIKfWD4D9Jy6B6oklE7wYCwMwcrvwOkTpJmZfxFwp9gJQxPV9Q7MR7Rp4PCrQBUdNZOaFkIJ\npoc2cYUd3hr/9Zf/HV87cWfYjVVgJwmMpRN8UEr+8fb0FO28dHKV5M6ik53WSX+1LHZCj8SiyWZO\njs0mFAN/8Cj52lOqe/TQF1JA8cMnwCUUTdif+GBZwBQMovQLbXgNu9KJkwYNp2P4SI+p0EeTJ5d/\nKarFJfS3okCx8z1fdJKX1RVLqnTi3BLsjBFiIfDfJJ1AEAV/eWfRSa8KDaETlnSoxk46f7i4ZJ56\n5XXg9ZJO5KFjSieMVOQsgMW37D7MQn/4hIVMMC7C4ihbQ8gleAcyYs2BYg6a2o9O8PxQGyzOI6Kd\negKmSb56bl9adLLTZE1S7Sg6gXoQNap0AoAyO53Mn3dQXZp1MC2T9JHbwQx8ZMo4e6lbAopFJyhh\nmlLx5xFFh7f5tHlERjZISwyS8OZh68EneGsxnJAF0wYcM1scZVc6UTn+Nnfo7OSxqvES2o1FJztN\nyiTVDqQTDJx8k0pikPT0yaKThMDsIvnAiXOTjsw4MJubJA/6cO5MspmW+Rw6oQdK/EmR38J0+wHz\nUJJqDQA9eA4m8+ATAJStM5RLZkOTrW970wmbjrsmdLrs1LiLF52Mk+WMNeGtOvSenYbMDk3rlG72\nQTpRwifHCyyzZw0t/vHdhhZH0QnuodXASZJO0Ew3YMq0Eu6ZWTV20kYnPpeA5JM/JmfxDf18ey+j\nJnhglt7FAyUhxTMhmuxKJ1YC9JbKnF8IIiC+1wfb2dh1KjY/L5coyejEf9KrM6JmOtnqNMMnx0vw\nunQCPc9ndsKdOubR0YOiz6vGQvBCSir0yRyswlsadIdOSrNGoxrORCTpBKBWrYcBCgRF8AAs/sme\nzMbQhN31c/yKZi3uFztZdCInd5P2L49T3N+3mG1/7vTaaWZP19hP7sAoOvn53/4NQiaP4yM/fpRE\naoZPSrUMKXwPOqHHWkMKSZ4+wR15A5rQ3XwmlPI5dAIzlacTWtJJ6+RjJxh1k9Mqwyc0xaPeXYwH\nTRBKZoug7OTDcF5UMQ4xTZerBNEEoho7QQmtdsVOLqckfocpndAYRtswO+nkeflOFiQzpIvSiXRa\nzVBiHaGldFJN7lSBZtGJOguIC/jt9ok1F/nYSSl8AotI3l2Mn8DB2GlvLd7JttAFCGfn8cDyLZU5\ntKWIJiDwIwEl7NsqcBUJ0BOs/XRSjZqAlFhW6DsxebwQF51Iv1hli/7ytzToMrODubNM7IRFShig\nqCmzkhir+R0rxfPh504QSiidlCbieKM3vEUaNWFPSzsmgjJ8RKvCUyTA6AR+AafhVGxP5y9DJ3AC\nYzZbw3yb3GF3xlFU2tg1fDKbhHuUG6+16AS32s40bQKx6AS8ILwoo8AnpZ6HgAJBEcolMo6C504g\np8Pu9yn1Z4/CB8ROQIwfSycsaoKxE8CUw1I8eyjPqvNgCbC7f/vDJw393xqFYyv8tp2GunouyWxh\nwVVX7X5Pr8JrT6GT/gCJU8NU4g3lnyzA6IQO31c8/FbSAwMaxBQglQYxSgwCbcfeAqDgkNUUD+WS\nTzt3ImMnIMCGuUjq1VTFnKjJd0j8qDMoU0lmdaZBAjPQydZtoJPtv1tu6LTMzhXpRO0zpgwyUZPw\nCK1/Y8gemHJLUy7pJHk7MZ1iK7zBZqF06ERaDdmKBShqKIWdjW2wSvtdsnfsBAWFmPI5dGKhCU3u\n7BFBodwj3++nS6vmvSUg6eSU5A4M80En9N/eg2f1LzppOHSyR4rnE+gERY3ROCsQIj/PEOHegAJB\nFPmgtjkTOrjSz6KTx56rmGg72Pp1NqcmdFDaJUDxaUN++4t7l/JOM94prnV5KAGGJlt5+OT4oyfQ\nVa544QDGFrgZnYRBkUxkhT7sxHKKwwHllnZcnjuhgMICJCzD0gwoPZJkfWABFbg3hy5AGjLpaXfs\nouY7kNc0jG0Fpw+kBPOFEtve3JtOVAqhJ05KwOHTRvO30Iex875q208Ckk4AUBadPIyL8yCQSYyv\ng1Ol5I6PKWBt/fzOWECZRLxjF16eTmjGh4qd3qeTCZ8MOSBFGYUBynY8FiIom6AwjiKpZawYO2vb\naScd0gmIsbPz819OKUTGS9gnW2F8wCu9sIE/SvSzGGV+RcJICbtDB5HlEUQ59t8FYidT3bbjB3sG\nxk4yEZSkv8wUu6Udd+hEnUd2HBXlxvblvjxHSRIZhQVU8FAFQAngy6hG9zA+x9MJWoyZxTJE1EAb\n+LKIgRYIC1exQy2PoxsSPil1aYhgP7MSK3ZyVnLnGnQCMdsZNOYYOgF3mKGKUWUmEe/YKR5FJzJx\n4Ie1BgoT+EMCCgWpgc2NlT/UtiudYGwJlwx+MrlYhoia0YkVO1G9ewZrMKZCc0YO38hB9dNJCU36\nmxsyL1eshD4llvb/xKMnl6GTGTaIfloneabET2DRb0eRR6aeW5pyVG4Z07JiJ1b4BGpgeRZVsG33\nFYfmzGGUzNxRyjk45bEHneD0bW8gxcnoZKqAazi5PQUaMjsqxDD+gD8ZnTBvIdNGw+lEogltQmWR\nBSht6oQUskVKaHJn0Yl36ITm/tvkPuqqJJ348ZVFJ6OmI6ynSifo0iyeywDKTnTyHSon0ZQ8l9CL\nYBSZa0MJZwocSSfb0BBWZtjPZOTTU4bFTqwwg5rZUQ+gsBr82IkMooylE3U4LGe0lbEaVb/qkfa9\nr8XYiTwDe8oz2WjY9akJB09AyZEfZk9VIYBBd87tUopqi6PILX4m7DGkzLmy3UnrLDoBv6XOEQjT\nj5GoeRachSMdv6OoGCx5h5lnkmgngev9eU3DqEbp3LHYicTHWyq2jB8wTJFRDdXTy+QOAw6VTmRV\n+EiVfjqhlVP/hO8lnTAKYd0bpXWfUI8TPtmQ5fg7d7imHTwHV6ET6GeSTvyS+djJkUdPbmnEUbmZ\nzDvpBAmGYcokXMIGC73a/nNW94bHTnAZwkTQzA4sPXo72y0Vm3po6xSIlb7xz6awgAqjE5hKp4Y2\nOqFO6Jdff8eXFQpq/vxg73a55pBONhCh+R2MnRwMKFeik7POxoZoghjBwicyFiLRhJYBa3v80ZO7\nWvAGOgmTOzJShVEKpJbjrRKSh8W+J07xWDphaIJ0QheOnBH8BN8cP0d7tOizAjXuGN4ID8Niye1y\nNXYy9lRsM2oMuXCPSbl0nRREgEXgBbftLDrxzqCcYmQzdAJebTidtIVPqo9COUWqB6xhlU5o5KM5\nueNk0w4WJrhbP5N47gmM4XSCQ8bYCSo8PRu7FWPTBDEkeB08TftpO4rXf9iJ6surmR1WyZBTsVCn\njJdsn+BXrIwVX8nHXbByOqL95uhCNTM6QUBBOmFnZncd2sViJ8eHT9D0Ux+gBkXYh1A+DJ/I2Mmo\n8An+fG54MOU2lpotFUkndFdtOfXM0RNfpHvLk0YCwhNO9EDMrqbEqnw4nWwbesALi06AQrb/MUx/\nzPjrdQ9AobETHx3U2IlKJ7QeP3Yy5FSsJA8rKELhg9KM+rks4MRaAFZOWR0TNirDJ8+QyVfsBHnl\ngJ5fj06OBBTqwBroBB0DuhAJKyybc0pyZ29veoAe++cxIXjANtNW1GFaOkEoCYmE6tuJ+SaYlOF0\nQtEEMjv06AkGSDbPKmd8++zb487xCKXO1QHilYETFVZYSdVhh5kdeVXPqVgHGvyvkoCyVYKRkh8/\nHrpj/euciDtdjtkcfA6bFVPZddQn08nDeEVxadUWH+BQWccydGKFT/DzJJ2oAZUwBNJWYO87YHdV\nX7/yb+V+7bOpLjl0wrxag2D30E+rw+FBJbjwrIk4l05k+OQb8k4Vy5DpQNqgdtx5nImKLBRH/Ht2\nLBJqphMLFHyMaAaazIVD5uUeldBDJ8+Ezlfs5PvRseRgyh5DXnSiSFV1A0gnMryB2W5JJ2H4xAqW\nyO1vg4/MXPIJdGIBrnXupJ9OIFozcMU6EE9zN+h66RsY5tj+5Ic2nE7UGBj9kIVP5GxCgXOhLS9A\np2QYNZFHQ/x7dpg/+I4zfX0Rco/sKlQYZv0y3ABREPZSP2QHUNRTJmqLQyblfpUgpkBmB17AK3ge\n5ed/+7ftNXbsV6UTsLbDDa61PWW+wTpNIj8Hy0gPoKjHStTtL4WeDGe0lflYOnFub2mTJLtqlHI6\nIRPGJX7Gh/LKWCOSjGD1N0qpArN1WK0ElM25wizA2DHJRT/s79W5NYTxDDTxcLewf8+OjJ2E3JCZ\n/VBEYSvHFAj7+ckF3p7JRgAF00DDAeXCdII7wlGY4iBIkk6sPbrM1LDQyFl0Ajn7UX50tqWLyp0/\nqCH32T2k0i9Ypnj5gciSGFGAsMFhkzUwdkJXujoEpBBEMTpMaSiOlMOuAqd2PB8dCe/ZYe6hYQhO\n4MSPCUFQZDiUsDqhDwNVtEFEV7kEKITeZkzvMaYPvx81osvTCVrhHkZRt6cUKXroBMI8Po4wX0Lz\nQcw7Vu8W9p3rjdGEGp2MU6fb6x4iGRhBcdAk7KFPJ0cCykDTn4SJO4VGGgy9QyosdkJPnPSDSENX\nSxmfzvpXKqdTgHD5RiFbjARYBDI7239/+vFjSOWskuFsuipcElgSWBJYElgSWBJYElgSWBJYElgS\nWBJYElgSWBJYElgSWBJYElgSWBJYElgSWBI4SAJ7ZI9WnZ8ggYHHCz5BXGuMSwIDJbBW30Bhrqom\nkQCHnkm6tbpxOQks+3i5KVsdvo0E1uq7zVSugaAEFp0sZRgjgWUfx8hx1bIkUJfAWn11ma0rZpfA\nvnSy1d4mgOYL25oLr5qtP2GHjy9wP/u4Jv14LdparIo9WR7085QRqY2O7c9VVt9OU7BTtf3aQv1r\nf22fVsOik9SMT6v9qd4fUugq9jEvjDXpeVkNLFkVe7L8WBroH+/Y/oxdfUmRNghhp5p3qrZhgNYl\n8/dw4GBHVZWik+aFlJkStUzmQiaChkvyQty18nw3Zi4p7SPXrZl2rhlJTjjp1lZMdU6s//jn5PNS\nFXu1/EWn3u+2Qydsug8YvmPS95ishnhbRghjy+w08IFj36+HzZJspBMYiWUTkWb8ATtWMlk/DLtq\nbWnleDlKMDT00uj7cghn3VnMbHS0k3TKwyaa9SN/oUonzk6ClQ8tmlqeahqtwZlEx46rvBsqOZuI\nfP3WCsrInA1WVYxMmUxbvhJa46WrUi4uaxExa6tWwuQWKr9TiZwC35hYValitIxYqZLqBKk6bHXP\nmbtku87ArdWkylzWk5/WpM6U5sjS+ba1wHoIPamqgSyf1FVmoKo636MJndfyATpaIq2/tIlOGauj\nlluybKtqiNXpd1qkhsO6Vu2A7G2ymD9P0lijBkvdkh0OV3KnlmQul5bO6VVGaFgGambzjh/SN76N\nU+txhpYpH2ppRnQl7WWK4SgkFaCqRcm+se7586LqbV6ZHZmrw2Hlq6vMmj7LKJXEGOrPwGUrV58z\nEaEB6eyYnKlQZywDmPEaVM4N9WR0IFxKDXNdMh3OjISTxRoKx5I3C3uXRK1+vsnTySiv2WwIqoro\nsFTYByjgeALpM0KlcSxdqEDNY99Pn6R9tCRgdb70uWMBLcFWhZYpb638qpxL2kJV0dFJOSO+x8p4\nAqdpS2nluvMBaz/l9yc09BYZfcgsaksgVZ1hbTEHSVuRX+VF0dYrNJjMcpbWuNP0WfU0t9spcGty\nVa/E5BYqdptZaFOM0lVowZ5v5qcT2mPHFmQ0W7WDav3hylc9gaNSx8u5pBYNhaUEmG5Jc6leIpeK\nurDl3LFF6FSeXI2OQbGUEIwFu9BXRVVzQvmrqqt6fdkZa14cOlEvSVrqHjoptZsXmqoAoRH3HYyz\noi19S+oJt9Ha+a2MFjkDrA4tKWpcC5a6ql3KiCWpe2FVTj0l3QsFKAtUl6FlW6wxqjbKEUgoq3DS\nhxfgmi+xa+wkhWvYNxz5BdZGJ1b98Llq6MMpSc66uoBHLcKwk/0FpH10lo3jCPvpxJ9Ey1mGmpmZ\noHzlTJ2SSiLrd3Qy4xIy856cR6u5HjpRuxd6glC7rkUnyTmCBegXHqUSYZewM8xyOnMX6g9tdJRh\nTNbTrMPhhaEk83bJko/jNB2RNnRs+CUxnagDyExqZrWoLl9+mHEM4cp0LHtYf8+qLnXMt7xWP/NN\nDFcgKlU240mvxrok1UaViRRFfhJV55S3ApnVnpmRTD0ZR2vVk/k8ow/JeQyHUzUamXaTRibEkQws\n+mtT1R9fJhklyUwQdD4jih47luwJipq2lWw3MwQ5lfSqUXOU0T2qM6Hpq3bMkXamqoa1P1AbS6ri\njxQV+/EmhCko45Sk6yQ5YLm0MvVLVW5eomwuqUTUxcCkpJZPdkZWpXprf7BJOY9SGrWecBJDoUm7\n5jgVae9Kkyh1OE8n1Bkwy1id9Le1l9j4WvWrn1uLiDWaUR61n765kIuCyU3VB0kJfj2ZecSGwg5b\nXaI15KcYTaVcvKpi9yzPUDEcAyIVIKMSYW/lCvUdB6pHWDM1FCjk4XNkrU1LIal6h8bEsiHW2NVG\n5ZBDG+vPbF63k3PUWYxbqs7q1uU9EhhiFHo60HPtKM2+tBB6BLiuvZkEjtTkUavv3Ck4UmJjAfH4\nnp87U8e0vujkGDnHrVgbrPjKOUoMsY9XF8IcU7F6MYUEjvRYQ1bfuVI7Ze2PmqNR9Zw7BbO1vujk\n/Bm5gWXxo5oZEd9DCJmRrjIfIoEjPdall8+JnR81R6Pq+ZClkRxmik5OoVp0eMmRlIpZaTw/vVdq\nYkj/x/an2v9S+RNNTKmfzYUPM0Btk37WIs3L0x/X3v3fr/7DFMMR9bmrbz/Z+trVtlJknWH/T5/i\n0zuQX+YDS34onaAErVkfog2h0ucnckh/rGU5xLQNqSQvkONL7jQFvsvJD3OgsuUbbSupSnLv/u9X\n//GK4SzkthnpvGo/2Y5aHRnKOaatNlGP0jGH58KvWM8PmPQUnbQJNHnVKLknm5MiVi88t1eq9Wkb\nYLgsaYGeUat00lPhHuPtqbNnLG3Xtl3VM8bqtW09zF+VL1nteVt5i6vaaht41cC9wa4btrFDHlhb\nyU6W2q3q8GE6xhoK5x0LIJeUhlYqDBIO6MTiKWhJLgnrc6swax5nPeQ4Bm6ldjP+mIqyQV2q/Vfl\n4/dTbcJROKdLVOylhcd6SCeFK5bxQzmyw2xmQTKWfKpydoSm2nf6IVOJpPI7cmiYdHV2wkFhQ0yY\n9HNpDphWsPEOHJfVf9U4DFyMjl5JOXfqs9rt5rXmdM//ytdha4z+2K2FE65Z1MaQDJhNkP3BcWVs\nhWq15ARZa9/qrWoQVB0Oa0jaFmfNZlRL2l5VeRw3ZC3Gkq1wuson2hGcnFSUDjVkTFGqA2blfQnS\nttjCC9uVnc9PQ97WqErP7L4/ZLWflliSn6uznB+UdTkzIpb1ocWsRqUZlUJzOpysli5vv35pH9Xy\nlhKGsrXWecbKqOqEHaZv0GGwN76OOfM1dlz+YrFWTdgH58LQaCTXZmbe8/0sTTrV4dDa9PTT77+0\nPGpbzroOR20Zt4xjcmx7aGClWfO7mumnU4NlCnrmLmPwYZh+58OhOUrSoP/YJaVneW/tu1t/hVeV\nXu1VKDXHUyZnLtTvUfVY2pmZDksO4QJrUB05raFyq4YglFt1UNZYnHpKSlWtx9K9UKOqk+L7A/gW\nyzhv2DT1WJyMMjvWI3N5XkolyxuqZUhLGaMUuuRkAbTjSWPr9C25fJIN+bqUnzu5iDK60T+JeZMV\n6kN+KmXJBpvjN5dc1NUl4zia0lyj2FGxH2+sISVXml+DuoT8Tiel4y82a+k6bkP2SlrzjLbJjr2J\n+z3fke9nm7JaqtOgN+r6kfVXLQgVTnK1JxuFuVaFXxVmtR5fzfKTHuobHYhUV/jE+tyx/nmzQKes\nYVzOorN8YUl1k8bEkXNGn6mErcUeTmW1gCVtR7cdQ5R36vlFqrr5zPSpNsFaU76u5nXSVxVLPmr9\nmTHSCg/QMb9LqhkpTR/IwefXjIZzS7sTneQH7A/JWWzqBDvtquK2Fptq1pPyDTWPrbSSdrJRZBZV\ndbVkhkl9fzheqwPWZFUHlanf6ST1LqFSZerJWNLMpIcToQqQDUeOrnm8w8eVt2hWn30R+YqUWReZ\naWrrWzi54dAyLiHTt+ryyfitUMcyfqdqB6y1WZpE302o/iLTT2c2S93LKG2VEvLO2m+9Uw7Up4Bu\n7xU7yQ94WjpBYZXsSHKGHPk0L35rQhsUOjPkpwKlf6pJ1mkJISPDhjIWiaqWlAozab5Lc5oxSeEs\nqC2y4cjRhZ4jbxakrpbGJQv7TVc12VeSTG2Z4VjyDKevp4C6+hg+ZnTYIk7n8+EGKkkVmbnI0EPY\nf8uQ9vTzLDppUHJHn/3aMjY5ydxP9c4wbJsG4/qRk20tLbUhWk/oYCR/JUHSUv3M7Fpai8vAGoL6\nubp42LhYiyhhqlglITcYSsc+shkPXQ6rytJyR1yWfFQldFYR7QktVq2H9kedLNUC9iibtCnwifW5\nVE5rcckV5Kzo0ricRSe/UmsOjZ2zNpPSlnqe0Z+G3pbWoL+6pUHwDWN+LWcsMDPj1ppyXI+60i1t\nqdYTGljH3yXXsjM7am/30zHVcLG1by1wajpYPepXcmjNcnheWFoSn1Y4ab98Ormr0Kqad1c5rHEd\nI4GGxXhMx05pJbn6ZhPabP05Ze5Wo0mgNDM7S4Jtu5/PWX5J+7gUaUmgXwJti7G/3WlrSK6+2czR\nbP2Zdn4/s2M8QvOZUvBHnVz5apTvc+TZIKXPEc4a6SgJLDVL5gKwmJoWGTUdDfXM1p+GIaxLjpHA\nopNj5Hz/Vqpu46zt712N41nj6p/Hs3ruxJMHLtdjwgPJ1cc6U527avmqGGfThGr/V/mxElh0Mlae\nn1tb0j6yLd3B8jrGVRw8qK25E8c10GOVRlEqXJqRsTWPrc0hqsxEzEwnQwTF/Flp3u9UmPt1+27c\n5hibY/CHTCWYtbd/d5qhNZYjJVClkyP7RlfgKe3u3egoc7B3P/36S6MoFZbtSvONFTbU7FzSUFvD\nLCRX3x6dGVXnkHokfjUIU/rFtkrmuSqUbVVutLysPGwuKZlFJ0lBrWKBBCz7SDUMqpCf4Of0W9ae\nWg8tA0sC/6u+sVhc7RKtQa5eOV6nvDVqSxSWrH1hJl2UI2RnjvebR4cdHfkMtIBS0ywRqZNuKVVJ\nmJ32xZl6+hUKzRcsfIurKaO9eEk4kOE67GhCs5LI9U611JK2ZUakcBrqr9oKZ1nJOXL6o06oX75Z\n7I7Nf2pkqF6rwJKAqt/hIlTdAFv2lFT8BaauEGpYmYWl1tbpCbPgYX/U8qwta7nSz8Ml7Vu0Np0M\nG1WHP3YefTqxvk32PBSLrIepsdpQ1ZrTbozqOatT5QOmYOpgrb6FFWZ0I1SVkhN1uhp63FATnDmy\n1mnz+rX0x9GNUlsNUqV2LJTVopNQRKvARBIAW1ZaQkkTn3HtSANyjYVdqlqKZPlwtSeHn3HPzQ4v\nc2FYJjmQznqSrVSXRMlhZ+Yi7IDq9cOr/AJy9YVUnSkQCodReDgKZxJD9UjSQwMzqWSDInUMSLjG\nkzhF61Hl0Kz8eamq47UmlMmkuXtJrX72LVSvVaBZAntYpebODL9Q2sdwYSR12qpHvVzaC8e4oCGj\nKzO0OKywVb65noxFYF4hFDWrs9kSqX3rnEfH5avzMsT9WI1KdysNsVzIVflDKw1XObqhVhhOjV9A\n9jDziWNbnOZK0rDW4CjdsPqZXPsMSvAqR9XlJVYlec3Ji1Qqeegg6KBCNQtrswzLm8DballXZSSQ\n16pMbbOVCVeg7HBSp601pl6OH8o30vH4tizZbmhxqvXsTSfMEoWKFNq4znkMBRj2sKdA6G4zihSK\nKDmnzQORq0/V7fxgraUR1uAPYSCdNMsqc6FDJ5YfDT931p2qP9V1GhpYZ+DJJby3GrP6OQtmZm6V\naZbAjQFFtY++1c4viczqhTIT0kmVipImoNl4NVy46zwuOmm2J1R0qm1hcx2yRbW8pdtH6nC/9EK/\nrhKqdKV+Pda6s5xCwzqlHSgRc94Uh7IaOB2LTgYKM67q0+gEjJcKLtKuhS5Q1kM/aaYT1smkJZLj\n8le4Kge2/EIFsoRZskTWeP3Wd51HaFr1naOGnPSXvlo682UpuWrN84VDlUDROU4Ov1IlLL1sqTxV\np0xvR02oPxeZnjhlMhMtBV5a49J2hdbSWYP90FCq3J/0qjly1ubbRHRO6ro8Y+JvKaXhBveWUlqD\nWhLYQwI7rb5RbmaPIa86by8BxojrVwD3nXFrf7Nvq4fUvpN9PKTvq5ElgWtLYKfVt+jk2mpx8d4v\nOjl0AhedHCru1diSwGdIYCCdVCP8nyHgNcoTJLDo5Gih3xVQBtrHzinxN3x7y/944773Btcf0d6t\ndyrDAZfPIIF5Vt8BAl9NfIgEFp0cPdF7e8ejx/Nqbx77eCKdnOKoDmtUbeiw1s9S7LBdSwLMtob1\n9BSYZ/X1jGJduyRAJXBtOrF2dcfvX/NategkL6uw5Gz+cm9Xfe54z209VIazCjh0wkztfj1cdLKf\nbFfNZ0ng2nSCUksaiLOkLHlwhp6M7YNqH/P4CDOI6MYYTtbDFZf8RDitiiqG0xlsmikSHVQmJGNt\nl9WmrX6q89IwXjqoJDb5WJ+sxNIrZ7x5PYFBSa9f1Z825e+Zx07p+R1edNI2oeuqmSUwF52odicj\nvkUnGSntWkbax+SkWH6FgYVKomoTkmzYwFUEkfVLsgkFaPVH3UPTfiZdV3W8lgwtAPL3+slOOnSC\nNTgr3SpjbUV69CecUEdzaD9DOXeKLuznLemELeRQCKvAzSRwGTpRdy2WwXI+9+s5ZnZvuepUOsl7\na+mTSp7McauyD45rpFtzv1jGwUMZq54Gj5WXp9OuQw9700lGaJbXD+mESTujP6X1npzHUN9KjSYL\nLzpJCmoVu5AErkQnPnOUDN+5M/QhdILeIkMDPp0wNfWpNKSKTH8avLu85HQ6seTWtlgacMrHHaoh\n1rZBLhZ1+tr0p2QHuK18JZiS6lRqq1r4lnQCC6pT66qSXOXnkcB0dKLa06q/cbZZM+j6LZecbx+p\n2Bu8S3K779OAv/mW34ZaJ3ulapdVT4Mq7lp/ON6GDifpJDSIO+lP2G5D/zulVOoSVdpbWpUFKG36\ncI+rpqMT1RxYuxZ/D+3sZU+xIMyU3EOBkvZxJ+9S8tY9dJI0/aX+NCjhrvVfkU5wXrDzzhuVJvOz\nYJUM5XbASvf3Bgd0YNcmkqtv1z6syo+XwGXoxBdN0nBkdkIHzMEtF5u0j1S3mFTlV75TYWrK5pHJ\nM/QWfgEGUtL/ORri6KEqnwZlC+tR+59UOWfKLNbPD8HhAHV+M/qDvWrTn6RYJILTC/PqlJdVteS9\n6WRFUKr6cI/yi05OmMeqTTyhi/UmP8E+1qWyrphdAg4zzd510r9PWH33mKkLKdXpXT2UTkKv7OxC\nnN2zs6uTFU6yjENRnK4Z1Q5MIthqt/Pll3HMy+oqJW8zp7dffSt8cpU1NbCfc9HJwIFNXtWik8kn\nCLrnZzouMYTVyU+QwCfQyacByjHofEwrbWvwODq5nz9ukzh1ez01zHbth9jH2cS++rMkQDH69tL4\nHD9yDDcc00qbWh5EJ5+jUslpuJ9AFp0kp34VWxIYLoGPWn13Mp7cAX/9jTvY4XoiK/x0OrmTMo1S\nl/vJ5KPs4yg1WPUsCQyRwEetvvsZT4h+MU2AT9SZVTPO1fKO4lUz2jup3+6xkxM1aWYqvF8OdScF\nHWK7VyVLAveWwKetvhPdyk6KpNIJ/TB8T2XCarOuVcfS4zd7rlXjOm+AMkr0Vfga1S6tZ6ykhvfw\nZgvs0+zjcH1YFS4JNEvgA1ff/eynGjvBD9GdWeRh+TuHVCw6aXadzRc6PflmieblISVb1R51YHRK\n1BXoYNBYSY2SDNW2yXtYGvJO9rGqRaU+r8JLAveQwE6rb3LhDDQOP/34aXu9bW6/PpGf7yQT6Qsc\nCnmLKETnVFjhpNMpydbxwj3i4j3vqav/Wofy6FcWRfrs2d+9sTWUpn9s03vUtpN9vJmU9pD8qnNJ\nYKfVN79ge+wDwsf25pfff2wvZBH8ZPvwv/7P/8TAZQ+xlOjEijSUPs+MIoMyqmvOVB6WuQad+BRp\nDTIj2VBA+xXoWVf79aq55v3s480E1SzhdeGSgGPrPnOZtI0aKASIZIMPeMGH8Aa+wtcBgLLoROr2\nXHSy9U+Ni/ixKUtBF50cac33oxPQisln80hRr7aWBGSceK0RRytomITBB0UTBBREFvpm1yxPnk7Q\nHjKT61hI5kD95UMLJxdaqf5knXKY/KamfEWjSlp0EtZ/Re91J4OyK50sQAn1fxX4ZAnsvfquK1sa\nJoHczQYcatTkIcNX7AShhEVQaPbnujK5Ss+ni52ofihDHpkys83KopPSjNxJXKWBr8JLAsn97hIU\nSoBxCSZxKHDQOIo8hsLyO+zCI8/Mfua0XoNOnFiWs2mYn1fu5G4P2L3dSVyfaW7oqOdfnheaowNW\n34Wk8fAX2tkRiIjQ0yQ0jqIeOqHlMXDCqGXXjM+1xD62t5PSydhBTlvbndztMfZxD4n99I/nJzSH\nqOhO2d8hfZOVLDoZKNhjVt/ADu9alYUmgBcyWYOfwLcOxNBbe2hteKj2gLt7dhXdYZVnTrdMRyd7\nuJ/DJF5t6E6DPcw+dgptYxH2+r/++n/CJ9Xpm7N8yevTWcMLWQ30T8umVD+HaOicArxirw5bfZcQ\njkMnTrJGfqWePqEoA+EW9lqhlFBJkmu/i07YQWj6Z9g/dS/V6XgaGj39ktsM+Uj72CY0QJCNRawX\npZbTFaO5A8mVz/iAitSnE+yYRTOygDqWfD+bRfE5Fx65+iaXqkQT9cRJBlModljlrdt8VhDF0ZPk\n2m+hE6SQzKGhyVX59O61OdrTu306XJbkxrjkz3/92WEUDKUgrEwo7f6VL6MXYezEohZrLvw5Slqo\nawn/rN4uOgHJq2gCdFLFEfWmYqsS6w7kpD5UQ49DQp6wAC3NUbtk9dMapizPgePr78zlbrkf34/1\nzdAJC38lJ+kDi5W87MzyOdg+JuXGuORv/vvfbPCx/RfeqC/49r/85b/AC2BlZsmzvuW9vkMbtE5K\nLcy4sGJq0w67XEiqk3f14NU3rTSsnE41oMJoI0M2GKFhj0gJZeW7Z7xc3TzQxWUtZ7YPYctZ1i/3\nLaUyamGrD75wOMrI0vK+rIZA2Qpz+XgYavD8BSa0j2oqx+cSwJHttb1BiNneXyiOsiudhHpotZ7v\nVdjEKkAl8PP/4u2AP0pWFoJYARWHOUqBE+ckSsbxJfFdpRPq9Rs2G9YmRFUbh36q5ZPWIKATDJOw\nY8zsaTZh3CwzSR+1kChgJqdqcvnMRif+ERM1aoLxEuQShBIMoswfR8mrEy1pbcKczVnGJFkbqcmV\n+Srd29Bk0QlMFrgY9WRrlU5UNAl9HH0WfjV8ApAh3b8aqmygkJ56mKuiVYWRD5V+WBzFqUShEzxy\nDJOK/8Un/rKH0vgHmylXXmXNH9lPC5yP7MOQtqaikzY0gSQOpH7Y6ROa5ZkWUFQbFFoQ1EAJK/CJ\n+jmjFnX2fUOWp6gh+nnLShadfPtO8YAT3EJn6MQiEvVgrOXy0EU20MmTscghDGuBNNBJZiOB1Sbb\nDReU1c92OsGJhHul2F05zvEihpaSNFf4JJzOSxeYh042egC8CE+/+hEU+JaGTyDdc6fbj63NzaVV\n8XM6v+gEAyfO/cDgyMKzIyGgNNRQ9XpsJxBSRU/Is0oP1e1EtX452PftFplCnCp2BtYJcFElgGJY\nGN5Up+pzrMwNRjoVnfi35DjnYfHQCURQEHQws4PX3o9RqtbnBkp76SE8cjq//v3K7Dz24saTYWn4\nxAeUEE0ymR1ZScblOSFGKxpKjW1PyNPZnKi9qkZnraElTQ253EWTJHtCxMW5NfzS5mB1PpMjPFdK\nfk5HQoZFKng8lvIKhFIwy8OyP+cOvK11P/nSVue66hgJYOAEQuV0G31MB+ZpRaUTiiaYc6GbbZag\nCQEFK1QdnHp5hk46xZj09J2tnHL5G504J0gydALBEgdQDpiqU4S4Gp3EPmKow2cOSTAyB6RSDqCJ\nzPjgJ0sTJpEAeG7rNUknO7ux6ISmdZiHwk0y+CN6IuThhn75V3pogR0TYecZ2K0h1vab0Qle1TnL\n4eUfQCdkCikYqmeCHIT06WQld0JVu26BGXZvPp3Q+24QX5yzKRJQrMAM3rp8oRuPr6tpas8ZiGwp\nD/76/fenO//KhkBC5Lr/aFpnkr3BWcJkd29Q94SHDVRA2RgFXhRH8MPtzR/f/1nUQgEID2tu0tiu\nPkAm96eTMKkWHgii9xhj+AR0gt3jc8CErSaOl8AkdIJ33MjwCUvWtJ1NoZUwskF2ud+RlOPVKdki\nQomCI1+A8h9/+l+3FxT7f397EAn4dTyxkWxotmID6QSc7mwDzPeH0gneZEpTOew5aeCeIILivH77\n+Z+3FwMUYA75j4ILflsYwutWnZ1QA6vtqb/n2rwoaMmnT9mJTtR7fC69Etqk/AlXTUInGzFYz1sb\nTicO36wgirQy/atAZmosKGGfqxdeN3wiAat59d0DTRBK4A3ekwGjQzfEPg/RBAAFXxALofChvh9F\nJ+wIqnr6lRGDpQbXphM6uziFTlrHOhYE2kDzO5J7Fp3ABu5mSfFm+9jvtLAG50gs3AxMeaIZVuip\nWFohDaXACZVpn4wyUOaZqoboBkYLMEGTRBNWbAulQEzluuETFjhpzuxg1CEziXOWweMm9I2kE+aw\n/PDJVphxyfYnDl+NndAPG3I6GXqwyqifS2qB/ifjH2qx5LVsW9KjNi+78X5HFjvgk0zrYPoNj8dK\nnQAM+ihAUSlEWkyeOO+Z1TOuHeKBOjse0gmGNJywh/Ooe7x/JyQbuBt5Aco3OJKdYMMsY7SgjUjk\nVZDxeXx+tX9qZqph9d0ATR7u9vXIUIkpeATECuGryR0fTSSjYDQFvtrprAkLnKgEYBFJScH9gI3F\nwVL9nHry/XlWYp2EVe+SYsyBSsBu+cEIG5Sn2nNROsl0uxp8vk1SvME+5tU0U3KjAXYQBP/EH8qB\nN+ymm7YDKJmrFp2wiaM2KzOnWKaTTr5Z5HVa9okm8Oel/i06efPNhE5oyATPwzI3hM7rG87eT59I\nOjldO2TQohQvaei/FTtxIAlaGUJIfEtTohNM1tCTR6gZdPqRSG5DJz6gUDTJb/LukRSfgU4kMcCv\nDeNzSgBNWOQDAiphOCSDI7LMSu5I41hlFPTHiPJ0yWy7VQkfmdWHtV0IUB6i+Kfvh7DJ0FTSFd0j\ncEJjJ/Q8LCZu6MZYPWMgwycsp5OU567FVDpRwxVMH5p7lcnsNJfJ90qJndC7b9TYCd6JQw8qy+wP\nnkiSsRPQpHwvJynpLGnMheM9Ahn7KPM7102Kz0YnmKCBAAY+hF7SCX2oGuIF/iIgfdMAKCt8Yi1e\nFvt11jhjEZb4l3D/iK7LO4rFJ99HT64TPrFuOCqtPjwoekUjzKNxr9gJOyVJzz5i+ITeQ0qDK3g8\n9g8//TQbnTiBE8yzqJDacEyE1qNuKt6iVu8/CaRqYE8fcHT8NwgcKKHxErxTXD2YgnQC0EqXxEXp\nhKI6m7zOyLN6cO9ap/ZK9nEP3JSZHYAJfCA9pnWsY614KsV6g6SSx5RFJ/5cZ9QG+AOg5Ld/+Rf8\nL8UU+Bz+UV55y+C8Awp+daGbdwbSyW3QhB5zpDtnvH+HJndoBAXPJCCd/PbjBwWUPcxUtU6fTmQy\nxSeMZOuluIiT7jmaTp5nWt+fY8MSQxgsYUSCR2JvRic08gyxE/nKbOZkmQvZzYybSa6NtmIqnWDg\nBMACD50goMiEzvNpJX/6y+9/+stffv7T1hl0e5RakqSy6KRtNulVkIIBKMEXwgrlEvqekgpmf0xY\n6e/l/jVYaPK9yyTbWTNk9brD9k50Qne/uH+mMXt6xgC9lQyfzEYnJUqwAhsNillq92g6ARqVL5al\nA1KR+TzUFXmOGgMq110bMr/j3B5cPSRLAQWvbVCv4y+ZgU7k7TaUTvCJriy5o3IGFP5/fnq8KKCo\npLK1S18s9HL8XNyvRaCTX18viilIJPAhTpCMptA9A1tol5DYQDq5rvl988HkVlPcCSNzYMwePvnb\nP5kpAvBrTzR5hU9mUAkr9mCd3BpohP1zLSxm42Rpe7r0du5EcgYAyrbggSoet32TE86MTmhWj3EJ\nvZ3HOb0xg0KEfaBDg8I08mxFm1nY2Qk4o90EY3SV8EmPFoYyzxRQH2NPszkADfQ8inrKhGZtJKOE\npLJdwg5GZDq/yoQSgJQNynYjFcYo1p9y6clTtPOvMpo7lr3Nrz7YT96PTuiOmqVycMgWoMB2eqMT\nABRI7oQKuQrsLYE3OlHv3EEu2Rb5Y9p+/KC/TYBEQslmUwJUCIq09ADKdZM7D2x8HcWC6WGRZ5od\nl6FmGXB2kj4XApS8fdxJp5E8aAQF6QTRxL89Jx9HoZiyjZ0RCf6502A/sFpcOBRTIJriYArsHGgB\n+IQCCqzfyUW66EROEMvX4B4YvQ+9gRRPmUg3B84IFAx83Pbf7f3kKnH77nl0AiGTh6/9+rmB7b/A\nlUgngKt4jw++YcoBf7LzSjegEzoEGnmWthJ4xUqKo620Airzm04I9MG/s9YMnilhdIJ3FAO+SDqR\nR08ko2z5HUz00HQPcAkMGawbvEFeOUsat2wXxQuAgqEUC1D+46eftpeSXf3lF1h0+IM7ky8xH03y\nqw/3ineKndBgtkzroJMCBwQ7Z3r0BM+pwPql+Z0FKOeaEZ1OEDNxC4hoAuGvbYI3TFFPnMC1qCV4\ncBoKs8/PHXxP6zI/xbZ06n7uuQBepIK8Ivdz8odCenq797Vb/2egE/mDw/R5J/hcEwAU/wEnFqDg\nikBGQdlSTAFG2VvsH1s/zgK82dRvAxTGKIgm8AZfD0//RSf0GMdH0cmd0IQdfVUPndAt9EYnFFDY\ntnlzbZRRcL/xsQvt3IErdAKpHLoR3LoIdAJoAnRCAyeIojSnw0IpSCc02nbu4HtaV+kkuaWTtx48\nmP1f/gUZ5XI378xAJ48d5Os5sHh2xKKTDKDA4VnKMY+gyNfhle3Nf/y3/wZrBI7Nrn9nSUAFFEYk\njE4omnw/k+2sASTaHRs7uT2dSF9DT8hagIJeD93cyu8kdHPHIm90AuDJ9iWwC3yeFXqhJSZrWIgM\noyZUGzB8gvfyIPDuOLKdq6bhRLp7ZtID7Ei+HtHmf/xHGnN+noqd+2wsmM7TYycOncDpExY7QUBJ\nxlGAeGB+sTYIkOCk76x0q3pFArAleEzEdiSOvFRAoVwCe4D5fw6Qool1TD65+uSe6roqxRI0NIhC\nT5ZgwB523fiSKR5GJ3gA5UQRjUqUj6rnYFE8tRpTOdTUouXFqMnTNIu0Dqbu6G07DEqwDGWU61K8\nSicweRRQMDvOws4qr2DMmR7ZA9s0c+R5Kjpht+QggsAb/C/cAAwnUdhjYTNPWsMpxlCKXDgHr+SP\nag7jJU/aeOcSZBSZ02Ge/nke9grrC4/IqBP9aXRC0QTv1mGehQbvfyE/xwNc8tjMkMdhILex5E71\nhGzb2bvvvPgrEEs/kXWq0w0Iwr5K1jMnvrw6L0ImdFMIdAIWAdI6lEIsNEHlwDgK9ei3CZ/4gKWG\nna1QCtDJ9qLHYxed5P0uPRiLh2HxOWyUTpBIAFAkoyQftsZCKXg7cb7Pfsk5rcao0bXVA5ES5BKY\nAhY4wU+wpOQS+qs9bT055qowrSN9ktWx28ROGugEoiaQ1qGAQk8a0PAJODuMoIBDDP9JzshcYs5X\nlDWm9oFCDLMbqhmZ37Y8hQk7v+0PhBKUFwZOEFAociKa4JQzvaEAi2uDRt6uHj5J9n+LnZTCJxh2\nnpxO0HQmd2/hWu0pQM+dMDqhjIKPt2ePTaN/soCKf4QWMz6PRfSVQuoZBb12fgsyaqTJejAY+VC8\nry0T2C6gE3iDkS2Zx4FUztvv/80dONlGN5xOLn2/JMQ8ZO6GPq6Cvkeng/kBTO5Y4RPUHzyAApiS\nVFEZrvBXsRNuCZc/o5MS5bSFeZJCGFLsKUmcD1YpJcfnNvGLQGlchOXzmN68hdd+/yHP0ia9+5DR\njq2kuhHZrAwAyu+//or/ZXEUTO7QpPjMmZ1Hh79+NHUeOoHkDqMTPOKKv/lHD71SFsGkD8IKDa5Y\neZ+thj//9fftVaUTZsuYiobmaaxKz18bAAegCQRRkEjwq+8y5Id1KJRkTnJMIopkV5Orz8lHTzLe\nTDesDTDeLiqj9Ygm9L5iaAs32/JO1c390c15HlCeNZO1HY5LZQVr+asRGsdW+F9Na2S+6QQDJyBH\nnBiYHtyjAIsgc0CIDHM9VnSE3ujF7kP+TDrZAIUyCjWscLsjjZ3Mf+hkfjrB4AfN/sDRE+uFBoVi\nioyp0E+aoyZJAwHF0JAldz/UdbHNlvRqtAlWGJtmvU26xtBAZwpsawHPsTIcUZ9q6EDJ20OZM22f\nUeZJ/18bAGeXkpyCG9CJiiZ49ISiBjuGwnbR1O9QsWBy59effsBr+z/qDXfVArmyZHNyVSIMlWIn\ntHDS/uw6dnWklMOewSsERkQTGjiht4/DHOPE06OvGCYBjUGCYXRy0TBj2zrfbA0ES4BO0LzShzHw\nQO7EkWfa1aR93FW/2R3FeNBkew4K3pgD75FL8E2mY5RjIFJCX81oAl4/1YEvKTNA8S+UOKLaMizG\niCf8/HgbR6FE/cVNP4hCIWb+24kxNrno5Km3WloHb8zBA5HswVrw57aP/uVrLw2v7+3H63gsC58A\nnTzStV/nMjdvmFmkPWUWnTB7wukE0QR/dwDzPixwgmiyRVDwsTaSXv1js59GJ5jceewCvx5kqTwt\n6nWvI+wUp42dXIJONhzBp7RRNMHTJwAxVZsiIy7VGhr8OmWFcMMUUojaAcs+Vu1mjzTy10oQgSWT\n+R2rtwMo+SaPLTk2swM7yUvfkcBiJyqOyHMn4GVYmP9N/1+AAmU2lwdcQt8804ijFYA6YCd+4Ljt\njCmQu0e/3dGjbKnvDU3AANHAyfYeJmn7HBASIx/IntsboBM691BMJgJl4OSiS6VtkePRE4QSh07A\nMM1OJ1vMebJzJ3A0BJhjewNEAoDCzsbiDcYNdNKy2uxr8rETZonCC6u0US3/cHjk31ixNNSWp5ML\nPUwoTEJJ32OJrs1wNUzEHpcwNKGnGOlXLIRP78rBXTTetoP9xOg+Aoqkkz0Gteo0dZXhCdDJ9oIZ\nwtAWoAmNi1A6YVxC0YSdn8Wv2OFZGme7xGy1LXKgE0kkED7ZhMxOnIABXbGTpEqwe3aQTpBRMNcD\nBLPo5Ns0kwctsF2aujOTURzAlORM5Yu9Hcl6/R44fijrQTrJhE/8dEm+kzuVZIdO+s+dPOboyrET\nSSfqTRj0xAm7YThDJzK/g8kd2Kivf8dIgMdOvm+m+u03GtSiag2TJ5ETiRUhlN2hQ8/GXppOelY4\nGFb1QZZIJ/iQqMnz4nNmduAALD10gpkdSicbmmyfA8G0JXcGLtGkX+/M7MBqz9MGBY5MTCU5iqTc\nYKX853/4hz/++iu8WB6HfoJ1bmX+/f/+T35yh4HLJeh/yLkTasavmFJP0gk9dIKxeUz3QLAfdtRM\nFdFzQQ1qciepvatYvwQUOvnti0tYvi3M2NFgGuYCVbAFDbv02dhOOmFost0bSQMniCaY1pnTerKN\nXT623K+1Vg2IGpROaFoHgiUQNYGMzx50QiEgHKwMXjqXNNAJEAZ2iQKEmpHJUAgLk5SGEAqEFUAi\n2TCF0vAzpvi6Z5iuEQQU9S4efHr95IGTTQ7s0MmQ2Ml1wydJNMETBcglMrSPgCK1EQuz/M5Oh04y\ni726ZOYs37B10WMn28RQOnHQBHRdoglmcKyDJhJcrpLcoYukoc8QOGGPtoSHN9C7iPnjYufTuG86\nmezcCYud0HuJJZrgeZTqc0p8s9KwFI+Z4Wk7Fg4fUjYUOBisyPCJpBMZU5kT/WEszyVGntpi9ba0\nN+i0YOFM7VQgTyeY2UHPBZ9gWgcdlrnP+Yqs4AsyOzuNy+zDDnnSg4dAm2uwPF7sBCMoIZ3gLOL0\n4w3oVl7QCqucKL5k0z1r+5m7IT8LAkKWx02uQSfEbpbsY1LU1WIsdoLPZKNvIGoC507oUVm8zbja\nqFq+FD4Z0mKykgYbkaz5gGIsXoLHWlkUBI+esJuH8UGxNHxyLTqxzsiXVl+PBTtglvUFJW4kVj0I\nvWmD5nTkqQN2PsFqlDIKlsEPR0lDXZWXXqpSMg3D0WMnePqEHoZVE3VbJ1QmRS3xszyXO33SubA3\nU/g4V2XQCd7ieIngMws7l+zjqFXN6sFTsfh0E7x/B5/xytCEPkMWMj6j+jYPoKgZnFHDPL4epnj4\nJ3IG0ok8GCs/mZ1OyAbAuYOvuvo67djxk14KnNBTsap7gg/z4RAsCU4QoiqWQywJhztgEi8Bd67O\nrJOTzZcv9RMKW5WH/YQC1Ra5cJ6d+MrsgPTxjUWXMlyGRFJCk0vcWty5qh+m8P33VOlJWNgYXSX4\nPNu5E3bDTuanhpFd6M/oTA4oDYu8ahSmKo/nTugbK8UDqEHphK2mRSdo4enNLFPNuLLtzgVO6F4X\nDTV9qgV1VVW2gPL0LMtAoVmxE/p5+J5uh1iF1rXNQ2AVqvU7ZZLtmnQScglqOU45TQBRPcCbijNZ\nnjzPJkc4sBjj92pXAUQwdkJzOvRnyS5GJ6+9XXX3NnBenqr4dfeNDJY4mEIfhUKvnRlQPopOkEjw\nnh28x56nPsnxWDgVC6/wvuLPjJ089rLE5VdN2fDF61eYCZzQFAy+l8md/NETdHDIJTQ9NFYCFp3Q\nVrCMRR6WZXBIpXkUDu6E/cw3qtMJ6G5SZVEV2MTTMygZLpmf5XvWM544wawZJtHpTTospzPzbQVT\nZXbYM+zDwAn7zWH6PNmx+R2MeebXZGCp6wHSUU3vXQ+yiGyInTiRIUaW3wFACQMnzl0wew82rP87\nNvn6kZ2BmZ0L0YmPJnIbTP1IJ53QeAnEYNgrnMRkgSqdMLf9BCnDMnAf32FAaFU4tCQtNWyrTDrJ\nilUchLYY5UI37zxN4bsIegIngCaQ1lGPwfo7vDm3d/PQSRVNLHYhR1IePzWcXAJhMRpxZYVhxWIB\nVlINR/m7lmQEy2o3YyXD8TYUoFkb9SkmW51AJPSpqUwDKcpj+AQvYW/wzzkXF4wXnsIsfxhISjg5\n72978fd0SXIv2jC5PZeEUZPQrVgRfRryV3tIc0PSqW3fbqwySmiZdWfFJCxKCD+vzotleS5PJ6XY\nyYmPCZJJ7u85NgKhzoYPr0UiUbM5FppMbkDnOXcif/wvjJ3QBBBCCTk5O5JOHCsguSS0U46RcsBF\nUpEEFHUH1rDjqVo9Vp6GSRg6MEBh9+wwcKGZHQtNZo+dvKPJfrGTE02ury0hnTieJeQS575iaJee\nm1QzR1enE2fjpBKwSjwZOik1RFt5C5+ULMs2N06kxIm5hadlR816aTjSSsIDoODFjlzB5gZe7EGW\nstFHmdedw7Dhw2ud1Pg16GSCcyc9sROW4nndaXwcnTAmSNKJLGbZCH1fKJ4Ya0HP8XSCYRLQfxbI\nlIAiH2oClyCdYH4HKmR/TgsoamRoyB3FT5V7j52U7mHpsav5a9vQJDxpEB49wXYpkVjxlVGuSka/\nnBX95rONpz+/xcneL2DuvzAjWj2Zfm5NNFgSNsxaNDtDJ1CmGjuZhOWpKaSAAhq5sQvFF7QmMpry\n/cm7tQUbKoPP647iwoIhh2GTIRNWTALKn/86BZ3QxRkaFL6S3eyyZBE17tJgUPITByVltBI+AYag\ngI5xlBBQkE5oJTJ8cg36f/3KJn1Uo7qvrW5Ppe8f5WirOmCVr9JJMlji00nP4cJRAz+yngPWePNw\njqAT9UavkFcOXipqTgetJKa0lWJfwQMajpZHWaEetgsE04x0ghs7ur2jwermOd7pQra3k+y/U7us\nWgic9IRPJNN8Pfz+CEBxKMFK02BGhsuhcthtBjrBuKMMEmyLgjKKXAU+oDA6YQuKLrTZT50feO5k\nkg3hN4UX7yLGNE0ynM9uNZXtHuyAjrGWPUbj+B6200kmcALRQnqIGvA2RJMjn31iWUmWfGFcwn71\n49vMGY+dxp0fnWO2R1SDKNMa0MeIiPU8hU4QSlQ6kQdK8sGVyelERkpLeyCfTqDyUoVVy7UpDz39\nikEOdpeN3B5gQw6gUDpRWf8SyR0JbbueO7kHnVTRBD0UJnHmv3W0utauW/5oOklyyWF0wphDtZIY\n4cBE+KbKaAFZ2pvZFBVKmIVl6fCr3FR8Fp3AD+LgCwInf/Pf/yZPHmpmR/LNwNt2zNi1ff4DEYFh\nnxVTscqrTc9AJ7g0aJhELkAaX6RnRJJ0Ig+d4PpimaPZjPjxdDLP0ZP8DpY6lAY0YftnrO14Uey9\nHxiu3rvuXqC3I+lEHkeih04w1pIHFNDR4WKlcEDpAZIv9DlOaCvRgIJ9xKAflG8DFGp22ZaR3UM4\n58E9Zj33jp0gjmwgAq8tNEIZpYdO8MeKaSXw4X7qN3PNu5oeK45Itwr0yAiNoNBrVf+NsUb6vBOM\nSqqhlDnDk0/6fz93AjkvqTkNq08SwPEu2aT2dHx9Dzo5RQ6LThytfqp33mIibagxMXramR1WytPJ\nKcFG1URi1ATfMMRht95Qu2mFT2hIhh06odu7J6nA8w9m+ncYnQCCWPDhfKvejyMDJ/CjPBJQPpZO\nzjKULJDJFog8xBrSCe4cGJ3I23xm2wB8o8n7TcWLTqT7gLsu8L8NERTprSY5dLLrJqHTmRzQNz12\ngrPlsK2EEkzHSAVqCJwcltyRY5RWkgWcZQEaXFFvcVRbwe0di52wGxam3tvtdkdxJi6iUkXmefaY\nCUI0oXSCv3X8abGThi14p42Dy2H5qCFDuvTYQlAjlzR2Au/p4qKYklynQwZYrcQCr0UnKp3gIyoa\n0OSUSAnVB+qD8XPumHNn3tWqWIqENsG6gfkUeonaVSig9raq6k55IYT3U6sUKr+7Ik62yqOv7D4d\nqj2l2MnB4RNpJWFTRU0kQxNq49TLrW0Z2FZ2z460p6z+gXPfU9Vzb0c2dkMcGztQQtHBeu8cOlHz\nNSx3Q6vdkIV2AC7/NEDp0Yq2azddghOybA8Af7LP2WqyAEVepR7nUgFlhiDl3nSiHuw43U8/vWMl\nrUMDJ/j8tCqjTBspKcUnrMLsc3nmjEIJcomEGIkj7MK25Z+jk3fmwBu05B03D83+KizLAEyAlrM3\nTI3yjHKY6mwWAe7EkVYSP8QYCZgw1YiYH77PA9JJdXs3p/VsoBN2vnX7k/3eTZJO1KSPH1bZLmGV\nywzRopPh5kZWKMOQeDsxLBD1nCzWg2VUztiulcfC1LSOcnTsgMHbTTzpX9xRPCp2cjM6oadZq2gy\nCZOxaESD47cSsg104sRUVGopUVR+Yb18yuvBvaC1iB0IGSwWQskDFZ2dL4FZp7qSJxLWXH48zSWt\nZI1qImFLB21Z8ZLQ3rGaMWoSW88JzqBIAqvSCR4lYff94udwaoTFMyTQqEdSrKMkNOmD8OGcXNm+\n+tjTJ81LqXShRG36SRJQ1DUowyp+Wudt3f3TV6bpvH/qDoeaHda18urT4hOT+GmVnJK+owFNJhl1\nP50g0Fg4ImMkVQpRy1vt9q+ep1ZjtAPQBDjjm5JegRAIjeALSm4fSC6xtIQdsU7q3N7hE8cSbU1j\nvISlwKUZ9cGCtYLxmJbt3QzW8/1ugpJ9BCCQoREVTXwtp5ewQyQSXCi1ON/SYhiD6V9sVg0yW6zu\nReBD/K+1Vdqvn8NrzhCAjGWqqVKMuPBM6Cv56KOJetNcpnvDZQIbHtWSLDrx/UUbmtyMTmTQZe/Y\niYMsnavjLXaCaKJWSrmEJm4wm5NRjiSOsGJ704kjRAB5ShJoyCRt+JyhlmeXZLd3GxmcGkHpiZ08\n0GT796ITiGdAjIT+OF/yzIeEDP8eH3g+Ck0hqfmj7Wls8EA2+Ha/h7OptkPNDVMu+d455I7LdZqJ\ncy9ngOIcEpdqCZ84d+zTk15s9Z1JJ+/oD0Ow0jrArHlatYITM/jp4wMnmCg4V8lHxU7a6IQqT4Zm\nLGUbm+J5oxMWMvF9tsz+7EcnB5+NfYPBVwg0YyJlMNnJ70CFWCA0oPPcYqDu7fL2Uc3OADHgcZD8\nWVQ1s6OeRMF2t4bwwCyiCT5GBd+wAM9OgOLbArQCKq+oFu10Izu8A8nwCbSrAooVjaBoopY5HlDe\nukHOnSw62SlwMjOdlLhThmDpHka1z/TDjIWxyueNf8k4PKv9sf3/x/+yqVZ6JDYDJVc5fSJlByOF\n8Im8AVgaLx9QWDJInviLD528P//geOv5dABib5dXUJU8KAr0o4l8dCzSDwAQhGrwaIt6ugXBBS7B\naEppgYWFF52EIgKV84/HYiUM+nFBOemSZ8bkfWW9XZjp4qAyaj/x9iWrkcLqs++IuW7spOqDZPkT\nw/ODFOeG1XzHTvKBwQfQvR93LSnHtZI7SCc0v0PjHCqgOAkaKA8QQ3HH4RJn53c8nah7u228Bfso\nHsAKOPKooXgHbzJwgrkePEQCsIKYAvWoKR76+R7hE4dO4Cv6Xxksye8oLm29IKkh14uq/3lAQeLx\ngisHnvF6dENwP2amnMVeWH0T00lzWqfkgNTCi04mtA+XoZOzkjuUTmQExUqBoyVVmWP7FumEPvLE\nOwpnbOzUE4L76ZmzAc3bRyVA9TqJUu15hk6e6PO6+wYuQRyhv2/s3MC8BVd2OoBi0QkFEVrGKV+V\n3uXKJwHFiV8yBf6OSRjr67HNOJhOtp68Awp00jl0ko//++7/9NhJM500P+mEkgoDlNJ2/XJL6RId\nprmqbGanJ3AC2mCFT5yvzqITCBTRDlMT6YR/AUFwc2Y994n+GoiFMvLzt9jMUdbze2P3/hgGMJ29\ndNL0izZJOsGoDJxHwcAJfVwbeywbIxVIFcGHkAYauLzpIqTVIogsOmGJG7asWFABl56zN8ATJ07U\n5Bki/dL2A4KUTk7HuVsHJJNcfb77Pzd+0IMml6YTa/nTmVXNQr8JUi1Mf7WjatiXTv72T2/PO/HR\nBDTMyfuctXjkslGxwwoyY5jEsZVWJkjNiPMN35F0om0x++nkYV7r/j6DJsAirCTSiRU4wUiJFU1p\n6O2oFbvqoasPFw5dfRib9BOsznGTN/o5hE4c9A8PnSw6UelE9T5ODkj6l4PDJ2qWVvZhYDJ30ckj\nWMJebbGTs8InKtTnAQVOmWQYRW6e5CdKLPpg6/kOKNif5O5toHNN0glFEIYjtAYAEbyl2cnyHPAE\nlIFSumVVFqAAo8Ba87Orz3CIQdvqKtsvfOIkTDNokqSTmdM6mcCJH3Tf4+jJDHSi5MHTN6+Ea/+j\n6WTTmFL4xI+dTEUnYP5k4sYxYcgo/gFYNFVyb+cc4rPahUbhFSqrVeBtY6eldbYCM9MJu8GY3tJs\n3XuMSRwLU4bnd5pn5zMvVFcfMAfuBKBM6T44XGJ89e32hCELTfAwbJjW+RA6ccLq/Wiinrk5l07C\nhC/MO0v6DLHDTtOsfhnIYWlo2R8okOnnvpkdS2nabtuBq07J74ThE2oEfQ4A0+lbzG+eMAIVSg0i\nvwNWL98xx8n5ezsYb0bbxvpRjHywZ+GrwEE/lLkeiS8WlOANyXscQMnL52C76XTMz5rnR9RQ0gEU\nOGyOW4gkoJhoAidV9zl98o3+2mLPoEly9U0bO4HnbIWPMzmeTlCwDcrZcImVspEIApWHZNDQB7Va\nrIeRh+yG1VVaLbNdTqJq0UlqBq3Fo0aYHSsGbj4DKGrkGcO8Kp3Qdi2eaIigPK2niIFDZ/BWglPo\nBHMxIZHk6YQ9hI1hCqUTOFSbUqDRheahE9VyjR6uXp+1+nCJlQDFQxOi/A0rKOB+8VN/9Blx/q06\nVPi+SmTc/ykbv4ff6kOTIUdirfuVjlxoJTrx0cSHDH95WkPOQJKKLwxiHIJhHbsknRy/ipz1kwcU\nSgwQHWkIO5tk8763c8LFJfP6ltMRezu0/snd20CntWEBnF2Fp+CX6EQ9Kou38+Cb8OjJOoBCJ9TZ\nAw2cd1aVs/row1HCtUZzps7aGRs+GZLTQdPfSSfHG9Vnz6PASXgvxQfSibrWuC/vO54i1cmq3yKS\nTPkwVPNWScaODLmj2DpiEh49OSW5k6cTK5MiLVEVUJSTetqZPqg2eLZbZprtXyPDjDjd2B0cO8kf\nibXAxakBHiML6BMySmf4xN+RSKnS5erELZjJUOuxmFJtIgTQU+hk65UKKADxLBxibQac41zmTf65\nFRRHTbTACfYnGTgJpyYTn5iTTkI0AX/RcO5kOxBJX86zXg4Ln4yNnXRr6KMCJxYidybJoEiyGNXq\np0XKDGnTYzm1Jf1AfVJTiSGgQJ4y09VRZfzYox9hBgPKzBykk/N5cQtNLOgJz7VkJGNRDuZ0JqGT\ntvwOUAs9s4L1IJ2EaNIfPnHoxDcNziLPfEVtbtIGOTDk74EyytZTRi5ASSew4iSgVNEEVlYpAKkO\nzUqYqugfCifcG4TZk4Mt6qjASTOd5B9mPyedyBW3x/YgaRmgWBI7ksXa6aTEIuodxT2PZYPwyZHL\nKVzbAaDYh1vxl9/9LI9DJyxh5NwqiciSsa3fOR3txAnN6TwNzctAhpZ0SIH+2ImMqcxGJ3J34nxi\n2RE/NiPnImOLVTu4h3FMqgpbfbCUAFD8CEobmjzWUd9DhkI0oSe6MkLw6SQ0X8cHpMGAhx0Ld6qw\nv+30R3C55VAyKyIzR2GZUuwErS6zCagJzevRqYF+lYEMtXzmQuZTnvWEEnwQTceP7CCU9NPJkSsq\nXEWqfVQDGCzwgAYUd3vyKkQTNWtDPwzTOklA8dEETCcLO4e7t4xq5csMoRMMnNCTKzKtgw9nw5Mu\nMqbSnN9J0oO0Nc4iZ6SSsRFM8qpF9g1fszXMT7pT0gqf4M07uNCAVzBEkV8ybwuzn07cR63kczqZ\nvUFovo60peBB8AbMzlt17kQnQxbCnSphhiuVLhlCJ+GTYX2tpfq993xk1vbWWyd8Qg/ho2vHB0bR\nux9xq4emECLS2+uPv/66vWCwFpGEphYDLX74pJTTydjH4XPURifhvcdqToc9OpYeRsGvTqeTh9Hv\niK+qE5SMx6jbuOEz7lcoUzkYO8H1RSMluKySNxsPPIASon81cAJT72zxkxbsmGg07UyyYyHB7Bo7\nQfEerNKruavSCcD+MU9ASS4hNdWNWzR60g2zOdKAAl5QRkEuATqhL2CIUuwkQyeh9VQ3difGThru\n2fEfwuYfhlW/bf75YhnnsGK2MryhfpIMnGZCHReiE0B2dgxWcgkUyGQ/U9TSFEGx0joNh2FRAa5C\nJ/1oInM9Q9DEyewsOjmLk86hE1XDqo9oY4q+kwSTaAK0JPM71FzKhAilE2ZYkTwklOAnwCX/+R/+\nYfsE31thj+/TfBBStg2rbz1lTues2Ak9DJsBFKfMFlNhwZjkeVj68Pue8AlufBEIQshQ8cL6UCZl\nLDpx0jdqhog6yJ3WYL5augBxcbE1mMIO+yfB+eVw5r3yT12hcvdSqXJM7GTv/A6zpfBn8mQJeodF\nJyXFCAs7IbfwWrn2M3ueUrVvNidzZX9mRx46adDRCelEbuCoZZR+3TegNGoC8PHT3/0dsAgDFPgW\nX8HtxC6dtKFJGFvO6FWpDKRg1JOtCBbwKBQGJRI7IN1DawtvJ7YOoDQDSmnsq7AjAVgFeFSLHYwd\njCawlCqAYm0eJqGT/QDF2uY1WH66jx0VOPFjJzcOn+xNJz28clrsBJUSbwkrxU6kTu+RNM0HTuiq\nViMomM1hhlUCCj24ikERjHxgsAS+opHqTMiaGkd1z+dbTytwcjydPFp8AUp4msR/VhuyCHJMPnAC\nz7OnT0ZZgDIDPMHSoLFJef8Orp0ByJJO8Tzpf3vMifi9KjwvXw3GhKuvZMd2AhS1Dz6aqN+yD+9N\nJz2u/chlaEV8QTObe3ImnbBb1TvpZPii6lnSElAsi2MZUAicQD3UetIIynA6eTOdmvV0biU4+NwJ\npZPqg2LD8iU6GXj/TvMyXhdKCchT5+zu4pF0kougWOhPT6dV79aBgQ85d4IWePhOry1wYtEJ3dne\ng07k9HHH3PFrf8AHfhN0+VjlaSV55siXlEt4XzpRf6B40yf8HO8HK6GJVXjgoqqiiWQjeoOAsxlS\n6YSiSUgnGFYJYydPw/fKqbNedZrOE+kkc+gkJBJaIPmUWHYvD2SR+p/PdifUyMeNe6yYJTG2uNgB\nFLayeiMoUfikc335WjGWTgbu9DZD6tjSztgJoInlZarg4ruPvCb3rF+2CpzDYdhKuHBYz2V52Sj9\nJPPeGXLYPf/aN0DJSLb/3AnVp4aDUQ7KwGLIjMITSvSrVGoH1HbDIK1qQGnuXBpNTO7QyAq+d4wg\n/+rdnmaspzOcg+kE0joZLknmfSiRsLtyMs+zZxGUld+he/rMeuyxYhk62fdsrEH82DEroSOfNRBa\nDHWww+kEAKXHlsLl/javh04QTY6hE4wcZJS5uUyGTjJlZCzEoRm/Qvy22i5agB5p7EUnjtLAg/CR\nbYcETmhYsnldhcvJB6OGaaB0gkf5ZEKHJXcAX3rp5PVAbqjqkQgX6XB2R/RUdEJ/TDgMjUhGoQdm\n1WOwWKD0sztQ1XbtPIAyyvGPqsfyrw3Lx78EFxeiSW+AJHEvjwxJvnG/tsp67iWmFGhutZu2W/i8\nhiqjUCs6nE4w3I7u4wZ0Qn2wAxZsrpMbwpAq8nTyxgq5AyU9RoM1l4o6ZGInvsbIb6XXr57lpnTS\nsK56uKTnsStgQNntxP5NNxiRLtGJGhp5cgm1ua3n9ZJLZZQHwiOxwCjwk8Uho6gFEE3gWxoFob9X\nLL9Vj6dADVU6Uc2T9SFNADNbxmaBL28jey0NYqkefzcvzZMzLnW/ZdnuUJfY4joATejp9W/od5mm\nH00sfXib1g5AycdRmBXN5Mcb8IWlbEI6CQtAhSGEgR6GWlctQOsMSQLmutREWGeeTkrt9hcu0AlG\n6kI6YaERmf/rpJNQ6WkB2m0mL/pVZ/wm1GxrqqgBzVhPIBI8YmKRipoP0j/U4iX0SbX0AI2jcGfR\nCQIHPLBE3kKsEgmgDL33GIsxWNk+RxJyTsvS+EoVUFRzY5kMZiKxmGOzQnPG7KNlLsN6MkERZ1xW\nKNgx35nYyeDTr4nwCTxPSHkNfXq9CqaWQEKbmTGAli21kjiZRqt0kvEmbWUyNnwPQFl0YiotwxPd\nvvx4pA9xyh06wd8urp5IKkVKQqW3CtDVFVaSWa79p9z3oBPzqdvCOL4ldNwfc4f7Myekky1lI7M2\nNOkDB0rwvl+HQthTT/DPzE8WSzrZ2s0kdyyXH3px5ssduxlSRdI+hvX004lsItz5OTpZXVyZ7UGh\nDFtQxjbgErETaQzDrR01sNK84yfgTfLGtsGzJA/PnkUnNPQlV7G668t4bVwX4QpKxk78fjqE0RxE\nCWInNFKXp5M2BcorqAMWVOnH3hDkdy+j2eokydS4vLOA3lwgYye0vGU6rROvSkZc+znlrYnwRseD\nYyePpfIVLIGXevQVGMVP98gL6cPZgGyQPNhNOhhKgbwSe54bXBUCyig6QVgJHTw1W3LWHFO1N52o\n9XMLVQlrVxdXgTzyEZR0WidcYp17g7H7sdBcY3PgDpwbLat0AjdS0Fcyd+ME9bevMjZ8j9hJs/O+\n/YUmnVAuQcXC/BzGSNibDJeoaZ2SgpboZOw9Qfm7dfKqI4+eOLc+4lkTH2KYnfXoRAuZsFsJwsAJ\nxer8wDtLssfFJu/NobCCl8gHxeInVlpHDajQwMxWIPPjO2PpRE2OWF5f3V2dSCegRUwr2pAIK6Gn\nztUHso0nEoYj9vrqf8yJBE2PYPqOnoQ4QguwwMlAOpGnYpOhEXqPj3Rbi046rfEel+t04rv/7dsk\nq6qw4tBJklEydAInuUorqrlwBrrD+LP8qXf1RgOMnah0Yj3CwaKT56/tGNs7flbXVcCDYyeYu4ET\nJP6RWDX748RUKKyoFAIhGSwmj6psLULgpBlQqpkdOjlhLJdxwDyZHQkou9LJ7mjy+tUIq6EhaZ3k\n3uAwe8hsr5PWwZJQJmn/Zexku7DHJcHlSTO+wid7gIhap0In4TGlHjpRdYjGZjKIEPYwU8nAMkm1\ntibV396xe4ktKHHumWQPYXszlPDIk4hOMjHnw+gE8zXsqIeT5fHDKkg2EmKsEyeQygnvEgI6SeZ3\n1CRLPvNCV7LUtHz2OkxCV62zGg7xxyX74I8uj/7nnJBNrK/MEuvM7Dwg5qgNG7WuIZ1g6sehE/qV\ntentAZS8Da/q/2G+/H4NiaxupL6Y3MkkcfJlaLzOOS+yVRgusDyADwGUvFqHNjR8eGUYOJHG10OT\nL6Np0QnFoIzpPIZO6DkSig4sfNKQ5cHDKzJwwm4zBtrAMyiZe4LC0yf3syxq2uiUYWLm9KBISfJI\nyq9/Pypwkoyd9NBJs1HNXIgHY3voJO9rZMl84ARFfYomf1qjhE5+BM/1oxEO0KeBr4F0MoQ5kpUA\nLfUrDT3rGj7sJB8++f7RPttihnSSQZO8feyRFTviShGBIoWFCxDtwBe7FRkfZ0JBR72FmJ5EsdJD\n9ERLw+NPeqQ027WdqZn+4SQX18HsQtEkucT6Yyc9gJI0iSxqkqQTdUeK12JwxTp00umJSnSyAKV/\nSSZreNFJFDJhOncMnaghwTB2UspfNiw5dvgrKWi/WN6AlsInSCdOVEalk2rg5AA6ARZhx05lbkXC\nhwUQEAL5Sr7we5L9HyvO0AlFn62hzOmTIYo0TyXHxNIy42VL5mAKyaRNr04nFoJk0ASOnqjnTg6j\nk+oOcyV3Muuuv8zThpSc9B7JHTV2oip3hk5Kw2kuXNXpJKD4x10lneBxWnlrMVg9P9fu08l39CXS\ntb29EQucYHqFPb+EnVS1np+Gh2oZuzDcoZfTX/iDVvyAzVa+dDY2EvD6/iGBtkhMhumPpBYWODmS\nToaHT1hgwz9xohrbRSdrbasSaKETCE6MDZ9IOlFDIP1oksT5EFnGosk2N/JsrPzBd/qcbOceH4yU\ntNFJQ+Bk79iJfGwJ0ol/OhUoRL6sgIpDJ87TTfxHqkCspfps+2WwLIPVIJnM4gpPfY3CF7a++tGk\nYfX1G9LMrQx5Y4v9UeMlu2Z2qmmdldlpWIBtl7TTyVhAScZO+hdVfsE4gDLquAmbs/zNO3CaFV7O\nUxwoneRvNp6NTiSa0LxJeOOMjw752IlKJ1bfMFsEERcAlE8+G9tmnuRVbbETlf5ZkHIUfIT1zEAn\nAyMoyaOs/n5Phk/wKAlsUxm1dB40oZcP32eOUvVVzyx0gnlH9obp9Ax0shOa+AbUPyorn+cG5Ut0\nAvjShiYNu7f82juSTtjNPpjBoSkePI0Lj5FV6QfrmTa5A24+vNMYpkllgmZQsBoN+9Oc2ZGLK48m\nUBL2ACF5hAX2QJO21YdA4HPDkO1cGIqG0yc0Xk5PojTQSfLu4obASd5wrZKdEngaiqoK5o+eJLUE\n9Y8yMtNpwALU44zGq2Wqg5UngjuFbl1OAyGhmaOPc1UjKPegEwdNAA7ysZOG24ytYyv0SbJObIb+\n1iBkl3bSHFptsiF2sg9RQ33eifptM51gb2kNmf70nEZsWFzsWa43oxMIn4TGkBUIy/eYZbr5PIZO\nVuDkAIvU3MQ3nTiHm6TCYWTMOX0S/lKxjM5JdmY3yMCfpQgKQ3L1OEtyRe0XNcH5wwfVZ+iEPctV\npniqsRO2oXwcmE3/2+NUrAofABkIJQ6+ZB6Y5hxAUX9VB599Ahf68ARlMLlzzNET6FJIQiqFyOAE\n4xLkg340YW1V+5NWzO+CpcUl44gmnbjPqqcLeafASVvs5BkVez0bwrKBVTopGWe58WOfyFB6Kafj\n741X4KRhER15CaeTJBqHdNKAJlTtJENg4KSZTuTBKxmbOf6sCZvs5JOj5H09ACIsxSNvVZDQgyab\n1Vk9rLcTnfinRjZSkXyQj6bQZ5zIhmTgBNEkfLwK1kZvTk5GNfrXfwZQqjRAM0E9GRbqSlns5C0C\n9PrBHaufDVJKLi7GJZjWUejE+Nlhuco606bhYHtWH+4wM5FmC1bQujI6SToUPFwiwyf03An1Ecmo\nvFNsBU5CvTq3gEInGX1ip4pKPJvRMJVOMHCS6SELulC4sS6Xn7NhHjNVmbsfJUkATOB/6ZNO5J3G\n8un40iKXAic9uzdLqk7WBn8QGOIomQCGSjny93Hk/cmUUVQ6wdblc1NoLgkfr3KMFiGgWEGUBjpB\nQOmhE4tIqv1pECPge/gwQ3Vx8XMnwCWVqEnPoa5wsD10gimejF3dm05UQ636lySdwLWy8AqchEp1\neoGT6STEGoQMXBWZXKk8S9tAJ9i3g/VYhkAse8puKkbLi7fzyAvVhNGQjV2nfZQrwWcOBAsIn+AJ\nj+QdOsgc1plW58QJYxrWT+gJcskpsZOHv3kd17XuFWqgAedsSj7R00MnPedONpnAo33kEfL8+vpe\nPmk0wcXFTrFU6d93Ff2rj+bonaCyQyfwlRr8yKfOwerScI7lI0p0IitZgZPT4SPsgE4nIUSzyW57\n9klSvUCzoUuouEl1p+EWNbNDR8reI3QfrMfUhjL+UG8exjKZfaFFJz0nTp4J7JeBDHUuU4AGJDJh\nD+qM1bQLow1WJ14CVBGiiXUqFk+60DeYPzr4pmIfUJyMCbq6PMHk6YRldhziQT2hrrfUkEyb4hOD\n1JUVrq/n8kmjiZU2HYsmQyKXsAejhp1aXblLxJLsLCA1s6EfkRiE1dJ7jK3YSdKDyMsP3nBmLN4q\no2xQYeXL+fPdfz+dVBWLoklJ6fFULF02DqnQoZ2ixEAnuMnLAAqwRWZTmKGT6omTXenEeR4JjX+w\nNJCPFwwXKM2w38fJ37MTHnaBqsLDqmONVBhBGdVcDzSM6kNYT2ZlqYACR0+el6fRBFfxrjmdsauP\nRVBwT6jSCQ1jy3MnYEhL28iqW6k6Ebrh3DoWKozqL52rOmN7DMcbunezS7zYiX/6uqpJzOtb8Trn\ncyf26KwBSScs9ogrkDV9CpqAekkzmkmWN9CJdbq2Qcv7Y8u00cxREvpoeXr6xCIMdqYEzqjS46sU\nU9QbdrbyLCWU6edZsZOn34pSPA1zzS65BJpYK0vSv7rWnnRSPG4Ce4z+wGQ4RwNX32Yeqdenh1LZ\nAVUa3hhCJ1g/i6A0OAvnkh7D7qv6opNQUUsFTDqB2XUARdIJ1ek2qk2iSQnJkWnUIIrVYo8GlyZA\nLYx0olo3i1SATraXgzIsdmKdrm0Ywkj7aDziDM9zsJ8DxAOnMoChBj8ol+CvBsLP4sANwCqa4CNf\n6bmT/M07GDs5K3wCGauDW29QpF0vYSsL0SSk/8cNO//0OFSrn4S1qYXRSVtgMpTJwNW3tcUAhUZB\n8D0YYWfvF3oQ6xahnn1vyDFg2P1kPc1sMsFeCMRDnZm/wDA6AZSBG4mHowlUTjUvHzBU6QTjJeqJ\nmXPRhMZOMDgcWk8MPufpZCCaPCzauHMnTkBCfaIa3leM9/JgRITeRwPFthe7uUbWaSV0ZOwkeQiX\nhnmO5wMqz87Wr26dKZ00nJDldIJQ4t68g4CyE5qMXX3PkNt7BAWhhAWww72fH4CXZlzihWqiQwqR\ngXD0TSGd0AyLGiaUts46qkWnJrN2RtUzP3lkehjTiRWokPoBTv0ANOmPnVh0kiHrjFg7y0gbmqET\nKOOHT6xnQ+GDZZt7PopOLDSBKIVKJ9tXFFB6HsLmH1hx6ETeTiwP3h58U/G3kX2PRfUASsbCNqvQ\nAReylVUFlLfL01keejPdTmMctfpo9wAsmD136ISGWGiOpgQoKnYMBBTojB878emELgG5HNgnzetl\nVD076dsx1QZ0gkGLDORiKG94+KQ5cAKKiB1jMRhaLfQ5qbV7z40MIGPWJjwkm6STzmevSQmMso8q\nnQA00Ltz8RP2tHi84yYZ1aDFwlt1gE7gv6z+8DH5eGEPHDQrHpWqn99hYW1179jcjdMvVFMz+cX1\nTSf1s7H7BU72iJ1gBMUHFGZdZQ7IPx6QTO7I2Hlb7KSEJiBVX/8zBdoARdJJWz2nr7ieDoynE5ri\nqepQHpyrmR11FTE6mQRNZGYH8zuWGZWoYcVaoCr2bX/gZJR9VNEEfkgPT3swhqBnTsHv0lMjeUZR\n0YTdXezQiWwID7JgJXh5z4ptu5YJNnymftIUQjEwIvSN30kKsmwnqsbMVe2iLaqmXB3Ck05EIiYJ\nKG+37aQfxQYRmuF3Eb/FOV6Ca1OPYL7eI+Jsr2gBChrzUuxEHoyle8s2h4I7T7z5OSmlDHxk8B0X\nSLJdFYzy6yvfyuQlU3QCibqSZsAl+SyPU1JtWt7hZvEK9AQqoVVNiyYWnbDbjJ1cjxM+kWjyfbdk\nn6oOiZ04aR0aO3GegAIEUAKUMGRCT43gj+bkuYfSSYgFfZPgXc1k64dw8nQiASVEEyxArbYkjOf2\n/YU++Kf/OfPZrDMys4O5zgz6t91UDHSy38yO2hs4PWTGXDWklo/I0AlN1uf3qBmXxNAkn9ZREcHS\nUqrSlhiTa4rpuaytVM+uWrd35Sk6ecrr5ebzpJIHFItO5DOCZHbTj6NYRIKfz5PQoZPtm9HMMRT/\neCw9pDLEdPbTCYQ91IwJy+xIMsCnqIH7Z4AS8oeMx/gHY9Xkjs8rGNc5JbPzMLXvp098TkpaQCwm\n3yRttHVh8+fNdEKfMOTcFuc9wN5O9wxZYh497Bk7QftPrXQeUMDAhg/QohtOB1DyO96tEjxHSFvP\nx8hHxU5C4CghSHJt7o0OB9RfoJO3ZZ+OpmSCKA6aDKQTdTnNiSabqB06yR/l88+g4G/xDNGzIXRi\nOXia2aFl2O8VI8QA6Fg3BldhhZaHmimdgNeXJ1HmORX7vbETx2MtVEpawDnpBFVRHUW4stg9wJRU\nlMRQ+radIavMYT4aiNqpLbrbtPI76s0yx9OJDJkgoBxJJ74q+rjJOLvfwO6kFftV20gnMpriB1RA\nrR0KUWHZQhMZBvSfxoZHYaAVvLdoWjR50om9FcMnw1oP5A6DK2PRBKKgPfYR3KR6RhU5wwlO0LOx\nEDjZKmRnUHqghB5AQUCB/jh0Yj2XZb/17Ncskzv3oxNKJCaduCvLeezy85EnX4e33p5qH51BuUHs\nREZQQkChN/EeGTtRQyYNdHLWOl3tYrTp4VOcBF6BNEnqB097wJuH9/p6g/rK3lTpBAGFJXrkGmDt\n4p/YsTlVwc9w46Pr1WS5jybIJWMtZj+dsLQOhYn8IQ+GIBDkyLzYAVjWuqwWe4sun4VP2I3NkNk5\nK63zXO0id2Z16ZjYCcVZ1mJzZqdAJxpS4NqBc6yM/jmdpO/cGbvW1ERAz96gZAOpGXcAhVr4Uuyk\n52CsEzKpHoktyWQV3kMCXbGThg6pgGKhiRM7KdEJojS0PjmXgFT9+DM7NZJ55CX9scA9bGU/neQR\nxCkpQYRGUBwEsQiGXkJTRQglFp1sF7LYySXohMaiQ0ZpyOywMBuDCalFVWqh9asOO7Oy8LlBklHa\nbireY8Wpkf8Gm9xwCd3ysffW/tMHFBoOD+nEagJtu7NlzW+2G8SyLhkrgaPphAVRnJgNUrBVhp2i\n8u/ZwdoupJ2OGUU6wTtu/Fsid4qXDLSP1t06eWRxAiSABZkISv6oCp7hTfZ8ztgJZKZOjOiEADTW\n3iW5H+mELhw4Zt52287N6ASzPLjbpDFplR4G0glk5+ULOhPeJNGgUUktpWQvbWO+3f4wmNWTfB9m\nKHkCnUjNVs+j0JylCih5OrlKvIQpRJ5OqA2F3R7b88GfuypcT+wEPb3KIv6Dzqo8AadShpyZBeJx\n6IT2fAY6eewNxG8YfRqd+ICCmR1gERZxfK4jJ6FjHECZefX1mAV6ho+9Z/Qwlk4YoAAbZR6C1bY7\nzdCJU6ZKG9Xyzgxmet6jALteexqdIKNQJaYUkqcTiAT6sZNdhbhT5c8bBOgRvNd7GjuhUWjJNwdw\nyXMqX3jSIA3Hwav3wshTIDQ0wp7PRm/kSUZQMlEWoA0oSftv3byDKNMgn4GXMFHj8eGBTYRVnb6x\nC7kf1pR6171y2w6sSvcMyl3pZJtr3Ps5CRco49BDc2YnzyU9504yPj5TJlwawzlj7171jCi89ptO\nnGxfWEtPAf+0rJPfobp+y0Tjtx0UGzJJJ5DZ6ZmIzms7YyfOvcTOrbmw71cL0BgJDQ/QYyhJCvFz\nRn74BE+fzEknH5jZecZOjCAHi51g5hQXl7JniH5wZ280eYTEOvYGnQsfLw8tuQUo0nrLYDkcv2Un\nbfFMbiZqUnoOGxOpfzqKHdWikQ8n16POmlpe1k+nzGd91nM51zPjy3NozpNw2kJhVY33NZudDA/v\n02l79k61zweUtzZ5Kp0c0B8f7dsCkk5aB7CAwgdwBotVQLE///V3eGHiBguzbkOLW8k8ndCzsezu\nYqzEPyKzNbq1eG4a5WEQtczOmU+wFT9lcoQa/9NXolOLdlh0QnvFV2V0586H0MkzhvqVZMkfPUEQ\nkbtNyijsRiHpERigqNH0/P0QEke+IYxobOj71auQS6xvoQC3WsZK8fvA6vH/PGLpVdrgdCIjKMfQ\nia/ZKp042RxGJ0cOoSL8uOyH0In062p+RIUSiiaIIyEENAAKQxn6eHtGUVY2CugE/hvP/T4l1MzO\nx9GJfU9cmU6iJ50c8Bj7SWInbxv6L0ZhmJI8GqL6IHZbA9RM8UWGT5iDwNYzjGJ5cce7+0GIKiUk\n6SSkjWq7+1idxloVOmHKcbxrV+MoyfCJRBZQyuNH0Tgh75dZR09uFjsBOsGn0cuQifqUNhYyqbp8\nIJhSBAU7Jg++UCLx6QTCPNXeDlGnF5P9jPLEnw0K+wNmTs0gOOFrv7y6R3xzctp+EQ2uFQYPa9gK\n+NzPzp2w4EfppuLnbT5D5s+uRJXzzm2mqgdjDjDRQycMKXroJHMAxaETqnU9sRNfS/N0YvXnueG3\nYzA+TqVmd+dCOp3A/AGZnuXXUa1Rs+WtPXlevjygvG/R2PPWDggdh3rYYx/Zhl49TcIeVcLyOKFz\ntfoPx0H6Xyyuo0aDAEqwreY+h3PhDBYfwYL3E8G5mbAzML9Yc/N7dmFoIqu72HA3iUNQAUXGTuTi\nKt1UfMza7Fl9zepUuhDsefKACDt3In0QRmVYyWT9oTtIal2Gg1VKCLU0Tyf+LDj1hEuvNL97FPbo\nBADlLDpR44TytJSfbmTrYYaxVGfx7Wzsi1HuRyf+bcMMTfBOE+tkSUnIbYDCugSV+I+JY3QCWFDq\namdheeikGjuRdJK04zTgkbfpMrgS1hPa/Tc6EUdG5HOWVbww79x5v8PumMAJSInhY6eq7HH5QDp5\nDFkkd5K5/mrshArW8ei+s/fVMsMiav0hYVhXhRfuoQDVOgM6CRmz2l5neZnfkXTi313c2YHjL/d3\nePSR9sf3jbmZNvsoT0Lg/l6GNIbgiBRUG6D4+R15J5Gkk2TcYsjMQlqH9gof+pKMnahUgX6ROUjn\n8xKdUEChJrVKRVKGGe638MK52//7J3h+/ftL3M8/RLvCSjDDzk6/qtEO9mgJdVe5K50w4GOKR3Vb\n8roqin46sRiULTTW+s3pZJLwCQhdTTcOROZwjR1fQNKJ3N6BQTwmhmxJoHn3Jjf06gNLMh60Z3by\ngIJRE/kgOBpB2aJB+IJLVDoBxNl7dI+1I+7WQTlnWk/SQGis87ENWdVYOtnqzywua1mFJ1fwwbIH\nLMzm1dezZPLX0hOpVTqxAt6wU82k+/Ggwm3u5cxLPoNKnbXtd3kcO5mKTgBQwvyOk328anKHRIwt\nOjkXUJrto+U1Zepkv2XwZN/Wc7L0KAnmdzY0wR8CxAO8DgPt+mA0X8hn0Uk+2CZLZmgprD9DJ7Cs\nzNMn4mGJ9HcEMY6yN6A0r7691xRYbIYF9FyjenaQ3Uts7ohety77DxOnz8tYgBIuigNUItnEJekk\nz8t4theV8op0QmPF9G4CtIOHGUFHq5rto3Sc9MDm8WdIt/7AkdvSUVmaJaF3xFDGcmInNB6TYYXk\n8v4OP7wCJ/J8TzJy48Q8rNhy+DkEqzNjUU2qGmCHOrG8X39IJyxNw7tqowmszeDyzMhzZZpXX676\nrlLNx00gNOJbbOt4rPpMLHmPcdfArnbxzEpixXgeffaPOs/m0TO3kznxw9mGk1Fy9kvu+JjteQCl\nTfUlmqh37R58Cy7wAd4WVCIVmtxhfMPohAWHsDA8XnYUo0A97BDMbD+eHC6BJMSE9bACz6AI+YGI\n6sqSgUz2yTGA0rb6quJqK78rnUBsRv2lNrk1ZZ8MdAQhKLcpcOYqLJMp3DaD1atG9SSOncxz5873\nRvDHA6jVaJ765MH9lLI6bc3lNzMKgEJt32b47kcn8sEnZz0gBPw6e6qKhSzs4Wzq0RmgHJbccX7F\nkN6a1KA5kkuQ/Ni544NvHaqOZddYNF1TcomF8Y9tYfqAsuikmU7CwAlVJItRWBCF/jmQTr59U+KJ\nrnn9z7j5RSdT3FcsdVFFZgjfqUqJkb099DKvc20lJaCA4ZsEUNp2b/6RWOq5z/KgeJdQPtGDg1Iv\noXRioQn7vBRKwQ6zO3TU8EkyrdOmsf1XtSlVtV0V/eWyss6e4+UIOnRhUjrZ72TYMYKqChYCG/TY\nh3UHg9xq4sNh841ubTmMIk+f7OEFLJ7IcIYcaeYqSSc0kJNUDCv2kxf+m3fOpWvDypXYCcwxvma7\nqZhFUNQfdLCecHxpOtkGngSUvY/gqVqVXAZvSizuccXNvTyuEary3gVoKMUnFYpc6k3R7ENgETy5\nAudqWRma7kH+UN/gUVz58BXglTnTOjvFxjNawZYV8oQKKNbjT2jchdVwQPikYfVlJNNfJqQTNQTe\ngCbULzi7Vti4Jo8hqjrpizpPJ6HCP9iuz83nL6cl2VWWEKo40gBAnE4AStjB5m06+9V0pxp8XpZn\no+4NKCcej22wj5tzpZ6SHdhE93zwoRNfUTOMQo+eSM5wbtuxTqJQaHMe+KZ+5VyLNzPvtDbbqs3b\n97b61asAUCSO5AOTPuLsDSgNq2+g9JyqGJ2w44A+mjTHNpyTKOyEpdNE6NrVAnntVYGAfRj2ITBW\nabjx6eSb/LSnRWc6mSmjho4eim2dim3Wj2NUX8ZRrMMo6gCvMjomTD+CctazTxrso3+b65x0AnOB\njKIemGV0oj5VNpMnYvkdFT7CZ+xaNOOgSZspUY1Lgx3I2/eGyp1LRgGKhTi77hwaVt9Y6Vm1AZ3I\n44C4b7R+zbize0lAsVxAZgn00ImMTzwNyztPZLrhoWE3nVj9xN4mewj6WZ3Tt9iJGjip1nhi+eTB\nqGRY78SBhE2rgMJuYjw4v9NgH5N0ctaJk3AW5K099NyrfFYseyxKBlBkGT92kjlrgrQkbwvCSVRn\nk34bbtpYVbS8X89ZdLL1EG7h6cELH3H2A5SG1Req95AClE7YAZQhZ038sE347IkGOhmivdZC82mg\nOiNyKTnthkteEkaVOdrKP3/Fl541geMm8KoK5cTyyYNR9wMUeRDvunRCYwZTpXVUxZa5Hhk7qYZP\nnBSP/Mo5aOLkepw7ljObwsxOKMMZqgHV5Vzfe7UZohBQ/JWlAsreO4cb0AncoTPW3Wy1hY/uVFts\nU91HVDV3z05nsaRiZxYpi9mU8KhKG2p8yI/9fDWxqcXXv+f1X1oCcDJWXZJi7SwGXc88QPCKo0Ph\nWHbwlOROg31UYycsnTFt4ISpKGWUkE7kfcVqHEW9o4fdq8xOuYanUjCh4wh2VzoJzV/ScHeaCP/y\nvQFl+M6hYfXtKkD0I/Ip8nuHTPjCFI4gefQkXAVhARYvdP7Er2idbb4/04qcetau2h8uWKSF4rah\nxEyo2N908mDAF6Bc139nUo/XHR3oigQUuksbbgQTnFuItFmZHfTK8wdOVEZR6aQaPrHyPhJHaDbH\nek+TSk7UxNnchFThmzxq794sjjBtM9AJrCw1xZNEf3/nMPzW4qvQiXUMdj87rHqB5PPsqaJaCmz5\n7PBzaxXQqcw7ctUy5y93Vrfaz6o1UCUZ8jFr+s21DI+zhb0ZXiBUzWnvl86LQibL8RFSV6STmQ/D\nJidlVzpheRwrrUM/p2gCj07xB5LZFGYMX6aeJNM89kvFLVpyspxiElBK6K8uzJ3W5uR04pw4KT1y\nrW1OpRdI0klbc+uqURLw6AQiKKNaOqueEFBuMEa51dvJCB4QO6Exg9CPnqVUgXf/esKsTLIw8Go7\nFctqDg+d0FROBk0sDqjulpL1zEwnsKyQUdjRriT6M8TZaWFelE4OQBNQMJnoX4Ayp/GkvQroZP4B\nZHpoAQo8++QedMIAZScjuDed3ABNHqYwopPkuRMnuROeL4FEEj6ubcuRJdHkac1fhsEyFpl1B4AC\n/xyjw6qaJLNDe0UBpRQ+gUoooNBH4yf5JiPqCelks6vshIdM6xxmexedZLRotjIfQScqO1/9sWyq\nJql2cKARXHSSXMDqkRrGXs2xk/BCCiXIJRcNRCUFvncxFVDyK0s9xZK/PBzdFenkMDQJwyfVnvjA\nHU5WWEDWH15yywI6nRyf4j1AuBY+V1XzgK72NLG3HbT6VrWP7EGx7FaUq7tS68AvPqUeDvyCEELa\nSBZgUJK5PadH0z7t2k7033VhVlffAXPHYicscHK81R1o/x16GOI6F508gZLhCQ3GDhH0Acsg2cRA\n7Uy2eEox9WaBgbu0/egEvGk1B3GKkMNGk3TyWG4jGAVYB34/md2eE3Z1FchLYFpAmY1OfDQ57LgJ\nndmS/W84ZYUONa9Oq6QvAR47kbByGwmWtPPSo6aAst/jKZmIqvZR+m/qVi8tf2AO62AsnAhhN0tj\n2AOiKQ0vWkN4z/CJ4qUW5sRutDXdTyfy13yG7Byqq69t+PmrZgucPJak8eATNYpj0UmovXJLbx29\nooEAFKxTv/qVQ1FhVy0DPk9UQsnsVEeVV9kTS8Ld0Vt0kf4XDm0dH2PcWw5AJ+z33Ic/YmEgndDs\nRunw5t6S7KnfOnqi0snbJu8rmlJ99XT1lGvnMYKl4fcDSv6XBfMdm5lOTjwM++31340//aXiEp1Q\njFBnx9Fq+hXN3aiX+MEb/NahqLzyQEnWverle5Q36eT3v/yZSnCPto+sk9IJEMkNHmbvCFANn+wK\nKFX7yJw3BE5ugyaP1f6PPzm/wHe5B80NX63XpZPO+MceB1Cqq2/4bPK9CjGwjE6OT+vIrWmGTvw0\ngqW9eTrxp6CfTkrry29ub22x6g9iJ/cAFBY1+TQ62ekmxp7YiZXWufphWBYCUZM7YezkLFtAt1BW\nODr/Odg7x2tK63mVqK2FF/BwFHj5O4fh4ZNp6eT0wAmiCQ2cI51YgfPQW+fpRNXqEB066QTXctgQ\nLTnbArRjJ788YyfJ4Z1rUgMO/fH9szsQNQFNvUFmhxpEZhb32KI5ci7ZRzVwAs/nmFmRqn1zzsZO\nO1K2IaHLX31vmVGnHhlJnja2rM64DExun/zx11+h8PZmezmYouaGNl7pOYBSWn1VNW4rjwb2xLt1\nAE1wd8osv5PWH0Un4fJxwgZvWx3xxCB1EanOOuPBM2Xa1KDnKpNOHt19AUpPA6dfSxUUoeQedALm\nDKwhvtDGXY5OpnXYzTrMzsZiKGVmDnNoQzWX1fJYSXJ32Cz8/S5kt8UBmlgvlTnk2vwoOjnmqN/W\nykYmeBhW7ktvRidsP2AtNHVdXIlONi7B15z9zpueUEePWSr5DidLqmhC923yVOwk504+Ia3z3NnY\nd+5Mi2J+LETGfgfSCdsqJRfCfsVYYJI2hHjhowkEUWQPP41OMJmOYYz9Zu3bK09AJ1tnVK0Ovaos\nIJcehk+QS/Aqq7Aj9tlWnxTdM1X8hiZfEZQDlGmnJm5JJxmbKHPbc9IJPtZ9Wofdo5nWnTvTDjZJ\nG2EIpBobn83IyCVGOQPwgpb56e/+bnv953/4BxlEYRcC9NDTYNvCvHfsBOiEnvzYe0/IQuZq1PyW\nN2z2GKvZrtUzOzejE1gYNOl46cwO2sTNFMJLNYhz0on01vAYsZmTHT2L9op0oibLLXrwYy1OeDnE\nlx6x91wL9KBmaoAzILODZViIRa5Hmmx97hB+/Xt8EBH+uODNzp089r6vQ36MTsD87gooULnM5lza\n8vdo9RWv5XTyjBG9Mjv452w7m7ys5Zntq5+KBbNIbaK6acPoMezMcKvXYwQzgUF/auR52HvTCVAX\nu7V4ZhSDlY52gc6mFftVw8hOPRiRZqoyQ2w5E5VEfIE3lDPgEwYoyDRQmF1yezrBmw/wV1eRTvYG\nFDyQS4/o3uN+iLwHvG5JETuBPM47nWBa64rjlIEToBO47f5ywT1EEzoX24cIKJRa6C8VU5O6xzyq\n/oy7H8NP3+9hJ29O/YJ00q8hV9zPhGjC7sdh2RkgD0knbC/BoiYfSCe4P9wCKDsBimr299uXNmg7\nPSPSv9wk6A+v8/gK9dgJ2wzdhk7wd4kpnVwLUJ7bNaEpCCX00fXUekLsxLq8X/MWnVgyhNgJvX9n\n/tjJEH3or+TgGtRkjUyewiKCeCSyBaIJpH7U17aFgAsloNzv3AkmVtTYCVjdvekEYyfQB/hzj9jJ\nXenk3HCmce7k919+//0XhJLr0gneTgY4cnU6cdAE7tBhVo/GkNH8nZLZgeeywy21NNOBR2Jv9qBY\nNXaCA595sA12VmWIUfUcBigUTVhgkgEK0gkNe2BQU+UPTO5AmnXRCYYxeg6gANyoL+QSZvbzdKLm\nK80dSP3GkUvETtgqPnhRe3SCgHIDOsE8DhI01dqrhE8cOqE7ubdf/nudv9sJSnC5WrET4BL4JR14\nTCqjE/zxvzs9xv66dDLQ/g4EiwNMkJozhUCInzaFqAmck2UxFfYbnNa3t7xn53m6iDz0EogBT8hS\nQGlQFUATgBO6C6UPf6NmnyX08zZfemhp62iZTPmG8ToLs60/1HTLylUQmYJOvjrxHT45uE89M8c4\nGkN58DmN7wGdYDRlp/Rnz1jktRZhgHFU92QYPjmFTtQ7dOgRURo7mTnf0TmPmNyBsc8cO/lkOnHW\n13NjQFmf3HdD06bWPgFWorpIP5xO2hbXw56/XpJO0BGAzVc3pUmb75PHE8JesRPpK53L2wb+tvOJ\nniHr+O7MuJy2+jsf1qDETh75QkInYRWTFAB1VDlaoglN9BxzgHxvKVn5bLZ7268bjN8hZMLuVWEf\nQtQEMj6fcDCWxo0uFygauEUZVdWoeiBAUkV/mTbFTYKVY7XQ5NPoBB98guGTql1Sd6E0m6PafDT7\npU1pxotDGR9N1ALVgbPyMk5DaclfIJlx+fGVzs6Hl3t0MnDxh/3oLABcAijNAAWCe/ChGjvBb5Mo\n3dnVnS6fhU6+oARDBQxH1JwOpZO7hk9g4IxOpgUUGShGw2p9JT9X7SY3N4lsPb2E2kpWVeey8unE\nD4fABgBqUB/QrN6k8wnPO3moDcns0GQ6hq5pePvpWb/2mf6EQgEImbDAyTOb49r8PehEdZcNCl/S\nZIdOLPetLihKTiFjlXrYU1ihk6/O/QJf9FR95LUY5WNo8jwDpWkqvRX+aznES+LIEYVtgTWkL9WG\nHhc7eZ17BSL5eorJzzJ2gqkNDJwgncBV4cCvWEDSySaHaelE3TAxg4DGwbGPdKZosTbDsqvRdPKe\nSeZwDp1k6KQz8apS4wwrxaITPH1Cj4lAwIOl4yWp4CcyobOhCW5HwaSraR2Ml2dOnziqy1bBriqq\nzqa/+vz+JFfuiVp0BzphUT6qspam0mUAmnohOqFEwu4fxufDyjed5i/YyryIxHo0Kg0bYB4HWQTv\n6LklndBbdSi0XY5OVNpI2rjJ6cRR7046YQdW9njYCWx859xPOnRCU+qUUdAgw6ZRWmZKJ9TaoyPA\nq9ihE7YjhfKh983TCY1APONA9R1+aR7D1WcVkF1FLQoFcliBm9AJDQlSFQT9A/2mn7PyqNaHyb2t\nIXisE/73+RtjJLDMoGSLM+OtBG0tJq+y4iUIIvRGYvWIyaMG+He78AnSCbzBkNK0Z2OpUVDjKE4c\nGK1hySxm1MzfCGZqaC7j3GuDaR2oXEY08RMrgtL5pBP0giWv1iyK6oU0egGBDcyq0Ht2VDr5hRx6\nddpl1lsafMQgTCdBGWdHqi4BJmqLWqTmO7XJcVXnMVyt+f5YTculV1WDtvIenUB+p63eI69i/CuV\nFSMlKiwzEj+y59W2Nku3PXoB/gtv6NE8TH4zE1ltpaH8ky3I+VbkEszgYJYHP2ENYSUNHZj2Ehos\nkcduIHwyFZDlbS4aayr8G9CJShjqr1bJtKm6Hv3MzpCgJtrx2RYC0AnAB9IJPfaxIchWhh1DoWGV\n6tYRy8vbHXCPSnets0mMov/BfZvN3et08mKoa9CJP4UUPsLJzgT6wkr2K6AeNLHiJft1Q6eKr7AH\nQsn2w37oejGyggXUpMZsfrpfgOzwDaMT+O1DjKBMwigOnahfWTESVtiqNi/kfOykuvvEPnCsJ/cP\nZ3KmGNfEgAo++X7XwAn4s+ZR56egWhJBAZ81Ip/jsMGJBSiAF1ujUCDZum/waRB9qzVfbbL1/mJn\nIcKM+sPxhGj5hN1tmPsJ9a9hFNsldI/lBJC/I8ltzdSvYvBB/8TKaOJm88qqJ57EPdcFoF+hHsFh\nz3pBQKGMcrocmE2gMRLVC9LyLI6CNkRCTNW8qFbb6U91HlnOVKZNIU/KXs/45dfypCzC/rToZEjg\nZHI6obfVsOQOzbDQyIrMwj/GmAOUsBgykxpKr6rNDcrPibZUqzmlwHe//+XrRwHXvyUBQwLfJ1tB\ng4xTI5i1ATQ53QHvOp8wQHa/Ek1ssSQXoAl76Mu9RbSr/NsqB87YCAPTpvJ3IeSuANqCC+FndCDl\n6tSDz78fcuIE2bFKe21SKl31SOu8H/uTR08wyQK3zxyJDotOSrN5fGE9dDKzxh8vo9WiIwFOJxrL\nIprcnkseTK9xCTzFX/7GED2dswHK9qLgsgDlsKUnsQNSOU6whPbNiWWqERc8rj5qgHNuf1U6ASaQ\nx2BL6ZthcsvFY0Y1t+opScBK7KzPlwTGSQDuN/6Ef+RhdPD4NXk6GEkFn8/GyuAjYb5zZJ8gulPH\nuOEF/vPTpplujq0t0+KkZbT7JZ9dfYVJnmdXt0/hk/VvSWBJYEngOAl8CJq8Elv0dDA79yqTPnBA\nWOWYZwjzc6R3nEaulg6RwItOIFiiwwclkkUnh0zLamRJYEngJYHP8a9fx24WnSzVXxJ4SGDRydKD\nJYElgSWB8yVAHigHsZDtCDCeAv7u3lekBB7Ltr3Y3To0iILHdD4lL3b+FK4ejJbAFg6BiMiKi4wW\n7afUVzqrsgovCSwJSAngMRH6E0Lbh/K3PPDkLALK9+Hir5Mr9Hkwn3CUeKnTXSUQ3t9714GvcY2S\nwLpneJQkVz1LAksCSwJLAksCSwJjJLDoZIwcVy1LAksCSwJLAksCSwKjJPBGJ798/XOqDguM6taH\n1ONL+0OEsIa5JLAksCSwJLAkwCTwTSfSUwKLSCLJ+FT1wq1tq0LWCm3aac7q4R7TTLuRkYDsgyrh\nPbq66lwSWBJYElgSWBKoSqDNtVVbSZZ/0knVcebHYDl1/Nz3+mEsB8epVgjf0q8kBlnMxCRIL2R9\nztSp8hbUY5FccgpXsSWBJYElgSWBOSWg+tb8h86g2ObcceLSxaiux3JS+SiAWpK1TptG96cOU6eT\nED7CAhIaKCUwYlALM7BQex+iD2tURRkHa2ijVMQ+WjkckySeOZfZ6tWSwJLAksCSQEkC0lmoDsL6\n0GpL+j61Ielx0LH6Xix0uLKASgVqPyWgnEAnrLsqTFiEYYGFSgyZhhDT8vTA2sIuhXSSnFpn7KUF\nsAovCSwJLAksCUwoAfTE1H3kP6zSiay55PicuEMYksjTCRISe8MGu2PsRPa1RCehLCi+WG2FwZU8\nH1AiWXQyoRVYXVoSWBJYEphNAnkQUUv208kQt1tyx3JXTykkE+OB8nudO0liFCUM531+hrAknWkJ\naD1BrTD0Yk1kEtdmW12rP0sCSwJLAksCzRJAl8F8BzopufWlJTH44Xt9WqzkpMItuuXN2edJpz+A\nTnCoTEx+KIbCAVwoB5D5MENqjGbCP9mIfHyRimhNoRym03lWOFSL5vWwLlwSWBJYElgSmEECqp3P\nf6jSieqgQydFOYnt5KXvRl+PbovVLz2dU9KBEstjencUZyIWM8y92gcVqqbt7erYksCSwJLAksCS\nQIMEkpv5hprPveSGT2NTYzbnSnm1viSwJLAksCSwJLCHBO5KJ/8/7d5FemD4AtYAAAAASUVORK5C\nYII=\n",
+      "text/plain": [
+       "<IPython.core.display.Image at 0x108575fd0>"
+      ]
+     },
+     "execution_count": 30,
      "metadata": {},
-     "source": [
-      "Basic Operations"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "from sympy import *\n",
-      "init_printing()"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 1
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "For each exercise, fill in the function according to its docstring."
-     ]
-    },
-    {
-     "cell_type": "heading",
-     "level": 2,
-     "metadata": {},
-     "source": [
-      "Substitution"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Write a function that takes a list of expressions, a variable, and a point, and evaluates each expression in the list at that point."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def evaluate(exprs, x, x0):\n",
-      "    \"\"\"\n",
-      "    Evaluate each expression in exprs at the point x = x0.\n",
-      "\n",
-      "    >>> x, y = symbols('x y')\n",
-      "    >>> exprs = [x**2, cos(x), x*y]\n",
-      "    >>> evaluate(exprs, x, 1)\n",
-      "    [1, cos(1), y]\n",
-      "    >>> evaluate(exprs, y, 0)\n",
-      "    [x**2, cos(x), 0]\n",
-      "    \"\"\"\n",
-      "    ??? <- Write the answer here"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 2
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "x, y = symbols('x y')"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 3
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "exprs = [x**2, cos(x), x*y]"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 4
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "evaluate(exprs, x, 1)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 5
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "evaluate(exprs, y, 0)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 6
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Write a function that computes \n",
-      "\n",
-      "$$\n",
-      "{\\underbrace{x^{{}^{.^{.^{.^x}}}}}_\\text{n copies of x}}\n",
-      "$$\n",
-      "\n",
-      "That is, `x**(x**(...x))`, with `n` copies of `x`.  In [Knuth up-arrow notation](http://en.wikipedia.org/wiki/Up_arrow_notation), $x\\uparrow\\uparrow n$."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def uparrow(x, n):\n",
-      "    \"\"\"\n",
-      "    Computes x**(x**(...x)), with n copies of x.\n",
-      "\n",
-      "    >>> x = symbols('x')\n",
-      "    >>> uparrow(x, 3)\n",
-      "    x**(x**x)\n",
-      "    >>> uparrow(x, 1)\n",
-      "    x\n",
-      "    >>> uparrow(x**x, 3)\n",
-      "    (x**x)**((x**x)**(x**x))\n",
-      "    \"\"\"\n"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 7
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "x = symbols('x')"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 8
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "uparrow(x, 3)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 9
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "uparrow(x, 1)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 10
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "uparrow(x**x, 3)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 11
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Write a function that takes a function and nests it within itself n times. \n",
-      "\n",
-      "For example, if we started with $x^x$, and $n=3$, we would end up with \n",
-      "\n",
-      "$$\\left(\\left(x^{x}\\right)^{\\left(x^{x}\\right)}\\right)^\\left({\\left(x^{x}\\right)^{\\left(x^{x}\\right)}}\\right)$$"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def nest(expr, x, n):\n",
-      "    \"\"\"\n",
-      "    Nests expr into itself (in the variable x) n times.\n",
-      "\n",
-      "    >>> x, y = symbols('x y')\n",
-      "    >>> nest(x**x, x, 3)\n",
-      "    ((x**x)**(x**x))**((x**x)**(x**x))\n",
-      "    >>> nest(sin(x)*cos(y), x, 2)\n",
-      "    sin(sin(x)*cos(y))*cos(y)\n",
-      "    >>> nest(sin(x)*cos(y), y, 2)\n",
-      "    sin(x)*cos(sin(x)*cos(y))\n",
-      "    >>> nest(x**2, x, 1)\n",
-      "    x**2\n",
-      "    \"\"\"\n"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 12
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "x, y = symbols('x y')"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 13
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "nest(x**x, x, 3)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 14
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "nest(sin(x)*cos(y), x, 2)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 15
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "nest(sin(x)*cos(y), y, 2)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 16
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "nest(x**2, x, 1)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 17
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Write a function that replaces all trig functions in terms of $\\sin(x)$ and $\\cos(x)$. You can assume that the trig function will be of the form $t(x)$, where $x$ is the variable.  The trig functions implemented in SymPy are\n",
-      "\n",
-      "$$\\tan(x) = \\frac{\\sin(x)}{\\cos(x)}$$\n",
-      "$$\\cot(x) = \\frac{\\cos(x)}{\\sin(x)}$$\n",
-      "$$\\sec(x) = \\frac{1}{\\cos(x)}$$\n",
-      "$$\\csc(x) = \\frac{1}{\\sin(x)}$$\n"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def trig_rewrite(expr, x):\n",
-      "    \"\"\"\n",
-      "    Rewrite all trig functions t(x) in terms of sin(x) and cos(x)\n",
-      "\n",
-      "    >>> x, y = symbols('x y')\n",
-      "    >>> trig_rewrite(tan(x), x)\n",
-      "    sin(x)/cos(x)\n",
-      "    >>> trig_rewrite(tan(x) + cos(x)*sec(x), x)\n",
-      "    sin(x)/cos(x) + 1\n",
-      "    >>> trig_rewrite(cot(x) + sin(x)*csc(x), x)\n",
-      "    1 + cos(x)/sin(x)\n",
-      "    >>> trig_rewrite(tan(x)*tan(y), x)\n",
-      "    sin(x)*tan(y)/cos(x)\n",
-      "    >>> trig_rewrite(tan(x)*tan(y), y)\n",
-      "    sin(y)*tan(x)/cos(y)\n",
-      "    \"\"\"\n"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 18
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "x, y = symbols('x y')"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 19
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "trig_rewrite(tan(x), x)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 20
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "trig_rewrite(tan(x) + cos(x)*sec(x), x)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 21
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "trig_rewrite(cot(x) + sin(x)*csc(x), x)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 22
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "trig_rewrite(tan(x)*tan(y), x)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 23
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "trig_rewrite(tan(x)*tan(y), y)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 24
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Suppose we are working with the series expansion of a function at $x=0$, like $a_0 + a_1x + a_2x^2 + \\cdots$.  In this expansion, the terms with higher powers are less significant to the calculation.  For example, if we had\n",
-      "\n",
-      "$$1 + x + \\frac{x^{2}}{2} + \\frac{x^{3}}{6} + \\frac{x^{4}}{24} + \\frac{x^{5}}{120} + \\frac{x^{6}}{720} + \\frac{x^{7}}{5040} + \\frac{x^{8}}{40320} + \\frac{x^{9}}{362880}$$\n",
-      "\n",
-      "We might only care about the terms with powers less than 5\n",
-      "\n",
-      "$$1 + x + \\frac{x^{2}}{2} + \\frac{x^{3}}{6} + \\frac{x^{4}}{24}$$\n",
-      "\n",
-      "We will see later that this is can be done automatically using the `O` class, but it can also be done using `subs`."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def series_reduce(expr, x, p):\n",
-      "    \"\"\"\n",
-      "    Remove all powers of x in expr with power greater than p.\n",
-      "\n",
-      "    You may assume that there are no powers of x greater than 10.\n",
-      "\n",
-      "    Bonus: which functions are represented by the series expansions below (you\n",
-      "    can use expr.series(x, 0, 10) to check if you are right)?\n",
-      "\n",
-      "    >>> x, y = symbols('x y')\n",
-      "    >>> series_reduce(1 - x**2/2 + x**4/24 - x**6/720 + x**8/40320, x, 5)\n",
-      "    x**4/24 - x**2/2 + 1\n",
-      "    >>> series_reduce(1 + x + x**2 + x**3 + x**4 + x**5 + x**6 + x**7 + x**8 + x**9 + x**10, x, 0)\n",
-      "    1\n",
-      "    >>> series_reduce(x*y + x**3*y**3/3 + 2*x**5*y**5/15 + 17*x**7*y**7/315 + 62*x**9*y**9/2835, x, 5)\n",
-      "    2*x**5*y**5/15 + x**3*y**3/3 + x*y\n",
-      "    \"\"\"\n"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 25
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "x, y = symbols('x y')"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 26
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "series_reduce(1 - x**2/2 + x**4/24 - x**6/720 + x**8/40320, x, 5)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 27
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "series_reduce(1 + x + x**2 + x**3 + x**4 + x**5 + x**6 + x**7 + x**8 + x**9 + x**10, x, 0)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 28
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "series_reduce(x*y + x**3*y**3/3 + 2*x**5*y**5/15 + 17*x**7*y**7/315 + 62*x**9*y**9/2835, x, 5)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 29
-    },
-    {
-     "cell_type": "heading",
-     "level": 2,
-     "metadata": {},
-     "source": [
-      "Evalf"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "At the 762rd place in the decimal expansion of $\\pi$, there is `999999` (see the below comic ref: http://www.qwantz.com/index.php?comic=1013).  Note T-Rex is counting the digits like\n",
-      "\n",
-      "\n",
-      "        \u03c0: 3 . 1 4 1 5 9\n",
-      " \n",
-      "    digit:     1 2 3 4 5 6\n"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "from IPython.core.display import Image \n",
-      "Image(filename='../imgs/comic2-1040.png') "
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAt8AAAH0CAIAAABq69b7AAAABGdBTUEAALGPC/xhBQAA3JlJREFU\neF7tvT3ONElyoFnKEHuF4QEorTYH2A8LjLaDBaiRUksFLKjtagsQXRfYA7Q0pDA8APsApYzYF6BW\nZ+gL1Ea+lmmvpf2bu0eER6R/zC7mm+nhP+bmZo+beUT+9NP6tySwJLAksCSwJLAksCSwJLAksCSw\nJLAksCSwJLAksCQQS+D39W9J4C4SoOp+lzFdbxw4C9fr+urxksCSwHkS4LxyXk9Wy0sCgyWw6GSw\nQJuqW3TSJLZ10ZLAp0tg0cmna8CNx7/oZIbJHU4nW4WnjOvgdkFumZEmi2WqUsvsXX9zx8ZeWB1m\ntTzrbX5+rWGOsm+j6hk7HVtti06Gi3RVOIsEpl11swjokH4sOmkTc957dbrJsHt715/xvlIaUq86\n13t1mNXyw+kEK+zsyfB6Qo1KFlh0khTUKnY9CXRaq+sNeMoen+5FRklllA8Y1Z/DnMrAgfdURa8N\n6wkLyFmoXlItP3zehyvAPCOCoS062U9nVs0nS2DRyckT8G5iVGPquBz2Fe6e1c9DwwoFaCVW/VRo\nFK3a2mV2NjMjjt6qX/kylHTo9EEtTEXH5Bz2B2SueJpc0irUGWssUibW0FS9cqqt6qEUkSO0qn6i\ndiX1ik5Ehs8c5bFGUdI3v9uLTjLTuspcUgKLTmaYNmmtpIdTjSwWk1jQ4LSk3VeBxvL0eLnsqlpP\nxmuGs2MJivVBFdTAflpjr84jkko4cFZAbcj3ghmdccqoPczUycbo64ZaoU9LodKG6KmunZByfFVs\nWI8ZHVh0kpHSKnNJCSw6mWHaxtIJtf5Ji5n35b5rsSBgEjqR3SjJxwGCKoU47ZZkZflRhxR9zLU0\nIfTNeXp29FMuRhWFHda08C4p1VAfnHrUrmYgsscELTrpkd66dmoJLDqZYXp2pRNmv/yNo+OcVFVx\nvHK+XWxUyiGcHd+dUDdmbamH9PNcOqlSV7586K2T3pc70VfSKoSGPJ34pixsKANtKvpk1gWFyKq+\n+Utg0UloIlaBq0pg0ckMM7crneQHKLek6ibV2SOq5TMdyOw71XrydGK5lkz31BBFgxws+TQP3wpp\nOGKxKI3KIdPP0nRYcBBCQ5JOQgGGDbXRidVu83hL2ggq/favev0qvyQwrQQWncwwNT6dOBbQooc2\nSuikExiF5S/DLaBKAOHslOhEAkrSaWXoxPejTCyscOhcHTlkHGE4L5YYnX6GdJLUB38KjqcTfy4c\nffNVsW1dZPR/0UkopVXgkhJYdDLDtKl0Ij9EA4d2XzoP+ET9nHoL37U40ON0tbldNq6wn+ounwKE\n2kmLft6Me+I2GbU8il123lpitJPSseWF4Hh3X68cN5zRK2vhWONy5OxYoSSdyCgC654jJalO1tKT\ndOu3q46rqm8h1r9VOIM5W31YEhgiAccuDKl/VZKRgGMNM5d/cpmk1/lkEa2x5yVwOXVirJN6cHJe\nHKvkksCJElh0cqLw5XZ/hs5cqw+XcyfXEu+n9fZy6rTo5NNU9IPGu+hkhslesZPqLCyJVSW2ymck\nsOgkI6VVZkngCAksOjlCylEbVV87atbyhxuiERz9/ZxeZB55HiOfY1o5Wrfma88/l7POncw3Y6tH\nIyQwys+N6Mvn1lGik4EuwfKmA5vYaVLn7OGik52m+5Or9VV9ZXY+WTduPvZFJzNM8Fl0Yo19lO9X\nvXW1crV8tZJtpA2X7Kobo/ozSj4Ngx01hIamP+eSRSefM9drpG8SWHQyg0KodCKnhu+Tvv72+w8F\nZP3+vIfVJoXG6ET2P+w8uwTLW+MKB5sMb2Tqp1Ky5KnWU5WDA5E98mH9V0VHP0xqRdWkqMrvKIYj\nan8dUUJlYwmn0tEHS0TNcsDOZNY7L5NcmavYksD8EqguoflHdMUeqvRAByIdSXKYkg/YharLSfqh\nkC2ggOMJMqOwehjKpKddS25hnbKA1c8hQpbiRZln2mWOMJyvsM9hAR87Qn1w6lfHK7GjNEZVPkzm\nVpdC/bQWeLJ+OtHfZjyU4CqwJHAVCSw6mWGmdqUTxwg6vq1fLNSy+31IUk7SmmOxkCTynjI/Fr/R\nksdKTkGGL8P+Z1yspS1sXpoBJXMho8Zwrq3p2OnzsD/WnDpq44uFGvDH+6TSrGJLAvNLYNHJDHO0\n6CQPCpm9r5RnxrNm6CcknvnphPkzVZ7Uy6rlQ6DMO8oGEyQZhTtp4xcVMpSWkY9VT7PcFp3MYIdX\nH+aSQINpmGsAt+jNbHTSL1TLW1QpwSqf2fuGJJFHotCrJTfNtEt5/x2igCyQkY9DY9ZwSoqRGWCP\nQDLXJuWQoQ1VXNYYM2PP0HC4XvhCK83QKrwkMLMEFp3MMDu70olvxKtmNCmu5r1g6Gj92Ikz2NJI\n2e78SDqRgYFFJ6oEqnRCBcuubaaTJD2Hq6Z5vSw6CWW7ClxVAotOZpg5SSdg9azP830Gq6fWo7p5\n58Nqo6y89Ad5XKjSmyO6pO935OYvGcfNSE/mzHte2ur8+t5ODsGZC+b/QlRylM2CjLwVckpa/aT9\nsZRQ/ZyqSjitqormx9W83tmo17mT0sJZhaeWQGn9TD2SK3euatDzY80TQL7OTyh5rtzObf3G83s/\nwS46ubG6fvrQFp3MoAGLTmaYBdqHE93YiU3PNgvD+3M/2S46Ga4kq8JZJLDoZIaZWHQywyxMQiez\nieJO/Vl0cqfZXGO5uQQWncwwwVU6oRnxPfq/d/1Wn89qdw8Z7lpn6GX9AqPknK8n7PCu4uqvfNr+\nr9hJ/+SuGiaVwKKTGSZm0QnMQt7bzTBrJ/YhdJaLTsbOTijwsc3la1t0kpfVKnkxCSw6mWHCqnQy\nQ59XH06UQOgswwIHd362/jjDV7va0P+GSxomZdFJg9DWJdeQwA3o5BgrsOt0qnSiTo01X0wIoUyg\ngGzXrz/fT1p52BmnsNVP37vkYzBO/VIUo/wWDRSpE+fLGcTlK2R1fkfNl1UP7bAccpLOfflbleRN\nHPf0RMgZPcEZceoZbkYWnQwX6apwFgnkl+4sPRb9CC31tD2X5ox+knE/tAzKISMQ5r/lJaoLUbun\nOp5MH9QB5tsNpzXTByoH34NSJnBKhr2SBVhtoTzZ3Fli9DupUlFn5yU2SZ30Nc2fMlXDeyrMaCBF\nSX95jhJpaRYWnZTEtQpfSQL9dJKxlbtKJOOEdu1Af+U4C4xXnJrVUefnIrSkfgGLhOjnbfOSbDcj\n80wHrDJWN+BzlHOmibCrIRU5Xt+qvGF+28aSnC+UG+tw2E+1vC9/Js/quKyVpe4EnA+r7YZ64mDo\ntxlvq2VdtSQwoQR2ohPpbukWRK5btTz1BNKKjfUQ506NL67mHV4ebtQZyVheqj84I3nGkj1Mejt/\naJY8w+Zoz9XhD6QTden5VGR1LxxXOL90eZbWQnK+pG4wg5CcMkf+jimzWi+tLGs5WO0uOikp0iq8\nJMAl0EknuAKtpdjzObMpalsluzPt9PumWZWh9WHSJvpOZRNU3uuEUk12Cd1VhoqsRmlbmXaT+kl1\nDx2klFIoChUvnD5b6yscWnV+HZn7gyrpiex2OBDWOq53OgtsIpJzmlGhJK1mVDevG6WS1IA/3pcu\nPqtwv9Wmwz5rFOqewDflYVfHzmBVztXy4XA6C3TOsmU9rVVd+twyfKHl7ZTJ8Zf7Kq1qrGPoMxoe\nyrDkdUoOrFQ47Kf0XqGOZTyx065DDBnJS09Gr8rofMaGhHJzupofheSzsP9hx8LVp8rfkWFJHyzi\nDMcViiIcV1sBasAf79tqOfiqjAYnuzTPkIf0ZEglVONLFQ6cl+T0hc7Ad43h5dLawkJVqy19nrEI\nljUZIpzDKpGysgRlmdqq0Q/L+wWYM5C9DftvyTbfrlNDvnVn8Tq66uh8XmeYX7HqZKYGOhzanIb5\nbbMDsieq3JjCMEDMzxcduxzjKD1U16MFteo84mzCt3mtqJZkrWdbcjpd7cG55XcVbmloQ3oypJJS\nt5sLH9DVkl1gA+EL47UILUvU87lvlZolPMmFbY5hks6vbljI+AmSOcBGfYIYm8fYSCcqC/udsJAN\n+SsDYo6/sb7yjWMDHTO6r7pAH4GTphy67YsUh6auMfqtWo/TE38Ijptn0J0c7BDlrlbChKYKs4dI\nkvXfwD7uPcvVmV3lGyRwAz1co26QwLmXHEcnksEll+TXgEoVPub7TlrlLcvB+47fmVHLJzHiCXWC\nkRxDDVXUtM58/305y346A5TUEg6zs0AVHJP6w9YMvUptUS3vawJdGp1COP3yRSenT8HqQEkCS2NL\n4tqv8Ml0wpigmU4yTnEnOsn3WSKItfkO5zuz86bNOeX9/mcEq3IPzqxVf0luoUDUAs100tbcusqf\nBR/+QumFCpMp4DgeRvzVDUPY/6sXkPI5ZkRntbvf6EJF3a9pp+YJ5XwcnUhXgZMk34TTI72mukMF\nE+ObJN+5Mn6y/kwqnOPskzX4/cnULxty9LKTThxGKY031IdFJ20iOuAqufrapj68Kizg49GiE18Z\nzvJeZ7W739LIK+p+fZA1Tyjng+iEzocDJflpS3pNtd0MjjAIyDSX6XyGHjIaadWTqd/qp/p5ZuCO\nPPOizoy6WoYqd/XaVX6UBK5CJ6q9HiiEUVWteg6QQMaYZ7qRMarN9WQu3KnMKPlkgPjbjJcGk+/i\nnejEYsyMNDL0kJkC1gcJfIyu8E+nk8mF5A8zX39GXBlROGV66OSA7m0936+V/WquTopFJ/JzEIj6\nudUoLZwfslyGVmew3eQl1pbUGld+vNABXPjSArAhVMujNqrzFU5W2B9/ndKppzKvKgNthVnFZFV0\nRtigSvrp1EOnxtIrVQiyP6pUM/XTdh3llPPiy6dqHHahE9bFTJ/kJUx7SsZaWiKrS35X/XqYrlPT\nQP19Umn8S2RP2tazuj4tOgmNo9or5yprsfn1ZPSnoUw4ulDCDY2WLilN+gE179Ef6RXYemGG0gIC\n1fEzI54UkTVMqb24cFjNVp+tDlj676xW2SL1Osxayv5QY4UXqsOhdlja5FIP1bkLlcrRB0v+jleW\nfQjr91XLUshwXJZHy/THUsWMhlv1h3Wq1rttTjP9DMtQA/54H14wSYELdXUPibUNv+2qPfp/TJ2L\nTqpy3kNDVDpRfV5oPR1EsDxBxo357kfKpNpPx0s1+H4JEGp/nGJW/8PZdwpIPLKkGqJAKPAkAlqk\nFQ5zyHw5XJXRn0yZ4XLwG3WmuGpnkuUXnSQFNVexzAKTprzhqrmGXexNP51IzwqWy/K4+fLOUPLd\nVicUPsT/Qm1JW7mHhliykt6LG6Nos9Rswa1hygotCbOuhorpzFTSi8tJpJ/I/vjlM3QYYoRDdSX5\nhPOYVEurnrD+5EgPqMda+0kJqMvcWv6yTn+A9NtSf8LV4WDWmyI1V3TMhdLSHdPubK2UlONjhWYt\n9cxswrWq/VU/p+WdRR5OXFgg9CtQg9X/vAHKSClTRqpf0ouElTd4C4fSEOnYpIdGPOynrNn3ImqF\n0sdYXodV7lxolXS8RcaRl3TYEruq576ok3qV6Z5apkHfSvU47j/TZwcWk/qWNw6l/mQWiKXz1IZf\nJrPTPOB14edIoJNOQg6ghtVarlWLxqginCzGIpbHCj/33XbYDafAMXRSklt1sqqTmHHhGa/sa+AM\ndJLxvqHysLlrxkHm3al8HMfvs6ADSRkPnZGPOo89KmfJM6yzn05KyzCpGN9mPLxgFVgSuIoEdqKT\nN5x3kybggdTy4S4wY/vQw6FRyFCI49WSjZYUIE8nUlxhQ7TyfOerdKKSRFW7pBzYeEOVYAQpnbEq\nDcv5hfMSMpaj2yWdhx6q8qlCsyMBp34LUKSvrU66Oi4HAhy55fvvyNPvv9MxZwkwgMsvw/zqfnY7\nvADVJVxscqhSNKE4nEqkUKQyWcOx1pX6uRS3uuClq6Cy8qfQl0NyUlYxJoEGU4I1WDNirb3q55nJ\nyqxz1Hk0SapBp1VZ2pvpUkOZvFVtqHxdcgMJZPS8Z5h719/Ttz2uPXe8A1vn7jgpLNXYWZZdYlfo\nAxy/rl7r90cOqupLrPoZD6GHYOVVxnJ4ZeAEJyf0lsU+gU7o4nJWQaiB+ynAopP9ZHuPmvc2d3vX\nP9ssnDjesU0fQSdOj6XRlPDhkEGScvrpBH2A2mG2GaW7WPqebWrluFg9syn95fqzB52AJsiafSXP\n9yRfMr9S5PaAUbWzr+if9EUn/TK8dw1jXVre2t9VqnvL8zC5nU8nqq3P7AjzO8W8voYgtejkMNXs\nb6jB0/c3eokajrRfi04uoRIHdPJIraPDOavdNpFaOwertmr5aq/662+WfzudOEZHdeGqUJySaiDB\n8jf5FjGAoVZloRILe1jbVuiG9d8wdmJFaKr6tMrLWV4yoUrbbC8axHhdOum3y464fvrxE301CPZy\nlxypdYtORqlH/yponvd2OrEcNg17OGXUryiRqKCgIkupRb9Lvhzlt6w/lEtor6rjap7OURp5j3os\nlr3H6BpGcQoonNJog3DkJf12Wd+SfXHJL7//oK+bwYpqwRrMWsMl6jwO0YcTKxkih4H9L/WnVJhh\n5RsGJAdA23N8Nt2u6Qv1/XGQIXxY7fr9yetrM50AizA6kcNn9avjZTZxJxOZnOhLF1t0MsP0XZdO\n6KIeIklAEMYl6p8IK0PazVdiLZn8UnpzJy+TSPeEqj7ID516Mq6EtYhTKS2w2rRV3mnaH5fqJdkl\nqpB9eVqNhuOFAr5iVPtj1YZuUfoyX6/42JN67HjZjH6rXhnlpUoNR8jYCrWwZAStifGXhKphsj9W\nsYZxDbePyfm9R7G8Sb3HeOccRWlhTjgEaVLbOpnkkg1WWBzlMFJxrKJqdR05WLaOfu7YQ7mvC2Wu\n+hTqF9U61f6wGU96ccpD+baSpOX3Qbpja1y0Y+G4nFnIXytdmKUDqt9888ihEqwCSwJXkcCikxlm\n6up0MmSHkEeTjU7+6//8T05AZb85tThMOr+wD83k0dAWc6I4CpVXcA9M3zCwqPahSnWha1f9dJ4F\nrf5XxzWQTlS6Dfvzhiah1EKlXAWWBOaRwKKTGebiBnTSCSghmmw4Ql8STfBbiKzsOq2SUUIvIvtT\npRNrqZZcEhQu0Qnzf2H8IxnqwHoy9Wek58vBn6CQ0kJ1qtISq9ChJVU+lIreCoQdXQWWBK4igUUn\nM8zUPeikGVBCNIFgCcRLWOHtw+0T+BbzOwcACosr7E0ntP6Gtpgzw86HXrka87BWU7IeJxThu3M2\nHSHNXDR2oo5r0ckMNnz1YbwEFp2Ml2m9xtvQSRughHSCaOKclmUnUSiswFf1aQmu6CSGUuyksy06\nEpVIkt7aoocwflOlkyptVMtnxosRpozm7Bc78VtnkZXxWp4Z/CqzJLCHBBad7CHVap13opMqoKho\nQo+VOGhCv3q0u1HI9u+LRYBO2A3J1Xnxt6pyN1+dR1neiYswP8SAI+9KS3SCs8m66vRTFbKDL5lx\nJX2/I3+/wwz+UJghdVm4Bp/n9aFt3uXsLDrpX+OrhlkksOhkhpnIW7EZepvpQ8FZvjMEO+4qISMM\nn9Bcz3A6yYx9lbmNBPJ0ctaQV+zkLMmvdneXwKKT3UWcaOB+dJKPoDhpHTxNknz8CTt9woIuQC2J\n2VhFlgSeElh0slRhSeA0CSw6OU30pOGPpRP/xEkpcIIPQWEoQ+/0WXQyg7ZP3odrmcQVO5lcnVb3\n2iVwraXYPs65r7wlnYQiD9GkRCfO/cYTAkpy3e29d++sv5C/ix66KrVFPR8TKtWnFVh08mkz/kHj\nTVrJD5LIGUNddIIBDzh3gjka66lrmVyP9UyUqSIoPh900kOoy531n0InoxbLPepZdOIpeV5Bw6Wy\nChwvgUUnx8tc3SZ+2jqSgRM8JoKhjvBO4zZGWXSCGthJJ+raUetsaEiNndB6GupUB37pehadLDqZ\nwYXt0odFJ7uItVjpqG1csdkzi8tf+8MwCQ2cwL3BSQqhGRzKOng54k4noKirxvqQSlk6QvUTRNWM\n43TaVfWKftgQuYFLQgkw2mZXNWse63BGPhmEum49i04CXfq0bV/z0prwwsvRyS2V7dPoBChBPvWV\n5XQa8jsMUBjWQIuAO82PaMvEBtR9Pzh1ZgQcd5tUdVoDbdf6nMYPknSiVgX1hCPCYk4lecO46ETq\nzxug5EX5OSWTC+lzBHKVkS46mWGmPplO1CfTI0b4gKI+qC0EFNpiNYhiuXPLa4be1C8Q7umr7Yb9\nUeEJzXuGRUr0Vl19DHFC+Vj136aeNzRpFkd1Gq5VftHJteaL7Z8uNH0X6mpeJZJ00rzdz/fkmJIs\ndoK4ADfp/O2fHg97pb+tYz1gTaZy1E/kPcbNgDIhnTD/pIY0aEyFTnHozqDAPHSCncGONWssXXSh\nHJxWzq1n0UlKAW7pNlIjv3IhqtyXGMct1SxDJ+jRLzFNnjV/PRyWngLBwyX4HHoVKeAYCjuh4jAK\nRRyZ5aGNJqU6IZ2oPa/GVJwYA+WA02MnamgnOXc+YfRXAuR0cD2LTlICv6XbSI38yoUWncwwe0k6\nqaYhZhia7AOFEiAGevTVohMshgXaAif0hCyCTkmwqgfK0IBqIa0LacSiwa0290eZr5fHzQzc8tDO\nMJu1VNbZBgeXrmfRSVZ/FqBkJTVNuUUnM0xFSCfgv0tOdIZx6dv615FYiSnsea/sbh2QwEMIv/xr\niVGsW34wElOVrbpqrKXkR/7VaAQa0oy7Zf4JZB5CD42I+KqCVSXpBLmKlh9IJ9ZiqXqfe9Sz6CRr\n6Kr6ka13ldtNAteik7sqmE8nt8npPB0nuWEHz5dg+MSJneBtPgAoGUbxb0We8Bmyuy30j6g4A3MZ\nQVyonkUnmQl9lrmr/yiI4FJFF53MMF0hndwjaiLpBJ8Mi2EMdmCWhk8gwgGMAnSiMgqeNXEelILt\nLkCZQf+H9OFCSFEarz+uRScFYS46KQhrgqKLTiaYhO9nW8nO3Cmnw+hEHhyhERR69BVCIHh3MQOU\nP/z0028//zMEXf74xz/SamnsRIWVRScz6P/qQ7MEFp3URLcApSavU0svOjlV/G8RRz2v/+V0Z+jk\nkD7gWRMMhDA+APLAm4qRS/CNDJ/89uPHBigbl2z/GKBkHjK7ACU/s6PiE/kW+0v652b661drOExQ\ni05qM7jopCavU0tfiE5urFfmAb0bHYalgRO8VYdmYWjihj1J1s/vAJ1s4RMEFHoTkJPfebSy/Xvd\npZw8G+un4fKreVQ9+Rb7Sx7mdPu7ijUsOhkozDtUdWNHcofpIWNYdDLDhDp0cqfAySZqjJ0gf2Do\ngiIFO33CEjQAHHD65Ikm74DiB1Fozkje++MLnLrnHlc9qp6DtbdnyAd3dTidmItUe8bJYYJasZMW\nvVqA0iK1w69ZdHK4yJUGVcN3vxMnjE5k4IQ+Ho3GV+ST2fDbjU4AUCB8sjUBERQElO2Nld/Bgyz5\n8AnzOs1OaFQ9DdqrK9v7b/vRamn5zHgtk1I1NWp56MDxYSeVJjkZEExx+lkdly+3RScNS+D74cct\nF69rjpJA1WQc1S/ThZ/Ygf2aXnTC7tmhp1JoTIUdQ4FTJtu/B5q8Tp8goAAM4UkUiTjq89zysRNw\nk21acSKdyKAC+ns/3pDZcFoCqY7XKs/60Cz/0qzJVlRYkUhniVqVM9YZVq6y49OGlAb2yYUz2vzJ\n8plh7ItOppqFb7P1+qGZO2V2MK1D32AAA/M1NPMCmAJlEC/wT6QTmt/ZYIVGUCCIIhlFRZPw6Anz\nHM3ecVQ9PdrreEHVU2ZozLL5A+mE+eYeCSSvbaMTtZ8OdamdCX3oip0kJ5EXCyXbWO+6bJwErkIn\n99YlnAVGJ3dCE4hk0AfJ04fTQ5aHHoaljyRhgIJ0QtM323sZPoHICsCKPGLSEDvBMAO4mWY6GVhP\n1RioSz7pNZPjlat10QlME4cJ91cCvq3B12UOvnxXW9WGTy5/b6dyg5lddDLDJH4CnVA0oU99xeiI\nPB1CoykWoEBQBPgDz6AglMDn9B+No0g6qeJg0luHOjaqnlJDe8RO1ICBxLhwvGNpKRSLX2C/2Anl\nj7CTqtBW7CSUm1lg0Um77A65ctHJIWIOGvlAOqEHYOXJEjz0CuyyPf4EnoDCUjxAOQAfiCZWBEUy\nCj0MiwmmvD5IDxo6XWv7y5y644dkDSUbaxFJhgZKDTEiOSB2Uu1efqIbxpKRp0VyVscWnZSmLFV4\nV6VJ9WAVsiVwCTqRzvtmU/rhdIJpHXroFWIteOMSxDwYxwCaIKBgcocCCqoKO48Cn2O18CajV5Y2\nVg1dtR6r/uZ26YUOPdB+hvjl2JOqqVHLh/3MzGBbGccKKev3PRHDoFAOzRJsKDRa4PG+bWwfe1V1\n8XysoE4ZeKj9p/SKNXp7Fbo9nbC0DsUR+Apv0sHbjNnJWTV8ggRDyYOekJXaK8/MwidD/i3vMESM\nq5K8BBad5GWll7y9d+kV0HnXX4JOzhPPQS0vOqEPZ6MnZ+kjSSC2wfI7avhE3sJDJ5IelV1ocpCK\nr2b2kcCik165LjrpleBu1y862U20hYotOnk+EbVQ06RFZexEIogEFHo7Mb3Xl+Z3aPgEsOMP8GS2\nr6e0AaZMKpTVrSWBbgksOukW4apgVgksOplhZj6WTtgNO5jlUW8nhoOxMF8IKJJOfv3pBzDK9tVw\nQOnM3XReXtXV4dvCZP/72002xARyvDVr62d1Hp3yi04GCnNVNZcEjl/Pc41/jt7cm06cwAmlE/q8\nE3qvL0AJvhid4G07eDZ2oxMEFIijDAyfdHqjzsur2tpPCdL9Z/rQ326DoBouyYzFL3NKo7RLi076\nJ3HfGvLn7fftxwVrX3Qyw6RJOoHwwD0yO9aRWIkm9JEneL6Ekgq9rUaGTzah4W3DG6Agrwyc4k5v\n1Hm5OpA96rQk1tNW6dpS4SewnpHCO72fi04Gru5CVexmP7Z/on9aRpzVUGj7Y4ouOplhqh06uTqg\n+HfrqM+nl0dSEFBocgcADo/N4q3FwCgQPkFAGXX6FbyRPl+vT2W8AWMJoTPL1I+VcM/0/it0aifR\nkctvLVNAS2b679ecDKt0yoH2Ux1XqX7HRFj1MEGxYs7UVM3RopOqxLrKsxCufIIkFLA+p5lpWgY2\nanTv1dXLu1y86GSGmfwoOmEPs5c/zsfuN5ZZnrfI9hegAKbA6obwCdAJ/TdkoplzVb01c43YbsYx\nW/Wr3i4TM5A9tAhD7bZ080kx5tu1AkKOGKlI1ffWh1gnlXOzbJFTZXM9dSYlLEHzMajSxatwXgJI\nD5I8YAfJuISFfOFbpBCGJlh4AcqbcSd4kp+pVXKsBHw6uW74RN1FqKsbH3OCaEIfJgsPO2GBk6d1\nJuETWPs0ubMHnbDlIzXBcqvgzHzNsbxas7dzLnQGQr14OF4LL9jn4dg7+xOSIpV/BtFOma+qYSH2\n++tt9fpVPiMBx5BZwZI34PjzY17w4ZI0YozWsOFh1ZmeX7oMVe5LD+TSnVfp5GEcXzHCiyJ1nk7k\nT97gDcZ0Z6LKAfckdIHvETiR7kqGFuim3C+fceoZSvBdUp5OmJ97wp/9zNMSZmU8fZJO1H5a9Sdp\nD5vmzj5y98n6HWDtNFyLTjoFGFxuwQejChkBZk9qAsuFqWhp71b4RM7EopN9lTtXe0gnVwyf5NEE\nljYsT3yDt/BYp2LfnNlX3BQxZSc0cWjDcj9JOKDeUXXSB8dOwv6Eei2ZqbSxT3p9B2h8ukrGTqrD\n7KfJsEVWYNFJVWKF8qEJQ9vE6IQao9///JqjV5jXQRNM/Vx0P1oQbqLoopOEkHYv8sl0Ig/GsiXP\n9hvOssXkL76Bg7ED5y/jNR1SCT10pn4GSaXYSTLGoNIJCwv5Uu2nE1WMzmDVr5LytGgs1BwmE5VO\nrDJh5ZkCi04yUmopk0STsNjzwMrGKGQLRbdi6sk7jBi3dP0u19yDTnDeLzotFp08fAk5AD7W0e4q\nq3DN0sgoi5LSrQXN1SYzs/uhiRM7ga/U1UQnt5lOWP3WBlrOqeWzpcoN6b/v5h09lyOiQ6bfOv1U\nVdqaFEv/rfqtysN+qmpTQj1nqS462cWOhfYLjZE8RofkQePAGNe1jt1Znz/hZpdRzl7pDHQit7yl\nGQGfDZNLq5pd9KR/STq5UH4nXN3Wolajnm3TeiGYu5Curq5OJYFFJ+OnwzdeVjbHOolCjVcVTbD8\n1fffbZN0Lp2AzJupMby8TSbHX3UzOmlAE7rNWCfGjtfA1eJFJbDoZPDEhcYrpBMfQWhkBQ/cqcdW\n1HraNmqDZXRUdSfSSagGMhxCYyrh5Rc6YORHvNlI5w8JhFNTCpwwWJl/+Eet3dXOkgDPJ448Y/WZ\n0g2NVxud+FdJZKGJAGf7fu85OoVO/JiHOlP0tg7/ctiF0/KIKdNO5Z3oJFzddIKcEydWBGXRybRq\n7B+PGNhty2qNOswxsKt7V7ViJyMlnDRe9CR/c7KGhoudSugmW9rE0hmIkZI6pK6D6SQDFkgnsjAF\n0IwisXzBtI6tRCeTnz4J58Va2v59dpn7ig9ZMauRFgmEx4HzlTpVLTpZsZO8IiklQ+OFHqUHStjW\n2dmO01YAU6xzeV3DnvXiw+jE4RKLCGlmR26ycaZCPcH6F53srYaZ1e0fM8owyonzyLeqr6d1qZ9L\nP4qfsK/gT+Zcpa9VP6FzOhACmlVF7cPAjg2sSh1jtf5q+WbBWr19072xtX9UbZbxotspRITQ6zCw\nCO1assKPApQD6CQfL4EZlErCVEKdaD82Njmg+LGTh996PzsMApnQdOTpBAOWlDutpTfP0RPLFWU+\np2UkiDTTCau2ml6hwKTGHvImwkI3GBoOUJJZqP8wKFm/7LyDfWG7Tv9TZCCeq5scV89C5n3uqevD\nrw3pJIMm4bmEfkz5nJx33vSUVBeIJOQSGeJCDaE1gNNKuq5w9idM1YVWTC6cCekkjyZ49IRqSGmK\nzxp+hkLYSkHHLIMc1LlSF87eo29mb2Qxfx/PmpO1WfXX1r729HeVxtqaS46RAk2pIb9+KQq1vApJ\nJTEmCy86SQoqLgb2i0VK2DFGcELJOEdyx9xW4SekeEbRCYMJOBuRmUS5LX6jh+3nk75eYwEFN+5n\nOTnpwNRtKxa7H51QQEE9yQPoWRN3aTphMQz8U8Up6d1j+/5VouStG7x4lU7UbjvLbdFJcqLvVuww\nOnE20BmX6eSMzjKLO6lCJ53kAyRS7Opxk7ecxesHCpBOwrgIA9+wPFDU6dGUD4yd0APLyF4sfEKR\nd5LkDtuqfuPj+xeOv1cDITS+It+HsRMZRLHMBVYuIzqOKfDRORysRBYaxbFE6g8h+W2IMrLAopOd\nfM3s1Vp0InPPVYaQpyYXoGS0oZlOwqwNyl+dSisuBbjw6Dn+dtJXF0NAsRTGUgNZ/kRGaaCT2Y6e\nJENl6jqFa1n4jVWI38KEnjVZDbETNZxA3bNkC/YtFFC9uFqPs/CRMxid0HG1jZGCmuwAq1MOMGOs\nGKVZQRH6eQY1rL4lu6Q20VlnsmlFMfJXrpIcq0VmhzmJzLkTeUm4RfY9pUNCYATVXf49JreBTkIu\nodtinzJp6AWPEz2W3AYokNB5/aN0os4Ic3sZWJFloOnjw2MfSCfsyJEKN9aHqIHOTFHWGbhU2zy3\nvIrRAGMF6ekz3h3Jwx+vSgaLTny68oEvT2MDVRFZ7Q1bhzfwORX6GyyEAHA/pfBJElBKdT73c9vk\nC0A53oHtpCQlOslwSR5NfCgEOqEvJEU6HXh8gdJJdZZZeWSUnTycast81yIXzqVjJzIBJwcolY2W\ngeF/R9q+ZErni87pQOJ06ESNbVjbfZU2LIhxducNe3QrbqH2v2QfqINn+uz005FbJjrCN8Dixhmr\nEmdLEO4WZKNy/baJrmrnmfRmvJGvOqSzyqt0gptmSic+x1DTk+QSbCXvusCGgi+8K6Akl1CSSyia\nVPmSzcvTo7yOxEI0BX1SfhJHlRzo4e5HJ/nViiETxEq26jFrgxkcxhnw59biFuRCQGH66QRdzjJ9\nq90lgT0ksOhkmFTVLSCjE+QA3AnJVE4bnWQcldzVMXNJjekwuZxXUUgnbVySZMGQYDBeovqqzISO\nLbNTNMXfq1lM/yC2Of6V6IRNOttdqNsAGhjD3cIvW+xkIxTtSTBMbWQcZR7RzTGBqxdXlcCikzEz\n5wROwGChB6IGi/oDZshY6toKojT7Jycqcxvr5tNJ3utIH+NfS8urUZNqhaVZpkplXYgdUAtAHmHM\nwiBnHvUotHZvNkDzqA701JNXEho4ocARhj9ZjIROH20dPv/OL7zYhdkQ/LNn1OvaJYEZJLDoZMws\nOHSCZgs2RixBgIkVh1RCA4c7tnC/noGeSRxD/8Q4dJL3OpIkMqzgAAqE7h2GsK71kULtFfV8mW6z\njXj/FDxA5/VPSfoYj425Lp3IUGhm8YIybMESSOhgRJMqic92uPmBYgxlhsyjMn3ao8l2akttXT2z\ncnw/k93YSTLyUMhODVWr7RfLopOqzPXylrej3GDRCQIKmhjmvZw/22IqvsW8PZ00o0kS/uSxgzwZ\nqCE0K9kXVguqBf1xRm1xT+gdM4vnY+kkwyVYBgEF6QQ5wxcyi69kZmRUmX7309OTvFfeu5971x8o\nwJcgeiS507X9vVp0MmZqfDqh2IGxE/Rh6Dyoqfr9l39VX7/9/M/b64+vfxJc5M5b+tRPppMkmkgR\nhSigFoB6kteGaKKGvvKVJ0Mpqno0M6tFJz4tNTc3Zj2/IhBJ2TpT38AoLBASjmgIRIatHB+TaOiS\nHmHa2Xn3u2Hs9qiqRtXTMwX9fVh00iP/72ufW5+vI/fyJenEisOjM3tYZw1QGJ0ApWz9wP9SU9Vg\nGY+JCY8RelSLmtk5mE5oIs93dSHHOAWSAEQjKDDRVQ2JRK58/5l0UhIsLYyTUuWzrTwkhhrmaLsE\nfAkGJFhkQp1E6n6YK1KXntMxJ8CmUpGpVKRh1eXv0U8qukz9sgxKviQ33b5xl96oDyA9Z96tr6gK\ntakinbi30XRW97GXMzphLpDSiRVFB9dF61EB5Q8//QSAomIKMgpQi4yswOcsngzF4No7/ZOrN4km\n8mxQ0v33bLUz7BISTKkDACslP9oAr7oVc3+oCDp2uirmtaXtuMnYEGY/nUhAUclAen3mbpF10MPl\np1JW5TMN/Vb1+rQzO/VTkpw6cGzd6ieTW4/QSmLMNMRIVAVTp0ymCR9DH0Juq2VdhTFztFMSUHC3\nSpM7ql3DayWg/PbjxwYoklG2KcB0D75hHz60/wtE8MXiLjebR0YnJWczKrNTwgWncDLpU2pOheYM\nrJQY5aJ0UtKWGegEVnfzEpa+U3UH0i35Lr/qcUs+yHHzEkr262dIRQxWbkAnKhT609GgmdSALzpp\nEODzEkknEAhBs4VBdfzQ2gejz8BoCqZ4HlDy4we8KKBAJ1jghCZ9VF6R7NI+/imvfFPu3K8K0/na\nAwhK9OB0phpEUWM/NIyH6Jyhk9LBiAY66fGyozTxdDo5OIDk0wkDfXS3FsEwvxJOilp/5irVTUoa\n2LWfN6YTa94XnYTKOVEBlU4AUNAxYBn8xPcZMoLyHTh5BxQqCAkiFFwkkdDyEwl0RFe+l9Yd0cRP\nEcrdfAaMGhI94URJOgkd/+l0EvYQwp/5WFee+dgZlFC8owo4dCLjJdT9hzGJsIdW/aULt8I+JezX\nz7vSiT/vODtScxgdhvNoFVixk2bRvV1ISYLaLGrm1DKqj6HnQmgE5S1wQgDFOjIiz8yyVA5eeL9D\nJ2Ctnv8qdDJPTqfk0jLwEZYptUgTQ84qWnTSINVSdGqICWumEwcLkh07hk726ydoeN5bs8LNw5ct\nOp8gMahhJHWmeuiEySSpCazYopM2ufGrMI+jHjeBbZZM7oC38AEFyvxhm6gf32mdZ2bnBShW/IMx\nh/zzllBClyjod+iVaQGcrFJwotREmLJp9mfJblj7/uZ2nWjHLemkIXDyt3+qHUCeNrOj7pVl/IC6\nltDIMj8Ulrd252qjjvuvtquWh/qlnr9tkMQP+KH/tkSXFIKkLgoiauWlmqVIZZ3S5Fq9yjfNpPcG\ngKVaVmFKJwxQ4E/cDGEsRBo49gnzjgAoACJ49GT78Ekqv/124xxNm4LhukIKzDhvGrjynVCmtkyZ\nZiZQL0y2GBar9soCFGa1w6TJXdM6k9NJ2xI796p8GODcfk7V+oWEtmInYzSH0QlYdnSKmM5nx1Do\nn6q3YIACNwkjhWCiBwAF8zhjhnT9Wiid0BlxzmQwNGmgE+bUQwhojqNYNbf1WdZWpRNrr7/oZJNM\nA5ocHDu54nK/kKOdRLzXktiik2FqQ4+VII5g1MTK7NCSIaAAf8DmUjLKBiiLUeh0ZuiEUcuJdFLl\ngzz3hCUddGPJxxBZZOTjWnQC9y75EmsQ16KTYXY2+l3JgQ2tqs6VwKKTYfJnh17lHho2Q5jZQQsI\nBtHZ8tIIih8+wZt6AFOGje2aFTE6ceBPBjDCsFbo8ocUCGmgIVLS3LFMZ3w6CR0/xCBPVLdMD0OZ\nS0EtOgkPIuA5jM7Zz9czNpCQb7dzgKMurw6/Wr6/n4tO+mX4rAHtGlKINFIss0PNHDKKtH20ns18\nwwEUDJ+w/A69r+fDQyns3IlFJ/RzFjtpduRDLszQAMv9DWnXqSTTJYYXNHaS8f0n0smQwAmGS6ms\nFp0sOhnmaQZVVKWNavn+bi466ZehTicAGcyaszwOtYZQ3mIUWttWjEZQNhzBc7LsgSj457BBXqqi\nDJ3IMygAl2H0fgYOkKywR69AJ1EmIaDcmE5CrVBX/fZhSCdbAfYCPbzUggs6e7x78zs0W38Onuvq\n8Kvl+4ez6KRfhs8agC2QSDBMQq05yxcgkbBtVhhHYYACdMIYhcVUho3zOhVdkU5C3x8WGA4oD22E\nf7kf5bkonQwJnFh0Es6aWuBgOgH3Q2NduNapn4APVV/lOzCrflm5065jfqr10N6ynjtVyQ5U260O\nwZkXOl9sOP48shm0hkArWXRyHden9ZQldzBHw/IFmPoBlJEhFthFqYwCVUFDmN8BNKF0QtEEbz++\ntnDrvf8oOhkOJbTCEqBYdJJJ65xy7gSDQ6EMcUXLkvSrNhaRVx1PJ6rDlp6b+jbHx7MlC+uRkocs\nQD9pdodqh2W7WEw2lB+U0+GG/lvyt/qTYUR1mM5cZMrXjXHLFZSZ3lSnpbKPv4baX0wQ0GgKew82\nTkIMhIItQIFLEFDw5p0/fJ2E3f5rvT5tfuakk1Gui9UTetbOAk8Xvsk0iqBci05wzWbgyacTdSH3\nTPfxdKL6WsvZw+fo50Jn7EODjMcwD5o3XyU68dHEihKpnZHthjLJwI0vfzWW0zCPDr3BV6Wx5CfL\nKbnoZIgYn5VIA4eJauQJ/IRlecB5gA+gaPJQi68PmWWUERTAlF9/+gEvOJuyvfA5KJ/2QJR+OnG8\nUbOz73FXzrWZo6wNfaYe9yHPlyo6PemkkyPDJ3TBZugkFLKMg/ZM94fTCTrFql/M04laM3eK7495\n9b2pygrJ/lvtHkAnrGkVR5KjGOhQF50MFOYDI6T9wr0mfIt0wgInYJQxcUMZZesixFFUQMETslsx\nBihb+Y9FE9zVbSqe98roS3Au8teWSvY4LfVav3V5SbK3arrB7/xV6GQgmlgR0M5Znp9OMHyS2VtX\nYydOXMG32nk6Ubvd7IadCzN1WmUOoJNkKGiks0zUtegkIaR0EZVOMMVD6cTalLOwOUDJd8xNAArU\niQESpBN8g4Dy2+c96j4fO5Ex+b3pZOwmuyfGgx5U5ZUG/9pPJweET9hSxbWZhDbr3EmDuPJRqLQd\naiyY9IK0GL5v8L7ykk7vLnMTfgzA6nxmLBl3XqWrKp1YRJiZR7CNqnxUMdLyjepVv2zRSV1m9hXW\nbgxcHf2WRVDAHKvJnYcKpgEFwyc0xbNdjmgCb0aOeeK6MnQiQ1kYvvLddrMbw5jZWE/W2R+6+6dV\nNXRyfjqxkjhVyKNQu8e0ThI7oWHIjOezTEI1dkKdU8nMqNyDtVnel8FEQ+tygLLRMOoj2/XlpvbT\n6jztD6NMvx6LhErzUi286KQqMa+8uiGjzKH6ALRxNHCyvWfJHRpBURvCCAowChw9wTMojzt6XuGT\nkWOeuC6HTliwBP2xzOxIjuzkgAZ/71wic4Wd3etEE6Bw3dBHT4hnPd/PN1t00iY61JCxMyslOfFS\nm6trzcGPuYbx8b1ZdDJSBZjVo/ESDJ84+zMoL5M7LL/zDMeRLA82BJfjXTyUUZBORg547rpCOrEC\nJzJ8Ut1VV0+BVB0bhZLh/CRZrdS9UXSyU35nVOCEBkuG5+lQA+deYZP2btHJpBNT7Naik6LA3OLS\n8FGvBgwBn2BJVgCtEmUUlU4eobb3ezvxT2QUCJ8go1j37ED5kYKYoy6LTthm13LGlBRLu+oQZUrO\nXi3MQiYUUMLWk2Np7uRAOhkLKDCh1vDb5CYDJ85jYcMnxjKZ33JV7mcbqmmU/Xqyah4igUUnQ8T4\nrCRPJwxQ0DJS84TJHYceWKyF/smCKIAm3HN82eu7GkGfTsLACYa7QESUBcPQCMuPsPLNjp9RiMQs\nOagki6jF2vo5lk5gpXSqKM6gI41mOqGBE3gWgCO3EqB0jrrNtMGqabt27FWTdKNzUNYREFlt23jn\nma9OQakCeQOU4Q18VIUqnVAXgrETPIxC48OqUYNLrPAJzfLg5Rg7wTeY66H2Dk32XeeI0okao7LO\nWFAQkbwYYorFEJ0ZE9oT6hGdLA8bdZVUGuhEOtRv+1I8dyKPoTR4axovcQInIMMGdoGrqKAWnYyy\nJ23eelTrQ+opDaFUGLu36GTITN2/EtX80biIdGz0ktAZONaZbe63qhijMBbBdhss/lUmMk8nDEGc\niWABlXDKsIBFQvka8iUpBqnvk5iSb5GSMVOPUXSCQJ/UWIy4sJ1Acuz5YkxKIZ3kwyfz7x/aHGoy\nbDCq8hPtVWkIpcInDuqwpldmZ6SoLTqxnJ9qN62NOwCH3100Z+qbb9wmu9iwzpECOrauPegEZgEm\nlAm5wZfvdAkNyMn31ifSH1e7p+oSPQ3gRy/yQEAlT3WKfU4rzDTdEFyRIgrhI8z+oHaxaOjeq8fK\nQYDXpPNI/2SfP6O5pK7AZHEXxH+Ip79+icss8MDCD9Z4k1AlJSCHYA1Kyhk+sT5X66lOwd561Vz/\nopNm0SkXOnQC4V8oQKMp6CqYJVUZxc/vZEZCA93Ypfm3aJmhqbYD9JsJWcYzqBsIXTKdmoc//uVf\n4aUSYVgbK+Dz5fYtvSErU7nKIqoEZJQlUz8FNXWa9qATuViYYsusUCZrkyEYVk8DnWyXZABFWgCM\nBrUth/xVbBOvOm90gaHPzoQE1DLJdsP6aQE5NEoq1K/LATrXWrKt9k3tKpWDJSiHwPLzPlvJRScj\nZyRJJyzIT/0Hgsv2IRgjMGTsl3faOk27h14Q4zdba4eZv7b+V69C5VbphDpj6mLhPaCb9aLhE6QT\n9U1IG6yAWgkQyW8//zOca/ZfW5k8VfjsEtaDPbFuB5N7vgYCyMdUJDqw8CRdX7Lahr6pIgrDJxlA\noXQiaay6FkrlfTfsOHsVWUIPjeEB38ViPVVKsDps1WN1uNquNS46zAw5hQJs6FhJH84qvOhkpOQz\ndKIGTqQ7RHtEXREySkOnsW8YwmGQdL8ISolOEAczdAIyRKbxAaXz261jlE4QUzYdYO/hKcAWu5So\nJckl0CL9r7qTftv89Z2NbSAVuir3oBMVZDOAAowSErDa5103EvPTCfNbvj106EStx6EBi5CqsRPa\nrgzeMMhbdPIUV4PbW5d8q5dmeam3A5fGQugszE49n2q5HtmE4j8LTbB+rHNXq1fsdW9xRicyc0H9\nCgyczoXvoWnhh/Re+Z2xb7YeQshk+y+8CekEcAGIAf751BIGY9QCrH76J5s2nAV/mTRgR/ISn05Y\ntNLHF7XF5vBJUsGcYTaYgsyimp9OMqOgZWBEyRjD3nQyKpYTYk1VSrOVX7GTkTNSip346QbmLJkh\nq1olSie446deZ6QUpqnLohMWNKICQZT0Mzt4ya7hE0AT+soEURidqKRCwQUjH1BS/lNxB3HED5yA\nS6Cxk8cnh4dPVDBlCxCCZzDv8isrZ2TpSeZkST+dQJ+HL7hFJ45ImTL7wldBx4/lSOaoxk4khw3X\nEL/C/+N/+0m+Gvqw6KRBaOYlGTpRzRyzUzSt0x8+YWhyp+hIaBpAv63dJ5UtxUF0TlL4zBvtmt9h\naJIPomC8JEMqanZGfmgFSxro5ERAkaERGTvJ0IkKuGE6rFQAVSsMEQ0HlDydqPRJPww9K3XGnGLf\nHwrHnLqaHPGpQn7L/B8U8PvcTydMPtgcBnh8Oaij8Ic20smJuhQQ+euf6Ye///XP2ws/yXdmFzr5\nHP/HBG3RiWNf6Gadej4KKDSJAHmfkj3CHSFcm1eOq5eUsRPVObHYCd1ny1AK+3a//I5EExZEYbke\nYBfkEos5ZManSic+uDhWkn7VHD5pyLw4gRO5MP00kFpViTmShfNoAl36qHV9rl3K89a5/Tym9W/m\n+EIQfMHn9E/21bOA28vxdALL+zNXS5VO1JCJFSzBRMx3NiGhgDgdn4YmbxuUVyrBohMqJcYf1p+I\nknsAio8m6rcyTBKSCiug/skyOH6dqj7KzM5WDLQxjAoMLMC2AVbNNLnDtIXGVNj7JHPki1Xp5GNN\nbsIEjixSCpyMbHjWuvQkzitSQnlFfe8HVBadjJz2ZoObN1ssGRH2Hq3tB/Lit3ITOpEuBz0luAQf\nR2RibgY6ATXIJF/U8yIsOxNGU5CE2KGWPJ082HEHOnESN8mgC8WC0+mkCmcfuMZDAziqgArZoyq/\nQT00iGIFVBxYUUMpu9DJB27TQb16DO4egIL9+cwZoZkdmt6ShwYysRPn8MpYQCkFTiy7RrmBvacc\nk/zKD6v4ttUy68PDJ2p0hAY5ks6erhr1Epnva1u81lXw0MUkTrEe7gco1XMeUivOzYmssMcxDASc\n8R9/+f/gRd/jh/BGwsojGUT+DaaTT07rnEInPnYsOsFTsZROZIDEopOMP4Mp4DGt1huMtxZH0Qku\n8ySCyAiKFYwpmTln09lD83JqfHeed/ZhfnZvOmlGk/3OoAwBiyGVlHRPurrmy4dfeK40hg+HVUgz\nPv/+P37GFwMUiSk0iLLoZNg0NZha6SbbNmHWhmnRCdIJ7tTZDhv+7ImdwAGUUeGTIWji6DTLxTj8\nQb/CVE7DavFD4g2rxgli+cfPM6wJBzicDBGeN4La2hasf1UnnexxBqXqStXy1UoalO1Cl3yONNSz\nKfRDRJa3U7TkYQRPG9I5u7Cu9osudnZv18s77WyPmVMFTvvzmZNCMzsOnaCg6JkD5oR8xzYqfLI3\nmviQwXCELRb/W2dlhXSiZmSqoZEkeSSL+Wu5IXaSfHTsVjOkdZL9dIq1GWGZvuH716+/M9Mt5x0u\nVPWhlDZiHcA/rfrVyuUo6CfOJaX+O+P6HDoJ3S5NBlFAGR87aVsV4QDmL9BjU3rQBHf/b2HMH282\nbtEJ0onc+8LEYbKfBbSSfqI/fFLK6TQvBwcymvnD74xPJ5APTQIKOzCUnJqGYkk6yS/bPJ00B07U\nzpSsseX1ASlKKmfFThgBYJ3W52qjDp349eQHqNYDmgxdSnbYKVYVaUn+VyyMJ1Tw+Sgj6QTD41cU\nTX+fz6UT8I74gugu2uVFJzSDw/a+VuwEQ/cZ9ybp5+EYKqdPDgic9Ct5Qw0ZOkHnnRF1Zl4AMatL\nkmkC6wxiK+pPnk6gZMgozedhrZ7MRidvOyjN02dIyI+dqMQjkcIhjGT9tCGLxtTxqp1pWFk3u4Se\nn9UBpWfAn5zWgS1g3rZKw1e1dLK804GSkerRgamuRb+I8RIQ0Vg6oU6LTkGJTo4JnJwyOyGdwNqp\nAgoNccGcyshKdUmy6fPphC3AkDwygNIcRnKsR37t50MLoSKVvDXfIkdxmiQ9yD4kB2j1x4920MgK\n8geryoGVUKSfUIAByvbn278eESw6YeaMRjLCgwv9dEK378xS5y1UjwLMdm2GTphDAh9juSV1EulO\nmrnDPKDkAyezCTnsT4ZOGgDFohME0CqaAOLgVZYaWOs0SSfOMldzi+GGJ7Qb+bWfdN7hjFvxjyRV\nhPUn6wnpBPvpDLzKE8mMTzjGjy3gAUqPUBadUFPC3F5oK0MrkykgW/nMnA7bu2C8BKRh8QTu4NXI\nluUnrEgMZBYyyZ0bowk4ALmtVO0M0DzVcwcTHTqBr8IVJyeU8T1tguqMuhL76YSOPYQSmrQNLUMS\nUK5IJ1S1QsiweCW8MJ+LWXTSgxDbtYtOOgWoX+6HhcFcSmShe7XQymQKYIUYudlltFeoVMZOLDpB\nf4Y/LdsGKDJ8FQLKjXM6jBEzKkPjBwz7WPoG0QHe4J+dsRMZPsksuq1M548Ss4En6STZtySdUJRM\nOmxnTiWV+vRDY/ihqtDKsdqwz5JOnDCP7I96uSM09lXYvXDUH1KAPczteyJ6xv/JsRMZ0rfsC0ID\nvoGSSUMTFltQgjqMas224/RPdGYwCxg+YVtznKAwgsIAJaSTewdOSrGT74kjERRcHQ6dyI0BzEI1\nfIKK0bZn6Amf+EEjX+syNqHHsK9rlwSOlAALnyw66RW+EzhJWsnQxOQL5LdKvcOe+/oSnSTDJ3RD\nzw73SN+GxGPld/7w00+LTvJZHhZNwajJHnSClefXXXNJK2LkR1DyzS2DMLehWr17kwB7+P2ik179\nWHTSK8Edrg/phGbBaGrAun+ExWDU7E8pufPbjx9JQNlBPAdVKSP8+YYhoiAjizSUhViJLIhRlubY\nCUziYYDCAicybic5WF5iwcpCk7y+rZJMAtZjXncV1F508jwJuGvfp6xc9XPUXIYRlPxOKFNymSSa\nU7AyO4wpwSvARla9eYe5SYtOkoCyoQm8MoAypdanOtVDJ49JfD8ny7JylCkppjBkaTvGkSeAzJLE\nMiwBJAMnIZ2UOrZMQUpNV6EvCTAcsX5VWFLLQPktOukSJp7tgJVP/8QtF0UTNI7sWys1UDJ2auFl\nkprpxD99wg4JNYdPEE0ygNKlrGdf3EknDqDQ1cS2B7AoemInGD7pX4yyBjhCCy8VNfyDJnk6gfrP\nVoHV/tQSoKhh4Uj4OceajhEvOikLjyEItYbMlPhfoWVxdt79BnGZpJBOmOti8+KET2gEJRk+eUzH\n+3NjnyGTV/jEj6CUlXWmC/rpBABFnjmlThpmkyFFJ50cACglNJED9LkH6WcmdVh9mUgCzx8E/uuf\nQ/ioFngjnsqItwu3tuhPGQ87d3LvzA4Aytd/Hi/f9lnfwsVgVtC39eOIrGEBin/uBP2ZzA5g3CvM\n78g9Lk6EpB8KKN8hkwhQKkt7xrJD6AQGJn05A5SD6aT5Jh0nauKkdTAglDQXK3Ay43qYo0/7cYnk\nmGdbuYHvSydgIHI9uWQpZJRmOlGNizz6l7RBVrF7z0JGdVQ6oTF/KjoAa+obYL/uA4pDJyyzQMMn\nNK3zOHTiAkpmpDOXGUgnElAknYDY4fP+2IkfPmmjEz+nY9FJFU228h9CJ6BgMy+B2foGBHDwK8Mo\n2LG9Yif3Dp/gHq4NTZx08nA6uT0mhmveohOcO6QT62BQCCjqhDLowUgMxk4WnYRz5xSASVG9NULJ\ntHQSoomzJ6Fh18zWZdFJj5rd8tojQyYq/WDGh4mXdQzp5O2ndjqnBO3+XTfudFv2TPC8Mj3ohKo7\nNuASdtwyY33CMnedhaSW+nTCGAKmgIVPMidk/fAJ/RbDJ8qRWCN8khzpzMXGxk5we+ADCo2QWVsC\nf+Johs6JkZTCJ5jQkSkqfy2DqVFzW86FH0InD7Gs8ElkAk6JlzjhGf8o7r50cssICrMp8jBslUvA\nI4J92YNOPjx8otIJzBGNmrBY+n6AAnTC0EQeQKE3GEc25wLf70En4KdVQGG5njyaWMFL2pBEgSSd\nNHAJ3fzgNJewZtHJzMvDepRI83lSdbDfsYp0Kmcjg4OTPqw5HU36s3fUPd9v4472op9LkEXkmzAi\nUipwv1nIW5wMnVA0wfeSMtFFJb2dk9xR6YTdwoOAkh/stCV3ohMKKOy+XHThDbsFubhg6i0KCekk\nn8phsVh1QvN08lE37FwldlK9d7fnsSKdSZyzGIWeOHlL64ylk9uET9BqbOHVX7ad91eUleZxqkYQ\nPRwNmewUO/nk8ImkE5wplR4ondCAFuyq6R46ZBS1flgReTqZFjhKHduPThBQ2C0wACvw8meKhc0s\n7nfCJw61UC5RqSKDI0zUJTr5nJ3J5HSCkAGu14ma/Pv/+Hl7JRMi6jnThmAJbY5CCbw/ElM8NOmn\nE7AX9IxhyZBNW/hp6V5ogmYFs+Chu1KT3CqmlEIjmcKfY6S4KX85RnqGgFEgc2AWoGyfsw166Pas\n8AnSyR+//lknZLfwybTLodSxXelEAgoyAcxXOE20QBud0BbZe8YfDTiy6CSpbHMCCgYwkvkaWiyJ\nBYx1BiZlgBUGVuhXxdAEjxOhARlgEJlFuJNrBOMiV0toBFUTyfZt+8VOPjZ8wmIndJowNAIfqnOB\n+1Q8kcAARb2KEic93YLBtg1HgEs2RQrpBEsmbfSExfamEwAUCG/QqMkxdAJTLAHFshWdE7RiJ5YA\nJ6STJJFYI4LLj+QDSQ9Htk6Pmzy3/d9gMujYs3TVdwIUKxncGTtRXVomLpIsc/sp0OflPXbi04nM\nskleZBkElv1hOsCmRgYUGZqox2MBYi797wA6wRAmMgpiirMw5fQ1xE7wEpbH2WnKFp1ci0761eAs\nRsHAyTGAQtHkcXvR1z8GJwNiJ7CVoUbh9q5x/tjJZ4ZPrNgJDWmAZKzwCUZNqBMCF2idLLFAk9EJ\noglER/DPx3lY8uuAaN2uiymH0YlkFH9hJukEicdil2O4BEeX2ZB8zt06uEAmjJ30ownWAEGU5lRL\nG2HAEZntHEzb5fmUkMzpHEcncBhw4FTNVlUbnVjpnoz1aShz7ykoxU5YwgXppBQ+CQFFzhEFlM/J\n7xxMJ5RRQjrxw10wgxadsAMux6yvZOzkA+kEt9qzeYdR/cEgSgOjNOPFDelEhk/uDSiXoJMPDJ/Q\n2AnOkYx50K/kOWUnv0MBRT317CR3MBZC8zsy17OFUh4f/vbbip00WHlrYcrzQNapL5oqUk+/7nS+\nxMxfvH6iS6oW/WTRSYO2XOISxIU8o6hBlzyvQIv5QIha0m/u0NgJbl+YyT5me3G8ko2ik4aISOmS\nu8rfT0VvjILpG5apUbfOKqAwOeMBlAygYKPO0ROW32E38lCUuRymnBI7sUyQfz5MriaHTg7mEiez\nI5OJn7bSaSLgePt/cIsQRIGEC2MU6ubpe7gx+HGe4/VMtjydwIX58urRWv/hK/I87I6Zne9coLij\n75bLZhSdyFMOJfjIFL6l/PN0gkcN1N0zO4jA/qRBdesRWw7uyNogUkLvyrHOyW4DfJ5NuWAQ5Sp0\nkkeTU7jEohOqcjiEj1rmH3L0hFk5ySjWwRQemSCAkmSOtvAJtOtwCbSO3dt4C8/DnkMnkOK52eJZ\ndHLw7iHZnMzs+HQigxwUKVjKXwUUNb9DswY0fMLuFlbR5PtGni27c0E0wdMAQ56llJx3evTED5ao\nrp36ePX5JaVujC1MldBKJn5mWuejwieoVA6jsDiKGj5JpodY3CWT5fG5hELJVhK4hKEJNR1PSz52\nLakHUGBR3QlQLkQnH3X6RKUTGQaXAQ/ptFBp0XWxQ5HOUQbWIvy5sQguAXrPjvMk2cvldNgGaLht\nMWNmX/sfMDLNdII5HdhNTbKnQjpRxwVKuOjkME2bpCF8sAo8ahZejE7gk2d8gvzmThJQ8smdkEso\nmviPhNnljmI2Z5aNuA2g5I0g3hViGc1MdqazzG3EHpqGb+V+eSkqf8oTbF5YMeqf2NnDMIJCoy/0\nPdIJze844RP4IZ5wyBMWODizwxYj+9NagGpaZxIioXMKdOJbj89Z4FLb731fcbi6qbOXmIKf0AMo\nyArhg1x9QKEhkMwZWMz4ADbJwMkRsROMsqor6h4LaSCdDD96Au6TGt97yDxcqG/KTX6X2DkaQoMc\nGCx5TO7rhZgiA/4QJrSOs9DkDnqXrTweht0utw6dyBOy1wqizEMn7OhPmNbJ6NjBZUJT81HB0UUn\njvqppEIBhTFEeAaFPnNFHr+FqEyyEpaQUtHkODq5d4onNBnqyYNq+IRBRk8E5UMAhcVOLOcEuCC3\npJuUtog+QxOMnLPIP1K4AyjsK5rcseiE/XbxFSMoR9KJsxJvgCaOFaVg/SGr+2AuvHRzKqlImPCz\nPHjzjkQT/+gr5noohVDWmZdObnAGZSydOOGTUYDyIfZLpRPfgdFTqwxNrOA/TfMDslhnUHBmsQ84\nERg4UW8tpg+QvRygTEIn6hlSFtOa/NyGn9ahqntpV7o6v6sEMG6B0Y5kEMWiE8wTWdSiwsdcdOKD\n/6X95WF00hMv+cDkDqUTunW25ovmXCiabOETmrVRj56gArOSaiKJdgDyO86jY2X4BD5ht/zsatF6\nKj+MTpLLUB6LZstqWluUHGCy/5im7Jncde1FJQCMglENFjWxEjRQnp69pcdsKb6o9+BQWU1HJ3cF\nlKTVcGLLqg9TWWSFT/LmAP0iBi3wNIk8YoLb6Oe9Hu/HTeBDOSP0VCx2jJZUt+xwOAA7Ez7yxAKU\nS5yTPYtOwuVmra+kd8/r4aiSSTuTiUZvVeGtSPBOOcMx081Ko2S46mESsBhFBRSfTvCmZStTMzud\n3BJQklYjNJf+Mb1RgROoZ1oTPNB8ZOhEnjgBw73FS/AF5huExk4Zq3QCSu4cc2F0gkNmT7Vndxqz\n/A4+CmWgxPao6hg6YWvQSa45sZOZ78UFjbIOq8nPrQUOygzgARpOgyjfzELKzBZl2TRqD0X95DqR\nUWgQRQUUGTthdylbN+CoVARNnH/uhO4snQOhV/SaSTphO3hHCM7Rk1GMckU5V82HRSfP6MjXc0cY\nnaDtpmiCPAdUgYzCHnlCu4d0onoUSifs1uIwxSMZZfIsz8F0QheIs8SsMNi06yJvZJwDKFgJqDGg\nibTMiC9QrLru9i5/Ip2AMqsDtL46sbfVicDDs8glElAYneApFjx9AncmJzM7WNgRKRqQgxTRWWlX\n3NbnDUcmfAL+bBSFOPVMaHeqy8kvn6cT5A+QPN1BImdQ4GCMohpxB1Boc4BKG6P8+lP8VHuMlzBG\nAUAZK71RtZ1FJ+H5Enl+aOYVkTcylMlQM584Qoicneam9eMSGKUDUM+3m7F9fKbFU/w9wofaOn4o\nvz2ltxkxWmXwSIr6KBR6+w+SyttdOeRJ+U6Kh9LMRLETP7mz6AR323sDysy2uGd1fe8FX+ZQRq1o\n9AK/ZQaayp+iBn6OEGNlBPAq9fQJ3cjmn2rvPEx2iNCGV3IAnciJw6gYTfFYCwp/03H42AdWyMIe\njDasKBGqKCsAogC9ZdxD1Xtg/+mqZNWC/87riVPeqoSC0VuMk3yRHGzIH6zA5egE5AC5HgAU+qA2\nmdlhqRyKHX6WJwQUhrMHxU5uBij5bU0+drLCJ0lj4RSTsROaZ5FG2TLTgDK+b1Opmp6lVd0DtMge\nfLKNaPtkC4ewAInFJfj5Vr5faMNryHud5qZx4uj68ueLZeXmJ3WGERZ2JA+msOidam2wCfameZow\ngiLphLrw0J1jGMOqEFjH4SH1q7Bdp/+MeJw/O6V35OVAD+w+YUon+BULfjzTOl9BFAdQFp0cMZuL\nTo6Qcr0N9IvqWQQWPpGTyGInFqBYB2Oftsx4gCymkMCdUO9IszyIKQArIa9MCCh70wkLnMioicQU\nOmXzc8mbq3sPdbQxCqIJiE7FOCrV7f1Xs89Xp8SqsQe57jPBCUYnKnlk6glbZyQU/lk3Y6ddQW/6\nBRChqRwLTbC7CB/N+Z3TYid3Cp+U6MTf3GQ2f2MzPp225rSlk2iYxU5YfidPJ8AlIZ1YSUm8UIZP\nUHNgFvBRbHiIBEgFX2FM5cPpxD9rwqDkopqftzaqqUE0cWJLapzmF0IoicVnFtmVTqg/8yM0gBHs\nX2Zc1f4nQzKZpg8uo9IJDaVkjr7651798EnL9IySkbPMrnX6JG8vaGbBsR2Z/d8oRrmojc4ooaQT\nB1DYJMpDJ1age/scbzNWhUmxxgcUefqEogm8f9x1/NtvG4Vs1cpcz6fRibr01KWBh0surfBqsITB\nhGNYHDSh6q1Gm6jcemRY9e5h9AIrZPES1URkyvi2pb//Gds1QxlGJ/TPkEug/53hkzPpxAmf4Cqa\nYZLCPgykE3Cfi05CmWcKqHRCJYznQuQM0ug3GG4a3N7e41YSd+QOUufDJzguFjVhEZStLYijzA8o\nOAuZKauWsSaO+Vc8/lmtf7byqIcwcFA5fDmbH2czA5f7u52BT4Lp9+6gUTg1p9MJhGGgP9eNlFBV\nxxtzWKQE781JroskndCDtzQNNCmd4MJLSuHcYkk6oVkbJ7+z6GTUbFI6oQJnEyG3nmyLSdFkgxJ4\nYcikRCfSf1DlwS0poonKKHCKdougQBCFMgr8OUqAQ+rZj05QdFSq4b5/yKDOqoTSCegt7QlARhg7\nqYZdZUNtw2fORuJF0sEDAah6pTZBP2Q9t7okB8g9pSAkS88vxytwuEQGTpLxEhQd3vXjn43dytOS\nE9HJQ8lej/RWg95ty+Dgqy5NJ9dKopVmltGJ9GF4ItVKuIBwcHdK0QQ+zZ+vpNtThkqoP+Bs2KlY\nK7kDdAInVABKZuMSdDZss1uaRKewXHf3RhOwlpveARyrkkE1kzgeQsm3oqPGSwDSvPSoCV31nC4B\nAAWVTqp9y9MJAIoMtJwcO/Hp5BKOU+68rbhIeOgEEzpHZnYuIeTqwmB+kYajqGxVOgGB4AkVmF9w\nCfCSUIKfWD4D9Jy6B6oklE7wYCwMwcrvwOkTpJmZfxFwp9gJQxPV9Q7MR7Rp4PCrQBUdNZOaFkIJ\npoc2cYUd3hr/9Zf/HV87cWfYjVVgJwmMpRN8UEr+8fb0FO28dHKV5M6ik53WSX+1LHZCj8SiyWZO\njs0mFAN/8Cj52lOqe/TQF1JA8cMnwCUUTdif+GBZwBQMovQLbXgNu9KJkwYNp2P4SI+p0EeTJ5d/\nKarFJfS3okCx8z1fdJKX1RVLqnTi3BLsjBFiIfDfJJ1AEAV/eWfRSa8KDaETlnSoxk46f7i4ZJ56\n5XXg9ZJO5KFjSieMVOQsgMW37D7MQn/4hIVMMC7C4ihbQ8gleAcyYs2BYg6a2o9O8PxQGyzOI6Kd\negKmSb56bl9adLLTZE1S7Sg6gXoQNap0AoAyO53Mn3dQXZp1MC2T9JHbwQx8ZMo4e6lbAopFJyhh\nmlLx5xFFh7f5tHlERjZISwyS8OZh68EneGsxnJAF0wYcM1scZVc6UTn+Nnfo7OSxqvES2o1FJztN\nyiTVDqQTDJx8k0pikPT0yaKThMDsIvnAiXOTjsw4MJubJA/6cO5MspmW+Rw6oQdK/EmR38J0+wHz\nUJJqDQA9eA4m8+ATAJStM5RLZkOTrW970wmbjrsmdLrs1LiLF52Mk+WMNeGtOvSenYbMDk3rlG72\nQTpRwifHCyyzZw0t/vHdhhZH0QnuodXASZJO0Ew3YMq0Eu6ZWTV20kYnPpeA5JM/JmfxDf18ey+j\nJnhglt7FAyUhxTMhmuxKJ1YC9JbKnF8IIiC+1wfb2dh1KjY/L5coyejEf9KrM6JmOtnqNMMnx0vw\nunQCPc9ndsKdOubR0YOiz6vGQvBCSir0yRyswlsadIdOSrNGoxrORCTpBKBWrYcBCgRF8AAs/sme\nzMbQhN31c/yKZi3uFztZdCInd5P2L49T3N+3mG1/7vTaaWZP19hP7sAoOvn53/4NQiaP4yM/fpRE\naoZPSrUMKXwPOqHHWkMKSZ4+wR15A5rQ3XwmlPI5dAIzlacTWtJJ6+RjJxh1k9Mqwyc0xaPeXYwH\nTRBKZoug7OTDcF5UMQ4xTZerBNEEoho7QQmtdsVOLqckfocpndAYRtswO+nkeflOFiQzpIvSiXRa\nzVBiHaGldFJN7lSBZtGJOguIC/jt9ok1F/nYSSl8AotI3l2Mn8DB2GlvLd7JttAFCGfn8cDyLZU5\ntKWIJiDwIwEl7NsqcBUJ0BOs/XRSjZqAlFhW6DsxebwQF51Iv1hli/7ytzToMrODubNM7IRFShig\nqCmzkhir+R0rxfPh504QSiidlCbieKM3vEUaNWFPSzsmgjJ8RKvCUyTA6AR+AafhVGxP5y9DJ3AC\nYzZbw3yb3GF3xlFU2tg1fDKbhHuUG6+16AS32s40bQKx6AS8ILwoo8AnpZ6HgAJBEcolMo6C504g\np8Pu9yn1Z4/CB8ROQIwfSycsaoKxE8CUw1I8eyjPqvNgCbC7f/vDJw393xqFYyv8tp2GunouyWxh\nwVVX7X5Pr8JrT6GT/gCJU8NU4g3lnyzA6IQO31c8/FbSAwMaxBQglQYxSgwCbcfeAqDgkNUUD+WS\nTzt3ImMnIMCGuUjq1VTFnKjJd0j8qDMoU0lmdaZBAjPQydZtoJPtv1tu6LTMzhXpRO0zpgwyUZPw\nCK1/Y8gemHJLUy7pJHk7MZ1iK7zBZqF06ERaDdmKBShqKIWdjW2wSvtdsnfsBAWFmPI5dGKhCU3u\n7BFBodwj3++nS6vmvSUg6eSU5A4M80En9N/eg2f1LzppOHSyR4rnE+gERY3ROCsQIj/PEOHegAJB\nFPmgtjkTOrjSz6KTx56rmGg72Pp1NqcmdFDaJUDxaUN++4t7l/JOM94prnV5KAGGJlt5+OT4oyfQ\nVa544QDGFrgZnYRBkUxkhT7sxHKKwwHllnZcnjuhgMICJCzD0gwoPZJkfWABFbg3hy5AGjLpaXfs\nouY7kNc0jG0Fpw+kBPOFEtve3JtOVAqhJ05KwOHTRvO30Iex875q208Ckk4AUBadPIyL8yCQSYyv\ng1Ol5I6PKWBt/fzOWECZRLxjF16eTmjGh4qd3qeTCZ8MOSBFGYUBynY8FiIom6AwjiKpZawYO2vb\naScd0gmIsbPz819OKUTGS9gnW2F8wCu9sIE/SvSzGGV+RcJICbtDB5HlEUQ59t8FYidT3bbjB3sG\nxk4yEZSkv8wUu6Udd+hEnUd2HBXlxvblvjxHSRIZhQVU8FAFQAngy6hG9zA+x9MJWoyZxTJE1EAb\n+LKIgRYIC1exQy2PoxsSPil1aYhgP7MSK3ZyVnLnGnQCMdsZNOYYOgF3mKGKUWUmEe/YKR5FJzJx\n4Ie1BgoT+EMCCgWpgc2NlT/UtiudYGwJlwx+MrlYhoia0YkVO1G9ewZrMKZCc0YO38hB9dNJCU36\nmxsyL1eshD4llvb/xKMnl6GTGTaIfloneabET2DRb0eRR6aeW5pyVG4Z07JiJ1b4BGpgeRZVsG33\nFYfmzGGUzNxRyjk45bEHneD0bW8gxcnoZKqAazi5PQUaMjsqxDD+gD8ZnTBvIdNGw+lEogltQmWR\nBSht6oQUskVKaHJn0Yl36ITm/tvkPuqqJJ348ZVFJ6OmI6ynSifo0iyeywDKTnTyHSon0ZQ8l9CL\nYBSZa0MJZwocSSfb0BBWZtjPZOTTU4bFTqwwg5rZUQ+gsBr82IkMooylE3U4LGe0lbEaVb/qkfa9\nr8XYiTwDe8oz2WjY9akJB09AyZEfZk9VIYBBd87tUopqi6PILX4m7DGkzLmy3UnrLDoBv6XOEQjT\nj5GoeRachSMdv6OoGCx5h5lnkmgngev9eU3DqEbp3LHYicTHWyq2jB8wTJFRDdXTy+QOAw6VTmRV\n+EiVfjqhlVP/hO8lnTAKYd0bpXWfUI8TPtmQ5fg7d7imHTwHV6ET6GeSTvyS+djJkUdPbmnEUbmZ\nzDvpBAmGYcokXMIGC73a/nNW94bHTnAZwkTQzA4sPXo72y0Vm3po6xSIlb7xz6awgAqjE5hKp4Y2\nOqFO6Jdff8eXFQpq/vxg73a55pBONhCh+R2MnRwMKFeik7POxoZoghjBwicyFiLRhJYBa3v80ZO7\nWvAGOgmTOzJShVEKpJbjrRKSh8W+J07xWDphaIJ0QheOnBH8BN8cP0d7tOizAjXuGN4ID8Niye1y\nNXYy9lRsM2oMuXCPSbl0nRREgEXgBbftLDrxzqCcYmQzdAJebTidtIVPqo9COUWqB6xhlU5o5KM5\nueNk0w4WJrhbP5N47gmM4XSCQ8bYCSo8PRu7FWPTBDEkeB08TftpO4rXf9iJ6surmR1WyZBTsVCn\njJdsn+BXrIwVX8nHXbByOqL95uhCNTM6QUBBOmFnZncd2sViJ8eHT9D0Ux+gBkXYh1A+DJ/I2Mmo\n8An+fG54MOU2lpotFUkndFdtOfXM0RNfpHvLk0YCwhNO9EDMrqbEqnw4nWwbesALi06AQrb/MUx/\nzPjrdQ9AobETHx3U2IlKJ7QeP3Yy5FSsJA8rKELhg9KM+rks4MRaAFZOWR0TNirDJ8+QyVfsBHnl\ngJ5fj06OBBTqwBroBB0DuhAJKyybc0pyZ29veoAe++cxIXjANtNW1GFaOkEoCYmE6tuJ+SaYlOF0\nQtEEMjv06AkGSDbPKmd8++zb487xCKXO1QHilYETFVZYSdVhh5kdeVXPqVgHGvyvkoCyVYKRkh8/\nHrpj/euciDtdjtkcfA6bFVPZddQn08nDeEVxadUWH+BQWccydGKFT/DzJJ2oAZUwBNJWYO87YHdV\nX7/yb+V+7bOpLjl0wrxag2D30E+rw+FBJbjwrIk4l05k+OQb8k4Vy5DpQNqgdtx5nImKLBRH/Ht2\nLBJqphMLFHyMaAaazIVD5uUeldBDJ8+Ezlfs5PvRseRgyh5DXnSiSFV1A0gnMryB2W5JJ2H4xAqW\nyO1vg4/MXPIJdGIBrnXupJ9OIFozcMU6EE9zN+h66RsY5tj+5Ic2nE7UGBj9kIVP5GxCgXOhLS9A\np2QYNZFHQ/x7dpg/+I4zfX0Rco/sKlQYZv0y3ABREPZSP2QHUNRTJmqLQyblfpUgpkBmB17AK3ge\n5ed/+7ftNXbsV6UTsLbDDa61PWW+wTpNIj8Hy0gPoKjHStTtL4WeDGe0lflYOnFub2mTJLtqlHI6\nIRPGJX7Gh/LKWCOSjGD1N0qpArN1WK0ElM25wizA2DHJRT/s79W5NYTxDDTxcLewf8+OjJ2E3JCZ\n/VBEYSvHFAj7+ckF3p7JRgAF00DDAeXCdII7wlGY4iBIkk6sPbrM1LDQyFl0Ajn7UX50tqWLyp0/\nqCH32T2k0i9Ypnj5gciSGFGAsMFhkzUwdkJXujoEpBBEMTpMaSiOlMOuAqd2PB8dCe/ZYe6hYQhO\n4MSPCUFQZDiUsDqhDwNVtEFEV7kEKITeZkzvMaYPvx81osvTCVrhHkZRt6cUKXroBMI8Po4wX0Lz\nQcw7Vu8W9p3rjdGEGp2MU6fb6x4iGRhBcdAk7KFPJ0cCykDTn4SJO4VGGgy9QyosdkJPnPSDSENX\nSxmfzvpXKqdTgHD5RiFbjARYBDI7239/+vFjSOWskuFsuipcElgSWBJYElgSWBJYElgSWBJYElgS\nWBJYElgSWBJYElgSWBJYElgSWBJYElgSWBI4SAJ7ZI9WnZ8ggYHHCz5BXGuMSwIDJbBW30Bhrqom\nkQCHnkm6tbpxOQks+3i5KVsdvo0E1uq7zVSugaAEFp0sZRgjgWUfx8hx1bIkUJfAWn11ma0rZpfA\nvnSy1d4mgOYL25oLr5qtP2GHjy9wP/u4Jv14LdparIo9WR7085QRqY2O7c9VVt9OU7BTtf3aQv1r\nf22fVsOik9SMT6v9qd4fUugq9jEvjDXpeVkNLFkVe7L8WBroH+/Y/oxdfUmRNghhp5p3qrZhgNYl\n8/dw4GBHVZWik+aFlJkStUzmQiaChkvyQty18nw3Zi4p7SPXrZl2rhlJTjjp1lZMdU6s//jn5PNS\nFXu1/EWn3u+2Qydsug8YvmPS95ishnhbRghjy+w08IFj36+HzZJspBMYiWUTkWb8ATtWMlk/DLtq\nbWnleDlKMDT00uj7cghn3VnMbHS0k3TKwyaa9SN/oUonzk6ClQ8tmlqeahqtwZlEx46rvBsqOZuI\nfP3WCsrInA1WVYxMmUxbvhJa46WrUi4uaxExa6tWwuQWKr9TiZwC35hYValitIxYqZLqBKk6bHXP\nmbtku87ArdWkylzWk5/WpM6U5sjS+ba1wHoIPamqgSyf1FVmoKo636MJndfyATpaIq2/tIlOGauj\nlluybKtqiNXpd1qkhsO6Vu2A7G2ymD9P0lijBkvdkh0OV3KnlmQul5bO6VVGaFgGambzjh/SN76N\nU+txhpYpH2ppRnQl7WWK4SgkFaCqRcm+se7586LqbV6ZHZmrw2Hlq6vMmj7LKJXEGOrPwGUrV58z\nEaEB6eyYnKlQZywDmPEaVM4N9WR0IFxKDXNdMh3OjISTxRoKx5I3C3uXRK1+vsnTySiv2WwIqoro\nsFTYByjgeALpM0KlcSxdqEDNY99Pn6R9tCRgdb70uWMBLcFWhZYpb638qpxL2kJV0dFJOSO+x8p4\nAqdpS2nluvMBaz/l9yc09BYZfcgsaksgVZ1hbTEHSVuRX+VF0dYrNJjMcpbWuNP0WfU0t9spcGty\nVa/E5BYqdptZaFOM0lVowZ5v5qcT2mPHFmQ0W7WDav3hylc9gaNSx8u5pBYNhaUEmG5Jc6leIpeK\nurDl3LFF6FSeXI2OQbGUEIwFu9BXRVVzQvmrqqt6fdkZa14cOlEvSVrqHjoptZsXmqoAoRH3HYyz\noi19S+oJt9Ha+a2MFjkDrA4tKWpcC5a6ql3KiCWpe2FVTj0l3QsFKAtUl6FlW6wxqjbKEUgoq3DS\nhxfgmi+xa+wkhWvYNxz5BdZGJ1b98Llq6MMpSc66uoBHLcKwk/0FpH10lo3jCPvpxJ9Ey1mGmpmZ\noHzlTJ2SSiLrd3Qy4xIy856cR6u5HjpRuxd6glC7rkUnyTmCBegXHqUSYZewM8xyOnMX6g9tdJRh\nTNbTrMPhhaEk83bJko/jNB2RNnRs+CUxnagDyExqZrWoLl9+mHEM4cp0LHtYf8+qLnXMt7xWP/NN\nDFcgKlU240mvxrok1UaViRRFfhJV55S3ApnVnpmRTD0ZR2vVk/k8ow/JeQyHUzUamXaTRibEkQws\n+mtT1R9fJhklyUwQdD4jih47luwJipq2lWw3MwQ5lfSqUXOU0T2qM6Hpq3bMkXamqoa1P1AbS6ri\njxQV+/EmhCko45Sk6yQ5YLm0MvVLVW5eomwuqUTUxcCkpJZPdkZWpXprf7BJOY9SGrWecBJDoUm7\n5jgVae9Kkyh1OE8n1Bkwy1id9Le1l9j4WvWrn1uLiDWaUR61n765kIuCyU3VB0kJfj2ZecSGwg5b\nXaI15KcYTaVcvKpi9yzPUDEcAyIVIKMSYW/lCvUdB6pHWDM1FCjk4XNkrU1LIal6h8bEsiHW2NVG\n5ZBDG+vPbF63k3PUWYxbqs7q1uU9EhhiFHo60HPtKM2+tBB6BLiuvZkEjtTkUavv3Ck4UmJjAfH4\nnp87U8e0vujkGDnHrVgbrPjKOUoMsY9XF8IcU7F6MYUEjvRYQ1bfuVI7Ze2PmqNR9Zw7BbO1vujk\n/Bm5gWXxo5oZEd9DCJmRrjIfIoEjPdall8+JnR81R6Pq+ZClkRxmik5OoVp0eMmRlIpZaTw/vVdq\nYkj/x/an2v9S+RNNTKmfzYUPM0Btk37WIs3L0x/X3v3fr/7DFMMR9bmrbz/Z+trVtlJknWH/T5/i\n0zuQX+YDS34onaAErVkfog2h0ucnckh/rGU5xLQNqSQvkONL7jQFvsvJD3OgsuUbbSupSnLv/u9X\n//GK4SzkthnpvGo/2Y5aHRnKOaatNlGP0jGH58KvWM8PmPQUnbQJNHnVKLknm5MiVi88t1eq9Wkb\nYLgsaYGeUat00lPhHuPtqbNnLG3Xtl3VM8bqtW09zF+VL1nteVt5i6vaaht41cC9wa4btrFDHlhb\nyU6W2q3q8GE6xhoK5x0LIJeUhlYqDBIO6MTiKWhJLgnrc6swax5nPeQ4Bm6ldjP+mIqyQV2q/Vfl\n4/dTbcJROKdLVOylhcd6SCeFK5bxQzmyw2xmQTKWfKpydoSm2nf6IVOJpPI7cmiYdHV2wkFhQ0yY\n9HNpDphWsPEOHJfVf9U4DFyMjl5JOXfqs9rt5rXmdM//ytdha4z+2K2FE65Z1MaQDJhNkP3BcWVs\nhWq15ARZa9/qrWoQVB0Oa0jaFmfNZlRL2l5VeRw3ZC3Gkq1wuson2hGcnFSUDjVkTFGqA2blfQnS\nttjCC9uVnc9PQ97WqErP7L4/ZLWflliSn6uznB+UdTkzIpb1ocWsRqUZlUJzOpysli5vv35pH9Xy\nlhKGsrXWecbKqOqEHaZv0GGwN76OOfM1dlz+YrFWTdgH58LQaCTXZmbe8/0sTTrV4dDa9PTT77+0\nPGpbzroOR20Zt4xjcmx7aGClWfO7mumnU4NlCnrmLmPwYZh+58OhOUrSoP/YJaVneW/tu1t/hVeV\nXu1VKDXHUyZnLtTvUfVY2pmZDksO4QJrUB05raFyq4YglFt1UNZYnHpKSlWtx9K9UKOqk+L7A/gW\nyzhv2DT1WJyMMjvWI3N5XkolyxuqZUhLGaMUuuRkAbTjSWPr9C25fJIN+bqUnzu5iDK60T+JeZMV\n6kN+KmXJBpvjN5dc1NUl4zia0lyj2FGxH2+sISVXml+DuoT8Tiel4y82a+k6bkP2SlrzjLbJjr2J\n+z3fke9nm7JaqtOgN+r6kfVXLQgVTnK1JxuFuVaFXxVmtR5fzfKTHuobHYhUV/jE+tyx/nmzQKes\nYVzOorN8YUl1k8bEkXNGn6mErcUeTmW1gCVtR7cdQ5R36vlFqrr5zPSpNsFaU76u5nXSVxVLPmr9\nmTHSCg/QMb9LqhkpTR/IwefXjIZzS7sTneQH7A/JWWzqBDvtquK2Fptq1pPyDTWPrbSSdrJRZBZV\ndbVkhkl9fzheqwPWZFUHlanf6ST1LqFSZerJWNLMpIcToQqQDUeOrnm8w8eVt2hWn30R+YqUWReZ\naWrrWzi54dAyLiHTt+ryyfitUMcyfqdqB6y1WZpE302o/iLTT2c2S93LKG2VEvLO2m+9Uw7Up4Bu\n7xU7yQ94WjpBYZXsSHKGHPk0L35rQhsUOjPkpwKlf6pJ1mkJISPDhjIWiaqWlAozab5Lc5oxSeEs\nqC2y4cjRhZ4jbxakrpbGJQv7TVc12VeSTG2Z4VjyDKevp4C6+hg+ZnTYIk7n8+EGKkkVmbnI0EPY\nf8uQ9vTzLDppUHJHn/3aMjY5ydxP9c4wbJsG4/qRk20tLbUhWk/oYCR/JUHSUv3M7Fpai8vAGoL6\nubp42LhYiyhhqlglITcYSsc+shkPXQ6rytJyR1yWfFQldFYR7QktVq2H9kedLNUC9iibtCnwifW5\nVE5rcckV5Kzo0ricRSe/UmsOjZ2zNpPSlnqe0Z+G3pbWoL+6pUHwDWN+LWcsMDPj1ppyXI+60i1t\nqdYTGljH3yXXsjM7am/30zHVcLG1by1wajpYPepXcmjNcnheWFoSn1Y4ab98Ormr0Kqad1c5rHEd\nI4GGxXhMx05pJbn6ZhPabP05Ze5Wo0mgNDM7S4Jtu5/PWX5J+7gUaUmgXwJti7G/3WlrSK6+2czR\nbP2Zdn4/s2M8QvOZUvBHnVz5apTvc+TZIKXPEc4a6SgJLDVL5gKwmJoWGTUdDfXM1p+GIaxLjpHA\nopNj5Hz/Vqpu46zt712N41nj6p/Hs3ruxJMHLtdjwgPJ1cc6U527avmqGGfThGr/V/mxElh0Mlae\nn1tb0j6yLd3B8jrGVRw8qK25E8c10GOVRlEqXJqRsTWPrc0hqsxEzEwnQwTF/Flp3u9UmPt1+27c\n5hibY/CHTCWYtbd/d5qhNZYjJVClkyP7RlfgKe3u3egoc7B3P/36S6MoFZbtSvONFTbU7FzSUFvD\nLCRX3x6dGVXnkHokfjUIU/rFtkrmuSqUbVVutLysPGwuKZlFJ0lBrWKBBCz7SDUMqpCf4Of0W9ae\nWg8tA0sC/6u+sVhc7RKtQa5eOV6nvDVqSxSWrH1hJl2UI2RnjvebR4cdHfkMtIBS0ywRqZNuKVVJ\nmJ32xZl6+hUKzRcsfIurKaO9eEk4kOE67GhCs5LI9U611JK2ZUakcBrqr9oKZ1nJOXL6o06oX75Z\n7I7Nf2pkqF6rwJKAqt/hIlTdAFv2lFT8BaauEGpYmYWl1tbpCbPgYX/U8qwta7nSz8Ml7Vu0Np0M\nG1WHP3YefTqxvk32PBSLrIepsdpQ1ZrTbozqOatT5QOmYOpgrb6FFWZ0I1SVkhN1uhp63FATnDmy\n1mnz+rX0x9GNUlsNUqV2LJTVopNQRKvARBIAW1ZaQkkTn3HtSANyjYVdqlqKZPlwtSeHn3HPzQ4v\nc2FYJjmQznqSrVSXRMlhZ+Yi7IDq9cOr/AJy9YVUnSkQCodReDgKZxJD9UjSQwMzqWSDInUMSLjG\nkzhF61Hl0Kz8eamq47UmlMmkuXtJrX72LVSvVaBZAntYpebODL9Q2sdwYSR12qpHvVzaC8e4oCGj\nKzO0OKywVb65noxFYF4hFDWrs9kSqX3rnEfH5avzMsT9WI1KdysNsVzIVflDKw1XObqhVhhOjV9A\n9jDziWNbnOZK0rDW4CjdsPqZXPsMSvAqR9XlJVYlec3Ji1Qqeegg6KBCNQtrswzLm8DballXZSSQ\n16pMbbOVCVeg7HBSp601pl6OH8o30vH4tizZbmhxqvXsTSfMEoWKFNq4znkMBRj2sKdA6G4zihSK\nKDmnzQORq0/V7fxgraUR1uAPYSCdNMsqc6FDJ5YfDT931p2qP9V1GhpYZ+DJJby3GrP6OQtmZm6V\naZbAjQFFtY++1c4viczqhTIT0kmVipImoNl4NVy46zwuOmm2J1R0qm1hcx2yRbW8pdtH6nC/9EK/\nrhKqdKV+Pda6s5xCwzqlHSgRc94Uh7IaOB2LTgYKM67q0+gEjJcKLtKuhS5Q1kM/aaYT1smkJZLj\n8le4Kge2/EIFsoRZskTWeP3Wd51HaFr1naOGnPSXvlo682UpuWrN84VDlUDROU4Ov1IlLL1sqTxV\np0xvR02oPxeZnjhlMhMtBV5a49J2hdbSWYP90FCq3J/0qjly1ubbRHRO6ro8Y+JvKaXhBveWUlqD\nWhLYQwI7rb5RbmaPIa86by8BxojrVwD3nXFrf7Nvq4fUvpN9PKTvq5ElgWtLYKfVt+jk2mpx8d4v\nOjl0AhedHCru1diSwGdIYCCdVCP8nyHgNcoTJLDo5Gih3xVQBtrHzinxN3x7y/944773Btcf0d6t\ndyrDAZfPIIF5Vt8BAl9NfIgEFp0cPdF7e8ejx/Nqbx77eCKdnOKoDmtUbeiw1s9S7LBdSwLMtob1\n9BSYZ/X1jGJduyRAJXBtOrF2dcfvX/NategkL6uw5Gz+cm9Xfe54z209VIazCjh0wkztfj1cdLKf\nbFfNZ0ng2nSCUksaiLOkLHlwhp6M7YNqH/P4CDOI6MYYTtbDFZf8RDitiiqG0xlsmikSHVQmJGNt\nl9WmrX6q89IwXjqoJDb5WJ+sxNIrZ7x5PYFBSa9f1Z825e+Zx07p+R1edNI2oeuqmSUwF52odicj\nvkUnGSntWkbax+SkWH6FgYVKomoTkmzYwFUEkfVLsgkFaPVH3UPTfiZdV3W8lgwtAPL3+slOOnSC\nNTgr3SpjbUV69CecUEdzaD9DOXeKLuznLemELeRQCKvAzSRwGTpRdy2WwXI+9+s5ZnZvuepUOsl7\na+mTSp7McauyD45rpFtzv1jGwUMZq54Gj5WXp9OuQw9700lGaJbXD+mESTujP6X1npzHUN9KjSYL\nLzpJCmoVu5AErkQnPnOUDN+5M/QhdILeIkMDPp0wNfWpNKSKTH8avLu85HQ6seTWtlgacMrHHaoh\n1rZBLhZ1+tr0p2QHuK18JZiS6lRqq1r4lnQCC6pT66qSXOXnkcB0dKLa06q/cbZZM+j6LZecbx+p\n2Bu8S3K779OAv/mW34ZaJ3ulapdVT4Mq7lp/ON6GDifpJDSIO+lP2G5D/zulVOoSVdpbWpUFKG36\ncI+rpqMT1RxYuxZ/D+3sZU+xIMyU3EOBkvZxJ+9S8tY9dJI0/aX+NCjhrvVfkU5wXrDzzhuVJvOz\nYJUM5XbASvf3Bgd0YNcmkqtv1z6syo+XwGXoxBdN0nBkdkIHzMEtF5u0j1S3mFTlV75TYWrK5pHJ\nM/QWfgEGUtL/ORri6KEqnwZlC+tR+59UOWfKLNbPD8HhAHV+M/qDvWrTn6RYJILTC/PqlJdVteS9\n6WRFUKr6cI/yi05OmMeqTTyhi/UmP8E+1qWyrphdAg4zzd510r9PWH33mKkLKdXpXT2UTkKv7OxC\nnN2zs6uTFU6yjENRnK4Z1Q5MIthqt/Pll3HMy+oqJW8zp7dffSt8cpU1NbCfc9HJwIFNXtWik8kn\nCLrnZzouMYTVyU+QwCfQyacByjHofEwrbWvwODq5nz9ukzh1ez01zHbth9jH2cS++rMkQDH69tL4\nHD9yDDcc00qbWh5EJ5+jUslpuJ9AFp0kp34VWxIYLoGPWn13Mp7cAX/9jTvY4XoiK/x0OrmTMo1S\nl/vJ5KPs4yg1WPUsCQyRwEetvvsZT4h+MU2AT9SZVTPO1fKO4lUz2jup3+6xkxM1aWYqvF8OdScF\nHWK7VyVLAveWwKetvhPdyk6KpNIJ/TB8T2XCarOuVcfS4zd7rlXjOm+AMkr0Vfga1S6tZ6ykhvfw\nZgvs0+zjcH1YFS4JNEvgA1ff/eynGjvBD9GdWeRh+TuHVCw6aXadzRc6PflmieblISVb1R51YHRK\n1BXoYNBYSY2SDNW2yXtYGvJO9rGqRaU+r8JLAveQwE6rb3LhDDQOP/34aXu9bW6/PpGf7yQT6Qsc\nCnmLKETnVFjhpNMpydbxwj3i4j3vqav/Wofy6FcWRfrs2d+9sTWUpn9s03vUtpN9vJmU9pD8qnNJ\nYKfVN79ge+wDwsf25pfff2wvZBH8ZPvwv/7P/8TAZQ+xlOjEijSUPs+MIoMyqmvOVB6WuQad+BRp\nDTIj2VBA+xXoWVf79aq55v3s480E1SzhdeGSgGPrPnOZtI0aKASIZIMPeMGH8Aa+wtcBgLLoROr2\nXHSy9U+Ni/ixKUtBF50cac33oxPQisln80hRr7aWBGSceK0RRytomITBB0UTBBREFvpm1yxPnk7Q\nHjKT61hI5kD95UMLJxdaqf5knXKY/KamfEWjSlp0EtZ/Re91J4OyK50sQAn1fxX4ZAnsvfquK1sa\nJoHczQYcatTkIcNX7AShhEVQaPbnujK5Ss+ni52ofihDHpkys83KopPSjNxJXKWBr8JLAsn97hIU\nSoBxCSZxKHDQOIo8hsLyO+zCI8/Mfua0XoNOnFiWs2mYn1fu5G4P2L3dSVyfaW7oqOdfnheaowNW\n34Wk8fAX2tkRiIjQ0yQ0jqIeOqHlMXDCqGXXjM+1xD62t5PSydhBTlvbndztMfZxD4n99I/nJzSH\nqOhO2d8hfZOVLDoZKNhjVt/ADu9alYUmgBcyWYOfwLcOxNBbe2hteKj2gLt7dhXdYZVnTrdMRyd7\nuJ/DJF5t6E6DPcw+dgptYxH2+r/++n/CJ9Xpm7N8yevTWcMLWQ30T8umVD+HaOicArxirw5bfZcQ\njkMnTrJGfqWePqEoA+EW9lqhlFBJkmu/i07YQWj6Z9g/dS/V6XgaGj39ktsM+Uj72CY0QJCNRawX\npZbTFaO5A8mVz/iAitSnE+yYRTOygDqWfD+bRfE5Fx65+iaXqkQT9cRJBlModljlrdt8VhDF0ZPk\n2m+hE6SQzKGhyVX59O61OdrTu306XJbkxrjkz3/92WEUDKUgrEwo7f6VL6MXYezEohZrLvw5Slqo\nawn/rN4uOgHJq2gCdFLFEfWmYqsS6w7kpD5UQ49DQp6wAC3NUbtk9dMapizPgePr78zlbrkf34/1\nzdAJC38lJ+kDi5W87MzyOdg+JuXGuORv/vvfbPCx/RfeqC/49r/85b/AC2BlZsmzvuW9vkMbtE5K\nLcy4sGJq0w67XEiqk3f14NU3rTSsnE41oMJoI0M2GKFhj0gJZeW7Z7xc3TzQxWUtZ7YPYctZ1i/3\nLaUyamGrD75wOMrI0vK+rIZA2Qpz+XgYavD8BSa0j2oqx+cSwJHttb1BiNneXyiOsiudhHpotZ7v\nVdjEKkAl8PP/4u2AP0pWFoJYARWHOUqBE+ckSsbxJfFdpRPq9Rs2G9YmRFUbh36q5ZPWIKATDJOw\nY8zsaTZh3CwzSR+1kChgJqdqcvnMRif+ERM1aoLxEuQShBIMoswfR8mrEy1pbcKczVnGJFkbqcmV\n+Srd29Bk0QlMFrgY9WRrlU5UNAl9HH0WfjV8ApAh3b8aqmygkJ56mKuiVYWRD5V+WBzFqUShEzxy\nDJOK/8Un/rKH0vgHmylXXmXNH9lPC5yP7MOQtqaikzY0gSQOpH7Y6ROa5ZkWUFQbFFoQ1EAJK/CJ\n+jmjFnX2fUOWp6gh+nnLShadfPtO8YAT3EJn6MQiEvVgrOXy0EU20MmTscghDGuBNNBJZiOB1Sbb\nDReU1c92OsGJhHul2F05zvEihpaSNFf4JJzOSxeYh042egC8CE+/+hEU+JaGTyDdc6fbj63NzaVV\n8XM6v+gEAyfO/cDgyMKzIyGgNNRQ9XpsJxBSRU/Is0oP1e1EtX452PftFplCnCp2BtYJcFElgGJY\nGN5Up+pzrMwNRjoVnfi35DjnYfHQCURQEHQws4PX3o9RqtbnBkp76SE8cjq//v3K7Dz24saTYWn4\nxAeUEE0ymR1ZScblOSFGKxpKjW1PyNPZnKi9qkZnraElTQ253EWTJHtCxMW5NfzS5mB1PpMjPFdK\nfk5HQoZFKng8lvIKhFIwy8OyP+cOvK11P/nSVue66hgJYOAEQuV0G31MB+ZpRaUTiiaYc6GbbZag\nCQEFK1QdnHp5hk46xZj09J2tnHL5G504J0gydALBEgdQDpiqU4S4Gp3EPmKow2cOSTAyB6RSDqCJ\nzPjgJ0sTJpEAeG7rNUknO7ux6ISmdZiHwk0y+CN6IuThhn75V3pogR0TYecZ2K0h1vab0Qle1TnL\n4eUfQCdkCikYqmeCHIT06WQld0JVu26BGXZvPp3Q+24QX5yzKRJQrMAM3rp8oRuPr6tpas8ZiGwp\nD/76/fenO//KhkBC5Lr/aFpnkr3BWcJkd29Q94SHDVRA2RgFXhRH8MPtzR/f/1nUQgEID2tu0tiu\nPkAm96eTMKkWHgii9xhj+AR0gt3jc8CErSaOl8AkdIJ33MjwCUvWtJ1NoZUwskF2ud+RlOPVKdki\nQomCI1+A8h9/+l+3FxT7f397EAn4dTyxkWxotmID6QSc7mwDzPeH0gneZEpTOew5aeCeIILivH77\n+Z+3FwMUYA75j4ILflsYwutWnZ1QA6vtqb/n2rwoaMmnT9mJTtR7fC69Etqk/AlXTUInGzFYz1sb\nTicO36wgirQy/atAZmosKGGfqxdeN3wiAat59d0DTRBK4A3ekwGjQzfEPg/RBAAFXxALofChvh9F\nJ+wIqnr6lRGDpQbXphM6uziFTlrHOhYE2kDzO5J7Fp3ABu5mSfFm+9jvtLAG50gs3AxMeaIZVuip\nWFohDaXACZVpn4wyUOaZqoboBkYLMEGTRBNWbAulQEzluuETFjhpzuxg1CEziXOWweMm9I2kE+aw\n/PDJVphxyfYnDl+NndAPG3I6GXqwyqifS2qB/ifjH2qx5LVsW9KjNi+78X5HFjvgk0zrYPoNj8dK\nnQAM+ihAUSlEWkyeOO+Z1TOuHeKBOjse0gmGNJywh/Ooe7x/JyQbuBt5Aco3OJKdYMMsY7SgjUjk\nVZDxeXx+tX9qZqph9d0ATR7u9vXIUIkpeATECuGryR0fTSSjYDQFvtrprAkLnKgEYBFJScH9gI3F\nwVL9nHry/XlWYp2EVe+SYsyBSsBu+cEIG5Sn2nNROsl0uxp8vk1SvME+5tU0U3KjAXYQBP/EH8qB\nN+ymm7YDKJmrFp2wiaM2KzOnWKaTTr5Z5HVa9okm8Oel/i06efPNhE5oyATPwzI3hM7rG87eT59I\nOjldO2TQohQvaei/FTtxIAlaGUJIfEtTohNM1tCTR6gZdPqRSG5DJz6gUDTJb/LukRSfgU4kMcCv\nDeNzSgBNWOQDAiphOCSDI7LMSu5I41hlFPTHiPJ0yWy7VQkfmdWHtV0IUB6i+Kfvh7DJ0FTSFd0j\ncEJjJ/Q8LCZu6MZYPWMgwycsp5OU567FVDpRwxVMH5p7lcnsNJfJ90qJndC7b9TYCd6JQw8qy+wP\nnkiSsRPQpHwvJynpLGnMheM9Ahn7KPM7102Kz0YnmKCBAAY+hF7SCX2oGuIF/iIgfdMAKCt8Yi1e\nFvt11jhjEZb4l3D/iK7LO4rFJ99HT64TPrFuOCqtPjwoekUjzKNxr9gJOyVJzz5i+ITeQ0qDK3g8\n9g8//TQbnTiBE8yzqJDacEyE1qNuKt6iVu8/CaRqYE8fcHT8NwgcKKHxErxTXD2YgnQC0EqXxEXp\nhKI6m7zOyLN6cO9ap/ZK9nEP3JSZHYAJfCA9pnWsY614KsV6g6SSx5RFJ/5cZ9QG+AOg5Ld/+Rf8\nL8UU+Bz+UV55y+C8Awp+daGbdwbSyW3QhB5zpDtnvH+HJndoBAXPJCCd/PbjBwWUPcxUtU6fTmQy\nxSeMZOuluIiT7jmaTp5nWt+fY8MSQxgsYUSCR2JvRic08gyxE/nKbOZkmQvZzYybSa6NtmIqnWDg\nBMACD50goMiEzvNpJX/6y+9/+stffv7T1hl0e5RakqSy6KRtNulVkIIBKMEXwgrlEvqekgpmf0xY\n6e/l/jVYaPK9yyTbWTNk9brD9k50Qne/uH+mMXt6xgC9lQyfzEYnJUqwAhsNillq92g6ARqVL5al\nA1KR+TzUFXmOGgMq110bMr/j3B5cPSRLAQWvbVCv4y+ZgU7k7TaUTvCJriy5o3IGFP5/fnq8KKCo\npLK1S18s9HL8XNyvRaCTX18viilIJPAhTpCMptA9A1tol5DYQDq5rvl988HkVlPcCSNzYMwePvnb\nP5kpAvBrTzR5hU9mUAkr9mCd3BpohP1zLSxm42Rpe7r0du5EcgYAyrbggSoet32TE86MTmhWj3EJ\nvZ3HOb0xg0KEfaBDg8I08mxFm1nY2Qk4o90EY3SV8EmPFoYyzxRQH2NPszkADfQ8inrKhGZtJKOE\npLJdwg5GZDq/yoQSgJQNynYjFcYo1p9y6clTtPOvMpo7lr3Nrz7YT96PTuiOmqVycMgWoMB2eqMT\nABRI7oQKuQrsLYE3OlHv3EEu2Rb5Y9p+/KC/TYBEQslmUwJUCIq09ADKdZM7D2x8HcWC6WGRZ5od\nl6FmGXB2kj4XApS8fdxJp5E8aAQF6QTRxL89Jx9HoZiyjZ0RCf6502A/sFpcOBRTIJriYArsHGgB\n+IQCCqzfyUW66EROEMvX4B4YvQ+9gRRPmUg3B84IFAx83Pbf7f3kKnH77nl0AiGTh6/9+rmB7b/A\nlUgngKt4jw++YcoBf7LzSjegEzoEGnmWthJ4xUqKo620Airzm04I9MG/s9YMnilhdIJ3FAO+SDqR\nR08ko2z5HUz00HQPcAkMGawbvEFeOUsat2wXxQuAgqEUC1D+46eftpeSXf3lF1h0+IM7ky8xH03y\nqw/3ineKndBgtkzroJMCBwQ7Z3r0BM+pwPql+Z0FKOeaEZ1OEDNxC4hoAuGvbYI3TFFPnMC1qCV4\ncBoKs8/PHXxP6zI/xbZ06n7uuQBepIK8Ivdz8odCenq797Vb/2egE/mDw/R5J/hcEwAU/wEnFqDg\nikBGQdlSTAFG2VvsH1s/zgK82dRvAxTGKIgm8AZfD0//RSf0GMdH0cmd0IQdfVUPndAt9EYnFFDY\ntnlzbZRRcL/xsQvt3IErdAKpHLoR3LoIdAJoAnRCAyeIojSnw0IpSCc02nbu4HtaV+kkuaWTtx48\nmP1f/gUZ5XI378xAJ48d5Os5sHh2xKKTDKDA4VnKMY+gyNfhle3Nf/y3/wZrBI7Nrn9nSUAFFEYk\njE4omnw/k+2sASTaHRs7uT2dSF9DT8hagIJeD93cyu8kdHPHIm90AuDJ9iWwC3yeFXqhJSZrWIgM\noyZUGzB8gvfyIPDuOLKdq6bhRLp7ZtID7Ei+HtHmf/xHGnN+noqd+2wsmM7TYycOncDpExY7QUBJ\nxlGAeGB+sTYIkOCk76x0q3pFArAleEzEdiSOvFRAoVwCe4D5fw6Qool1TD65+uSe6roqxRI0NIhC\nT5ZgwB523fiSKR5GJ3gA5UQRjUqUj6rnYFE8tRpTOdTUouXFqMnTNIu0Dqbu6G07DEqwDGWU61K8\nSicweRRQMDvOws4qr2DMmR7ZA9s0c+R5Kjpht+QggsAb/C/cAAwnUdhjYTNPWsMpxlCKXDgHr+SP\nag7jJU/aeOcSZBSZ02Ge/nke9grrC4/IqBP9aXRC0QTv1mGehQbvfyE/xwNc8tjMkMdhILex5E71\nhGzb2bvvvPgrEEs/kXWq0w0Iwr5K1jMnvrw6L0ImdFMIdAIWAdI6lEIsNEHlwDgK9ei3CZ/4gKWG\nna1QCtDJ9qLHYxed5P0uPRiLh2HxOWyUTpBIAFAkoyQftsZCKXg7cb7Pfsk5rcao0bXVA5ES5BKY\nAhY4wU+wpOQS+qs9bT055qowrSN9ktWx28ROGugEoiaQ1qGAQk8a0PAJODuMoIBDDP9JzshcYs5X\nlDWm9oFCDLMbqhmZ37Y8hQk7v+0PhBKUFwZOEFAociKa4JQzvaEAi2uDRt6uHj5J9n+LnZTCJxh2\nnpxO0HQmd2/hWu0pQM+dMDqhjIKPt2ePTaN/soCKf4QWMz6PRfSVQuoZBb12fgsyaqTJejAY+VC8\nry0T2C6gE3iDkS2Zx4FUztvv/80dONlGN5xOLn2/JMQ8ZO6GPq6Cvkeng/kBTO5Y4RPUHzyAApiS\nVFEZrvBXsRNuCZc/o5MS5bSFeZJCGFLsKUmcD1YpJcfnNvGLQGlchOXzmN68hdd+/yHP0ia9+5DR\njq2kuhHZrAwAyu+//or/ZXEUTO7QpPjMmZ1Hh79+NHUeOoHkDqMTPOKKv/lHD71SFsGkD8IKDa5Y\neZ+thj//9fftVaUTZsuYiobmaaxKz18bAAegCQRRkEjwq+8y5Id1KJRkTnJMIopkV5Orz8lHTzLe\nTDesDTDeLiqj9Ygm9L5iaAs32/JO1c390c15HlCeNZO1HY5LZQVr+asRGsdW+F9Na2S+6QQDJyBH\nnBiYHtyjAIsgc0CIDHM9VnSE3ujF7kP+TDrZAIUyCjWscLsjjZ3Mf+hkfjrB4AfN/sDRE+uFBoVi\nioyp0E+aoyZJAwHF0JAldz/UdbHNlvRqtAlWGJtmvU26xtBAZwpsawHPsTIcUZ9q6EDJ20OZM22f\nUeZJ/18bAGeXkpyCG9CJiiZ49ISiBjuGwnbR1O9QsWBy59effsBr+z/qDXfVArmyZHNyVSIMlWIn\ntHDS/uw6dnWklMOewSsERkQTGjiht4/DHOPE06OvGCYBjUGCYXRy0TBj2zrfbA0ES4BO0LzShzHw\nQO7EkWfa1aR93FW/2R3FeNBkew4K3pgD75FL8E2mY5RjIFJCX81oAl4/1YEvKTNA8S+UOKLaMizG\niCf8/HgbR6FE/cVNP4hCIWb+24kxNrno5Km3WloHb8zBA5HswVrw57aP/uVrLw2v7+3H63gsC58A\nnTzStV/nMjdvmFmkPWUWnTB7wukE0QR/dwDzPixwgmiyRVDwsTaSXv1js59GJ5jceewCvx5kqTwt\n6nWvI+wUp42dXIJONhzBp7RRNMHTJwAxVZsiIy7VGhr8OmWFcMMUUojaAcs+Vu1mjzTy10oQgSWT\n+R2rtwMo+SaPLTk2swM7yUvfkcBiJyqOyHMn4GVYmP9N/1+AAmU2lwdcQt8804ijFYA6YCd+4Ljt\njCmQu0e/3dGjbKnvDU3AANHAyfYeJmn7HBASIx/IntsboBM691BMJgJl4OSiS6VtkePRE4QSh07A\nMM1OJ1vMebJzJ3A0BJhjewNEAoDCzsbiDcYNdNKy2uxr8rETZonCC6u0US3/cHjk31ixNNSWp5ML\nPUwoTEJJ32OJrs1wNUzEHpcwNKGnGOlXLIRP78rBXTTetoP9xOg+Aoqkkz0Gteo0dZXhCdDJ9oIZ\nwtAWoAmNi1A6YVxC0YSdn8Wv2OFZGme7xGy1LXKgE0kkED7ZhMxOnIABXbGTpEqwe3aQTpBRMNcD\nBLPo5Ns0kwctsF2aujOTURzAlORM5Yu9Hcl6/R44fijrQTrJhE/8dEm+kzuVZIdO+s+dPOboyrET\nSSfqTRj0xAm7YThDJzK/g8kd2Kivf8dIgMdOvm+m+u03GtSiag2TJ5ETiRUhlN2hQ8/GXppOelY4\nGFb1QZZIJ/iQqMnz4nNmduAALD10gpkdSicbmmyfA8G0JXcGLtGkX+/M7MBqz9MGBY5MTCU5iqTc\nYKX853/4hz/++iu8WB6HfoJ1bmX+/f/+T35yh4HLJeh/yLkTasavmFJP0gk9dIKxeUz3QLAfdtRM\nFdFzQQ1qciepvatYvwQUOvnti0tYvi3M2NFgGuYCVbAFDbv02dhOOmFost0bSQMniCaY1pnTerKN\nXT623K+1Vg2IGpROaFoHgiUQNYGMzx50QiEgHKwMXjqXNNAJEAZ2iQKEmpHJUAgLk5SGEAqEFUAi\n2TCF0vAzpvi6Z5iuEQQU9S4efHr95IGTTQ7s0MmQ2Ml1wydJNMETBcglMrSPgCK1EQuz/M5Oh04y\ni726ZOYs37B10WMn28RQOnHQBHRdoglmcKyDJhJcrpLcoYukoc8QOGGPtoSHN9C7iPnjYufTuG86\nmezcCYud0HuJJZrgeZTqc0p8s9KwFI+Z4Wk7Fg4fUjYUOBisyPCJpBMZU5kT/WEszyVGntpi9ba0\nN+i0YOFM7VQgTyeY2UHPBZ9gWgcdlrnP+Yqs4AsyOzuNy+zDDnnSg4dAm2uwPF7sBCMoIZ3gLOL0\n4w3oVl7QCqucKL5k0z1r+5m7IT8LAkKWx02uQSfEbpbsY1LU1WIsdoLPZKNvIGoC507oUVm8zbja\nqFq+FD4Z0mKykgYbkaz5gGIsXoLHWlkUBI+esJuH8UGxNHxyLTqxzsiXVl+PBTtglvUFJW4kVj0I\nvWmD5nTkqQN2PsFqlDIKlsEPR0lDXZWXXqpSMg3D0WMnePqEHoZVE3VbJ1QmRS3xszyXO33SubA3\nU/g4V2XQCd7ieIngMws7l+zjqFXN6sFTsfh0E7x/B5/xytCEPkMWMj6j+jYPoKgZnFHDPL4epnj4\nJ3IG0ok8GCs/mZ1OyAbAuYOvuvo67djxk14KnNBTsap7gg/z4RAsCU4QoiqWQywJhztgEi8Bd67O\nrJOTzZcv9RMKW5WH/YQC1Ra5cJ6d+MrsgPTxjUWXMlyGRFJCk0vcWty5qh+m8P33VOlJWNgYXSX4\nPNu5E3bDTuanhpFd6M/oTA4oDYu8ahSmKo/nTugbK8UDqEHphK2mRSdo4enNLFPNuLLtzgVO6F4X\nDTV9qgV1VVW2gPL0LMtAoVmxE/p5+J5uh1iF1rXNQ2AVqvU7ZZLtmnQScglqOU45TQBRPcCbijNZ\nnjzPJkc4sBjj92pXAUQwdkJzOvRnyS5GJ6+9XXX3NnBenqr4dfeNDJY4mEIfhUKvnRlQPopOkEjw\nnh28x56nPsnxWDgVC6/wvuLPjJ089rLE5VdN2fDF61eYCZzQFAy+l8md/NETdHDIJTQ9NFYCFp3Q\nVrCMRR6WZXBIpXkUDu6E/cw3qtMJ6G5SZVEV2MTTMygZLpmf5XvWM544wawZJtHpTTospzPzbQVT\nZXbYM+zDwAn7zWH6PNmx+R2MeebXZGCp6wHSUU3vXQ+yiGyInTiRIUaW3wFACQMnzl0wew82rP87\nNvn6kZ2BmZ0L0YmPJnIbTP1IJ53QeAnEYNgrnMRkgSqdMLf9BCnDMnAf32FAaFU4tCQtNWyrTDrJ\nilUchLYY5UI37zxN4bsIegIngCaQ1lGPwfo7vDm3d/PQSRVNLHYhR1IePzWcXAJhMRpxZYVhxWIB\nVlINR/m7lmQEy2o3YyXD8TYUoFkb9SkmW51AJPSpqUwDKcpj+AQvYW/wzzkXF4wXnsIsfxhISjg5\n72978fd0SXIv2jC5PZeEUZPQrVgRfRryV3tIc0PSqW3fbqwySmiZdWfFJCxKCD+vzotleS5PJ6XY\nyYmPCZJJ7u85NgKhzoYPr0UiUbM5FppMbkDnOXcif/wvjJ3QBBBCCTk5O5JOHCsguSS0U46RcsBF\nUpEEFHUH1rDjqVo9Vp6GSRg6MEBh9+wwcKGZHQtNZo+dvKPJfrGTE02ury0hnTieJeQS575iaJee\nm1QzR1enE2fjpBKwSjwZOik1RFt5C5+ULMs2N06kxIm5hadlR816aTjSSsIDoODFjlzB5gZe7EGW\nstFHmdedw7Dhw2ud1Pg16GSCcyc9sROW4nndaXwcnTAmSNKJLGbZCH1fKJ4Ya0HP8XSCYRLQfxbI\nlIAiH2oClyCdYH4HKmR/TgsoamRoyB3FT5V7j52U7mHpsav5a9vQJDxpEB49wXYpkVjxlVGuSka/\nnBX95rONpz+/xcneL2DuvzAjWj2Zfm5NNFgSNsxaNDtDJ1CmGjuZhOWpKaSAAhq5sQvFF7QmMpry\n/cm7tQUbKoPP647iwoIhh2GTIRNWTALKn/86BZ3QxRkaFL6S3eyyZBE17tJgUPITByVltBI+AYag\ngI5xlBBQkE5oJTJ8cg36f/3KJn1Uo7qvrW5Ppe8f5WirOmCVr9JJMlji00nP4cJRAz+yngPWePNw\njqAT9UavkFcOXipqTgetJKa0lWJfwQMajpZHWaEetgsE04x0ghs7ur2jwermOd7pQra3k+y/U7us\nWgic9IRPJNN8Pfz+CEBxKMFK02BGhsuhcthtBjrBuKMMEmyLgjKKXAU+oDA6YQuKLrTZT50feO5k\nkg3hN4UX7yLGNE0ynM9uNZXtHuyAjrGWPUbj+B6200kmcALRQnqIGvA2RJMjn31iWUmWfGFcwn71\n49vMGY+dxp0fnWO2R1SDKNMa0MeIiPU8hU4QSlQ6kQdK8sGVyelERkpLeyCfTqDyUoVVy7UpDz39\nikEOdpeN3B5gQw6gUDpRWf8SyR0JbbueO7kHnVTRBD0UJnHmv3W0utauW/5oOklyyWF0wphDtZIY\n4cBE+KbKaAFZ2pvZFBVKmIVl6fCr3FR8Fp3AD+LgCwInf/Pf/yZPHmpmR/LNwNt2zNi1ff4DEYFh\nnxVTscqrTc9AJ7g0aJhELkAaX6RnRJJ0Ig+d4PpimaPZjPjxdDLP0ZP8DpY6lAY0YftnrO14Uey9\nHxiu3rvuXqC3I+lEHkeih04w1pIHFNDR4WKlcEDpAZIv9DlOaCvRgIJ9xKAflG8DFGp22ZaR3UM4\n58E9Zj33jp0gjmwgAq8tNEIZpYdO8MeKaSXw4X7qN3PNu5oeK45Itwr0yAiNoNBrVf+NsUb6vBOM\nSqqhlDnDk0/6fz93AjkvqTkNq08SwPEu2aT2dHx9Dzo5RQ6LThytfqp33mIibagxMXramR1WytPJ\nKcFG1URi1ATfMMRht95Qu2mFT2hIhh06odu7J6nA8w9m+ncYnQCCWPDhfKvejyMDJ/CjPBJQPpZO\nzjKULJDJFog8xBrSCe4cGJ3I23xm2wB8o8n7TcWLTqT7gLsu8L8NERTprSY5dLLrJqHTmRzQNz12\ngrPlsK2EEkzHSAVqCJwcltyRY5RWkgWcZQEaXFFvcVRbwe0di52wGxam3tvtdkdxJi6iUkXmefaY\nCUI0oXSCv3X8abGThi14p42Dy2H5qCFDuvTYQlAjlzR2Au/p4qKYklynQwZYrcQCr0UnKp3gIyoa\n0OSUSAnVB+qD8XPumHNn3tWqWIqENsG6gfkUeonaVSig9raq6k55IYT3U6sUKr+7Ik62yqOv7D4d\nqj2l2MnB4RNpJWFTRU0kQxNq49TLrW0Z2FZ2z460p6z+gXPfU9Vzb0c2dkMcGztQQtHBeu8cOlHz\nNSx3Q6vdkIV2AC7/NEDp0Yq2azddghOybA8Af7LP2WqyAEVepR7nUgFlhiDl3nSiHuw43U8/vWMl\nrUMDJ/j8tCqjTBspKcUnrMLsc3nmjEIJcomEGIkj7MK25Z+jk3fmwBu05B03D83+KizLAEyAlrM3\nTI3yjHKY6mwWAe7EkVYSP8QYCZgw1YiYH77PA9JJdXs3p/VsoBN2vnX7k/3eTZJO1KSPH1bZLmGV\nywzRopPh5kZWKMOQeDsxLBD1nCzWg2VUztiulcfC1LSOcnTsgMHbTTzpX9xRPCp2cjM6oadZq2gy\nCZOxaESD47cSsg104sRUVGopUVR+Yb18yuvBvaC1iB0IGSwWQskDFZ2dL4FZp7qSJxLWXH48zSWt\nZI1qImFLB21Z8ZLQ3rGaMWoSW88JzqBIAqvSCR4lYff94udwaoTFMyTQqEdSrKMkNOmD8OGcXNm+\n+tjTJ81LqXShRG36SRJQ1DUowyp+Wudt3f3TV6bpvH/qDoeaHda18urT4hOT+GmVnJK+owFNJhl1\nP50g0Fg4ImMkVQpRy1vt9q+ep1ZjtAPQBDjjm5JegRAIjeALSm4fSC6xtIQdsU7q3N7hE8cSbU1j\nvISlwKUZ9cGCtYLxmJbt3QzW8/1ugpJ9BCCQoREVTXwtp5ewQyQSXCi1ON/SYhiD6V9sVg0yW6zu\nReBD/K+1Vdqvn8NrzhCAjGWqqVKMuPBM6Cv56KOJetNcpnvDZQIbHtWSLDrx/UUbmtyMTmTQZe/Y\niYMsnavjLXaCaKJWSrmEJm4wm5NRjiSOsGJ704kjRAB5ShJoyCRt+JyhlmeXZLd3GxmcGkHpiZ08\n0GT796ITiGdAjIT+OF/yzIeEDP8eH3g+Ck0hqfmj7Wls8EA2+Ha/h7OptkPNDVMu+d455I7LdZqJ\ncy9ngOIcEpdqCZ84d+zTk15s9Z1JJ+/oD0Ow0jrArHlatYITM/jp4wMnmCg4V8lHxU7a6IQqT4Zm\nLGUbm+J5oxMWMvF9tsz+7EcnB5+NfYPBVwg0YyJlMNnJ70CFWCA0oPPcYqDu7fL2Uc3OADHgcZD8\nWVQ1s6OeRMF2t4bwwCyiCT5GBd+wAM9OgOLbArQCKq+oFu10Izu8A8nwCbSrAooVjaBoopY5HlDe\nukHOnSw62SlwMjOdlLhThmDpHka1z/TDjIWxyueNf8k4PKv9sf3/x/+yqVZ6JDYDJVc5fSJlByOF\n8Im8AVgaLx9QWDJInviLD528P//geOv5dABib5dXUJU8KAr0o4l8dCzSDwAQhGrwaIt6ugXBBS7B\naEppgYWFF52EIgKV84/HYiUM+nFBOemSZ8bkfWW9XZjp4qAyaj/x9iWrkcLqs++IuW7spOqDZPkT\nw/ODFOeG1XzHTvKBwQfQvR93LSnHtZI7SCc0v0PjHCqgOAkaKA8QQ3HH4RJn53c8nah7u228Bfso\nHsAKOPKooXgHbzJwgrkePEQCsIKYAvWoKR76+R7hE4dO4Cv6Xxksye8oLm29IKkh14uq/3lAQeLx\ngisHnvF6dENwP2amnMVeWH0T00lzWqfkgNTCi04mtA+XoZOzkjuUTmQExUqBoyVVmWP7FumEPvLE\nOwpnbOzUE4L76ZmzAc3bRyVA9TqJUu15hk6e6PO6+wYuQRyhv2/s3MC8BVd2OoBi0QkFEVrGKV+V\n3uXKJwHFiV8yBf6OSRjr67HNOJhOtp68Awp00jl0ko//++7/9NhJM500P+mEkgoDlNJ2/XJL6RId\nprmqbGanJ3AC2mCFT5yvzqITCBTRDlMT6YR/AUFwc2Y994n+GoiFMvLzt9jMUdbze2P3/hgGMJ29\ndNL0izZJOsGoDJxHwcAJfVwbeywbIxVIFcGHkAYauLzpIqTVIogsOmGJG7asWFABl56zN8ATJ07U\n5Bki/dL2A4KUTk7HuVsHJJNcfb77Pzd+0IMml6YTa/nTmVXNQr8JUi1Mf7WjatiXTv72T2/PO/HR\nBDTMyfuctXjkslGxwwoyY5jEsZVWJkjNiPMN35F0om0x++nkYV7r/j6DJsAirCTSiRU4wUiJFU1p\n6O2oFbvqoasPFw5dfRib9BOsznGTN/o5hE4c9A8PnSw6UelE9T5ODkj6l4PDJ2qWVvZhYDJ30ckj\nWMJebbGTs8InKtTnAQVOmWQYRW6e5CdKLPpg6/kOKNif5O5toHNN0glFEIYjtAYAEbyl2cnyHPAE\nlIFSumVVFqAAo8Ba87Orz3CIQdvqKtsvfOIkTDNokqSTmdM6mcCJH3Tf4+jJDHSi5MHTN6+Ea/+j\n6WTTmFL4xI+dTEUnYP5k4sYxYcgo/gFYNFVyb+cc4rPahUbhFSqrVeBtY6eldbYCM9MJu8GY3tJs\n3XuMSRwLU4bnd5pn5zMvVFcfMAfuBKBM6T44XGJ89e32hCELTfAwbJjW+RA6ccLq/Wiinrk5l07C\nhC/MO0v6DLHDTtOsfhnIYWlo2R8okOnnvpkdS2nabtuBq07J74ThE2oEfQ4A0+lbzG+eMAIVSg0i\nvwNWL98xx8n5ezsYb0bbxvpRjHywZ+GrwEE/lLkeiS8WlOANyXscQMnL52C76XTMz5rnR9RQ0gEU\nOGyOW4gkoJhoAidV9zl98o3+2mLPoEly9U0bO4HnbIWPMzmeTlCwDcrZcImVspEIApWHZNDQB7Va\nrIeRh+yG1VVaLbNdTqJq0UlqBq3Fo0aYHSsGbj4DKGrkGcO8Kp3Qdi2eaIigPK2niIFDZ/BWglPo\nBHMxIZHk6YQ9hI1hCqUTOFSbUqDRheahE9VyjR6uXp+1+nCJlQDFQxOi/A0rKOB+8VN/9Blx/q06\nVPi+SmTc/ykbv4ff6kOTIUdirfuVjlxoJTrx0cSHDH95WkPOQJKKLwxiHIJhHbsknRy/ipz1kwcU\nSgwQHWkIO5tk8763c8LFJfP6ltMRezu0/snd20CntWEBnF2Fp+CX6EQ9Kou38+Cb8OjJOoBCJ9TZ\nAw2cd1aVs/row1HCtUZzps7aGRs+GZLTQdPfSSfHG9Vnz6PASXgvxQfSibrWuC/vO54i1cmq3yKS\nTPkwVPNWScaODLmj2DpiEh49OSW5k6cTK5MiLVEVUJSTetqZPqg2eLZbZprtXyPDjDjd2B0cO8kf\nibXAxakBHiML6BMySmf4xN+RSKnS5erELZjJUOuxmFJtIgTQU+hk65UKKADxLBxibQac41zmTf65\nFRRHTbTACfYnGTgJpyYTn5iTTkI0AX/RcO5kOxBJX86zXg4Ln4yNnXRr6KMCJxYidybJoEiyGNXq\np0XKDGnTYzm1Jf1AfVJTiSGgQJ4y09VRZfzYox9hBgPKzBykk/N5cQtNLOgJz7VkJGNRDuZ0JqGT\ntvwOUAs9s4L1IJ2EaNIfPnHoxDcNziLPfEVtbtIGOTDk74EyytZTRi5ASSew4iSgVNEEVlYpAKkO\nzUqYqugfCifcG4TZk4Mt6qjASTOd5B9mPyedyBW3x/YgaRmgWBI7ksXa6aTEIuodxT2PZYPwyZHL\nKVzbAaDYh1vxl9/9LI9DJyxh5NwqiciSsa3fOR3txAnN6TwNzctAhpZ0SIH+2ImMqcxGJ3J34nxi\n2RE/NiPnImOLVTu4h3FMqgpbfbCUAFD8CEobmjzWUd9DhkI0oSe6MkLw6SQ0X8cHpMGAhx0Ld6qw\nv+30R3C55VAyKyIzR2GZUuwErS6zCagJzevRqYF+lYEMtXzmQuZTnvWEEnwQTceP7CCU9NPJkSsq\nXEWqfVQDGCzwgAYUd3vyKkQTNWtDPwzTOklA8dEETCcLO4e7t4xq5csMoRMMnNCTKzKtgw9nw5Mu\nMqbSnN9J0oO0Nc4iZ6SSsRFM8qpF9g1fszXMT7pT0gqf4M07uNCAVzBEkV8ybwuzn07cR63kczqZ\nvUFovo60peBB8AbMzlt17kQnQxbCnSphhiuVLhlCJ+GTYX2tpfq993xk1vbWWyd8Qg/ho2vHB0bR\nux9xq4emECLS2+uPv/66vWCwFpGEphYDLX74pJTTydjH4XPURifhvcdqToc9OpYeRsGvTqeTh9Hv\niK+qE5SMx6jbuOEz7lcoUzkYO8H1RSMluKySNxsPPIASon81cAJT72zxkxbsmGg07UyyYyHB7Bo7\nQfEerNKruavSCcD+MU9ASS4hNdWNWzR60g2zOdKAAl5QRkEuATqhL2CIUuwkQyeh9VQ3difGThru\n2fEfwuYfhlW/bf75YhnnsGK2MryhfpIMnGZCHReiE0B2dgxWcgkUyGQ/U9TSFEGx0joNh2FRAa5C\nJ/1oInM9Q9DEyewsOjmLk86hE1XDqo9oY4q+kwSTaAK0JPM71FzKhAilE2ZYkTwklOAnwCX/+R/+\nYfsE31thj+/TfBBStg2rbz1lTues2Ak9DJsBFKfMFlNhwZjkeVj68Pue8AlufBEIQshQ8cL6UCZl\nLDpx0jdqhog6yJ3WYL5augBxcbE1mMIO+yfB+eVw5r3yT12hcvdSqXJM7GTv/A6zpfBn8mQJeodF\nJyXFCAs7IbfwWrn2M3ueUrVvNidzZX9mRx46adDRCelEbuCoZZR+3TegNGoC8PHT3/0dsAgDFPgW\nX8HtxC6dtKFJGFvO6FWpDKRg1JOtCBbwKBQGJRI7IN1DawtvJ7YOoDQDSmnsq7AjAVgFeFSLHYwd\njCawlCqAYm0eJqGT/QDF2uY1WH66jx0VOPFjJzcOn+xNJz28clrsBJUSbwkrxU6kTu+RNM0HTuiq\nViMomM1hhlUCCj24ikERjHxgsAS+opHqTMiaGkd1z+dbTytwcjydPFp8AUp4msR/VhuyCHJMPnAC\nz7OnT0ZZgDIDPMHSoLFJef8Orp0ByJJO8Tzpf3vMifi9KjwvXw3GhKuvZMd2AhS1Dz6aqN+yD+9N\nJz2u/chlaEV8QTObe3ImnbBb1TvpZPii6lnSElAsi2MZUAicQD3UetIIynA6eTOdmvV0biU4+NwJ\npZPqg2LD8iU6GXj/TvMyXhdKCchT5+zu4pF0kougWOhPT6dV79aBgQ85d4IWePhOry1wYtEJ3dne\ng07k9HHH3PFrf8AHfhN0+VjlaSV55siXlEt4XzpRf6B40yf8HO8HK6GJVXjgoqqiiWQjeoOAsxlS\n6YSiSUgnGFYJYydPw/fKqbNedZrOE+kkc+gkJBJaIPmUWHYvD2SR+p/PdifUyMeNe6yYJTG2uNgB\nFLayeiMoUfikc335WjGWTgbu9DZD6tjSztgJoInlZarg4ruPvCb3rF+2CpzDYdhKuHBYz2V52Sj9\nJPPeGXLYPf/aN0DJSLb/3AnVp4aDUQ7KwGLIjMITSvSrVGoH1HbDIK1qQGnuXBpNTO7QyAq+d4wg\n/+rdnmaspzOcg+kE0joZLknmfSiRsLtyMs+zZxGUld+he/rMeuyxYhk62fdsrEH82DEroSOfNRBa\nDHWww+kEAKXHlsLl/javh04QTY6hE4wcZJS5uUyGTjJlZCzEoRm/Qvy22i5agB5p7EUnjtLAg/CR\nbYcETmhYsnldhcvJB6OGaaB0gkf5ZEKHJXcAX3rp5PVAbqjqkQgX6XB2R/RUdEJ/TDgMjUhGoQdm\n1WOwWKD0sztQ1XbtPIAyyvGPqsfyrw3Lx78EFxeiSW+AJHEvjwxJvnG/tsp67iWmFGhutZu2W/i8\nhiqjUCs6nE4w3I7u4wZ0Qn2wAxZsrpMbwpAq8nTyxgq5AyU9RoM1l4o6ZGInvsbIb6XXr57lpnTS\nsK56uKTnsStgQNntxP5NNxiRLtGJGhp5cgm1ua3n9ZJLZZQHwiOxwCjwk8Uho6gFEE3gWxoFob9X\nLL9Vj6dADVU6Uc2T9SFNADNbxmaBL28jey0NYqkefzcvzZMzLnW/ZdnuUJfY4joATejp9W/od5mm\nH00sfXib1g5AycdRmBXN5Mcb8IWlbEI6CQtAhSGEgR6GWlctQOsMSQLmutREWGeeTkrt9hcu0AlG\n6kI6YaERmf/rpJNQ6WkB2m0mL/pVZ/wm1GxrqqgBzVhPIBI8YmKRipoP0j/U4iX0SbX0AI2jcGfR\nCQIHPLBE3kKsEgmgDL33GIsxWNk+RxJyTsvS+EoVUFRzY5kMZiKxmGOzQnPG7KNlLsN6MkERZ1xW\nKNgx35nYyeDTr4nwCTxPSHkNfXq9CqaWQEKbmTGAli21kjiZRqt0kvEmbWUyNnwPQFl0YiotwxPd\nvvx4pA9xyh06wd8urp5IKkVKQqW3CtDVFVaSWa79p9z3oBPzqdvCOL4ldNwfc4f7Myekky1lI7M2\nNOkDB0rwvl+HQthTT/DPzE8WSzrZ2s0kdyyXH3px5ssduxlSRdI+hvX004lsItz5OTpZXVyZ7UGh\nDFtQxjbgErETaQzDrR01sNK84yfgTfLGtsGzJA/PnkUnNPQlV7G668t4bVwX4QpKxk78fjqE0RxE\nCWInNFKXp5M2BcorqAMWVOnH3hDkdy+j2eokydS4vLOA3lwgYye0vGU6rROvSkZc+znlrYnwRseD\nYyePpfIVLIGXevQVGMVP98gL6cPZgGyQPNhNOhhKgbwSe54bXBUCyig6QVgJHTw1W3LWHFO1N52o\n9XMLVQlrVxdXgTzyEZR0WidcYp17g7H7sdBcY3PgDpwbLat0AjdS0Fcyd+ME9bevMjZ8j9hJs/O+\n/YUmnVAuQcXC/BzGSNibDJeoaZ2SgpboZOw9Qfm7dfKqI4+eOLc+4lkTH2KYnfXoRAuZsFsJwsAJ\nxer8wDtLssfFJu/NobCCl8gHxeInVlpHDajQwMxWIPPjO2PpRE2OWF5f3V2dSCegRUwr2pAIK6Gn\nztUHso0nEoYj9vrqf8yJBE2PYPqOnoQ4QguwwMlAOpGnYpOhEXqPj3Rbi046rfEel+t04rv/7dsk\nq6qw4tBJklEydAInuUorqrlwBrrD+LP8qXf1RgOMnah0Yj3CwaKT56/tGNs7flbXVcCDYyeYu4ET\nJP6RWDX748RUKKyoFAIhGSwmj6psLULgpBlQqpkdOjlhLJdxwDyZHQkou9LJ7mjy+tUIq6EhaZ3k\n3uAwe8hsr5PWwZJQJmn/Zexku7DHJcHlSTO+wid7gIhap0In4TGlHjpRdYjGZjKIEPYwU8nAMkm1\ntibV396xe4ktKHHumWQPYXszlPDIk4hOMjHnw+gE8zXsqIeT5fHDKkg2EmKsEyeQygnvEgI6SeZ3\n1CRLPvNCV7LUtHz2OkxCV62zGg7xxyX74I8uj/7nnJBNrK/MEuvM7Dwg5qgNG7WuIZ1g6sehE/qV\ntentAZS8Da/q/2G+/H4NiaxupL6Y3MkkcfJlaLzOOS+yVRgusDyADwGUvFqHNjR8eGUYOJHG10OT\nL6Np0QnFoIzpPIZO6DkSig4sfNKQ5cHDKzJwwm4zBtrAMyiZe4LC0yf3syxq2uiUYWLm9KBISfJI\nyq9/Pypwkoyd9NBJs1HNXIgHY3voJO9rZMl84ARFfYomf1qjhE5+BM/1oxEO0KeBr4F0MoQ5kpUA\nLfUrDT3rGj7sJB8++f7RPttihnSSQZO8feyRFTviShGBIoWFCxDtwBe7FRkfZ0JBR72FmJ5EsdJD\n9ERLw+NPeqQ027WdqZn+4SQX18HsQtEkucT6Yyc9gJI0iSxqkqQTdUeK12JwxTp00umJSnSyAKV/\nSSZreNFJFDJhOncMnaghwTB2UspfNiw5dvgrKWi/WN6AlsInSCdOVEalk2rg5AA6ARZhx05lbkXC\nhwUQEAL5Sr7we5L9HyvO0AlFn62hzOmTIYo0TyXHxNIy42VL5mAKyaRNr04nFoJk0ASOnqjnTg6j\nk+oOcyV3Muuuv8zThpSc9B7JHTV2oip3hk5Kw2kuXNXpJKD4x10lneBxWnlrMVg9P9fu08l39CXS\ntb29EQucYHqFPb+EnVS1np+Gh2oZuzDcoZfTX/iDVvyAzVa+dDY2EvD6/iGBtkhMhumPpBYWODmS\nToaHT1hgwz9xohrbRSdrbasSaKETCE6MDZ9IOlFDIP1oksT5EFnGosk2N/JsrPzBd/qcbOceH4yU\ntNFJQ+Bk79iJfGwJ0ol/OhUoRL6sgIpDJ87TTfxHqkCspfps+2WwLIPVIJnM4gpPfY3CF7a++tGk\nYfX1G9LMrQx5Y4v9UeMlu2Z2qmmdldlpWIBtl7TTyVhAScZO+hdVfsE4gDLquAmbs/zNO3CaFV7O\nUxwoneRvNp6NTiSa0LxJeOOMjw752IlKJ1bfMFsEERcAlE8+G9tmnuRVbbETlf5ZkHIUfIT1zEAn\nAyMoyaOs/n5Phk/wKAlsUxm1dB40oZcP32eOUvVVzyx0gnlH9obp9Ax0shOa+AbUPyorn+cG5Ut0\nAvjShiYNu7f82juSTtjNPpjBoSkePI0Lj5FV6QfrmTa5A24+vNMYpkllgmZQsBoN+9Oc2ZGLK48m\nUBL2ACF5hAX2QJO21YdA4HPDkO1cGIqG0yc0Xk5PojTQSfLu4obASd5wrZKdEngaiqoK5o+eJLUE\n9Y8yMtNpwALU44zGq2Wqg5UngjuFbl1OAyGhmaOPc1UjKPegEwdNAA7ysZOG24ytYyv0SbJObIb+\n1iBkl3bSHFptsiF2sg9RQ33eifptM51gb2kNmf70nEZsWFzsWa43oxMIn4TGkBUIy/eYZbr5PIZO\nVuDkAIvU3MQ3nTiHm6TCYWTMOX0S/lKxjM5JdmY3yMCfpQgKQ3L1OEtyRe0XNcH5wwfVZ+iEPctV\npniqsRO2oXwcmE3/2+NUrAofABkIJQ6+ZB6Y5hxAUX9VB599Ahf68ARlMLlzzNET6FJIQiqFyOAE\n4xLkg340YW1V+5NWzO+CpcUl44gmnbjPqqcLeafASVvs5BkVez0bwrKBVTopGWe58WOfyFB6Kafj\n741X4KRhER15CaeTJBqHdNKAJlTtJENg4KSZTuTBKxmbOf6sCZvs5JOj5H09ACIsxSNvVZDQgyab\n1Vk9rLcTnfinRjZSkXyQj6bQZ5zIhmTgBNEkfLwK1kZvTk5GNfrXfwZQqjRAM0E9GRbqSlns5C0C\n9PrBHaufDVJKLi7GJZjWUejE+Nlhuco606bhYHtWH+4wM5FmC1bQujI6SToUPFwiwyf03An1Ecmo\nvFNsBU5CvTq3gEInGX1ip4pKPJvRMJVOMHCS6SELulC4sS6Xn7NhHjNVmbsfJUkATOB/6ZNO5J3G\n8un40iKXAic9uzdLqk7WBn8QGOIomQCGSjny93Hk/cmUUVQ6wdblc1NoLgkfr3KMFiGgWEGUBjpB\nQOmhE4tIqv1pECPge/gwQ3Vx8XMnwCWVqEnPoa5wsD10gimejF3dm05UQ636lySdwLWy8AqchEp1\neoGT6STEGoQMXBWZXKk8S9tAJ9i3g/VYhkAse8puKkbLi7fzyAvVhNGQjV2nfZQrwWcOBAsIn+AJ\nj+QdOsgc1plW58QJYxrWT+gJcskpsZOHv3kd17XuFWqgAedsSj7R00MnPedONpnAo33kEfL8+vpe\nPmk0wcXFTrFU6d93Ff2rj+bonaCyQyfwlRr8yKfOwerScI7lI0p0IitZgZPT4SPsgE4nIUSzyW57\n9klSvUCzoUuouEl1p+EWNbNDR8reI3QfrMfUhjL+UG8exjKZfaFFJz0nTp4J7JeBDHUuU4AGJDJh\nD+qM1bQLow1WJ14CVBGiiXUqFk+60DeYPzr4pmIfUJyMCbq6PMHk6YRldhziQT2hrrfUkEyb4hOD\n1JUVrq/n8kmjiZU2HYsmQyKXsAejhp1aXblLxJLsLCA1s6EfkRiE1dJ7jK3YSdKDyMsP3nBmLN4q\no2xQYeXL+fPdfz+dVBWLoklJ6fFULF02DqnQoZ2ixEAnuMnLAAqwRWZTmKGT6omTXenEeR4JjX+w\nNJCPFwwXKM2w38fJ37MTHnaBqsLDqmONVBhBGdVcDzSM6kNYT2ZlqYACR0+el6fRBFfxrjmdsauP\nRVBwT6jSCQ1jy3MnYEhL28iqW6k6Ebrh3DoWKozqL52rOmN7DMcbunezS7zYiX/6uqpJzOtb8Trn\ncyf26KwBSScs9ogrkDV9CpqAekkzmkmWN9CJdbq2Qcv7Y8u00cxREvpoeXr6xCIMdqYEzqjS46sU\nU9QbdrbyLCWU6edZsZOn34pSPA1zzS65BJpYK0vSv7rWnnRSPG4Ce4z+wGQ4RwNX32Yeqdenh1LZ\nAVUa3hhCJ1g/i6A0OAvnkh7D7qv6opNQUUsFTDqB2XUARdIJ1ek2qk2iSQnJkWnUIIrVYo8GlyZA\nLYx0olo3i1SATraXgzIsdmKdrm0Ywkj7aDziDM9zsJ8DxAOnMoChBj8ol+CvBsLP4sANwCqa4CNf\n6bmT/M07GDs5K3wCGauDW29QpF0vYSsL0SSk/8cNO//0OFSrn4S1qYXRSVtgMpTJwNW3tcUAhUZB\n8D0YYWfvF3oQ6xahnn1vyDFg2P1kPc1sMsFeCMRDnZm/wDA6AZSBG4mHowlUTjUvHzBU6QTjJeqJ\nmXPRhMZOMDgcWk8MPufpZCCaPCzauHMnTkBCfaIa3leM9/JgRITeRwPFthe7uUbWaSV0ZOwkeQiX\nhnmO5wMqz87Wr26dKZ00nJDldIJQ4t68g4CyE5qMXX3PkNt7BAWhhAWww72fH4CXZlzihWqiQwqR\ngXD0TSGd0AyLGiaUts46qkWnJrN2RtUzP3lkehjTiRWokPoBTv0ANOmPnVh0kiHrjFg7y0gbmqET\nKOOHT6xnQ+GDZZt7PopOLDSBKIVKJ9tXFFB6HsLmH1hx6ETeTiwP3h58U/G3kX2PRfUASsbCNqvQ\nAReylVUFlLfL01keejPdTmMctfpo9wAsmD136ISGWGiOpgQoKnYMBBTojB878emELgG5HNgnzetl\nVD076dsx1QZ0gkGLDORiKG94+KQ5cAKKiB1jMRhaLfQ5qbV7z40MIGPWJjwkm6STzmevSQmMso8q\nnQA00Ltz8RP2tHi84yYZ1aDFwlt1gE7gv6z+8DH5eGEPHDQrHpWqn99hYW1179jcjdMvVFMz+cX1\nTSf1s7H7BU72iJ1gBMUHFGZdZQ7IPx6QTO7I2Hlb7KSEJiBVX/8zBdoARdJJWz2nr7ieDoynE5ri\nqepQHpyrmR11FTE6mQRNZGYH8zuWGZWoYcVaoCr2bX/gZJR9VNEEfkgPT3swhqBnTsHv0lMjeUZR\n0YTdXezQiWwID7JgJXh5z4ptu5YJNnymftIUQjEwIvSN30kKsmwnqsbMVe2iLaqmXB3Ck05EIiYJ\nKG+37aQfxQYRmuF3Eb/FOV6Ca1OPYL7eI+Jsr2gBChrzUuxEHoyle8s2h4I7T7z5OSmlDHxk8B0X\nSLJdFYzy6yvfyuQlU3QCibqSZsAl+SyPU1JtWt7hZvEK9AQqoVVNiyYWnbDbjJ1cjxM+kWjyfbdk\nn6oOiZ04aR0aO3GegAIEUAKUMGRCT43gj+bkuYfSSYgFfZPgXc1k64dw8nQiASVEEyxArbYkjOf2\n/YU++Kf/OfPZrDMys4O5zgz6t91UDHSy38yO2hs4PWTGXDWklo/I0AlN1uf3qBmXxNAkn9ZREcHS\nUqrSlhiTa4rpuaytVM+uWrd35Sk6ecrr5ebzpJIHFItO5DOCZHbTj6NYRIKfz5PQoZPtm9HMMRT/\neCw9pDLEdPbTCYQ91IwJy+xIMsCnqIH7Z4AS8oeMx/gHY9Xkjs8rGNc5JbPzMLXvp098TkpaQCwm\n3yRttHVh8+fNdEKfMOTcFuc9wN5O9wxZYh497Bk7QftPrXQeUMDAhg/QohtOB1DyO96tEjxHSFvP\nx8hHxU5C4CghSHJt7o0OB9RfoJO3ZZ+OpmSCKA6aDKQTdTnNiSabqB06yR/l88+g4G/xDNGzIXRi\nOXia2aFl2O8VI8QA6Fg3BldhhZaHmimdgNeXJ1HmORX7vbETx2MtVEpawDnpBFVRHUW4stg9wJRU\nlMRQ+radIavMYT4aiNqpLbrbtPI76s0yx9OJDJkgoBxJJ74q+rjJOLvfwO6kFftV20gnMpriB1RA\nrR0KUWHZQhMZBvSfxoZHYaAVvLdoWjR50om9FcMnw1oP5A6DK2PRBKKgPfYR3KR6RhU5wwlO0LOx\nEDjZKmRnUHqghB5AQUCB/jh0Yj2XZb/17Ncskzv3oxNKJCaduCvLeezy85EnX4e33p5qH51BuUHs\nREZQQkChN/EeGTtRQyYNdHLWOl3tYrTp4VOcBF6BNEnqB097wJuH9/p6g/rK3lTpBAGFJXrkGmDt\n4p/YsTlVwc9w46Pr1WS5jybIJWMtZj+dsLQOhYn8IQ+GIBDkyLzYAVjWuqwWe4sun4VP2I3NkNk5\nK63zXO0id2Z16ZjYCcVZ1mJzZqdAJxpS4NqBc6yM/jmdpO/cGbvW1ERAz96gZAOpGXcAhVr4Uuyk\n52CsEzKpHoktyWQV3kMCXbGThg6pgGKhiRM7KdEJojS0PjmXgFT9+DM7NZJ55CX9scA9bGU/neQR\nxCkpQYRGUBwEsQiGXkJTRQglFp1sF7LYySXohMaiQ0ZpyOywMBuDCalFVWqh9asOO7Oy8LlBklHa\nbireY8Wpkf8Gm9xwCd3ysffW/tMHFBoOD+nEagJtu7NlzW+2G8SyLhkrgaPphAVRnJgNUrBVhp2i\n8u/ZwdoupJ2OGUU6wTtu/Fsid4qXDLSP1t06eWRxAiSABZkISv6oCp7hTfZ8ztgJZKZOjOiEADTW\n3iW5H+mELhw4Zt52287N6ASzPLjbpDFplR4G0glk5+ULOhPeJNGgUUktpWQvbWO+3f4wmNWTfB9m\nKHkCnUjNVs+j0JylCih5OrlKvIQpRJ5OqA2F3R7b88GfuypcT+wEPb3KIv6Dzqo8AadShpyZBeJx\n6IT2fAY6eewNxG8YfRqd+ICCmR1gERZxfK4jJ6FjHECZefX1mAV6ho+9Z/Qwlk4YoAAbZR6C1bY7\nzdCJU6ZKG9Xyzgxmet6jALteexqdIKNQJaYUkqcTiAT6sZNdhbhT5c8bBOgRvNd7GjuhUWjJNwdw\nyXMqX3jSIA3Hwav3wshTIDQ0wp7PRm/kSUZQMlEWoA0oSftv3byDKNMgn4GXMFHj8eGBTYRVnb6x\nC7kf1pR6171y2w6sSvcMyl3pZJtr3Ps5CRco49BDc2YnzyU9504yPj5TJlwawzlj7171jCi89ptO\nnGxfWEtPAf+0rJPfobp+y0Tjtx0UGzJJJ5DZ6ZmIzms7YyfOvcTOrbmw71cL0BgJDQ/QYyhJCvFz\nRn74BE+fzEknH5jZecZOjCAHi51g5hQXl7JniH5wZ280eYTEOvYGnQsfLw8tuQUo0nrLYDkcv2Un\nbfFMbiZqUnoOGxOpfzqKHdWikQ8n16POmlpe1k+nzGd91nM51zPjy3NozpNw2kJhVY33NZudDA/v\n02l79k61zweUtzZ5Kp0c0B8f7dsCkk5aB7CAwgdwBotVQLE///V3eGHiBguzbkOLW8k8ndCzsezu\nYqzEPyKzNbq1eG4a5WEQtczOmU+wFT9lcoQa/9NXolOLdlh0QnvFV2V0586H0MkzhvqVZMkfPUEQ\nkbtNyijsRiHpERigqNH0/P0QEke+IYxobOj71auQS6xvoQC3WsZK8fvA6vH/PGLpVdrgdCIjKMfQ\nia/ZKp042RxGJ0cOoSL8uOyH0In062p+RIUSiiaIIyEENAAKQxn6eHtGUVY2CugE/hvP/T4l1MzO\nx9GJfU9cmU6iJ50c8Bj7SWInbxv6L0ZhmJI8GqL6IHZbA9RM8UWGT5iDwNYzjGJ5cce7+0GIKiUk\n6SSkjWq7+1idxloVOmHKcbxrV+MoyfCJRBZQyuNH0Tgh75dZR09uFjsBOsGn0cuQifqUNhYyqbp8\nIJhSBAU7Jg++UCLx6QTCPNXeDlGnF5P9jPLEnw0K+wNmTs0gOOFrv7y6R3xzctp+EQ2uFQYPa9gK\n+NzPzp2w4EfppuLnbT5D5s+uRJXzzm2mqgdjDjDRQycMKXroJHMAxaETqnU9sRNfS/N0YvXnueG3\nYzA+TqVmd+dCOp3A/AGZnuXXUa1Rs+WtPXlevjygvG/R2PPWDggdh3rYYx/Zhl49TcIeVcLyOKFz\ntfoPx0H6Xyyuo0aDAEqwreY+h3PhDBYfwYL3E8G5mbAzML9Yc/N7dmFoIqu72HA3iUNQAUXGTuTi\nKt1UfMza7Fl9zepUuhDsefKACDt3In0QRmVYyWT9oTtIal2Gg1VKCLU0Tyf+LDj1hEuvNL97FPbo\nBADlLDpR44TytJSfbmTrYYaxVGfx7Wzsi1HuRyf+bcMMTfBOE+tkSUnIbYDCugSV+I+JY3QCWFDq\namdheeikGjuRdJK04zTgkbfpMrgS1hPa/Tc6EUdG5HOWVbww79x5v8PumMAJSInhY6eq7HH5QDp5\nDFkkd5K5/mrshArW8ei+s/fVMsMiav0hYVhXhRfuoQDVOgM6CRmz2l5neZnfkXTi313c2YHjL/d3\nePSR9sf3jbmZNvsoT0Lg/l6GNIbgiBRUG6D4+R15J5Gkk2TcYsjMQlqH9gof+pKMnahUgX6ROUjn\n8xKdUEChJrVKRVKGGe638MK52//7J3h+/ftL3M8/RLvCSjDDzk6/qtEO9mgJdVe5K50w4GOKR3Vb\n8roqin46sRiULTTW+s3pZJLwCQhdTTcOROZwjR1fQNKJ3N6BQTwmhmxJoHn3Jjf06gNLMh60Z3by\ngIJRE/kgOBpB2aJB+IJLVDoBxNl7dI+1I+7WQTlnWk/SQGis87ENWdVYOtnqzywua1mFJ1fwwbIH\nLMzm1dezZPLX0hOpVTqxAt6wU82k+/Ggwm3u5cxLPoNKnbXtd3kcO5mKTgBQwvyOk328anKHRIwt\nOjkXUJrto+U1Zepkv2XwZN/Wc7L0KAnmdzY0wR8CxAO8DgPt+mA0X8hn0Uk+2CZLZmgprD9DJ7Cs\nzNMn4mGJ9HcEMY6yN6A0r7691xRYbIYF9FyjenaQ3Uts7ohety77DxOnz8tYgBIuigNUItnEJekk\nz8t4theV8op0QmPF9G4CtIOHGUFHq5rto3Sc9MDm8WdIt/7AkdvSUVmaJaF3xFDGcmInNB6TYYXk\n8v4OP7wCJ/J8TzJy48Q8rNhy+DkEqzNjUU2qGmCHOrG8X39IJyxNw7tqowmszeDyzMhzZZpXX676\nrlLNx00gNOJbbOt4rPpMLHmPcdfArnbxzEpixXgeffaPOs/m0TO3kznxw9mGk1Fy9kvu+JjteQCl\nTfUlmqh37R58Cy7wAd4WVCIVmtxhfMPohAWHsDA8XnYUo0A97BDMbD+eHC6BJMSE9bACz6AI+YGI\n6sqSgUz2yTGA0rb6quJqK78rnUBsRv2lNrk1ZZ8MdAQhKLcpcOYqLJMp3DaD1atG9SSOncxz5873\nRvDHA6jVaJ765MH9lLI6bc3lNzMKgEJt32b47kcn8sEnZz0gBPw6e6qKhSzs4Wzq0RmgHJbccX7F\nkN6a1KA5kkuQ/Ni544NvHaqOZddYNF1TcomF8Y9tYfqAsuikmU7CwAlVJItRWBCF/jmQTr59U+KJ\nrnn9z7j5RSdT3FcsdVFFZgjfqUqJkb099DKvc20lJaCA4ZsEUNp2b/6RWOq5z/KgeJdQPtGDg1Iv\noXRioQn7vBRKwQ6zO3TU8EkyrdOmsf1XtSlVtV0V/eWyss6e4+UIOnRhUjrZ72TYMYKqChYCG/TY\nh3UHg9xq4sNh841ubTmMIk+f7OEFLJ7IcIYcaeYqSSc0kJNUDCv2kxf+m3fOpWvDypXYCcwxvma7\nqZhFUNQfdLCecHxpOtkGngSUvY/gqVqVXAZvSizuccXNvTyuEary3gVoKMUnFYpc6k3R7ENgETy5\nAudqWRma7kH+UN/gUVz58BXglTnTOjvFxjNawZYV8oQKKNbjT2jchdVwQPikYfVlJNNfJqQTNQTe\ngCbULzi7Vti4Jo8hqjrpizpPJ6HCP9iuz83nL6cl2VWWEKo40gBAnE4AStjB5m06+9V0pxp8XpZn\no+4NKCcej22wj5tzpZ6SHdhE93zwoRNfUTOMQo+eSM5wbtuxTqJQaHMe+KZ+5VyLNzPvtDbbqs3b\n97b61asAUCSO5AOTPuLsDSgNq2+g9JyqGJ2w44A+mjTHNpyTKOyEpdNE6NrVAnntVYGAfRj2ITBW\nabjx6eSb/LSnRWc6mSmjho4eim2dim3Wj2NUX8ZRrMMo6gCvMjomTD+CctazTxrso3+b65x0AnOB\njKIemGV0oj5VNpMnYvkdFT7CZ+xaNOOgSZspUY1Lgx3I2/eGyp1LRgGKhTi77hwaVt9Y6Vm1AZ3I\n44C4b7R+zbize0lAsVxAZgn00ImMTzwNyztPZLrhoWE3nVj9xN4mewj6WZ3Tt9iJGjip1nhi+eTB\nqGRY78SBhE2rgMJuYjw4v9NgH5N0ctaJk3AW5K099NyrfFYseyxKBlBkGT92kjlrgrQkbwvCSVRn\nk34bbtpYVbS8X89ZdLL1EG7h6cELH3H2A5SG1Req95AClE7YAZQhZ038sE347IkGOhmivdZC82mg\nOiNyKTnthkteEkaVOdrKP3/Fl541geMm8KoK5cTyyYNR9wMUeRDvunRCYwZTpXVUxZa5Hhk7qYZP\nnBSP/Mo5aOLkepw7ljObwsxOKMMZqgHV5Vzfe7UZohBQ/JWlAsreO4cb0AncoTPW3Wy1hY/uVFts\nU91HVDV3z05nsaRiZxYpi9mU8KhKG2p8yI/9fDWxqcXXv+f1X1oCcDJWXZJi7SwGXc88QPCKo0Ph\nWHbwlOROg31UYycsnTFt4ISpKGWUkE7kfcVqHEW9o4fdq8xOuYanUjCh4wh2VzoJzV/ScHeaCP/y\nvQFl+M6hYfXtKkD0I/Ip8nuHTPjCFI4gefQkXAVhARYvdP7Er2idbb4/04qcetau2h8uWKSF4rah\nxEyo2N908mDAF6Bc139nUo/XHR3oigQUuksbbgQTnFuItFmZHfTK8wdOVEZR6aQaPrHyPhJHaDbH\nek+TSk7UxNnchFThmzxq794sjjBtM9AJrCw1xZNEf3/nMPzW4qvQiXUMdj87rHqB5PPsqaJaCmz5\n7PBzaxXQqcw7ctUy5y93Vrfaz6o1UCUZ8jFr+s21DI+zhb0ZXiBUzWnvl86LQibL8RFSV6STmQ/D\nJidlVzpheRwrrUM/p2gCj07xB5LZFGYMX6aeJNM89kvFLVpyspxiElBK6K8uzJ3W5uR04pw4KT1y\nrW1OpRdI0klbc+uqURLw6AQiKKNaOqueEFBuMEa51dvJCB4QO6Exg9CPnqVUgXf/esKsTLIw8Go7\nFctqDg+d0FROBk0sDqjulpL1zEwnsKyQUdjRriT6M8TZaWFelE4OQBNQMJnoX4Ayp/GkvQroZP4B\nZHpoAQo8++QedMIAZScjuDed3ABNHqYwopPkuRMnuROeL4FEEj6ubcuRJdHkac1fhsEyFpl1B4AC\n/xyjw6qaJLNDe0UBpRQ+gUoooNBH4yf5JiPqCelks6vshIdM6xxmexedZLRotjIfQScqO1/9sWyq\nJql2cKARXHSSXMDqkRrGXs2xk/BCCiXIJRcNRCUFvncxFVDyK0s9xZK/PBzdFenkMDQJwyfVnvjA\nHU5WWEDWH15yywI6nRyf4j1AuBY+V1XzgK72NLG3HbT6VrWP7EGx7FaUq7tS68AvPqUeDvyCEELa\nSBZgUJK5PadH0z7t2k7033VhVlffAXPHYicscHK81R1o/x16GOI6F508gZLhCQ3GDhH0Acsg2cRA\n7Uy2eEox9WaBgbu0/egEvGk1B3GKkMNGk3TyWG4jGAVYB34/md2eE3Z1FchLYFpAmY1OfDQ57LgJ\nndmS/W84ZYUONa9Oq6QvAR47kbByGwmWtPPSo6aAst/jKZmIqvZR+m/qVi8tf2AO62AsnAhhN0tj\n2AOiKQ0vWkN4z/CJ4qUW5sRutDXdTyfy13yG7Byqq69t+PmrZgucPJak8eATNYpj0UmovXJLbx29\nooEAFKxTv/qVQ1FhVy0DPk9UQsnsVEeVV9kTS8Ld0Vt0kf4XDm0dH2PcWw5AJ+z33Ic/YmEgndDs\nRunw5t6S7KnfOnqi0snbJu8rmlJ99XT1lGvnMYKl4fcDSv6XBfMdm5lOTjwM++31340//aXiEp1Q\njFBnx9Fq+hXN3aiX+MEb/NahqLzyQEnWverle5Q36eT3v/yZSnCPto+sk9IJEMkNHmbvCFANn+wK\nKFX7yJw3BE5ugyaP1f6PPzm/wHe5B80NX63XpZPO+MceB1Cqq2/4bPK9CjGwjE6OT+vIrWmGTvw0\ngqW9eTrxp6CfTkrry29ub22x6g9iJ/cAFBY1+TQ62ekmxp7YiZXWufphWBYCUZM7YezkLFtAt1BW\nODr/Odg7x2tK63mVqK2FF/BwFHj5O4fh4ZNp6eT0wAmiCQ2cI51YgfPQW+fpRNXqEB066QTXctgQ\nLTnbArRjJ788YyfJ4Z1rUgMO/fH9szsQNQFNvUFmhxpEZhb32KI5ci7ZRzVwAs/nmFmRqn1zzsZO\nO1K2IaHLX31vmVGnHhlJnja2rM64DExun/zx11+h8PZmezmYouaGNl7pOYBSWn1VNW4rjwb2xLt1\nAE1wd8osv5PWH0Un4fJxwgZvWx3xxCB1EanOOuPBM2Xa1KDnKpNOHt19AUpPA6dfSxUUoeQedALm\nDKwhvtDGXY5OpnXYzTrMzsZiKGVmDnNoQzWX1fJYSXJ32Cz8/S5kt8UBmlgvlTnk2vwoOjnmqN/W\nykYmeBhW7ktvRidsP2AtNHVdXIlONi7B15z9zpueUEePWSr5DidLqmhC923yVOwk504+Ia3z3NnY\nd+5Mi2J+LETGfgfSCdsqJRfCfsVYYJI2hHjhowkEUWQPP41OMJmOYYz9Zu3bK09AJ1tnVK0Ovaos\nIJcehk+QS/Aqq7Aj9tlWnxTdM1X8hiZfEZQDlGmnJm5JJxmbKHPbc9IJPtZ9Wofdo5nWnTvTDjZJ\nG2EIpBobn83IyCVGOQPwgpb56e/+bnv953/4BxlEYRcC9NDTYNvCvHfsBOiEnvzYe0/IQuZq1PyW\nN2z2GKvZrtUzOzejE1gYNOl46cwO2sTNFMJLNYhz0on01vAYsZmTHT2L9op0oibLLXrwYy1OeDnE\nlx6x91wL9KBmaoAzILODZViIRa5Hmmx97hB+/Xt8EBH+uODNzp089r6vQ36MTsD87gooULnM5lza\n8vdo9RWv5XTyjBG9Mjv452w7m7ys5Zntq5+KBbNIbaK6acPoMezMcKvXYwQzgUF/auR52HvTCVAX\nu7V4ZhSDlY52gc6mFftVw8hOPRiRZqoyQ2w5E5VEfIE3lDPgEwYoyDRQmF1yezrBmw/wV1eRTvYG\nFDyQS4/o3uN+iLwHvG5JETuBPM47nWBa64rjlIEToBO47f5ywT1EEzoX24cIKJRa6C8VU5O6xzyq\n/oy7H8NP3+9hJ29O/YJ00q8hV9zPhGjC7sdh2RkgD0knbC/BoiYfSCe4P9wCKDsBimr299uXNmg7\nPSPSv9wk6A+v8/gK9dgJ2wzdhk7wd4kpnVwLUJ7bNaEpCCX00fXUekLsxLq8X/MWnVgyhNgJvX9n\n/tjJEH3or+TgGtRkjUyewiKCeCSyBaIJpH7U17aFgAsloNzv3AkmVtTYCVjdvekEYyfQB/hzj9jJ\nXenk3HCmce7k919+//0XhJLr0gneTgY4cnU6cdAE7tBhVo/GkNH8nZLZgeeywy21NNOBR2Jv9qBY\nNXaCA595sA12VmWIUfUcBigUTVhgkgEK0gkNe2BQU+UPTO5AmnXRCYYxeg6gANyoL+QSZvbzdKLm\nK80dSP3GkUvETtgqPnhRe3SCgHIDOsE8DhI01dqrhE8cOqE7ubdf/nudv9sJSnC5WrET4BL4JR14\nTCqjE/zxvzs9xv66dDLQ/g4EiwNMkJozhUCInzaFqAmck2UxFfYbnNa3t7xn53m6iDz0EogBT8hS\nQGlQFUATgBO6C6UPf6NmnyX08zZfemhp62iZTPmG8ToLs60/1HTLylUQmYJOvjrxHT45uE89M8c4\nGkN58DmN7wGdYDRlp/Rnz1jktRZhgHFU92QYPjmFTtQ7dOgRURo7mTnf0TmPmNyBsc8cO/lkOnHW\n13NjQFmf3HdD06bWPgFWorpIP5xO2hbXw56/XpJO0BGAzVc3pUmb75PHE8JesRPpK53L2wb+tvOJ\nniHr+O7MuJy2+jsf1qDETh75QkInYRWTFAB1VDlaoglN9BxzgHxvKVn5bLZ7268bjN8hZMLuVWEf\nQtQEMj6fcDCWxo0uFygauEUZVdWoeiBAUkV/mTbFTYKVY7XQ5NPoBB98guGTql1Sd6E0m6PafDT7\npU1pxotDGR9N1ALVgbPyMk5DaclfIJlx+fGVzs6Hl3t0MnDxh/3oLABcAijNAAWCe/ChGjvBb5Mo\n3dnVnS6fhU6+oARDBQxH1JwOpZO7hk9g4IxOpgUUGShGw2p9JT9X7SY3N4lsPb2E2kpWVeey8unE\nD4fABgBqUB/QrN6k8wnPO3moDcns0GQ6hq5pePvpWb/2mf6EQgEImbDAyTOb49r8PehEdZcNCl/S\nZIdOLPetLihKTiFjlXrYU1ihk6/O/QJf9FR95LUY5WNo8jwDpWkqvRX+aznES+LIEYVtgTWkL9WG\nHhc7eZ17BSL5eorJzzJ2gqkNDJwgncBV4cCvWEDSySaHaelE3TAxg4DGwbGPdKZosTbDsqvRdPKe\nSeZwDp1k6KQz8apS4wwrxaITPH1Cj4lAwIOl4yWp4CcyobOhCW5HwaSraR2Ml2dOnziqy1bBriqq\nzqa/+vz+JFfuiVp0BzphUT6qspam0mUAmnohOqFEwu4fxufDyjed5i/YyryIxHo0Kg0bYB4HWQTv\n6LklndBbdSi0XY5OVNpI2rjJ6cRR7046YQdW9njYCWx859xPOnRCU+qUUdAgw6ZRWmZKJ9TaoyPA\nq9ihE7YjhfKh983TCY1APONA9R1+aR7D1WcVkF1FLQoFcliBm9AJDQlSFQT9A/2mn7PyqNaHyb2t\nIXisE/73+RtjJLDMoGSLM+OtBG0tJq+y4iUIIvRGYvWIyaMG+He78AnSCbzBkNK0Z2OpUVDjKE4c\nGK1hySxm1MzfCGZqaC7j3GuDaR2oXEY08RMrgtL5pBP0giWv1iyK6oU0egGBDcyq0Ht2VDr5hRx6\nddpl1lsafMQgTCdBGWdHqi4BJmqLWqTmO7XJcVXnMVyt+f5YTculV1WDtvIenUB+p63eI69i/CuV\nFSMlKiwzEj+y59W2Nku3PXoB/gtv6NE8TH4zE1ltpaH8ky3I+VbkEszgYJYHP2ENYSUNHZj2Ehos\nkcduIHwyFZDlbS4aayr8G9CJShjqr1bJtKm6Hv3MzpCgJtrx2RYC0AnAB9IJPfaxIchWhh1DoWGV\n6tYRy8vbHXCPSnets0mMov/BfZvN3et08mKoa9CJP4UUPsLJzgT6wkr2K6AeNLHiJft1Q6eKr7AH\nQsn2w37oejGyggXUpMZsfrpfgOzwDaMT+O1DjKBMwigOnahfWTESVtiqNi/kfOykuvvEPnCsJ/cP\nZ3KmGNfEgAo++X7XwAn4s+ZR56egWhJBAZ81Ip/jsMGJBSiAF1ujUCDZum/waRB9qzVfbbL1/mJn\nIcKM+sPxhGj5hN1tmPsJ9a9hFNsldI/lBJC/I8ltzdSvYvBB/8TKaOJm88qqJ57EPdcFoF+hHsFh\nz3pBQKGMcrocmE2gMRLVC9LyLI6CNkRCTNW8qFbb6U91HlnOVKZNIU/KXs/45dfypCzC/rToZEjg\nZHI6obfVsOQOzbDQyIrMwj/GmAOUsBgykxpKr6rNDcrPibZUqzmlwHe//+XrRwHXvyUBQwLfJ1tB\ng4xTI5i1ATQ53QHvOp8wQHa/Ek1ssSQXoAl76Mu9RbSr/NsqB87YCAPTpvJ3IeSuANqCC+FndCDl\n6tSDz78fcuIE2bFKe21SKl31SOu8H/uTR08wyQK3zxyJDotOSrN5fGE9dDKzxh8vo9WiIwFOJxrL\nIprcnkseTK9xCTzFX/7GED2dswHK9qLgsgDlsKUnsQNSOU6whPbNiWWqERc8rj5qgHNuf1U6ASaQ\nx2BL6ZthcsvFY0Y1t+opScBK7KzPlwTGSQDuN/6Ef+RhdPD4NXk6GEkFn8/GyuAjYb5zZJ8gulPH\nuOEF/vPTpplujq0t0+KkZbT7JZ9dfYVJnmdXt0/hk/VvSWBJYEngOAl8CJq8Elv0dDA79yqTPnBA\nWOWYZwjzc6R3nEaulg6RwItOIFiiwwclkkUnh0zLamRJYEngJYHP8a9fx24WnSzVXxJ4SGDRydKD\nJYElgSWB8yVAHigHsZDtCDCeAv7u3lekBB7Ltr3Y3To0iILHdD4lL3b+FK4ejJbAFg6BiMiKi4wW\n7afUVzqrsgovCSwJSAngMRH6E0Lbh/K3PPDkLALK9+Hir5Mr9Hkwn3CUeKnTXSUQ3t9714GvcY2S\nwLpneJQkVz1LAksCSwJLAksCSwJjJLDoZIwcVy1LAksCSwJLAksCSwKjJPBGJ798/XOqDguM6taH\n1ONL+0OEsIa5JLAksCSwJLAkwCTwTSfSUwKLSCLJ+FT1wq1tq0LWCm3aac7q4R7TTLuRkYDsgyrh\nPbq66lwSWBJYElgSWBKoSqDNtVVbSZZ/0knVcebHYDl1/Nz3+mEsB8epVgjf0q8kBlnMxCRIL2R9\nztSp8hbUY5FccgpXsSWBJYElgSWBOSWg+tb8h86g2ObcceLSxaiux3JS+SiAWpK1TptG96cOU6eT\nED7CAhIaKCUwYlALM7BQex+iD2tURRkHa2ijVMQ+WjkckySeOZfZ6tWSwJLAksCSQEkC0lmoDsL6\n0GpL+j61Ielx0LH6Xix0uLKASgVqPyWgnEAnrLsqTFiEYYGFSgyZhhDT8vTA2sIuhXSSnFpn7KUF\nsAovCSwJLAksCUwoAfTE1H3kP6zSiay55PicuEMYksjTCRISe8MGu2PsRPa1RCehLCi+WG2FwZU8\nH1AiWXQyoRVYXVoSWBJYEphNAnkQUUv208kQt1tyx3JXTykkE+OB8nudO0liFCUM531+hrAknWkJ\naD1BrTD0Yk1kEtdmW12rP0sCSwJLAksCzRJAl8F8BzopufWlJTH44Xt9WqzkpMItuuXN2edJpz+A\nTnCoTEx+KIbCAVwoB5D5MENqjGbCP9mIfHyRimhNoRym03lWOFSL5vWwLlwSWBJYElgSmEECqp3P\nf6jSieqgQydFOYnt5KXvRl+PbovVLz2dU9KBEstjencUZyIWM8y92gcVqqbt7erYksCSwJLAksCS\nQIMEkpv5hprPveSGT2NTYzbnSnm1viSwJLAksCSwJLCHBO5KJ/8/7d5FemD4AtYAAAAASUVORK5C\nYII=\n",
-       "prompt_number": 30,
-       "text": [
-        "<IPython.core.display.Image at 0x108575fd0>"
-       ]
-      }
-     ],
-     "prompt_number": 30
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Write a function that takes a symbolic expression (like `pi`), and determines the first place where `999999` appears.  "
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Tip: Use the string representation of the number. You can take the part after the `.` by using `split('.', 2)[1]`."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "'1.2345'.split('.', 2)[1]"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 31,
-       "text": [
-        "'2345'"
-       ]
-      }
-     ],
-     "prompt_number": 31
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "And remember that Python starts counting at `0`, so if you use `str.find`, you'll need to add one."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "str(1.2345).split('.', 2)[1].find('345')"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$1$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAAgAAAAPBAMAAAArJJMAAAAAHlBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAACGjDitAAAACXRSTlMAuxCrdpnvzWYiHG0BAAAAI0lEQVQIHWNgYBBiYGBQ\nnMTAoGwMJBhYSCVYw6ZHAPUxMAAAQGkI1Fjz0FgAAAAASUVORK5CYII=\n",
-       "prompt_number": 32,
-       "text": [
-        "1"
-       ]
-      }
-     ],
-     "prompt_number": 32
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "str(1.2345).split('.', 2)[1].find('345') + 1"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$2$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAAkAAAAOBAMAAAAPuiubAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIpnNu0SrdlQQ3e8y\niWbzIQYJAAAAT0lEQVQIHWNgVDIJYGAQY2D/wcCQycCwnoFh9wSG/AAG+wkM+kAJoMgEIMHzF8Rk\ndgCRKiCCPQFENjEwCjDwKDDwCTBI3b2rBVT8//8vBgBR7Q/Fm5CwxAAAAABJRU5ErkJggg==\n",
-       "prompt_number": 33,
-       "text": [
-        "2"
-       ]
-      }
-     ],
-     "prompt_number": 33
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "And remember that `str.find` returns `-1` if it cannot find the string."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def find_999999(expr, limit=100000):\n",
-      "    \"\"\"\n",
-      "    Find the first place in the decimal expr where 999999 appears.\n",
-      "\n",
-      "    Only checks up to limit digits. \n",
-      "\n",
-      "    Returns False when 999999 does not appear.\n",
-      "\n",
-      "    >>> find_999999(pi)\n",
-      "    763\n",
-      "    >>> find_999999(E)\n",
-      "    False\n",
-      "    >>> find_999999(E, 1000000) # This one will take a few seconds to compute\n",
-      "    384341\n",
-      "    \"\"\"\n"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 34
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "find_999999(pi)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 35
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "find_999999(E)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 36
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "find_999999(E, 1000000)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 37
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
+     "output_type": "execute_result"
     }
    ],
-   "metadata": {}
+   "source": [
+    "from IPython.core.display import Image \n",
+    "Image(filename='../imgs/comic2-1040.png') "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Write a function that takes a symbolic expression (like `pi`), and determines the first place where `999999` appears.  "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Tip: Use the string representation of the number. You can take the part after the `.` by using `split('.', 2)[1]`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'2345'"
+      ]
+     },
+     "execution_count": 31,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "'1.2345'.split('.', 2)[1]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And remember that Python starts counting at `0`, so if you use `str.find`, you'll need to add one."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAAgAAAAPBAMAAAArJJMAAAAAHlBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAACGjDitAAAACXRSTlMAuxCrdpnvzWYiHG0BAAAAI0lEQVQIHWNgYBBiYGBQ\nnMTAoGwMJBhYSCVYw6ZHAPUxMAAAQGkI1Fjz0FgAAAAASUVORK5CYII=\n",
+      "text/latex": [
+       "$$1$$"
+      ],
+      "text/plain": [
+       "1"
+      ]
+     },
+     "execution_count": 32,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "str(1.2345).split('.', 2)[1].find('345')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAAkAAAAOBAMAAAAPuiubAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIpnNu0SrdlQQ3e8y\niWbzIQYJAAAAT0lEQVQIHWNgVDIJYGAQY2D/wcCQycCwnoFh9wSG/AAG+wkM+kAJoMgEIMHzF8Rk\ndgCRKiCCPQFENjEwCjDwKDDwCTBI3b2rBVT8//8vBgBR7Q/Fm5CwxAAAAABJRU5ErkJggg==\n",
+      "text/latex": [
+       "$$2$$"
+      ],
+      "text/plain": [
+       "2"
+      ]
+     },
+     "execution_count": 33,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "str(1.2345).split('.', 2)[1].find('345') + 1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And remember that `str.find` returns `-1` if it cannot find the string."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def find_999999(expr, limit=100000):\n",
+    "    \"\"\"\n",
+    "    Find the first place in the decimal expr where 999999 appears.\n",
+    "\n",
+    "    Only checks up to limit digits. \n",
+    "\n",
+    "    Returns False when 999999 does not appear.\n",
+    "\n",
+    "    >>> find_999999(pi)\n",
+    "    763\n",
+    "    >>> find_999999(E)\n",
+    "    False\n",
+    "    >>> find_999999(E, 1000000) # This one will take a few seconds to compute\n",
+    "    384341\n",
+    "    \"\"\"\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "find_999999(pi)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "find_999999(E)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "find_999999(E, 1000000)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": []
   }
- ]
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 0
 }

--- a/tutorial_exercises/Advanced-Calculus Solutions.ipynb
+++ b/tutorial_exercises/Advanced-Calculus Solutions.ipynb
@@ -1,1766 +1,1884 @@
 {
- "metadata": {
-  "name": "",
-  "signature": "sha256:2f08d2f9fee23617e7f0ad2566e1b52216c8498b9a1db9e1130a7db64d335c29"
- },
- "nbformat": 3,
- "nbformat_minor": 0,
- "worksheets": [
+ "cells": [
   {
-   "cells": [
-    {
-     "cell_type": "heading",
-     "level": 1,
-     "metadata": {},
-     "source": [
-      "Calculus Solutions"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "from sympy import *\n",
-      "from IPython.display import display # This, with init_printing(), will let us \"print\" to MathJax\n",
-      "init_printing()"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 1
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "For each exercise, fill in the function according to its docstring. "
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "x, y, z = symbols('x y z')"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 2
-    },
-    {
-     "cell_type": "heading",
-     "level": 2,
-     "metadata": {},
-     "source": [
-      "Derivatives"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Compute the following\n",
-      "\n",
-      "$$ \\frac{d}{dx}\\sin(x)e^x$$\n",
-      "$$ \\frac{\\partial}{\\partial x}\\sin(xy)e^x $$\n",
-      "$$ \\frac{\\partial^2}{\\partial x\\partial y}\\sin(xy)e^x $$\n"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "diff(sin(x)*exp(x), x)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$e^{x} \\sin{\\left (x \\right )} + e^{x} \\cos{\\left (x \\right )}$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAALsAAAAVBAMAAADsqILHAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIpmJdlTdRDKr72bN\nELv8JKevAAAClElEQVQ4EZWUPWgTYRjH/5eP5prmkhtcMjXQjA5B49dQiDWCUj8yFBEH6SyIAaOD\nSyOIWgcTqWAXS/zARYonFh0ceqsY5LSbQ6niooPUjxCjQ3ze3Pu+vrm7SPqQXP7v8/x//1zeuxzQ\nq/ydw1VXbeE4NBR2luKlgOAK770ImGEQBB8Vw2sRoP8QCtDrXIeq/5pSKZDsMRFEfROO2HehgIQj\ntC1E36eE+roBlN7QhUVGAkXRwzOu3soOCQVS236qFrbDqoPrZdl7z9WM7AADIPip9YPZSQ5q12VC\nzJYyyS+8Gq9A0kfCQ2kTUyYfx6ZX7HQHN+9fOVagVigHaPlbM1kgnHEtIl6BkJ7YBS07VULl5RE/\ndcLUOIt1YBafgTeW0SZjwgLW8Nx6BERtWlOJeAXS27hRvepgwdjACFn6Ka0NedtddJBj8V+An2SM\nl0Hr4zhJv7hBayoer0KJDaxWHwDj186CXcB+avTxyv4eySadQ2DxX934FMU7WGJTfdP18HgVGs/R\nt7eAVObJ7Sq5+qlUxgXZ0djdrXvigYds0ovf3myeaTZf0VKF5ixgjPYyZa+d67BZmQGCShXYyq3L\nGGsp8b3nhPYLhm9zVKhGZx9lZ79oYrVEW0BvSCpeAOjVK/rpWSU+aQFPI5s4SqdnSwcTKjRiAxbt\nfe1CAaEC0E9FbLwz4dYpBx+UeLobo3+SDY0Ykr3ie69CegsR85KJj9FlJCnJQ+0oEu7W+eKB8nz3\n7nx38fTvDO3ILIxPkzunaZgouw4eDwVCOrsX+sI+K5Yv7iFXAOWyvuM92Ql6KMihR/gpj0EsxYMM\nyPNWRYz+8+mnBpjlo9WwBziC2kNTWp3jo+LiB8V5e8NT2zhKf+YtlEL9BQUbv+UNIjg4AAAAAElF\nTkSuQmCC\n",
-       "prompt_number": 3,
-       "text": [
-        " x           x       \n",
-        "\u212f \u22c5sin(x) + \u212f \u22c5cos(x)"
-       ]
-      }
-     ],
-     "prompt_number": 3
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "diff(sin(x*y)*exp(x), x)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$y e^{x} \\cos{\\left (x y \\right )} + e^{x} \\sin{\\left (x y \\right )}$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAANsAAAAVBAMAAAA9T4a3AAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAEImZIkR2MlTdu+/N\nq2Z6CBlbAAADt0lEQVRIDZVVT2gcVRz+ZndmZ7N/h+gpvUwMrhYshGBXCi0OFoqXsIuHYFHoNCtb\nsU2zB1trS8iCEGk9uIo3QReVHFqU1D+lXnSKN0nLGtRgvQxFC17arZo2IGn6e/9m3m63rX0k+77f\n977vfe+9eTsLxC0xM7UaVw+HSr/MNB7OgdF8+/wgi+Xr7J96oXDCuZxtqkLrpzSMPmc1F+qjEZ6L\nEAPJQbuwcEmJ7L8VAuxOjO92Fj19NMIXIsRB0FvK6l/FWv8oBOScGBMKeiqcwKCVp/xe1RVZPqrT\n9pKtSi2irjjRKyev7O5TcHvHeZXV/IzYIjULsmfdfCJIaKWCZxUQvXLyylh8a7pvZs6/3OtBpikI\nPW7k1fKolJlvRHoriCAH5DTGXFQc7C49rYYmJ56EWa41MXXtEOMm6P+5medrvpQmxoVSxZkTNU8w\nsA5fDSY3cPyro6/5RCVdwCz9vFDG8ATMGyBnwupiFukPsFta7DWcaLzpYMVoY4hxdOcMt/BRtiWk\nSAeMBVTcSc+UC8AI0MLnwI+hsUYKdtOH8Vf4Ldx9SHWZ81iyhdOoVPEMm4Jaro3rjS+BypH3wJ/H\nN6A+1U03hBTWkhDKOHMt/m7sdejpU9wZ4CaJslVQPYu37eYOZNrM6WR9Gvr9Wt0Tk6DiAtY6UBz/\n/tcG42idBvJtSCnsLmOj3eW/u/qKIGj+jQNgcadFXJHiHFxm/nMo+tz5rmPfgvZd2RcCBYooBsMf\nb7B52LGAFgVwqYjbubz84fLyRSKL4/Qhm7F1s9MXB0oC0jcw3+DOnUgt8a1Ly7xLo2x3qx6uN4nk\nL7ZKg9bJpaAj4U0eJq06aq+jsK7F8feaeYs2lwxwkA6NnD8g02ErSEnTUACE9OzmX/SR9AF8Qbv1\nZpFyhBSFgEhqMo7tm/54I6qsxWVC4A+6IvuRG2c0c+4CHd8hGOqLYK8j5b3k4dP0WWQ8mmWMTjE8\ngz1Syq4zbzIuFeARTzB4x8FnWhwp07czSyatu2PdphtHzpH6sx4S5bp0AJPlJ2CvbAutUv1xRu4l\nzfRwKZRS5KpCKuMwVvcFAbxQn67Obf40t7l66j+a2mrBWBx97DDdlcUavVSFc6tSD+6zXswzqXoV\nqbh49C70dcwkWtyZbxn8LsQD/ajgSkZKS7Ls+S3rN4n6iqJ/w5YmQM4hN+Mq8h79BckLqRHcQzaA\njn6A3scndKLkTNe3D9D1UJOyEtK81zN438LsyOGFGj3w/+mkm6W1Axp+INyjK8h5B3tD6kfMGMmO\nAAAAAElFTkSuQmCC\n",
-       "prompt_number": 4,
-       "text": [
-        "   x             x         \n",
-        "y\u22c5\u212f \u22c5cos(x\u22c5y) + \u212f \u22c5sin(x\u22c5y)"
-       ]
-      }
-     ],
-     "prompt_number": 4
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "diff(sin(x*y)*exp(x), x, y)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\left(- x y \\sin{\\left (x y \\right )} + x \\cos{\\left (x y \\right )} + \\cos{\\left (x y \\right )}\\right) e^{x}$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAWEAAAAVBAMAAABlFUKHAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMARHYyq80Q75mJZlS7\n3SINk/qdAAAEtUlEQVRIDdVWW2gcVRj+Zid730yWgBSRkmFbNanSrBrwwUtWC9JKLSu4RaSFeZEa\nKLIqFi9Y12gfgohjlJIghbXgQwXNEhFflIYi1BuyL1YUxEHyoPiQxMRaGzB+55yZzGVnd/vqoZ3z\n377v+/dcZgL8n8bsfbvLgGZeW8/DwbJcMej1sjUzmH0v6MTaHTIBqax1MN0CJmKBMqj/4+f0im/T\nejXk9XDC9BkuUc8RI+NLaXhMgA93Z9Cu+Lmk5du0kiGvhxOhr/YoFakYmaDUvyxJmKKwy7D8eMk3\nhZWzlZ9y1NztGaU/5xY+2QUQI+NJEaHXdSBtdcFGwifCfqqu/LwZjke9KP0xt2AxWuj6MTKeFDCZ\nrWaB67pARdi4YzupRbfzG5Xq13GUvtBSuC4dx8q4UsDxW6ZPAzPbTQG/7/5j1EzN2VixoO05W13e\nwN3P3X6ryZIMT4Exe2hxGlMzMC4DcwrndaxyrNk/38JvpdclniWCPkibbSic1/HyzLswpkdbGP7g\nRmZiZaSUMTPqKKi8fcpM2bmf0u2stopx/h6gjS+AI83UGtPJJjCFD5svwR5BYhX4hEEOr2OV48YV\n9Wf0SxiwJR7icodo8+5euR3ra7izfI+FA6klDJIu2YyRkVKfO0YDcjylJvHMspV8+a5MG98COy3Y\nouOLwJ/MpYugP46P9dYbKCwBOwTC71jm6B9Bbj1tw1iXeID0IVqtLmFwO04uYaH8PLBy2yXWdZER\nUsYavDcjF9A4+rMYxRQGlgArbYoe0xu7IDpm86LjIXZs4SBXDE9jyORiMsjhrbHMkUq8wUdawBWJ\nB0gfotVXJczreMXmJ2yT9I2X7y8zEysjpAZeOLtXIQWlP9gscN7S16lzZqsS6Rhslj1exiTJBU2m\nVjv6bK1Woaly0K7SWigCf0m87Ji/3mRU0cqOT9VqP9RqjzA40uSLki0MVad+2aAvOu6QEVJDDZGQ\n40XPEPNKmQt5Cok6cC9ym4GOxdeRe80Fy1RxM+3IqVA5yK/kedZuSDwg6QO0kVMxaXMJxBrvc7BA\nWKyMkBLb6o6vPYM/1hlHwsKjKFQgtm060HGhCXzEG3cTkg0RxvsK550KlQO+Jw3Psb4m8QDpQ7S5\nqsIxLcYg3SbP8eQNJjImECsjpMQ28Z8Y7ltKmOebF/Er8Jrcq08tfBfomG+l/NVC3SBxRW59+O3m\n5ijdwl7tJAoNiZf0IdrI203fRMLZ4eDL/AkUHN7SOBkhlajiCebF2Kkm8Tw+NjXb5FR60wGuL40V\nJ7YemNja99nfDV6PNlIXTs/v4QG/MCq+7g/zP4e7xm6OB2f/WBkT8w9KPPOkD9EmixLm3TwsT78N\n/cA7TW229BYzsTJSaq5kKiTSjmsEpjMB2zNPegYXos2+68r3ToWfDVtpx/cFbb+vdIyMJ+URBf7O\nUKGBdip0G93Ccx7gIRxrsWtT+Zo7K6/zuU3v0s66JcOdpTISI+NJbSMOb1vKGLQLdiQk3KTlBn/E\nV7Qed72+k0evaFPVPoAYmQ6p5QhHvvRKJCJdo+JGF0eLtA65Xt/Jo1e0A04fQIxMhxSv/zUNvkX8\nkSj7dm8rTL+rdzGzHTJRqf8AxgZl5oJxoIQAAAAASUVORK5CYII=\n",
-       "prompt_number": 5,
-       "text": [
-        "                                         x\n",
-        "(-x\u22c5y\u22c5sin(x\u22c5y) + x\u22c5cos(x\u22c5y) + cos(x\u22c5y))\u22c5\u212f "
-       ]
-      }
-     ],
-     "prompt_number": 5
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Recall l'Hopital's rule, which states that if $$\\lim_{x\\to x_0}\\frac{f(x)}{g(x)}$$ is $\\frac{0}{0}$, $\\frac{\\infty}{\\infty}$, or $-\\frac{\\infty}{\\infty}$, then it is equal to $$\\lim_{x\\to x_0} \\frac{f'(x)}{g'(x)}$$ (we will not consider other indeterminate forms here).  \n",
-      "\n",
-      "Write a function that computes $\\lim_{x\\to x_0}\\frac{f(x)}{g(x)}$. Use the `fraction` function to get the numerator and denominator of an expression, for example"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "fraction(x/y)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\begin{pmatrix}x, & y\\end{pmatrix}$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAD4AAAAaBAMAAAAd0vJXAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMARDKrEM1mIu+Zdrvd\niVTWGHL+AAABRUlEQVQoFX2RPUvDUBSGn7YxbdMP9Re04K4uurjcxalIBadu2QXp4qJo+wu0os4G\numhRWnARBAkOiltWxf/QWgRBRDxpSUksNwduzjnv857LvTfAPLrwfJBc1mEWfLKutNxyBK1qMTxD\nuhnD25BtxfCqIjMXw/M2SzGYbI9L4Qftwysn4jNePRoKc8AKGJ75lHEjvJAY0IXEJ7dQwBoUyxG+\nmHW5l7cbUpN5Ur0IBZVx+JbLf/DiE+n+RV/JLMbvmDfKqKjhHKs5mt8Cs97FUlFHjZz8t/SQNejb\nd+xh/IR3OKVky/m/uIbKzcabjXFcDxkqnQtp5f6liZgIc3gXUNhkthwYzKCQnHKNI0kzDilP8ijC\nPO/lfL1aJ+mOKThBIbnYOfG7bVkPfqGJR9F3NUxksyWf4uQAU8b9kbIzpQfCWVDo8x9x5EPeMJ02\nngAAAABJRU5ErkJggg==\n",
-       "prompt_number": 6,
-       "text": [
-        "(x, y)"
-       ]
-      }
-     ],
-     "prompt_number": 6
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "You may assume that the only indeterminate forms are the ones mentioned above, and that l'Hopital's rule will terminate after a finite number of steps. Do not use `limit` (use `subs`). Remember that after taking the derivatives, you will need to put the expression into the form $\\frac{f(x)}{g(x)}$ before applying l'Hopital's rule again (what function did we learn that does this?)."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def lhopital(expr, x, x0):\n",
-      "    \"\"\"\n",
-      "    Computes limit(expr, x, x0) using l'Hopital's rule.\n",
-      "\n",
-      "    >>> lhopital(sin(x)/x, x, 0)\n",
-      "    1\n",
-      "    >>> lhopital(exp(x)/x**2, x, oo)\n",
-      "    oo\n",
-      "    >>> lhopital((x**2 - 4*x + 4)/(2 - x), x, 2)\n",
-      "    0\n",
-      "    >>> lhopital(cos(x), x, 0)\n",
-      "    1\n",
-      "    >>> lhopital((x + sin(x))/x, x, 0)\n",
-      "    2\n",
-      "    \"\"\"\n",
-      "    expr = cancel(expr)\n",
-      "    expr_num, expr_den = fraction(expr)\n",
-      "    expr_num_eval, expr_den_eval = expr_num.subs(x, x0), expr_den.subs(x, x0)\n",
-      "    indeterminates = [(0, 0), (oo, oo), (-oo, oo), (oo, -oo), (-oo, -oo)]\n",
-      "    if (expr_num_eval, expr_den_eval) in indeterminates:\n",
-      "        return lhopital(expr_num.diff(x)/expr_den.diff(x), x, x0)\n",
-      "    return expr_num_eval/expr_den_eval"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 7
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "lhopital(sin(x)/x, x, 0)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$1$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAAgAAAAPBAMAAAArJJMAAAAAHlBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAACGjDitAAAACXRSTlMAuxCrdpnvzWYiHG0BAAAAI0lEQVQIHWNgYBBiYGBQ\nnMTAoGwMJBhYSCVYw6ZHAPUxMAAAQGkI1Fjz0FgAAAAASUVORK5CYII=\n",
-       "prompt_number": 8,
-       "text": [
-        "1"
-       ]
-      }
-     ],
-     "prompt_number": 8
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "lhopital(exp(x)/x**2, x, oo)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\infty$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAABMAAAALBAMAAABv+6sJAAAALVBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADAOrOgAAAADnRSTlMAECK774mZMnbNRFRmq1T9\nspUAAABoSURBVAgdY2BgFGAAAgUgZjR5EsDAmJwWwMDAXMDxUkByAYMqA0MTA8O+idMZGLgVGBoY\nGDieHACqbAAxGewQTJPnYNGDQAVBTwQYeBQY2BgYehnWeTFsY2BgupZ5gIHpnksCUA3cNgA/fhaR\n13z6xQAAAABJRU5ErkJggg==\n",
-       "prompt_number": 9,
-       "text": [
-        "\u221e"
-       ]
-      }
-     ],
-     "prompt_number": 9
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "lhopital((x**2 - 4*x + 4)/(2 - x), x, 2)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$0$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAAoAAAAOBAMAAADkjZCYAAAALVBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADAOrOgAAAADnRSTlMAEJl2Mt1EzasiVIlm7xEe\nOPwAAABJSURBVAgdY2AQMlZhYGAIYxB1YGAOYGAuYGBtYGB7ycCnwMDyimHeBgaWx2DyNRL5GCz7\nBqSS6yVIF3cAA0MUg6wDA4PQ5hYGAON0EpMbNABcAAAAAElFTkSuQmCC\n",
-       "prompt_number": 10,
-       "text": [
-        "0"
-       ]
-      }
-     ],
-     "prompt_number": 10
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "lhopital(cos(x), x, 0)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$1$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAAgAAAAPBAMAAAArJJMAAAAAHlBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAACGjDitAAAACXRSTlMAuxCrdpnvzWYiHG0BAAAAI0lEQVQIHWNgYBBiYGBQ\nnMTAoGwMJBhYSCVYw6ZHAPUxMAAAQGkI1Fjz0FgAAAAASUVORK5CYII=\n",
-       "prompt_number": 11,
-       "text": [
-        "1"
-       ]
-      }
-     ],
-     "prompt_number": 11
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "lhopital((x + sin(x))/x, x, 0)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$2$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAAkAAAAOBAMAAAAPuiubAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIpnNu0SrdlQQ3e8y\niWbzIQYJAAAAT0lEQVQIHWNgVDIJYGAQY2D/wcCQycCwnoFh9wSG/AAG+wkM+kAJoMgEIMHzF8Rk\ndgCRKiCCPQFENjEwCjDwKDDwCTBI3b2rBVT8//8vBgBR7Q/Fm5CwxAAAAABJRU5ErkJggg==\n",
-       "prompt_number": 12,
-       "text": [
-        "2"
-       ]
-      }
-     ],
-     "prompt_number": 12
-    },
-    {
-     "cell_type": "heading",
-     "level": 2,
-     "metadata": {},
-     "source": [
-      "Integrals"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Recall that the mean value of a function on an interval $[a, b]$ can be computed by the formula\n",
-      "\n",
-      "$$\\frac{1}{b - a}\\int_{a}^{b} f{\\left (x \\right )} dx. % Why doesn't \\, work? $$\n",
-      "\n",
-      "Write a function that computes the mean value of an expression on a given interval."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def average_value(expr, x, a, b):\n",
-      "    \"\"\"\n",
-      "    Computes the average value of expr with respect to x on [a, b].\n",
-      "\n",
-      "    >>> average_value(sin(x), x, 0, pi)\n",
-      "    2/pi\n",
-      "    >>> average_value(x, x, 2, 4)\n",
-      "    3\n",
-      "    >>> average_value(x*y, x, 2, 4)\n",
-      "    3*y\n",
-      "    \"\"\"\n",
-      "    return integrate(expr, (x, a, b))/(b - a)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 13
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "average_value(sin(x), x, 0, pi)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\frac{2}{\\pi}$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAA0AAAAqBAMAAACabMzBAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIpnNu0SrdlQQ3e8y\niWbzIQYJAAAAk0lEQVQYGWNgYBBSdmUAAsYEhvoGIM02gYHrA5Dm3snA9hVIM/9kYALRQMD1E0Kf\nvwChTSAUkwOELoNQHAoMgiDWIQaGh0CKce3dSwuANNf///9BNIUAaAoQgBxIZaAPNPYbAwNTTbvc\nQwEGhgiGQnYgBQQObGCKMYELTDM94AfT8yfwHwAxqhj4wcFhx8CiwMAAAMBWJoZo6bROAAAAAElF\nTkSuQmCC\n",
-       "prompt_number": 14,
-       "text": [
-        "2\n",
-        "\u2500\n",
-        "\u03c0"
-       ]
-      }
-     ],
-     "prompt_number": 14
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "average_value(x, x, 2, 4)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$3$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAAoAAAAOBAMAAADkjZCYAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAMom7VCKZRHbdzavv\nEGbh6M2uAAAATklEQVQIHWNgEFIyYWBgTWCob2Bg+sLAP4GBBUwyMIBEgGA1EDNqbQAxGXoKQCTP\nXwZWAQbmfwz3/4JI/gUMnF8ZOB4w1CswMLilLWEAAJ6qEfrOOFffAAAAAElFTkSuQmCC\n",
-       "prompt_number": 15,
-       "text": [
-        "3"
-       ]
-      }
-     ],
-     "prompt_number": 15
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "average_value(x*y, x, 2, 4)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$3 y$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAABUAAAASBAMAAABGPIgdAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAMom7VCKZRHbdzavv\nEGbh6M2uAAAAnUlEQVQIHWNgEFIyYYAC1gSG+gYom+kLA/8EKJsFiQ0UgqsBslcz8KopMMRfYGBg\n1NrAwMT+gaEfrKmnQIRtAoMxmM3z9wJPA8MPBgZWAQbmfwz+Fxg/MjDc/wtiZzFwHGBg4F/AwPmV\nYRkD8wYGBo4HDPUKDNkM9Q+Aet3SljAwXO7IDwCbAyY0YUzuCbxHYGxOBWYFGJulIx3IBACniyOJ\nEYNBrwAAAABJRU5ErkJggg==\n",
-       "prompt_number": 16,
-       "text": [
-        "3\u22c5y"
-       ]
-      }
-     ],
-     "prompt_number": 16
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Write a function that takes a list of expressions and produces an \"integral table\", like\n",
-      "\n",
-      "1. $$\\int \\sin(x)dx = -\\cos(x) + C$$\n",
-      "2. $$\\int \\cos(x)dx = \\sin(x) + C$$\n",
-      "3. $$\\int e^xdx = e^x + C$$\n",
-      "4. $$\\int \\log(x)dx = x(\\log(x) - 1) + C$$"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def int_table(exprs, x):\n",
-      "    \"\"\"\n",
-      "    Produces a nice integral table of the integrals of exprs\n",
-      "\n",
-      "    >>> int_table([sin(x), cos(x), exp(x), log(x)], x)\n",
-      "    \u2320\n",
-      "    \u23ae sin(x) dx = C - cos(x)\n",
-      "    \u2321\n",
-      "    \u2320\n",
-      "    \u23ae cos(x) dx = C + sin(x)\n",
-      "    \u2321\n",
-      "    \u2320\n",
-      "    \u23ae  x           x\n",
-      "    \u23ae \u212f  dx = C + \u212f\n",
-      "    \u2321\n",
-      "    \u2320\n",
-      "    \u23ae log(x) dx = C + x\u22c5log(x) - x\n",
-      "    \u2321\n",
-      "    \"\"\"\n",
-      "    C = symbols('C')\n",
-      "    \n",
-      "    for expr in exprs:\n",
-      "        display(Eq(Integral(expr, x), integrate(expr, x) + C))"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 17
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "int_table([sin(x), cos(x), exp(x), log(x)], x)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\int \\sin{\\left (x \\right )}\\, dx = C - \\cos{\\left (x \\right )}$$"
-       ],
-       "metadata": {},
-       "output_type": "display_data",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAOkAAAAuBAMAAAA/9CPcAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAq4kimRAy73bdZrvN\nVEThti0HAAAEHUlEQVRYCcVXXYgbVRT+ksnMZPMzG+g+iAoZlgorimZLER+UHVSKD5aGfWiFCk7x\nWRKoFRW04/pDKMIWoQ8V0aAvKuKu+NClIDsvfbCKm6daQdihiLYoNNG6lv6t59w79yYbEsUuyRyY\nOd/57rn3u/fO/UkAaanpSozG6XbOlcYpJ7XMjQPu+FWz9fFrAhMJzC8w10xirItJrGCsJjFU3EhC\n1fojCdXszSRU838moTrZTkK1Fg5UdQJJ56KBxf+TvBjnf6HqLXaPppqrSOCQgnti8NsLiunzT3/5\nRHN3H9cXWkoj48cl5UCnXPY0xBkFCwoMWXXpV4Cf6fk3K1RVaRiDo5FiYGqEbKBwzpXI+UsxW7z5\nDbWY/o8V2dBVPpLI3NT90EUEbM2adcmnj/eWa1w4QtCJczTbBzhH2gHpin8rAnjI1/h3jfC1hAWv\nS/WgfS0KjMFlKs0JFUKe02ly4gPx4mfvGOWSdWpPY4Xpx+jZ9fqjbwbAToKYXbjcUgTHygxR3fRV\nLLwxNd3C7sZeOMc+CYnJuNSxmR3nnyQ5D2yFK8KZy5hAvoTCaTwbEXMWMN3cezZN608UOoexWlUE\nMt8JK1FB5hq9+q0WWS9aJ5ByDwLUAApNYB6fNl8GiiHFwKRcms4JpFk1X8dkQPRr1C1k20Uf+JVC\nuoOf0gTF2iYGraNvkduwXRgbl6pwKdWOQH4R5/QKmIurHb3DF6rLUvUWjRWpZaqCGj1l4F1NMKlM\nnmxi8T9yku0Dmky+T+iD4IrdeZsTJyOgirsYWm1+Y0k6zH/Y6VOlPgacwarXYVI/YoJJZbaoToPo\nMYdnfSkCbpj3bpYIsyrwEr9i1X0hB7AqWGrxDMdjfZXJOZ+6yDNsXEWxTQOSBDJiVCeXKSUldrHH\n2drE3bneAjrPIccf0CZM883nQbzH1jyRXQyQCXpUTwO5yiKypPo5TfZNpMJzihAV4pd1lUCasnrt\nfapM39W6dR6gdYt8E/g428ZbxIcicZP7QWvrCPKVHlXaLuvNU3iYinjnnMWPnqsIzte21ILzuI4k\nqLXwBq36vPdDFV8RlfZQvJavG4HaOcZmhWga+UzjAavc2V/uPL/Kx/wl4ODC/EyT4Pf0zDZ+WYkU\nQXHXrLun9nYjiYypBR+Hpu/EhcZCRJRzHObKPdPHCBY4Ru/RxLEyW3aGQnUiqpLb8Yd1JXkiZq9r\nYgtQZz7NSbCl4LaC+MynujOifopXwyA7o8hnFNiG1zedGYpWJjaGNDar+B0KbMMbpbhySn64ob+a\neMGxZX3htvnivcAmjio6eEIRjfm17o5ZUMg9GCWhupaEaDJ/rcRVOPbh5oZt15H2JFUfafNDGre9\nIQUjpWv+SJsf2Pj98hfUwLLRkWv7uxff6FT6W951n99PjT7+B1zw9sIQfJxvAAAAAElFTkSuQmCC\n",
-       "text": [
-        "\u2320                       \n",
-        "\u23ae sin(x) dx = C - cos(x)\n",
-        "\u2321                       "
-       ]
-      },
-      {
-       "latex": [
-        "$$\\int \\cos{\\left (x \\right )}\\, dx = C + \\sin{\\left (x \\right )}$$"
-       ],
-       "metadata": {},
-       "output_type": "display_data",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAOkAAAAuBAMAAAA/9CPcAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAq4kimRAy73bdZrvN\nVEThti0HAAAEH0lEQVRYCcVWXWgcVRT+diezs9mf2UBTKVpwCBVSKpqWPvRFdlARHywNFaxQoRME\nEfqwgapYQV1TlVCh6YMiig+LviiISfEhoogj2AftYvZJCwoZRGgLQjfabkOadj33zrnzE7MhDevM\ngdnznd/vzp07ZxbwJTMyxihJtas6lCSdz6V3jljJs+Ynk+cEBlPYX6DaSONeZ9I4wfgujVvFahqs\nub/TYM3fSoO1+E8arJV2Gqw1d31Ws+77C9768TvyXubsL1TVTI/RNKESHmNgztvKFddPn3u0sT/u\nIit6SnOKY8DhvHvrDNao88ouKVBpKRTT2VeAP+laI+a10FEaV9hl8LqnPDGdryuzYDG6GtSqkND6\nj+TO8pF8MhKJZE8H7o99pHcj0SAIGIFbn2T37kg4hKUXCZucczH0R5FI8eWIr8o3lCOu/wrNbxn+\nELoi6FCLDM32PRFW7bkgyXQDWBTZtDc8ELXhkRb2Tx+EefpTl/wP07XvjYferAO7CELb8cAtaKPb\nLj4urFA0Wa87vodZRY+9Szj+wvPv1CkwYFG9X5q1yQZK/NBrXu6l3HvIWEeBs+T/iZ6YVfjQIPy7\nyLs0VryOw/iscZKMgaaUIQFXRFQJs8oe54ALDf02hUoNqNKyK1MrPBAvoNAxLGidK+OwKPIabQPy\n7bJDhGRqKxhwKTCDX8iKyGBstDGr7EGs88Ay5RoeVCkfgKpfpYlvwFXa9GvG0tsEQWvUkZkTsEZX\npo1BC+O4Rzii4o82nV3MKnsQ6zc+a8WDKs21Zeasr0yxUbMUXdV3d4cIi52BURe/grUyh2Me6Zfp\niokh6+UGPNFsvt9sfk9h2SPOyqXMesiVTeQkWWwBS8+iIDb9VeGuOrRGucPVOhYJax3aAXqYH0iZ\nI5i5LhJt8UPC9yp7hKwG9eVS3uEFW2QDHwEFeq6521QojunXZI/NIE+sn5N5rIWdZeeTfBtviexQ\ncsuEs5QlhVllj5C12AC4tODKvK5YB0mthVPmCRTtX8fxJdn0uiw25nHAh3QMy+9myyvFSa1OnqjM\ntmA+ohzMKnuErFkbqpQgidYdE4rA8JSDiZG78cf0lEf2FeDo1OHRBsGf6dJ2nDl+Rv/qvpHTZMQk\nt3P4YOBgVtFjort9onvXbzdsmlxnoUpLnsjtNZpg8GroaEyKxM0Js65NPhE4/ImYvxk44iCY+cjW\n45GNrMvrB3nmU3BUJmSW188DzqvAMwpsXQdfOt2VTQY7vXrtVYFtCmxda0Ncm/GfW+9/Teqw5p2t\nswWVBxjJsUcvjBtEEgSLVoJkAdWDXgATBAsJcoVUqyFMDsnPanJ0zFTo+br+n0vJ3MGM7d86DLt/\nvTbfqeZsPrdfmff/989Xv1pv0GfhqfDDt0Fan0P79jh97riJdv8CeDoMOFAR3oYAAAAASUVORK5C\nYII=\n",
-       "text": [
-        "\u2320                       \n",
-        "\u23ae cos(x) dx = C + sin(x)\n",
-        "\u2321                       "
-       ]
-      },
-      {
-       "latex": [
-        "$$\\int e^{x}\\, dx = C + e^{x}$$"
-       ],
-       "metadata": {},
-       "output_type": "display_data",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAJ4AAAAuBAMAAAArYb09AAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAq4kimRAy73bdZrvN\nVEThti0HAAACn0lEQVRIDbVWPWhTQRz/5eM1rzEfHUQHhwSxWLDQtHRwkQQqflEwONRBhzg5plAH\nB6WvwSGgEFEc1ME3u9jNbk0nUQLpIIJTM4gKDgY/aqHWePfu7t1F48s7OG+4+///v4/3v1zuJQAb\nkcMFHplZjhTHzBgxF2v7Yt6kn71o0g0YNbpboOia7a9h9nSxbrY9/DTrN/LFrJ+9Z9Zv31ezftmu\nWb9qU/pFVz4ekJlOJJUN5XqMR1ZvMpdP1wa7Wbf3n4uV/sakMudItJNyRfKPUzrqInPaJwkyIJXL\nHVlFVtyVzHelKsPLD0g8xUiW4HqwUFq9sqTjKiosi95VqjJ8QckfWJ52ZB2+Mv1DVke6k8izNFWS\nZRnFvU9hlhVUP6mMius2OzFnrb2ued1O1z5vYmblxC1HetGo2KTzAp0A309VIvWNo/fBnwtklrBe\ntvLJRwm66/kWHRuUdt6lMx/CL60ogSw/yGIHpwSTvBHnEYXdTVdEia1PCkou/FQl2QK/bgef1n1y\nDrgHC5FVRe2FPW8us7LwU5XAsy5D+ba9ZBfWLxIkHAbJeZmGXtPxVuvljVZrjOSqknwkTcoBdthC\n59gO0l2LtF4BbeXsQzoeUyRH8ziNyBD9KUpSbZcoBlwHbBbB2kOk+SZZaMCmemVUHZKM84LwU5QE\n6W0y+A6sOU7EK7wt5bfc5zguKnxNksN7V+CJ8FOViPU4HD1T98XT9fdrnUu1CxOuX+LBlY2T/Ply\nv6oS6vX4UzwkF/310ezdvlQnyTgD2JH+0xnA0CuNbuvxh7H/56/HsGeHwbfyYVjhOVOd8NwwzHYY\nkgZHvJ01JEHUmOE/Q0nDX7/IYlD3+liipK8JUlQrQaguNolDupJAfnthKRDXBWeOVXQlQfzfXemX\nZqu0dL0AAAAASUVORK5CYII=\n",
-       "text": [
-        "\u2320               \n",
-        "\u23ae  x           x\n",
-        "\u23ae \u212f  dx = C + \u212f \n",
-        "\u2321               "
-       ]
-      },
-      {
-       "latex": [
-        "$$\\int \\log{\\left (x \\right )}\\, dx = C + x \\log{\\left (x \\right )} - x$$"
-       ],
-       "metadata": {},
-       "output_type": "display_data",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAR8AAAAuBAMAAADjKADCAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAq4kimRAy73bdZrvN\nVEThti0HAAAEvElEQVRYCc1YXWgcVRg9u7Mzu9m/LI0PVgsZQ5SAgpvShwhKFpWah0pDBCNYyoRC\nwaddrIIK6hqirL4kFvypD7rokygmC6JVkK6CD0po4kupWMg+iG2p0FRrDG3a9dy5987uTneq5mXn\ng9n7fed8371n7r1zZ1hAWmQor7yQNMPjuZAokTLMjWk7VIISpVDJAfrCtWDAeDVkMzQfsmcMJ0I2\nQdgKmSDrj5AJSlwLmaDUnyET1L8eMkHFendB2bLEk43u/LbQc6rqs5tUz8uDeuY7X86Mjvcq58Iz\nGvG1T9Qeru7xYW5o7bI7YUu/FGJOJ9EeDZZl9GY7SP97Hae1E7D7oy8Av/LqYv63UnpSJ9W1c2P7\nckNitU4qUdZx0pZe9i+NdLTmDxwlqp6MxzoopPSMKLji0R96nt8xm0q1T1DcuxmzJGuiC/5aN04/\nyyarck53pvgFiVRp09q5oc38rSCfoN9bmd9IN11oQW3e/lUGhuJuLihb9+pSoqqrRfWbg4L2VB4F\nfpqrvM7MB3ntfuWBuTIwTBejsxdXNSBibYZbbzoyVoKMkYHTE0Q4Q8bE3Coyt05UOL8xm9IlFS2Q\nbjM1FJH0ZQXXYL2FiM2d8m6U0I+AaSffi7OfMwyzR3BiUgOILbuWIxG7wh/PlKApfFx9niAFPTWJ\nHbg42Ve2OVYVUFSmTrplXs9Av352aojbMDZSC3hEJL7EnYrEesYBzjLkR9M+DxC8tr6Og14JsjGP\nU8ygoKdZ63yFWIlhvAEoSm86osL0UHTHdYc1cE1wObKAnSLlOmcIkSXhFnkNAkc9QIDa5EFvqlAJ\nmsTtLpDKZXm//YWdYLd0GoCirHXG9x8T9j49PRTdRcEIq2GxAWxZG+aLIqQg3lJZ/ApBV2EKRAIC\n1BZ368V0YN/y8jvLy9+6zHPubyqXZFV/vehMrxIQggCXcgWJSJvX8/66gmpYY9ElY3bWEYiratzh\nHYklMzaRWec0SAAx99aOLTEv4p5OBVFCUzPEpedNiyXLiBnKjY3cJdi4UCUp35J5PQMrBZFKc/eQ\ndV2/ur4Gkvl5JCjoU07pNUTqpzQgC+Svtck2yizXlKCPEut4lYDcQ8WGenWlqoCiknU3X/+09dwU\nqoXVxJOUKmS/OJwXIZ/1teqXGJMuH7qfC7YGBO/Z4iqyD+lICspcSZWMMjEKOpvH57hw+JDIiBag\nKbrt1urZaLrDAzPNAcwM3QZ80GyK5PPAk7NTI1W6J3mNVn473tAA45ZZu27h6aVMCjKP3zn0BhFr\n8FLe2nFHFX3NpjhdsgvQVLqhKmTT6tk7qDV/oIGDRxnElVAuV0lz/96qJfMlmidhnrcJHvGIwFdH\n4qqXI51P2PzCS79SOdFlyfyX33Ndk5JLQIYXWq/Uka6JBCObPuY+B+CGbvv8OODL+P+h8Ta3U5V1\n3ueHWQ/qpW/Dx5hDlWFHYKOaGNDO9tupkdm9otrIqT4i+aDOgr+o3ceEZQknqHYb+JiqeS2wtlgP\npHpDrNm9GTdw1HsbgVRviJXeDBs86lYw1RPGCNs/DUn/MdSTaWkbNFJqC8LgxgthUNGmoei0Bb13\n71Hf4r1XohSsPN76QAmFqN13O6HQoUX8A0JEKJn2S4DjAAAAAElFTkSuQmCC\n",
-       "text": [
-        "\u2320                             \n",
-        "\u23ae log(x) dx = C + x\u22c5log(x) - x\n",
-        "\u2321                             "
-       ]
-      }
-     ],
-     "prompt_number": 18
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Now use your function to compute the integrals in this Mathematica ad.  Remember that the inverse trig functions are spelled like `asin` in SymPy. \n",
-      "\n",
-      "The ad below probably has a typo, because one of the integrals is trivial to compute. Include what you think the integral should be, and see if SymPy can compute that as well."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "from IPython.core.display import Image \n",
-      "Image(filename='../imgs/Mathematica-ring-a.png') "
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAANAAAAEECAYAAABZfLr5AAAACXBIWXMAAAsTAAALEwEAmpwYAAAK\nT2lDQ1BQaG90b3Nob3AgSUNDIHByb2ZpbGUAAHjanVNnVFPpFj333vRCS4iAlEtvUhUIIFJCi4AU\nkSYqIQkQSoghodkVUcERRUUEG8igiAOOjoCMFVEsDIoK2AfkIaKOg6OIisr74Xuja9a89+bN/rXX\nPues852zzwfACAyWSDNRNYAMqUIeEeCDx8TG4eQuQIEKJHAAEAizZCFz/SMBAPh+PDwrIsAHvgAB\neNMLCADATZvAMByH/w/qQplcAYCEAcB0kThLCIAUAEB6jkKmAEBGAYCdmCZTAKAEAGDLY2LjAFAt\nAGAnf+bTAICd+Jl7AQBblCEVAaCRACATZYhEAGg7AKzPVopFAFgwABRmS8Q5ANgtADBJV2ZIALC3\nAMDOEAuyAAgMADBRiIUpAAR7AGDIIyN4AISZABRG8lc88SuuEOcqAAB4mbI8uSQ5RYFbCC1xB1dX\nLh4ozkkXKxQ2YQJhmkAuwnmZGTKBNA/g88wAAKCRFRHgg/P9eM4Ors7ONo62Dl8t6r8G/yJiYuP+\n5c+rcEAAAOF0ftH+LC+zGoA7BoBt/qIl7gRoXgugdfeLZrIPQLUAoOnaV/Nw+H48PEWhkLnZ2eXk\n5NhKxEJbYcpXff5nwl/AV/1s+X48/Pf14L7iJIEyXYFHBPjgwsz0TKUcz5IJhGLc5o9H/LcL//wd\n0yLESWK5WCoU41EScY5EmozzMqUiiUKSKcUl0v9k4t8s+wM+3zUAsGo+AXuRLahdYwP2SycQWHTA\n4vcAAPK7b8HUKAgDgGiD4c93/+8//UegJQCAZkmScQAAXkQkLlTKsz/HCAAARKCBKrBBG/TBGCzA\nBhzBBdzBC/xgNoRCJMTCQhBCCmSAHHJgKayCQiiGzbAdKmAv1EAdNMBRaIaTcA4uwlW4Dj1wD/ph\nCJ7BKLyBCQRByAgTYSHaiAFiilgjjggXmYX4IcFIBBKLJCDJiBRRIkuRNUgxUopUIFVIHfI9cgI5\nh1xGupE7yAAygvyGvEcxlIGyUT3UDLVDuag3GoRGogvQZHQxmo8WoJvQcrQaPYw2oefQq2gP2o8+\nQ8cwwOgYBzPEbDAuxsNCsTgsCZNjy7EirAyrxhqwVqwDu4n1Y8+xdwQSgUXACTYEd0IgYR5BSFhM\nWE7YSKggHCQ0EdoJNwkDhFHCJyKTqEu0JroR+cQYYjIxh1hILCPWEo8TLxB7iEPENyQSiUMyJ7mQ\nAkmxpFTSEtJG0m5SI+ksqZs0SBojk8naZGuyBzmULCAryIXkneTD5DPkG+Qh8lsKnWJAcaT4U+Io\nUspqShnlEOU05QZlmDJBVaOaUt2ooVQRNY9aQq2htlKvUYeoEzR1mjnNgxZJS6WtopXTGmgXaPdp\nr+h0uhHdlR5Ol9BX0svpR+iX6AP0dwwNhhWDx4hnKBmbGAcYZxl3GK+YTKYZ04sZx1QwNzHrmOeZ\nD5lvVVgqtip8FZHKCpVKlSaVGyovVKmqpqreqgtV81XLVI+pXlN9rkZVM1PjqQnUlqtVqp1Q61Mb\nU2epO6iHqmeob1Q/pH5Z/YkGWcNMw09DpFGgsV/jvMYgC2MZs3gsIWsNq4Z1gTXEJrHN2Xx2KruY\n/R27iz2qqaE5QzNKM1ezUvOUZj8H45hx+Jx0TgnnKKeX836K3hTvKeIpG6Y0TLkxZVxrqpaXllir\nSKtRq0frvTau7aedpr1Fu1n7gQ5Bx0onXCdHZ4/OBZ3nU9lT3acKpxZNPTr1ri6qa6UbobtEd79u\np+6Ynr5egJ5Mb6feeb3n+hx9L/1U/W36p/VHDFgGswwkBtsMzhg8xTVxbzwdL8fb8VFDXcNAQ6Vh\nlWGX4YSRudE8o9VGjUYPjGnGXOMk423GbcajJgYmISZLTepN7ppSTbmmKaY7TDtMx83MzaLN1pk1\nmz0x1zLnm+eb15vft2BaeFostqi2uGVJsuRaplnutrxuhVo5WaVYVVpds0atna0l1rutu6cRp7lO\nk06rntZnw7Dxtsm2qbcZsOXYBtuutm22fWFnYhdnt8Wuw+6TvZN9un2N/T0HDYfZDqsdWh1+c7Ry\nFDpWOt6azpzuP33F9JbpL2dYzxDP2DPjthPLKcRpnVOb00dnF2e5c4PziIuJS4LLLpc+Lpsbxt3I\nveRKdPVxXeF60vWdm7Obwu2o26/uNu5p7ofcn8w0nymeWTNz0MPIQ+BR5dE/C5+VMGvfrH5PQ0+B\nZ7XnIy9jL5FXrdewt6V3qvdh7xc+9j5yn+M+4zw33jLeWV/MN8C3yLfLT8Nvnl+F30N/I/9k/3r/\n0QCngCUBZwOJgUGBWwL7+Hp8Ib+OPzrbZfay2e1BjKC5QRVBj4KtguXBrSFoyOyQrSH355jOkc5p\nDoVQfujW0Adh5mGLw34MJ4WHhVeGP45wiFga0TGXNXfR3ENz30T6RJZE3ptnMU85ry1KNSo+qi5q\nPNo3ujS6P8YuZlnM1VidWElsSxw5LiquNm5svt/87fOH4p3iC+N7F5gvyF1weaHOwvSFpxapLhIs\nOpZATIhOOJTwQRAqqBaMJfITdyWOCnnCHcJnIi/RNtGI2ENcKh5O8kgqTXqS7JG8NXkkxTOlLOW5\nhCepkLxMDUzdmzqeFpp2IG0yPTq9MYOSkZBxQqohTZO2Z+pn5mZ2y6xlhbL+xW6Lty8elQfJa7OQ\nrAVZLQq2QqboVFoo1yoHsmdlV2a/zYnKOZarnivN7cyzytuQN5zvn//tEsIS4ZK2pYZLVy0dWOa9\nrGo5sjxxedsK4xUFK4ZWBqw8uIq2Km3VT6vtV5eufr0mek1rgV7ByoLBtQFr6wtVCuWFfevc1+1d\nT1gvWd+1YfqGnRs+FYmKrhTbF5cVf9go3HjlG4dvyr+Z3JS0qavEuWTPZtJm6ebeLZ5bDpaql+aX\nDm4N2dq0Dd9WtO319kXbL5fNKNu7g7ZDuaO/PLi8ZafJzs07P1SkVPRU+lQ27tLdtWHX+G7R7ht7\nvPY07NXbW7z3/T7JvttVAVVN1WbVZftJ+7P3P66Jqun4lvttXa1ObXHtxwPSA/0HIw6217nU1R3S\nPVRSj9Yr60cOxx++/p3vdy0NNg1VjZzG4iNwRHnk6fcJ3/ceDTradox7rOEH0x92HWcdL2pCmvKa\nRptTmvtbYlu6T8w+0dbq3nr8R9sfD5w0PFl5SvNUyWna6YLTk2fyz4ydlZ19fi753GDborZ752PO\n32oPb++6EHTh0kX/i+c7vDvOXPK4dPKy2+UTV7hXmq86X23qdOo8/pPTT8e7nLuarrlca7nuer21\ne2b36RueN87d9L158Rb/1tWeOT3dvfN6b/fF9/XfFt1+cif9zsu72Xcn7q28T7xf9EDtQdlD3YfV\nP1v+3Njv3H9qwHeg89HcR/cGhYPP/pH1jw9DBY+Zj8uGDYbrnjg+OTniP3L96fynQ89kzyaeF/6i\n/suuFxYvfvjV69fO0ZjRoZfyl5O/bXyl/erA6xmv28bCxh6+yXgzMV70VvvtwXfcdx3vo98PT+R8\nIH8o/2j5sfVT0Kf7kxmTk/8EA5jz/GMzLdsAAAAgY0hSTQAAeiUAAICDAAD5/wAAgOkAAHUwAADq\nYAAAOpgAABdvkl/FRgAAv9BJREFUeNrU/XmU3dd134l+zjm/4Y41YAY4AKRAQuIgkwJlDaZE+knR\n4FB2EktO6HbiKN2hYrcT97O0Vi9bK89Wr5bc3ZH8nuN+K4nciSy3bTqW7I4tilLLUgyKjGiJhEjJ\nJEQCEEVwQGEq1HCn33TOeX+c87tD1a1CjVDeXeuiClW37v0NZ5+993d/93eLNF20bPihgICr+zBA\nG2sLQKzyuo2eVgMhom0/C2tbQL6GF679jISIEaJ2heuyFceeg+1gMVv6WUKUXycBeZXXlcbazrrX\nTWCt3cRCtv5ExVU8UeGfFqxd5+naofewY97X+kUdXgUD0oAevXZ2I6Zvx9yT7T72wh//+o5WrPif\n8n3xG7K4Kucx+tkpUKzbcIONHaj1T+09wdX2QmroGJYfmt2UB0qB6lW4YcYveMFG7MWO/cXVMqDc\nG9DQZjZyHnasldghT2PNwOOMWJAIrrrxuHWcDF3DdRnQpi6l30XVVfZCEdAbPVk7fNk3cwOKMQti\nezYBa3PAugVlBwtqY0GBuUrRQHnP7ZJrbdccRpfnN+485VUIn5cfTzK0ma07hDMbvIjl1wJr5VX2\nQuXOZ65wYdYSuo1778wb6XbeNPxCdLuxRbD2cHql89j+0MdFHIU/Vrsld3LwnxBrr3b4VnqfjW28\nweYP1iJEjrVX2wvFfqHbZZm23RSwYLG2uApAgl2yA9t1/e3WgSYbWXB6aPMS6zB2Me4q9DdDQXyV\n1xBY213HuWxpCGeHnoXfTa+mF4pGjWfLQjhYEzq2ZeHQuJ9tZBGZq2RE2l8ftcZrbddg5HZrMooN\nhevppq5bsHnjKRPD9Cp7IQmEYNOVIu1NLOrshwuEbBjYuRrXPt8Gj2eBGCHUD8H7LAVDrkoIZ5fk\nQaUXyrc9dxh9VLD0tsErmCFwZDvzOMvqCJZlOcq10vfmKuzg2iNwFiHMKhnNeo3ZIETM1az9uFpW\nAsIuOWZxtQxoqSeyCJFgbXgVvVA8BCZsRfJphxZKhhDbCWfbMZvRSr+HUfzaLskhylx0uwEEQ4lS\nuvxNjD1mhyoO0MXyZ+Pf0yLE1QahADpYCrDSXbv+6dirYUDLjWfghTK/sK9WGBcD3a0JKfp5lEGI\nYpuPfTUPJEaMxV6RcXG1kCvjoXexiuHTR9KGjWxlgNH48C28aqZjbTaEvLnN1yI2VD8Its54Si/U\nxdroqnkhIaqegiE2nkcsQ+7MVciDVH9hCWGXFEjtOs/F+lLCdl/zHGvNGnIVu/Zjt1z18M1tuMOs\nA/vDCOGGq7bDRqSBhKtRzXeP0F8Is8qOw0g4sbZdqvBx/nbdWNGvpYwe1xJvZAc5kF0GBw+DOME2\nG5DF2qwfdo072hVTolXvi4KrWDy1NvXgwdJ8c2PAyCYMyIz1Ru7i9oDKVfJCyhtra3SxL/Eqg5su\n1njh9FWrB42GbGVIMewNV9vdr074Zq3xfLGlOdgqlmNXD15L8EBcNQOyWNv191UuyS83tlY3aEDL\njWdQmS4JmT2gdjWCOG+si6xenBwXt9tVESfn5rfn5vbDIDsMBKx2XHbV7zfGKNlI/rPSdRVjDHo1\nTpwdiiCuTrjvjr+zyia6oUKq2bA1l387ajzl4uv6hb39sa0QIdaG/gJJtqa2on0etF2bgBxC0Ta7\ngEokazsfZbFcrnBd18+JA+XbL65W+Fa2waghe1kPzWuLQQRrxwEK5SPzXqh+FS5N4MO4dMt2sxKy\nFVeXWbIBgy9vfLitRmRt5vIxsXXnJ0TgAYSrhbwNvE+5dEV5QmJj4fCGc6BRrzNsPGaJF6peBS8k\nfKglV1mIq+U7Sy6cLdGYctdV23RT7YaT15UBne3KHdI+lLH5e+W+Xi3jGXgf7QxGjNmm7Jpwj+UG\nJGUda8cbhENJzOjPrfX2a1fxPiXKlCDE1fJCkX9mG9jRl/LpbN+AXMK5PQYkRIS1vY3ZzFIoYVs9\npR0CENaGZo5DPYVgaF1JhKhfJePJMKY9MH9/YGLEpkvPtL4LKZfvZN5I+sbDCFBgx9J4lj6H/669\nzbvjYDG6YpxZ92K05XPpr0zpgbbrIdfmXIaP0a60bW0fD3G4A3WtpYBxryuPvwx+rhb6Zu3i2HXh\nVzXWbuoOLrkVyzo6bf8Gjg/VVtseha/4JlfJUa8DtFjBaEZfUjKPr1KeY5cb9Jq6bqz1XnK7DGjr\nr4GU1atkPCnG9K4YhYz2jq39GbgFVww7awa8qqUh2zjkZdx+aJftAEJcDUSugoNF05U/y66vi9/a\n3F+LrV+cAomxW26G27IIr7RLr7egKkTjqhiQMYtLooiV7uWGmQjRkAGVZEA7lOTadVjm4D0GHkt4\nD7T9uZCDswOsTcf0269joQ291qE32lf6t/qAw62zHru9BrQpI15Sm5My3p7rOdbwk1WMZfT/1l4Z\nJJGq6gEQiRAS6WLncEzItlrBcSUmsR2Kc4cNS2DtAlejYi5EdbRIuYZQbeWwTnr6iuaH/lglH3In\nHmzTIjQYk2/piUhZ52poNxizCDZf4eaPr1etxUWMnIv7ZsAnGzCuVvM+jAnprpSM5R6H324DqvuF\nb9dnNCsambn6BnQF4GD8Y7t6l7K1ZmJrDlyvRvHU2p6j7Xif0t/Y7WoXXazzJsnSgCQulBNj2MB2\n/Da45JYup9CM81qLV8ELqf65bBZEGHjV7QISgvGehc1ow231Qsy28P0tUlbY3kZFt+lp3fYo6nIa\nkd1s2a2/EVSGM+1wKJRbyWhWWoj2CsZTZpI51ravkhda0UuvPaTrAwnZtixSIdTakbYf0sOYbOUL\nOTYqWSXwsQYp69tOO7I2cYzrVT7H2tVSk7VsVSFCVByVR/Qz7ooHFAqWw9ErUWtLMoQdC7sshQeF\naCNEc1tjYEENgwQxRrhwRTbKSso+glJ4YutvvPDX3m5isVgcp0wO3cetBxDEsqsmxvxXrHqcQiqk\nrGzLcQ7fPK3L2qNaHRhcVoEWVzw2IVwRuMzjlqyIssOTJeHZGqr44ySLxuiyOVRrm72QUD5UWE/C\nsZJ3Ej6EM9ti6lvlybZjV3fFU7uqb7FDYdG452AZWd8iv73om6v7dLhSyWSjXt+1oNf6KOKYT4lG\nULnlrs6ugszZkTBp/OuMN6DtZSdcuc5gGS4Sr3ZB3WLIt+EYNwhjj4uO7PYsRjbZJjG0DSNldZuV\ndyxaL2zuaK+wUzgPWhlxOWMeNbByldxmZeO5cn4hgeQqIHJl4XaFfG4duZBz9+l2mPm6jGUlRG6r\nVEKX5z+pn8CwFbDi9lN3Bt5nHR2mdhQY6P/XxWoglCsRiBAhKz6/FlcyIAl9qHEt4dtSr3OlpMx6\nL7R98LAQEilqjKUqbaAuZGzKtqf6S4zli198hH/8wf+Rd7/nn/Af/+ThFf/ItQVsRwiXew+0+X4l\nt3NvL/u6KOaX3CKxhiOzA2RuaAGPqg6V+XttWQF4lYA0RohsCVt4dbHwtT8k2B7W9jZM6Th+/DjH\njh2j3W7TarU4e/YsBw4c4OjRo9x///0uIZR1bLHoEsN1GM3yMxVYk27TbZdjZx3963/9Wfbt282/\n+Bc/z8MPP8Kjjz7Jz/zMT6zi1eUWG49xJNJNm4/tC4dsJ/pmjFtPo6DA+o7eLoNKBn8vRIyUy+tX\nwerhRc0jUHrF9Guj84VcatXyieX64uJPf/rTPPTQQ3zyk5/k5ptvHjGqj33sYxw7dowPf/jD3HTT\njQgRDI3iuHL4u/KvjefFbW0Y4o5vVELr0Uef4KmnTvCZz/yvANx55y0AtNsdGo06K9zjrd7P13bd\nrmiIjimv1GDxtVotms3mlh6t1vMuwe83yI3b9MW6wug+tUcEK7InrrAlBEMewq6Cvq2/hVoI6avF\n62Nqf+pTn+LBBx9cZjwAR48e5ZOf/CQnT57kIx/5CO1218esdk1h2pqS6i2Pk5bflK9//Un27du9\n7Of/4T98nqeeOrGOq7zJ8A09BKJc+Tm+BGQRIkSImFarxcc+9jFOnjy5xd6ni/ERwjAquBwZGvfD\npVQ0uyQzEUhZWzH8XINPjX1CfiVh8PXd1jLGdBy5tSWqx48f56GHHuK+++5bZjzl4+abb+b++++n\n1Wrx6U//rkNMtqSgyhZzwgY3aOnj0UefWPazP/mTh3n44UdWiBXUlodwxmRDU+jWDw6WvTYg+yWF\nhx56iGPHjm0D8lb2+4jxx7OuavUonVSIECkbq7iYNcToQjR8NT5jfJF0HcazpEhZVo3Xkgs99NBD\nANx7772rvu5973sfDz74IA899BD/9J9+kFotwpicTqfLt4+f4G1vfyMADz/8CO12h7e97Y3s3798\nx2+3O3z960/SbnfYt28399xz96qf22q1eOSRR/ohytGjR9m/f//Ia06ePMnx48f7HvPGG3egh9Zp\n6WHa7e6Itzk3cxGAU6dexFpoNGq0212sNShVJwgmOXDgwLLPK49reNcfft3x48c5efIkN998M0eP\nHh26t24G0GOPHeemmw7RaNT40pce4fDhQ/2QsjT2c+cu0mjUedvb7hoNMS0IqVCqzszMDGfPnu1f\nA4BmszmyES69NittkktzH2OSNRl3/5iWRW8rxcESpSZXDfPUv/yX//I31pT0Y1nbKAixrjzDGWGO\nlFdmJ3zsYx8D4Fd/9VdXfV2z2eTP/uzPyLKMI0dex8GD1/A//8//H/63/+3f8/VHn+TNb/4R/tW/\n+j949tnTfPWr3+CrX32ct7/9jTSbg5t/6tSLfPzj/5Y777yFRqPOb//2Z5mZOc9b3/r2sdXqmZkZ\nPvjBD3L06FF27tzJn/7pn9JqtfqLstVq8dGPfpSTJ0/ylre8hSzL+M3f/E1mZs5z6603EkURjz76\nBP/pP32Vc+cukmU5585d5NlnT/Hss6c4deoM7XaXdrvL6dMvIgRkWc7v/M7v8/DDXyOKIm6//fZ+\nbvGzP/uzvPWtb6XZbJJlGY8//ji/+Zu/SZZlHD16lJMnT/Kxj32MZrPJsWPHePDBB9m1axc333wz\n1moefPAP+Y3f+G2+9rXHufXWm/id3/l9vva1b/C1r32Dn/u5n6Ld7vAbv/GvaTbrHD58iM997kt8\n7WuP87a33UUURf1lKWVEEEzx4IMPcubMGWZmZti/fz9Z5lrvDx06tOK1OXv2LLfffjtxHK+4oIpi\nDmPSDQAUYvDvMhaFS0uCYGIZcFDe+/LrGg2oVL7MgWJDQ6xWZgKJfr/NajDn8ePH+cpXvgLAP/7H\n/3hN4d7MzAxHjhzhtttu4e67b+Gb3/wuly/Ps3//bn75l3+en/iJe4jjkG9+8ztEUcQb3nCLN4aL\n/Mqv/C/8D//Dz/PmN9/BwYPX0GjU+IM/+HNuu+11HDhw7VhgI45jfumXfolDhw5x11138dBDD/Gu\nd70LgI9+9KOcPXuWT3ziExw6dKi/u/7xH38OLNx5560cvP4a3vGOt/KHf/jn3HrrTXziEx/hHe94\nK+94x1vJ85ynnjrBRz7y3/FzP/dT3HrrTdx00yHa7Q4nTpzmfe+7r2+sx44d46GHHiKKIo4ePUoc\nxxw6dKgPvLz44ot85CMf4Zd+6Zd43/vex7333stDDz3E888/z0//9E9jbcZrX3uAVqvNiROnabe7\n/NRPvpObbjrE4ZsOcucdt/CRj/wmb3rTHXzgAz/B/n27ufPOW/gPn/k8zWadW2+9yec+AqUmkbLC\n0aNHmZ2d5fjx4zzwwAO8613v4tChQ6temwcffLDvjVbyPloveOBNbMiAypLPsNgJuIKplFPLNsul\nBrQOs5UIMeEKrOvp4rJXgLlteTG2r19IiBgpIhoNt5sMw8Hl96dOvTiSb7TbnX5I9dRTJ2i3nRzs\n889/b+xnzMzMcPLkyX54sn//fj784Q/3F/Tx48c5evToCPrk4Hb4k899iZlzFzd09m9721G/YXx7\nZPMYDnnLn91zzz00m80+3F+GwmUoNTMz4zc7jTFFPxy7445buPttd/H+D7yXD37w/XzpS49w6vQZ\nf32e5amnnmVm5sIgBPXJpUCg1OpNlFe6Ng8++GD/uJbC7EXRwhjtgJgtXToCpabW5NXW6fciEM1l\nrm4l73PFJH2k87PwyinjHwcOHBiJldf62L9/v4Oe11HEe+qpEzQadf7jf3yYr3/9CU6edMb1T/7J\n+3m7z5+WPu69915arRYf+tCH+NSnPtUPVYaPd/gcyscb3nDHisDBlbN1y+HD17N//96+0bRaLWZm\nZrjvvvtotVp9Izp+/Djve9/7+tfkk5/85EhuOXxNlzYRHj58cOTj+8bz9Am+9GVnTKdOn+GDH3w/\n73//ewdtlDK6Yufpatdm2KMuN6AEYzougoHlPT927WmGHSlgG5SaWHO5Ilj/bt7AUXF6q8LYV/I6\ndtkJGaxtAY2x7nj//v3s37+/v9NfKcEsb8yRI0e8S167Ac3MXOTOO2/hN3/zI8sxsxUMsVywJXjx\n0EMP8eEPf5j77rtvc7CtXbbTsFT25e1v/zH+43/8s35h+d5772X//v089NBDHD9+nPvuu4+ZmZmR\nazYzM8Mf/dEf0W63+wm7M0KLMcWqe+u5cw7Q+PjHP7zqoSt15VrPRq6NtZaiaA/NFloPYDAeNBjw\n9Wqrom6b9EDlkUwyOhpifSHbSoLkTr+rtSq6ttKOtPSmlAl86QUcDWNtTXaNRt2HbeP4emZFYun9\n99/PH/7hH3Lffff1a1bDnqhEocY9+nUfO25rHN9xM4DuX9P3MseOHeOee+7pn/uxY8c4duzYMuP5\n0Ic+BMCv//qv94+3DN/KKQwrPcpQ+NFHn1x1naxFeWct12YpsmhtgtbtNbVFLIOyVysoCIe6rYfw\nuqHigdNgm1xev7lSNX/V3wt/81YelnXfffexf//+fj1opceDDz5Is9nkgQceWAKCXJniDoPK/5/8\nyZfGQsLjDKhECJvNZt/zlAujzDXKMGvU252n0ahx5x23LLvLaytfKO655+00m00eeeQR9u/f388l\nyg3nt37rt0ag/2PHjtFqtcaWA1z+k62alB8+7JL/z33u4THQf9d7n7Uxr1e7NmfPnu2XA0aRtwVG\nmNPrcearIMVSTqwrUtmwAQ1CuRoDgfnV283XpmZZ1oV6K8LTv/Ebv8H+/fv59Kc/PdYTPfjggxw/\nfpxf+ZVfGRPmyX4IsNpx/czPvLcPJvzrf/1ZnnrqBI8++gQf//i/YWbmvF9gy1G/4UXQbDb7N79M\n2GdmZvrI0jBS+MEPvp96o7am9fDlLz8yEkYJJALBPffcQ6vV6htNueE4j9EYuRalgT300EO0Wi2O\nHz/e9wDHjh3j3Llzqx7De997D/v27eb06TN89KOf4tFHn+Spp07wO7/z+z6XsyjVWHGhlpvfzMzM\nFa/NAw88MAIuGJOidZcR+YEROsT6TKlcvELEKDWxbjtYM4w9PpQLgJ4XYhfrDNlW8lLG7wa1se+5\nc+dO3vWudxHHMb/7u7/L8ePHmZ2d5ZlnnuGzn/0sAL/2a7/G7bffPhKyfPrTn+aRRx4F4MyZsxw+\nfIhWu8snPvFvOHfuIufOXeTy5Xne9KY72LlzioMHD/DUU9/j2WdP8bWvfYPTp8/wz/7Zz3L48PUI\nES5Dl1qtFr/7u7/bX5DHjh3jE5/4BDt37hxJiD/72c8yOzvLmTNn+L3f+z0eeOC/493vfiMgeOqp\nE/zv//vvDx3PAgcPHqDRqLNz51T/OP78z79Ko+HgYoFAqjp5bjl58uSI143jmNnZWY4cOTKyi998\n880888wzPP744zz00EMcOHCAe++9l0ceeYSZmRkOH76eL3/56/z5n3+VLMs5ceI0WZZ7eBqiKOTW\nW2/i1KkXOXHiNI899iTf+tZ3eMc73sp733sPIAnDHcs8UAmlnzx5kq985SvEccztt9++4rX50Ic+\nNBJeAuT5xWXcwZX9yvj2Y7H0d8Idr5TRmjb5ka9pmtrhXXm95FBj5rB2ntU7UtdkOSPRfhDsW5N6\nS5nvrFYvGL0B5zCmu+a6QQlv33T4UH8olJRVwnD/shi8rLYvrbAvNbQycT569CjWatL05TXN92m3\nu5w69eIIEwAkUbS7X+1fmi/MzMzQaDTGkjdPnjw5EvKdPfsqu3YF6KK9ZrHtc+cu9kGXcsdUqkEY\n7hmbo5TnP+5eLb024+o+aXpuTXHb2ozJUU9VMEEQ7Fhj5LXFBgQGYy5gTG9wwdbldeyYaXIGKRsE\nwW62nuPVIs8vsSYa89jWBkeOjKK9W8LMttaQZWfHhoVruXZSRoThnnXH7uOPpSBLZzCb6b61hija\niwq2lm0NkKUzaNPb0N+KZcYkhu7lgTUzGTZRSF05jRJicoD3r9l4BiL2S7TyPVO7sy3sZ+fV1ibq\nvuIAeqtXDCOu+sPCVs5E0maTw5VFiJBb3zhnTBe9iZ6swb0UfUMHQRju3FSfktyaRVlFiPraxQwB\nrFhiOKOzQq3Fs2ztFhvQKoIja9RlGyBV/7U87BYZULapMSmuCFndhpH1lqIYP2Fho4Zk+1y3yqbe\nb8viI8cbqqzxQi/1OqWo93A4JzCms+5+oTUhJ6qxouGsba3aLfVAbsHZjf7xFslE2S3ZFLZDtkrr\nLlpvxToQ/bRDysoVmdZX1YBc38f0WqK2FXZNO+SVhi/e/DaEcV5wZCSEXIvVD8tz5evul1n5pm7s\nNrjDkWyFVJS1XkTRig2/gRTRluRio2/rdd625FqX2gZqLEr4QzYgtzClnBy/m65aJ7JYK8ZMqxYY\nMzzfZauO0wnj2TVd74HhjCrh5P+V5EFyy3IgY5INv5XFIlW8Jih4fcfUc3WfLfNqFqWamw7dtsWA\n3OKcRBCzstLnEnc6kjeNm89iMGarvVDJErarG84Stf5Rwy5gCwyoVLq0P2RtXzcKxGzwb8sIpMJW\nCjRYa9C6tUWe3t1YKSsEwdSWHec2GJBEqunBvmTHj4Uo3bNdpuFlx+xCmdf72srjLJnCdlXDWfle\naMyWeCCx6Vk5W5FzuKa0zSzMcMt29YEBJWjdWS6guwkAKQynt1TccVt0hspQbsWakhVDult2FEQY\ns8Cs1WjdYisROYfG1QciEms1nCHX4ThxP0zXYbdsMbj8h409KbUD4i00HktRtNz92SKnJmVjrDTV\nZh7bJFQsEKKJED1fy5ErhHN2FcNZvhsZ0/XyQltzjG7HnO8bztLH6dNneOqpE5w+/SKHDx/iAx94\n75IwLsNas+FFPDMzw7Fjx3juuWd5zWv28YEP/MQPzRSdCunGHo89dpwLF9o8/fQJ7r//fo4ePcqx\nY8eYmZnh+PHj/Z+t1/sURXvLED1XcJ7elgx0e0xIhCg5TTm4a3XjWX02peh7ofaW7vhSOtRoterV\n6dMvrkDb9x5ok/H52bNn+frX/8t6gaRBn9AW5RqbA0Qkjz7618sY1WW36UY8a54vbOVq3DLU7aoZ\nEIAYak4aX2RdaVQkYzyW8PpfvS01cueFxifPhw8f5D3vuWfl22wKP8l77Y+Stweuz+VKCkOrzxhU\nW7IoNsv4uOeeu7n33h8f+dm999575XNbxRtq3XVMtU3vESXqtj1T8bZ7bDZSTnvOmB2DwomVvc+y\n4qbrWnWojNmynckZ0AbrMP3uzbU9jh07xm/91m+tYikrG8z41ENsiQFpnWzimorlhelNPvJ8bh2b\nyOqbjxTxtoRuV82AXLJeus81ijOu0rW61ewEKWOf/NoNnJvAmGTNBNyPfexjIx5o6a2wdr1rZmtC\nuM0wEFwX59bt7q7uk6x+DdZgTNZnBsE2hW5DIMK2iSsPLdIaxtS95sEVFsAVu1adFxKickUS4HBr\nd9nEVfaXHD9+vN+V6TxkQrvd67cvjLYMjH+cO3eJxx77CkpNcNddb1xVp2FY9KP8fvT17h6cOn2G\np58+QaNRWzF8PHfuIo895vKyN77xLbzudW9Y8bxLoGJpuFgKKh49epTrrlubATz99AlOnz7D4cMH\nueOOW/y9rW6haLwlz+dXtIxxMcz4H7pfBMH0lhr3WAOytr3hCQnreSi1w2th50OOT4yELmua1SME\nRnewasIL049frKUewQMPPNDXSSsff/RHfzTSDSllhT/+48/xuc89TLvd5YMffP8VDehLX3qExx57\nkve//728+OI8H/rQh0ZauZeGbqU003DPy7ABnTt3kY9+9FP978+du8iXvvQIv/3b/6+R9/ryl92k\nhg984L2cPv0Sv/iLH+5/bimu32q1eOCBB/pGcvbs2b4Yy7333suDDz44Ysi/+qv/PXfffeeKG+nT\nT5/gM5/5PG972xt59NEn+MxnPs8//+f/iPe85+1bukCLor0uzpsdbzdYLEpWCIKJbV/XcjBycXvr\nGc7VT4/3wevpH/J8uX5f/JjH0aNH+52Zx44d48CBA3z4wx/m3nvv5Z577uGP/uiPlhh3jb//93+S\nf/7P/9GaDuHRR5/kM5/5PL/6q7/AnXe8jn/wD/4e9913H5/+9KfHhmj33ntvX+fswIED3H///dx/\n//0jTW7nzl3kV3/1F/j4xz/Mv//3/wt3330Xp703Kh+PPTb43DvuuIUPfOBvc9997+1/7tGjR/mV\nX/mV/nm/733v45Of/CT/7t/9O/bv38+DDz7IF77wBX7lV36l/3OAz33ui6saz0c/+ik+8IGf4P3v\nfy8f//hHaDRqfO5zXwLUlhlQqfO2Ucb18IoSCFQwuekC9Vo+VZYojBPz2G5AoY6UzdGEdQPDrgaI\n3Mq7Vbk4m80m999/P/fddx+//uu/PrYz06mihn21mSs9PvOZz7Nv325OnXqRp57+Hk8++eQy77Le\nx5133k6jMfCob3ub05877TXYhj/39OkXefrpEzz11LPLPrc8v1LaqvxZqZVw77339l9z8803c+ed\nr+f06RdXPK59+3Y7YcW77wKcIs/hw4c4d+4igapvWZ1G646/n5sf5qWCJkFQ3/b1rHWHwAl5GC/w\nrtbckrBRxCYIdniD9cov4zptxxmVGI15LQKtF1bcAcsbe/To0VVvcl/jWNX7yabjpy1p3fU724wP\nr/bt283nP/8lDh8+xMTEFAcOHOCBBx7gyJEja5j0LJZ97/KIQWvCsEi7EKIf1vU/9zUHaTab7N+/\nf+Rzx7330s8Wy4ZQseLC3bdvDx//+EdGQsjSqFWwfGS9GNNeIa7QcuHyWhcFbS6fsggREUXT2zbM\nqzwPZ/C9kongIGJjFv3i2T4jEiIgCKbI84sre5rVvNAS+NWxEzYfRjhyqRgfFwx9O+OnJLz3vff0\nmQNCKKrV67cVjBn53Pf/hGM/y4hKZf+GQxUXCVzZ/587d7GfH9555y0cPnyQp58+gVLxlu3kRveW\n133WfTlLMZOQ7XwY0+uzJOTgiN0EBmMWriist/lQruFVK+2GjcefikdttgpuD8cazmhouFxU0LV4\nb5YxLFaO/y00h8QMR2tjG99p18LlO3fuIr/8y/+TBxt+YQkyuBVFXO00rq3BLpnNs976j1I1gqCx\n7caT54NOaTkYYz+g1jilne00IuEVIKNRjbZVssOV60IZWm+Mqb004R9W0lzpnh0+fIhGo+4pPk8M\nXdhslRrPGg1ohcVigdcMfe5jjz0x8tuNfq4jkK6+Mh977In+DKWlYd9G8p+leaLWPbTujdRqNlL/\nEUIRRTu32XhSZzxDm6UUY/ThXc//whb2YYw74aivgG9XMZ4rbz4bY2rffPPNnDx5so/InTx5kocf\n/ktgIJ6+0qMklf7O7/w+n/vcwzz11Am+8IUv8KlPfWrVxdxsNvvQcqvVWvG1dg2f+/nPf4mnnnqG\nhx764hU/d+UFkXMlFYsyF/vSl9wwsqeeepZz52b7SN9qkrzjHh/60Id44IEH+MIXvuCQt3xxXQjb\neCuzhOGubUXdrC0oigXntYf2DfXRj374N+zQbPVB72UBZH5X3p7YXsrYd3Zm68uFxsTyrh/FdUN+\n4Qtf6EO7J0+epN1uj+ifgROdP3bsGI8//jh/+qd/ShzHHD16F8eOHSPLci5fXuDcuYt85jOf90Ot\nzvRzgFtvvYkoCvnWt77D00+f4D//52+Qpikf/ei/vOLw3OPHj/OFL3yBmZkZZmdn+exnP0ur1eLU\nqRcAuOXWm/nylx8Z+Vwh4JZbbuKWW24ijgef+7WvPUaWZfzar/0azWZz2Xk3m02OHDnCpz/9af70\nT/+ULMt45pln+nN5Pv3pT/Poo98C4MSJU9x6603LhhgfPnyIEydO8a1vfYcvf/nr7Nu3i3vueTuP\nPvo4Z8+e5ciRIzz00EMj7x9FEY888siynx05cqQ/eOzd7343112329F2NpPwW00QThJFk9u2Tq01\n5PksWrtBXs7zOmBE9HpnrbUGrPHGbHwsbrynqHnBELlNB5eTZTOjbOB1qpliDSooxfzWd5zlbJoy\nvHjllRc4eLCx5pvx1FMn2L9/N/v376dave6Kf3fy5EkajcaycR5FsUiSnF8z7eSpp57hmmuu54Yb\n7tjwjpokFzxp88rX7PTpF9m3bzf1Ro1KZQ8XLrTGjiRZSwg3MzPDTTfdRJK86hflRhe+8UDKgW3z\nPs54LrvrJOSQAclRAyoRmQEyY3GTCNy8FCmnts3CtW6TZef7I8rXX9J1+VsU7dt0Yc/agqT3Cnbd\nBT1JpbJ/w01lRdEmSc6ueSG4+1KjWj2wsaVnEpLkPMYUg9HwV7zKFiUj4sreTWsfuPM9vwnjcask\njvduK3CQZZd9iuA0yIUc9kByta1n0Kej9eKqY0e2AkJWqr5usu1wAj7on98cU1uIsrpu131Dr65W\nnEDKje+6xhSeSS7W0XhqvHDIZmFix3kTm9roDEEwccUJeFtjPGMGcg2wa8tqU+bc4sQPc21v22LY\nbMOTQKKLrWBqC1RQ34DEscWYdFOf62DhK085L8cnbuZ6GZOzPtqM9ZvL5nPiomhjdLYceVzjDmqt\nRakKUTS15Rp0g2NcQBet5ZfejtY35JUOdBiuLIrLXph9e1C5IJhmw+qTAiyGPN+8F3KdquF61hbW\nWoxON3H+EinVeFR5I70wV9i9N+ItBw2Im/U+C9jV9CdWPV83vDgMp7atYFoULfJ8ftVZwHa4DjTY\nbe0VT74oLm1bjUipssBqNrwItW5vgaZ2gFK1KxvisqY3s0njXV9T3cY9gcGanPUVYUvlnXCTi7O9\nzHhXdUJLfmEtBEGdYBvE610+3iXP51Yf2dNXlVrxCtpVojpDnl/YFiMSQhIE05uTugXfT283cRzl\neEJ7RcMZFVs0GzbeMjFd62bsjnFji3n92t4Wx7zeXL7hEK1Fv2GLNe1NdsmuL2W4bQVTY1KybNYj\nwmJZvjNOTVeO/aUdHdS6fCBwTpFf2hZlTikjL3y30UhOoPXqTO21h3HxaC60guEMby7rafFeiuIJ\nT41Zeyeq2OBCKbymnVjH9ZAEQXVT19T1+6TrPu7haxFFO7YFsra2IE0v+o1Frh6RLQcRlrimEeMZ\nAzJYgbGJD+e23oiUaq6uHLqGcGpZX/26DSj0CbNZg+F4sMWYDedBQsjNFRTXCXasN/mWMt7UwnX9\nPu2N57hYwnBiWyBrZzwX/HWRS+OKZVYznBvJK0fky0MLnz5hTMeLv2/1CBLpJ4YFa4Rlli9urctZ\nmpvA9YYER9aSw1vMhodTWbtelEBsqLhtrXUI3LpE5MWm+2u07qB1b4Ne0yJlQBRNb8uGkmWXPB9P\nLIm0GArj7LL8Z5kHGj85YbUbK9F6kaKY23IjckJ4U2xsipwLp4pifpPH4MTS1z71SG54+JYzBrWO\n67hRSWCPwK3LA8lN5T/WFuR5qz/UaiOPKNq5DaGbJU0voIvuUDF5BUDNjsHh7JphGDHyR8t3l3nf\nELW1jyCYdL0+1q7TeNwxG71xpvYgD4rWhay5BD3fkAFJIdc5WFZsYDGbdechQbA54RCtE3TRgw3V\nrTRhOLkNBVNLls1TFJ2RlOUKguhjtpYx0Nx4L7R6IlsUl7bFiKJoB4gl9RF7JeMpf6d9n73dhBFV\nkFKteTlbs/Hxj1tY6lkFQMjWaXh2U+FbH3nb2NEiZYUwnNjygmmWzY/kySM9VuO8zQp3S1prPfxq\nVzCklexoNF50YuCXtmGWT0QY7lhmMWtdbFonFMXGvVAQ1BGEq3uG/sEILBsf/7ieRSJgQyGNMesd\n47g54RCtexRFdwMG4KDuMJza8plDRdGmyBeWsU0srBquW2uX5EPDHsiWL7BjKllX3u1LbYU8v7Bp\nCHn5InaoXBlK2XUsM2sLX1zdaHE2QMpw9Yr5kutjTLEBKtA6c5o+K3h9AILW6Xr6RAiDjQuHWGvJ\nsrk1k1WXXttA1bdcHETrHml6CWOLFaWD7VqS7tKArDVYYzFDKJAZw0xYviDGJ1nGaPJ8q9kKot/r\nbtcZDAix+bqQVDW/iOzY07dL9qSNT69bX2i10XxkrS7IYlBBbcOJv9M6SDcwXc4iZEAU79jSNhpj\nMtL0AtbmrpFzc5fS3W1jJMZqSkNa271aWctAULa+zm5pjcgVWCc2tChLzbGNeqEgaCDKPGwNNSFj\nNmpAdh0v2wiAkC1pV1n5aa0TLdm4cIhL0u2GN8ytDd2MyX37Rg4Mcurx93DNLhpZTte21nkhY8yK\nxjF2pxzLWhCeU3R5C4XgHSrn4vH1vWfJkduoFyr1n4f7lVaVHzbFBg1IsSZgVAikWP/ics1ra0Ax\nrEvgA1Vjo8Ihed4eyrfWQbe2FqVqRNHWqYpaa8awDEYuJ+MDrNUcSp9MKoAmUOnnQANQwa6uUrzM\neEaBBa0XyfPLW4YtCSGHWLh2nRfRUhSLGzZopWqsddqGBbRefwgrpVoeKm5FtFfuwmX+s8qkuZFz\nDqobzH8849raNVjqaJogREAc72SrmjettSTJ+VWLuNauYiPL4rySRy5QqoZ0Hsep5PRHHl7xLi3p\nHLXLSED9fEDrBV/Q3BojkrJKoJrruZe+f0ZSFJ0N9+woVVtzPO6mNuQb9752DSe0kZxklXNfEsB5\n+H5j4VuetwZI5Jr6fQa/iOLpLWjYG3ieLJtdMwPC2rXcDOujoQmiaIczIGOMq6rKCZRqjqGVjHmT\nAQV5iU7ZcmPL88sUxSJb9QjC6dXZ0isk+u7mbsyYhSjn4KxJAt8DCRtRNRJr2q3XC2G7HqBiTc6n\nbFjbCEzukNgr5JtjDsB1mDa2tE0hz+bXzMwXq1z54bUOiiiaIgwnyhDODuBrnBG5xjax+pDgde2M\ngjyf27JCqxDCU9rVFY1nybJD6+66JgCM5mD1NRuB24HXm6spjw6tIhBn3fVf7+J27AO7js2isqHw\nbSnjek0Gi0WIkDie3rKCaZ63yPqim2vwPqt5f+HFdoQkjneOgFkjBjQwogZBsMJQrCUM7bXv5Zos\n27pCq5QxYTi5SgC78rHl2dyGP9PpENg17cTrpfSU+tgrJ/abg3DXmsEpGaPU+jtPnfdpwxrGXi49\nrSia3jLUrSi6pOnFNfUdrWhEQ+vKmFL9Z++yovJYA3KLpU4QlGJ140ADMXSAawtrBka0NYXWIJhC\nqurynp0roGTaJBtiarudee1eaD27/loc+sgIj3XWR9xE8TUJDiBVZUOCJUVRMq7Xc2yGIGj2Q6LN\nPrTukSYX/PR0saHLPuIsrEWpiDjeOzYnlEsNZ9QTVbzWWtUhc2NZCesjPxqTeXg73/TFcqGcL7YN\nMSiu2HZg7QY1tUtav1nTsa150Q6BLksNY5wDEoJ1J9rlHNTy/pa579KnRSJljDHLX7PSZuuuabEB\nPQpXa4rjrREHMSan1zuPtXpTBdjh+CpQNS9XNv56B+NGYow+Y6JoN3l+yYvwObhaiHWOhrSDu+8E\numeJoj2bnl+pVJUo2kGaXhwZRbKaRyoXt9addTdoKRWhVNWpyojVjFRgTT4yKuXKIWLg86DBWYgV\nDLm8P+VCHmeo5c+0zimKHGPMyN8sRZ7cbquwNkRrPXK9lh+rHHmfPO+S5+2xxNuVz18QRVMbCheX\nn6trigPTZz6IVfGZKxXE3GYZx7vHjnApvwYOe7/SPJuAMNwDzHqdLNYRuo1bxK6wmeeKKNrNZjH/\nIGh60mJ79GRX8UjWaoq85ecCrefznbST1sl4RU87uDrGI3Hr2yTsWCMY/t5a0NoAesQbjPvq6l9d\nsmwUFVwmJONzW2urFIUBslWNZ3gxuVrLPFprhLDeuJcvtuH3stYSRU2iaGpL4Ope74IPmcfs2WN/\nsIIDsBYEhOHEmupRaw50hZBE0S7yXK46XnFty8ItRAdtS4+obdyInDL/FMYkGKNHyIur5UKF7hGs\n0wu5PKgGzK96ggNGRrLm5Nh61ZmSDbLUEFyYUr6vRetsmdGUfzvMKEnTNlmWYH25YiVjQwjiGIRI\nxp73sBEMfzUmpdeb91p1om9gQvgBaqL8+eBvXIfp1DLptI0YT5Jc9LnXFYKfFX8weC+3zqfX3P26\nzkxREIY7EUJ5hsGGLGck5i+KeYRQhOHm2nWlrBIEU2TZ5TVnZ242TXtdRdJBGFdxXkiIlTimQ+gX\nq3qV4f9rbSkKs4pBuMJ3lhUjhrb0Ofx3abJIlrf7bdwlLX/kOPohJGRZe1m4stTrDIxC0uudx5gU\nKdzrBr+X/v/0vwrh5HErlWmMUd5DjzfOtTyy7HJ/I15zFjEaqY0YTxzvJgzXXovaUI+sU81R5Pms\nhyzFGkO38UaU53MIJEE4uSkjCsNJX+dZW+VZCMdOCILeumjzTqGzgi66DNei7NjkPR3RGBv2DMOL\nvFz4eW7Isxx8e0hZ5DZmOPm3QLef6C99j6UG1O0uUBS9Ie9jxuZNStUxprNq/rI0R7Y2J0kuI6Xo\nC69L6QxLSomSwz9TCCmIwgZQIc9zlFJ9Ax02yivnT46smmULbETlp1+lssLXoQIqlT0Ewfp6nzbc\nZB4ETYSQZNlFN3BIiA0Yz9DFyC8jZLCp1l3hC11Jcg5j1sYCKNVilFpP27LoV+rH9iqOJNc94tj0\nd/yli3vp91nWI0nSIaMw3lC88WiLRWFtp280A+Px/9emb3zGZPS68xR5D1MUCNyxCOuSbZN2sEWK\nCGvE9T1kYYbNewhjQAXgQQEZNxxC53McqQKElKTpQJlJKTlkCN6AVGlMCqUkSgWEYZU0zVBK+ZBY\n+deqfk51pXmvRd4hTS/7nGUzcLUTLKlU9ngVJq6OAZU7VhwH5NkFtMkGJ7ku43EL0vGWLhFFYlMd\nkFJWCIIJsjUWS50XahMEzXXtPkpWkCry8DDLvMrAG0CStFGqsgwSLr/XWve/7/VS0rTX9zrGFBhd\nGpDGGIuQIVq3B3+nC4zRLscpMihSTJGCUEhy8vYrhKZDIDSRtMhAosiphAmKi1iREQmBKqqIQmGS\nDqGZQwqwVqFtjAl2o4NJtIkwYRMT1NAWlJAYVaEnanQThTYWpYRnsEtvHAKlXHhYr++m18uRUhME\nAUEQoJQaMaLSe8m+9xr1SEXRoZdc2LDxjK7hmEpl74b5d5uWOZEyJoz2YrMLI3pj6+7HFAJjCrJs\nljgONlWVDsNpH8qla/RCljxf9F5Frun1CIUQIcZ0HGTdz1lsP9wqx8ZY2yEIWGYww19dt6gmTRN6\nvZ6f3qYx1qIL7bQWTAFZAkVBLs8RmIyQLlXTQtoeoegQ2nlCfQlVdFC2i9IL7GpexprLLhdRIIIB\nhiokkAMdYM6Db2XEqYYi1LKNaOnXUh8+jLkcvp5cTFBUdmGCmF50gHZ8PXlQp0cEqoaU7loHQUAY\nhiil+oa01KBKYyo9kpTSAxYX3YeLzaK3dSqVzU22ExcvXrTDFt+PXZVaVzLnPMgFr4Kz8ROzxiBV\nhUpl36ZOzF3os2sv7Fmo1g6s6MbHJf553qLbveB2/z56NvAUxhiKQqNUnTCcpiiKESMaNqDy2evN\nkfYuokwOukDkPao2IzYdItOizllq9lUi5phuXIJ8DptmiAKEXnLlAyAceiq/sRXOaEQGpP7/Zqgy\nUSpsBf45rDVo/OuHjcj/vS1AFIPXlpfeBrBQfz3diTvIG4foNG+jF++hEDFKKcIwXPYcNqQgCHxI\np+n1ziGE2QRyZ/spSKWye0MF1xFofqsMqDSiPJ8dYl6L9Z+bcG3hYdj0hdaNV5SzbI4sm13bcVhQ\nQY1qdd8gxVzChyp/VoZgWme022cxpofW9BP8gXFYiqLAGkWlupeiKNBa9w1Ja43JU0zeRnQvELRO\nEuVzRLKgGlmq5gKxniHkAvXaJYRHuoT12E2J38ih7/3/bSAgiiAMQQSIIoReAmkChXEWIhRIgxUW\nIS1Wag89CxDGU4aCwRtnKWjrPssugbXK4xguD1rv3bT/Wrh02Raw2LiF7p63sLjr7bQqN6IJiKKI\nKIrGGpMQliK/jLXZANWTYp1r1LdMRNPE8Y4Nb/TbZkCDhXvJ14rWYURL8iZrtS9m7d1UgS1JzlEU\nnfHE2DF1mGp1f98LlYYy/P3SMKzbPUeWtSgKjdZmxHi0LigK930Y7sYWGbZzAZucRxRtAptTVSk1\nfZFq7wdUzMuo4iL1uIMKU1dDCQZyataCMH3wEqslaRIhIklYBWljUBIbWAgFiDrkMaKroKcgy0Bq\niAWEAQQKG1oItA/VvCvRGnKD0AqbG0ThaVJFCnkKOnNWobwVSTMwngJMBjZ3RmML98S/xHpvZrR7\nOxNAZ/dddA+8k870XXTCa1BBQBzHxHHsjSigKOaxNiGKQgRiBLBgLWyPfp1rx6YVTrfdgNwYlAVf\nk1kD5Wcs6OCqimE0vSk1fmMSet1z2FUYwsMVfqUqVCr7RzzNSnmLy1kW6XTO9/9fFNobk6YockTn\nEjJvE8uQsPsKTfMqNbFIVS4SZWeoB5dRIkFKEPEgZLIKkAKhhYNaTYQwTj87N4rjp6sc2BVRdGP+\n03dC3nir5G13hSAlBBaKENpAS7swDQWRhIrEVgNEJNzrJC7ukv4CFAabaURmIbWQ9SDtDaSAhXcj\n5N6AANuFJMF2CpI29HqQZyAFBAqUhFCBUsN1F3eLtYaicPYoFbSvfSeXb/onLFQPEUURcRwDHaRM\nCILIeySH6gVqFGQQUqxiPJJqZQ9BuHlt7atgQB5qLFpk2aWhAHsdxjMCCkxtyoiybI40nV12Pksr\n/e4piKLdSFlZ0WiKouiHY3me02q9Qp6n6DzFtmcRJifsXCaa/x5NNU+1qqiJDpX8NM3ovIt2Ym8w\nXgbBShwwgcISAVUQMcKGYBWWEJSLlf7ikZCujfjJvxUQVRUzswG1qZBdO0MoJCQa2y4QnQK0cqs4\nCrCVECoCEVgIrUua/IBpjIDCQqEhLbCZhaRApBkUPg4LLHjDs2gwBqEtJD1YbKMXE9qdHlk2uN9C\n2n6EZ4X7GGH7sgsI6aO/ofxKa2gdfCftW/8pC9E00KMSV4jiiDiOPAChUCrwtabl7IfRBR9Qqeza\nMomsES4c2/gIgiZSBk5KyBQroib2CtSFPF9AipBgg5R3V2DteYFFMZLXlFDzoMZiKfJLhNHuvuEU\nRUGe5/3cpTSgLMsoki69+YvYxVdQrz7BRDHH1FSTqpontGeZMK+g2gVhA+QkEAORMxgrJIjQ/6CK\nkCHWhghqIGOsCEAEWAIQAlEPaF8O+O55w99+S0D9UAXCgOtfI6BQ0HbGQ5aBiKARQBA5AwoEIpI+\nVNNYaRwh2O/ObgSQAZGDTRHKJzqRhsS5ChtpiC0i0g6uKzLoFZAH2LyGtYJqJaAe5yAs1qQUhSXT\nkBWQ5aCNsxPpUy1jPT2ptLIyGjz1VWrPfBVx83to3fGP6GiLNg6trFSs59LRd9kWgyoRu/IeC2c8\ntdq+DbenX3GNr18AcP0UmzjeQ5rOLh+rcSW5rCFPkWWzIMSGWn5LMRJdpL6t2Y4YjtbGjSYxhkJr\ntE4IMgFUyLLMf35GUeTkWU6RZ2QLF8gv/oDs2S+za1Kxo55TCy8Qc4F6e5aoArICqumcCSHYEFAS\noWKEiEG4ijwidMmAUAgityhUjJAhiBARBs771AJalyQiKmjsjWEicgmSkJD7WCiTQAURK4hClxMJ\n6fIoT5RE+XBHWe8B/T0pLIQFeZbw8qWCCQrOtzTXTMDUFIggg7CAUDsjTy026SKsRMgIEcUoU6AC\nDTIj7/TIiy6GAqlcWhbiPIwpbdc/tXb4hPXonS1h9L/5MuHZk6i3/zKdiWv76GalEnlAYGBEfSIr\njhgbyCqV6u4tVzYdMaCimEP2t8btM6JKZR9pen4Zf2wtfUWO2azJsjk/ZnDt9Pfh3iYp6+T5HMYO\nAQJ6kPznRRme5VibodSU8z5Jj3ThPLpzGd2Zo/Ps11CtS+zb22Bq6lUaxXmavbYDvaZA1JxToeIN\nR7lkQKiqj90aIF2Ihghc3kLgvAYheMNBRqBCh6SFChpgpgwiLugEMUzWIFXQ05B5j1ETICJsECBU\n4Nq/jQ/TBBAICIwzGuWfwlFaEM4Dyarg/PmUlpFkheFiIJk6HLiQT+YumigKhNGIWEI1AJWhbA9D\nwee/Lbk0X3D/kRaVyNLJUsd5UxphXS5UgnjaQpKALhywYBgYkcDhIGrhBXp//j9R/fFfoHvNHSzt\nkCqNqETnDIYwdDD1ZiaZr9EDJeR5gbUThGGD9XUTrscLBMTxXrJsliJvOcrGspESq8V3roiWJOd9\ng1N0RaNZCjtLNYE2LYqi66YU+IQ/zwvyIYg5ywqKbBFJG9NtU8x8j+TE/02tEtMIDDvFWWrxi0z2\nNPU61CdA1YHaIEQjEtggQqgYZIgQVWc0QQSiCipy2bUKnKHIyHsilwMJobBSIeIA4tA9JyT7hGLn\nnoTkcgjdyIVXPeXeb6paKty7ekxiXXIhwEpH4iS0fsP2eLPwLgHrELpAoHbAjXslc4nh5glDGgvs\nTomQBkyEyHLophRpApUqaneMyFNsoZBCc8thwde+mVNUDHFDErQKjC7QpusL3AajB0ZSDSGQkBeQ\nZC7c66PjBlQM9WyWzmP/hsrNP0565z9Yds+dESkf4k1Tqexa81CAjSG8BXneISgDTzcoK0OISa94\nsz1G5Pp/pK8VXQGhG/FSThHF6Iw0vUilsndZoXVp3WaYe1YCAFI2yLIFitzlMXmRk+cOMcvSlDxJ\nyHsdigtnUBdOo84cZ2J6mslgDnnpBZoB1JtQ2wnVClQq3uNUgEqAjRWEMYQ1hKphRex07GTovE8Q\nue+VR8xUACrCyhBhJdYIIMCGASKOoBE79CwKIQpQdcENB0I6HYudkYi6hFB6L+XeU7cL9CsFUR1o\nuM8QgYJIOQMPpasF5b7yKrWvhHpgwYTYMOD6/ZbLPU1gLGLat/YnGRgFVUXr1RDTMuy8EcgjRKqg\nSNgznbGrKckqNZJ6RKVaoDopYRqAiUAsYnoFRQFp4dK2SEKlCrFyP8v8U1tn63EMoZ2l99TnkaYg\nuevn+vHJMLk1jncQe0ngtfS6bQwc65LnCy7UH4F8dZc8z4EmSm280HSlfCSKdvmWiFUGc62EzgmF\n1l3viQ4s67AcNpxh9GxQxLQURUynu4AuNEmakyUdsoV5Oi9/DxbOo85/j+k4oBJoZDRHPPcCU9PQ\nuB4qNYhcCQUReSStGmCrMcQNRFx1W6bw+YsMPFAgfYhW8eGaK3A6IEG5cAu/0MPIeZxKCHEAgQ/p\nCrdN72wYXpqx2CxC7PSFTolLLLAksyFpTzF9wEWIyBBiidWSZBYKJI0aiJp2BpNLkouahTnLnkMh\n53+Qc6En2XFTQDOx5LMZNgJRFKB9+B0HTO8LSRZT99k7BPQspJLKtKJZEzz3suXsCcEdBwW37jcQ\n5pw9F/OdVyZ54+4WnQQqoWGqVpBk0MugXnEpIxbSHBJvYNJHbdFO6D37nwgjycLtP4ubJOjg7Fpt\nF0Ew0c9thzl0W+N1NFk6R6E7WOvePxgsbCc+aExBni8gREEYTm8LeuG0DKaRMiDLLjlNbnEl4xn+\npfQq+xeIY9fROs5wSqMp4eYsy9BakySQJIb23AWS+VnaLzyDmTnFhJmjUY2IwzZx8iLTE9A4BPVp\nt6YD4aIu4QuZRApbiaBSR1RjUFUIXMgGoUvwjQQT4lZg7Mlo5e8DkN5oKjFUIlfgLL1JEA7yoqSA\nTgZdy45ayKshFLJKVIkcjFUYn40HJAuCYEIidoT98My0JL0FCZWAF58vuOGwoLHHVzRjQyCg/UqG\neEZTf03I4ddZwp0QYeCaEEwBufLom+ClZ1POvKg5PaPY/4pm976AG6+rMj0ZEExHzFjJDVHAG2/O\n+Kvvaq7ZI5iaEFTzhMsvxPyfz1Q4OJVycLrD3r0FWRtOnA95+6EcqyGzbpOqWzi7AGdbMF1xKVvU\nhOzUI+zYdZC5A3ejVEC1uhuo+ihDjmysW+GFiqJDls15eWTZR/qCURrNwOVp3cWajCCcIAgmt8Eb\nCa+vJb1Sj14XN9BavIiFJQx3LTOcEnLOsqxvOGmakqUpnbnzzL96mrnnv0H+gyfYv2cXVdmiYl9l\nMuwyuQ/qUxDWfdTl17LyG411GD2iugMRVb3HiH0e4wlkVrkajA7AVhw8LeSAWiDc60UcQi1y3iYK\nfJLv8yIi0BLahYOLtYQ4YPeegGBGk6QBUcn4FPhKpWSumxPXYyYbFZdodCzd8wVqd0R1f8z+Toaq\nSWes5b2owv47u8w9u8DOAzX3e4oBWU7kEBXu2NDoHa54dW2gsHlKqjQ6Vw6GtrCvXmHPPsXNtyge\nO1Uw07FM7YHpWPL+ewv+338Rcd2ejNtuTCm6UKQSZSQvXAi5eUfO7CLkuYsY8xwuzMFlXEQrBNSC\nWcQjv0/tp27G1vZgTECWZX0CarmOncaD3VTHa5rOuhGVPuUYbsgLxlDR+qC8RXtBxB5huGNbvFEQ\nNJAyIEkuODFyVmdzDxc/nbEsUhRusrfWA+MZ9jhpmpJ023RmzzL7wrPMPf9NWs89xqHDr2Fyd07N\nfptde53RRJFLS4LQpSuq5gxJxeXFUYig4rbBaNItqKDikngReXqydLB0HoGNwUhEIZxBWV81lYHz\nOjUBkXU1GIXnrsXOxWU5tApIA8fIjCKoBsSTFisz5tuSiczD0UL5PEvRmFAY43lAQY1UF7SDDjv2\n7oRqTPPAHGG9DtQ9Sc1VMGu7JS+LHguzkh21ijegwDNPe277zxWEBTfcZLjhJkHyfYW5LKkdLiA1\nkOUYC1FsaFYFaEE9lkyHnvotQuI9KUf2G76/2OCN+xdJF1Ie/k6Dr59U7FCav33IsKdq6PYs/+VV\nQWws1VAwX1h01Tnj5+Zgd2WW1/7FJ9j1j36PXq/XJwCUXmeYyb0xNk3Pl1+yEVracOauPvzhX/gN\nwWjvuoMDB0Q9a3O07vjfRVuemAkR+H6ZFGOLsd5uqeEMs52zrE2eW4yRzliShDRN6fV6dNuLtF4+\nwaVnH+Glr3+exZNPsLeec+3ujF2V73Pt3jZ79jokKMSFDWEEQdPF29GO4QJojK1MIao7IJ7wZM2K\nC9uUD7+EcuBASTUQkQvhjHDeCIkNQ0QlcI7Kagc11/zfy8gZS0fDnIYsgqDqwzvl6D1WcHFGkquA\n/QdjqDYgrLnXNZpEVUWrZ6nu3OkEUHpuRk91zzTWwJmXetR21AmjuI+6ZonGmIKwIlAXclQkcG1Z\nTs8PW3imgnWZfeGMQ6QCOwcq9EIiRqKN4NWzlkC43xc5HL7BooSlKATzc4LuvOWlWcm1kWJqUnPN\nNT2uPVjwg/mAC5HizbfkLASC4y8rDu40CAQ93yy7tw7PXoD5DJrJIr3Lr9B43T0Ib0DDPUXLNBrW\nRP8qPHvlkhdiGRX+HWUilMU1xo/47v/fN7wp1fOzWypbakRSxlQqB7ySfmcETl9K6NTa9MmaZZim\n9XnclImQNE1Jkx75wlnmnnucV5/8S3R7kT37JpnYNcN02KLR8EajQXUhqIFqQDDhjEbtAFX3u3sB\n5AHYSYRt+N6AMhyTPjD3bADpmQUmcAmTlSAFVgaIyPcIKD9PQxnSuYDzZwMOvL1KqCIXji1qmNfO\nY1UrUI+doRoHScndEZPXdJlvG5ja4YolQ5FDuEMgZnJMT0MkCISiQYHNnMxWI4jIFjTVuovirTG0\nXu2gapbpayaZ7Qnal1Omd4Z99NPlcAEob0wmh0ygqmCv897FSDAFsYAfOWI49bLmlQW47XUQVQLQ\nlqST8VdPGN58WDKfK/7kW01+8R2KnZOXeWvcZcddOTccTIknLQtnQvadU/yd9xZkieW5Z+BvvueA\nxQMTzoCCCM799X9mx+1fQdz23pFWiDIfWo8XKooOaXIZbZIrdgLYMgeyy4bwrQQvCz9nJyUIJgmC\niS2dICaEolLZQ5bNkuftZV7HyTmNAgRZ5sK1NE0o8nmwdYr5c/Re/Q6vfPvrtM6/yjUHJmhOzDId\nvUg9djUHUbicO2hCOA1q0n0Nm+5JRTjUa1FBGoFtgKw7KDhSrrovJEhJ0hVceElwYKckmHTAQGk4\njlEZuMp/gSt2aOHylUqA2BWTfl9i2gJiS3EmQ+gAVa/DdAzVpgcTYveewhlJY7pgbi5FJwGqhK0c\nSQahqkztyMjaGZXJBmpyisvtFpdPF9xweII9NzTIM+HdaoEQMLl/CpQrwEzeMAnWM67xEldSeIi7\n8NJBnjYQWoKmT5Uy018+O3db6g2BLQKqymIzCVZQrcPdd2p2VAVva2pu2m+QoYReE20h0IaFS5I9\noWFfrUCIgAuJ4MB1ljv3walCokLD2e8LmoF1m+AkXH7yz6m99h0kSbKsMa9sG7+y15knzxacwEgf\nwVt9QkkwvidHrMJXk76INIsxXZ8bVbY0nIuiPVgr3YQzO9ADKBkDha/d5Hnez3WSXg+9cI5s5ntc\n+u63mDt3jl17dnFg/yWmojNUfJ6d5+7ca3WIpiHYCbLpvI+quUiMXGDbEtGLsHkMso4IfT3GBmAU\nwrh+mvkLIX/8RUgWLP/sHymCHcLXVyzahohcIQX84PmcuXOGN9wWIqZCaFTRYUw3DeiiOfblFKYM\nE3nAHW+uUd3XHHizvscbaGfvmoo5nSYstlOmq9GSxhxFbd8ktt2BJIfKBJPXVmnkEhkFvl4iBt5F\nWIJa0xtMRqACz6PxTTylcRoPlYvQIQXSuJBTu4qnlaHj1wkLRUQlcO9vc4Gwheu5Uoa9O0NINJPV\nnMlrUseisAIlYq7Zm7jTzKDRtFyz2/CVx0Punss4fCNMThp2HxQceFUiLmt0Dpc7wHe+zfTrvwh3\n/FS/pygIghEvtFIYl+dt0nTOS06LIeNZzZl48cV16ouOWJ/WPYw5RxBMEoZTW4LUlScahjuwVtLt\nXvQ5zwCOTlNH7EzTzCFr7TmKV4+zeOKbzJ69THNqkhv2LTAVvkoUuDphljvHUKt7hG3KhW2y7tHn\nwG3AMnPsfNFzzAARhdho6EKaAIrAEdtsTF0p9lcsRilEy7cASIUtFM89ZTjzXI87DgnaLUFYC2Ay\nhIk6RTfkO9+2nD5bEIaSOFTceVeTiekKlb5BlF5l6TYmUFMhKIVI7FAnW9lKqpBBBSYqjlhKjpIV\nVDzcedcn0zDaWlo+9dC9LttTS/q0cnC88hQgo32eh6MJ+QkSWAfJiSBwncHWIIx2by+FK8gaX8PS\n7tirkXHhgXEds+85mvIXT4S8cEFx+DrNoSnozMHtN1mkgqkWVH4Af/I4qC8/yBtufSdZFveNaDUv\n5PrFZimKNsYUK0RTqyuYBitHd2JNhmStR+qKDlG8c1MshuFcxxXCGgRBQa93gTzPyHNNljmjSdOc\npNuiOP886QuPM/v8SaLJneyZmGdK/IA4dOsgT51XqVahNum8jqoNqGYy8Euu642nB0JLBydXnSqN\nsAJrBCIL3I0WvrmlKghrLoGOrCCqKRcWWQmFZecUfLdr+PKTkp//uxHqhtiBC1WBlIYdRxQ//qMx\nu7Sk87KgudfnTctunhkyDhcFBHHMtTtiHEAkh4KJsgdbukVeqTB+1pMZ+r8e9BI4N+Of2v8sc0TV\nYqiRh9KQfKFWSYS1WKM99075Wpc3ssC3p1rtEEcrHVWJ0P0ssCUHCkzPnXriIub3v9nrqGvodmF6\nwnLDLssfHBP8vR+zvOMOeEVD5wcv0v7eI9R+5G/32fNBEPSLqsNeqCi6JMklJ9GMWCUVWd0WAoYi\nNofGDVEj+rzW1fWNsRZjM9L0HEEw5ccwyg0bzwCiLhyzWEyT9F4lzXrkeU7S69F79RT5979O+srf\nkKsdTE4V1LKniPzGWPQcIhw3IJ5yX5UnAeALolKCzEG0wXZceB9IoKLpphZtIppTEnSIMJHLe6TF\nBhahLFlLM3vGcuaspBJbRNMTMlOD0IJ9Nynu1iGPfE2wmIZMV3xPjwC5Q3LDHle30fOK2QWNXCio\n7wiHFq9cYkRF31hCBfUpSdI1S/qt5NBz2BCHPc24x7DHsUM/04P3Ff5zxND3/YHHjgokhMRKiZCe\nn2ctKO1aj1BYoRAycOGe8SFgULgWVoEzOhP68NF//II/nRhqyqFwWQjX7oGvPy245X2WN7wBLu6C\n5MRfULnt3SO1wLId361hTZLMk+eLXhxGruoqRuW0xdCXMTmQHQsnrF0D2wltXEbrLlG0c006W8sR\ntoHAhmshKEhTg7F1er1FurNnSb7/BNnpv6JSCYknJwjmn6UmjKs/CudVohpEDUdLCyIf4Bi3fmXg\nmRcdMF3XcKmEK8sQOuZ03gv5mxciDAFvuCmgMel3X49UL1yE587A7p2SyZpkqirJL2aEoXHoGQoK\nwe6m4sCU4OTzhjdcbwmVgZ3GQcEYUBrZgB23CcKa77PpexvNQBpHDn0NEVISNy3FZe0SflHmP8WQ\nEYgluZEc+n6coRhG5HYIBscRaLfrFL5HuxRmKHWmbZ/OMhgsbI0L77TBFqbfv4cxCOtCXXIXCrv+\nBf/Zoga0HeI3zDdO4eZ97s9qMfy377G8cME1zZ56CeIq7LFPk559jvDQjxDH8YhkmCt3zPnBAHJs\nXWfpD0Z+N8YZydXjvbVNdrLLkLoeSTJDll1edczhSsbj8pyUNE3pdDquntNJaJ95gfnH/5Ti+a9Q\n21klzU4h2t+jVjWoBogmqJ0Q7nZwtAhcdCAzl/8LH8rLDMxlSM5Bd9axXVzhVLhai1FMVhW3HTCc\neCXk//prQb5oEYWEQmBzwXdPCNqp4NARQb1q2BFqQm2gZ7C5wUpN2rWEHcNb7oBT53P+88Mp5N5w\nMl94TN1imthniSIfQ9rEPRl+ZkO5iUvua7Eh6+XorIvTpWoPfW0DPf93mf+bce+ZDtgG5P5nwwal\nB3Ugo93TakaUQ4Rv1BPDK8p6xK5wXXRlGKzVoB0V48K5klpS1pdy6Z7FkkjTgCwPM3XEiNdeA40G\nvPUmqOXQ2An62T/wQFPuPVFGt3uRdnuGokjG1xmH1/ESnzHScmOXhXC2rwu8/E2v3G4wriGvZMKW\nA16jaHqZWOLSfMcY0z/h0oCSJCFJErpzl7jw1MPMPvF59lyzG6YWSTtniDz9rOxBk57+LrM+aQAR\nuXtx5pLk2l2GaQ29eVfGSArnoaY9QdR5+Ig8j8mLClM1eNMNmj98Mua2l+DOIy72W2xJvvOi4e43\n5kitmV8IyEOLsQLbMagJQeus4LHjOXfcHLL/TsFblSQMBDQMdAqHYikx6GWWajQK6y9Iz1IQeogZ\n4DyDUQW91GDy3AMES3KgvncRSzyLHOQxrvoxBCIM50P5gGdXFIOmHV2Azl1R1RgvtePRN+xQ5Clc\nbQgQtmS3CN+7E/jOOTno9bb498PlUKYY8m5LUje83WsXUbzmBjjkBqkTn/0rZnvz5HGFJFkkz3OC\nwBBFMdZK1/q0pphtfCbk9Ek8CheGO4Ee1qZjfNeVPdCArbDED3nGpdZd0jT3U8im+8blULyBoGAJ\nSed5PsIkWHj5e1x66i859+QXOXjL9STZU0SRQ9CEHqwV4TfZ/s88AhxW4eV5wZeeUPzDuwwt4TZ/\noeDFVsidUwWBcjep1ZU8OxNz/JUq104p7rvNcvOOnEas+JuXJXfeaiE0tOYt7W7AdENhWpbLLcuC\nEDz+hOVH32q9qoHmpusFU9dYbKK58bBwMWQv9yBE2R1qB4m5Ko3Fb7VlohZ41EtI32ynQQRUAsuO\nwNFnBrdXDxmGXBLCjfuZHELePGzdNxLtO131wIByH4fp1L2uP8/FuFAtc3/j7ofFFtZ53cI6dR/t\ni5pWYa1AWOmdkTckG7t8yNZd8da0Rnd+y6gWXc3zEwWoCefAD98IaedJ5sM3obWgXouRsuo1AuUV\nOZZCjDckOxz8GmcfgevUrCJE4Wf/ZH6nWBsO19cxRizXibYDhneWzQ9x6ioj8lClvkCWZX3j6Swu\ncOnE13nxr/5PlBDsf02dXvdpKk23jnTer/u5ml6ZgwaeIOBbqrFAx5J1LC+fkxzea6jW4AezAedb\nEc04J8vhYivkmy/V2FkreOplSUVZhE2pNwJu3hnywoKkV+RUlcIEiksJvPyqQXYEU7GhXQjCHYaw\nqqEL8YTk8G7fYtmx0DOefW37Omx9dqrwoUxRohthP58oEa5+56oy7sRDCLVkwhpEUnj0asgohkGf\ncoX1d7alT+1csi58oVcPWsSLIQMyvhZkXShnbeF1FfyKKgpE5t8j09g8R+TufW2RQ547GNs6gxXW\neGPJ3Gfb/socCh+jgRLQUhwkcXuRjcD6znjrI4kdnb/gYu0WNwTAREPglO23fq8pN1km+e7ONwgb\nRNFkicJJpKz4pD/FmEWE0Gx6si2DOTmOJtGjKM6iVBOlJjHG9guhwxy29uIcM9/6Aqe/8gfsuPYA\nsX2ePOsRNr2XT0H4DVB6JLXkVYgYbNVdVJlDMu94kEGgONOCO25wYMNL84peLtDG1RoffrbGVFXz\nhmt6fPVUk13NAtlsQVDjNXsqvDAfsdCGasOwZ1pzcIflC0/AP7jb8oG/Zcgt7JguiZ9+p+v6+KJs\nn5YOyRAydItDaawqfB9QmX0HzlMhfSjnk22pXX5GAbkALen1BDOLcLCwrq278NtzaXxllCaXGJAQ\no8G+Mc5Icu0Wf2EGelNOMdKrgfhwU3vEDTFQSvTvYfPceaC0QOQFpM44RGmM1mBNmZNphHUiJs6r\nSp9jAXTdTRZyELZJRr+XQ1FX4FutcF5onzrOjFokMTFFYQgC17ovpR3Z+NdQ7hwRkAyCKnG8oz/F\nPFgajklZIwwbWNvDmBZGZ15TTawcwvUnd6+ILPQHErtwbRZrWwgxMUIA7fV6LF6aYebbX+X5r/wB\nBw7twXafdry0ykDbTyUuwinXpvB6z8RuJwoD95qZS4K5jmBX07B/ytBOJYEEYwUvzkbsqGuyDF6d\nl7w0J/nxm9sEAVhtUCrDCo2goFLNaYQx0kc4lcDwT348p4tgx3SOCvwC7Sksxvf7KM8VkghZOKMo\n60fCLxIRIgJfoJS2j6tbESCUJ6UqXwEOFIvnJQuzgmuvV4hJQedlizYgyRzUa8wSA5GDMFzYQRG0\nfI0t8w7vZbR2xmOs/1p49Mz/TpdeyLrvMd64cqwxCG2c0Rjr2AVZDlmB1Zo8014ov0AXmZveR0Fg\nC5RwG1wQCIRKvRqj5xiWDIhhFVQ5pDlR8WIt3ltI5aITWRjq9lVa+Q4/qcP6sTBXNp7RbMQghUKq\nmDieJghqI38brNZmIESTomhRFC2McUNqBWIkPFhN1ccuec1AsROKou2pOjWKQtHrpczPnOHZL/4+\nl049xf5DDaR+lsoeZxzGushF9NwiVt5ojKeblTmPNHDpvODpFwXPnpfccZ3lxj0wVdF893zESwuS\nayctuRa0eoJmBeYSSZZn3DCtudALuNQRnF+ImZ3N2bXXrS8lLLWqcYiE0dRrOXVhIHF31ElQhQgp\nsGVYJgIPV3tPROHzGA9NS+t3ghLFkq4gKQOsclA1UrnqvlG89D3Dn39T8/bbFLccDpg7Z7n2Jokq\neo4BUYZkYtjbeDjZTb9y1X9KpoBvqDM+v9EuV7G5L4Yaj6CVYZz24iRaO/lR7RG5IkMUPlwtCmxR\noIuCQhdordDakBc52hjyQmNMTqFdCK9sSmAzAhUSR4K40iMKc5Twa60kO5sh9maIa1utDlhOfXCy\nlD7uwMTCE5xt3tIXuhwI/q8lOTFIqZCyThSVeiErFFJX79dpEgRNimIRrTtoL8jR70VfIfcZj7ZZ\n37OTk2WOktPrzZNllu7leZ77yh9z6QfPs3tvD+xFgimfEntwwJaIrGfSGNdZjHL0NGQB52YFf/U9\nicVy72HNzXstUsLeJvxYraCuDNrAdLXgfEsSKTcrZ7YjOb+geGVRUpiCM5cVCu2Inzm8/toeVdmF\nrkeIyoKiDLEidGtWuuRfCOsKhkaDcMVDh3CU7dve4KQnnKJcCKeUFxkpcyQ1BCtaXnvQEih4eQ56\nC5IbbxSEoYVF64q8S4N2n+1a6wZbubqM39G1NxyjnXCi9vUaoxHah2lFgShy9/vCexZtfL6isdpg\nTY7ROaYQGK3IjG+dt4a8kORaoE2KtplDKbVBW4PVvmPUpkhrECiUNEShoVKBalwQR5aw3CR9u1TZ\nr0js8AakB47KLuYyGskgnD2LmmCkFlTKma2867uZtkHYIAwbV5xWt2bNnyCYQKkGWnUpijZat72I\nnRxrRHaE6TpqPCWfzSFtGe2LL/HMFz9HZ3aBieZZZKVNWHV5rSjrjSWqiotCtHXaGPOpE5qZtNBL\nodOx3LbPcN20ZaLqXqMsvHaXoVYxWNfVzC17U545W+HsLFw34UrIH/5Cg394V87/8+0L1OowXc+Y\nvRDS7Xb50UMdVJL7loWKo+TIyDM3fFgk6UPBQgQ+Xrfek4gBBC2VC+sC3w4hLDZXCCWwSntD1N7Q\nLMJvv4EUvPag5LXXea9SGOyC9Uwfj26WMJLPUdwGVkp+miFvUwwhbVkfKBDaGZQ1BSYr0HlKkRfY\nQlOYAl24HixtIC8suYHUWLJCoq1CW+s09qzAGIU2BiNyLyXmQkbflYHE9plLQkiUMCgBcQT1qtdH\nqLh9JPKNun3Wkhpavdlgxpv1YKWQsHP+e4TkGBO7fcMbkVLLwzhXyhGE3tuEYX1NMNq6RLOEkARB\nA6VqaN1wXqno+rH3473PaA+P9swCZzzdbkLn4lme/8s/JW23qckTVJoFQei8jRUDyNL6TVDFbn2F\nCl6dgy8+K3nXLZaduy3tDlSk40pFgaPlxMrrqIce5PLvd2TasLNa8NdnFPfdpvkXb2uzmEiOHtRM\nNvxJ9KCa59y2e54qxnkfGXr4WfswzdP8hWcAWM8VsulA4KxU4aHwaJpX5JGFVyfRCOlaJPo6bVL1\njccOY6uWAZJl7WBMjvWUK+wg7NGFY0GbFPIeFAloi80LTG4pcicUmeWaIjfkWeGkvnJNWhiKHHIz\nUMcxZf3Xpze5dp3maQG5cTFUWQ/Vw8m+z00C6QxGDlGpRClPJ43T0PYyc40eNGNoNqBec02OVAY1\nvz47yb+/8CSOUmTV4RtdItOlq6v9EM6YpWmHu15uYviEn1S4dlL0hlTnhg3JhAlZdtmLLQxB9UO9\nPIM2BGc8SZLQ7SYsnn+Fl//LQyzOzhMV36G+0/egeeUkz3Rx4bYviwRefcko16QZSJhdgG+2BS9d\ngh+7wVKrOImCwIu1G+FuqvB1wUxCI7a86fqCb74ccGSv4fUHXGXcaMjaDi2WOKk3lMGm5c3KHAvE\nhP7OJc6QrN8abTp0B8VAsFAWQ3WcwhuVb1CTmfdKJYO5vLdOKMRNZPDJu8FX+J0BizKPwSJM5g1L\nYwuNzlJMUZDlBUWuyfKMXmpJcuillm4POokrTWUZpOkAiEvK+qkv45QSvAUBWii0lRgVkA9AOfop\niwDjicZFnpMmmStzCXe/qhWIY4EUllA5owmkb5GSUI2gFkI9hGYH9pQMk/oA0QePbg8TrHN/C8pw\nvzDExWXaaro//rL0NiWkFwZ1onhqzcPVtsSAhg1JqRqVSgWte45nZLI+jDEcumk9aD9I05SF86/w\n8uNf5OLMWar6u9R3ulpaUXjE11+Ewq+JoGQKGE/yDeH6aTgwDU/8QBIKw+lZyY17NAf3eYBBesPx\nUrLa3+SSYfb2w5pqDE+9Kgml5tqGL8mUoNWgvcbnOGCldTYhMw+1+m3WeoMyws8wjTBGYKxBYN0I\nQRm5XVcZH6b5XnvpjaysgfQTZyc5jLW+n8aHQibDGNcVqo1L6q11ox7TQtPLXTjb6zkhn8WeGw3U\nS6HVcwbTTb2Hj0O0it2M1F0HiWo1wuYOJib3ENQaBJUGQilUWCGsTRLGDVBuNmy3M0uvM481hqjS\nJIir6CIlS3q05y8gZYAKYnqLs6TdRWyRo3WB6nV4+utfodDaSUpId38jH15XA7c51gKYTlyUKWJo\nVZzaVyOAWA8iYOnBROkDAVH4iQ85yKyHjfxcWuuvJwqlqlSrO5ahalfVgEY9Up0gqHt0bY6iSLBW\no7Vrvc6yEjhIaS/M88Ijf8biubME6Q/4/rylmgtu2udgWeu9TuFj2zgayElZPzeqq0GmUI8NSSb5\nqTssDz9neKUtEJF1+XI2xACxA/DLdxsQCHjrIU2764wmT3wJxn9OwVDtUpU6zsKT6ZwemkUirPJj\nHSW5gUJLCu0n1VmNFYpQCZSySJk7JV/pK/pGYsVA2FD4rdwaJ2esPVxsrcHYglwXZIUlzayreZae\nQkMnhW4PFtowu+iFfAKXthnRoLrvCFOvv4U9e64lmphEVZvIqI5QEiElhdGEYZ1abeeyadxlyUII\ngTWabm+WRmUHjZ27loyBqRDUGoTNKYpCY22Mal5H0OtirCtZqOf+EjKDUdDquOusvPEEofNIldAJ\nrWoJsge9BcfErhfQ6Dp1nnrsDCoqSe4enSX35S1AmNRPEHQhrlQR9fo+KpWJEfWeH6oBLYW/laqT\npnMkyQLGtCmKzBtPRq+bMPvCCS6/+H2iYA5DwsVE8Jpp64rSPTe/qewcjn3KUfjSQBzC2Xn4/NOK\n1+03vGa3pVGx7NwB1++DCy1BnlnXcuJLIKYkksp+Xu9oWKlbt00fOeU99/+0BMR8MhoypAlnLbI/\nnkNgrKQoDHlRuPBHW/Lcok0Xi8Ra6eHQwhmO15+2aEdjwWk5Y1wtzehyajduPqrvAs8LJzTYKyBJ\n3ffdnvta8lITDbK5h/p1R5i4/g6u338T1em9BNUJRBAjpXIpZdEhSeZQKuyLbggBSgXU63tQKhor\nxFFqrfV6l6hVFZZGP68YkRTLc5RyUJnWiiRJMFYQk3Pqq5/l1HeeRFY9z7RkMfnkPzNwqS0ojGWq\nDgsa5gQ0JUzkMNWBiRo0I2hWoFmFWgWqsVdKTiHKPPik8EVbgZQVKpXd1Os7CYKt66DecgMqdyIp\nG0RRhTwPMeYyWdYh6fVoX77Iy098nSgusN0FFgW86bAlFi73EL53C+uaqQrPWwy9XsdfnYJLPTiy\n1/DyZcnr92ky63Q4Du6Av3lJMDML1zUHuZIeHp1hXfuJHGKLFLafbjij8+WX0MsblOFfUDZkethU\nG0tWFG4BZ9ol23qAFAscNOTe0/Y15dwsK4EVRX+nLGuVeVmbtC5Rb6dOsbObuDCsa9z/USETB49Q\n23MzE/sOUt93kHByD1Y4UmutNkWlMrls5hNYer2ESmWiL41cepZ6fRdR1BjxOsPqntZa0vSyK/+E\nNW/oJYu+8B7H0W+iuEaeg9YJUgoqs6f56wf/v8zOt1BVZ+yJp1+VSq9SOECim1l6OSymcGER9rVh\nYsoBCjtqMFVzhtOMYUcDphuuYbJed1IWJnUbno0c0hfHO6jV9qxrCvsPzYCGjUhrjRAVhJgECtJk\ngXPPPgm6h+28Qk8JRGEJc2ckNnc7rbXOYJKiXKhwoSPY2bBc7AhyC3ccsMzMGXIB0xOCF87BgYZl\noQenZgQ3NC25H+cprAfJKBNc9zNjBgx947su+qpUPrVR2su8+eMoScaFH8OT5a7onucu2dZmkGs5\nHGAU4C8HTGGcd9Ha/V2JbvUS6PRcONbzxqMDQXXvQSauv5nrbj7K9PW3UpnYhQyrICx5toDWKSoI\nHPc0iGk09hEE4bKR8UXRwVo3Bb00DikhihrU63uXhWvDj15vDkipVCpDsmKFR80dvKlUSBg2vMxY\nQlXknHn43/LcXz+KiRwQkOSe/2pd3qPKGi/ufK0P6YQAUwjStqWrIUkE8xWYjC07Gi7E6/bc30xM\nQiJhSjuwsRK6jhCZO/rNdmhkb7kBjRuL6NoTCnQhWXjlVWZPfY/u5b8hjmBh3rKj6nYMUy5C3xW6\nkEI7c239L807adddXcGtuy3PzgiM11GeS6EeW554Ad53i+BfvMWwfwK6uW/bN6MMF1M2TxZDRXgz\ngENLpE964y2BMu0J0WU+leb+eHO38HPjK0C+UF+2vJR9ZsYOxnnkvqhfWLeY2j2X6Le7zmhkNWDi\n+tuYPniYm29+A5Wp3USNaeLqTsIw7nsT51E0SZIAoddDE4RhlWZz1PuUm0e7PUe9XnXytH0NwIBm\n8xqkDMYaDkCSzGNthzAIMdYihHZsaiH8VPIcIUKiqE6WaXSRUJw5zqP/4RN0kpyg6RZ6mg007eMy\nTPbhWzdz11WbQVlN+ZlhNQtCWzIDF7vOM7fr7j53gV2h680zCUwWvsi6CLmaXBaG/lfvgYZHIfaJ\not0OJ//Lw+S9F4lFwXwXvn9esPM6i9EOQsWzWXILpy/D6Ytw8y7BfAq37LY8dwkqO6CdWopYUKtZ\nnnxB8IbrLDfWJYcnDXHome6eT1nG2CXLxfohbNrXMawv6okhMEx7TqO2HmWWg24CYwfeJ/HeJ/Nj\nSI0ZGI0dKDw54zLeU3nyai91yX6r5+7C5PW3cO1b7uLa2+6msfsaZBTR680hpEApQRTVaDQmCcNo\nZASntRlSxiOqnPX6bqrVxognkVKSZYtEkfKjYcpCoqVe30sc11fs9UqSRbJ03oEcUmCL4SHKOUWR\no3WAUg3SNMfOn+HFL36GU48/ivaMgV7mIgqtB9xaMSBikPlrUphBmOvuiQt9tR7049rQcWdnuq5l\nMHXNv5hkABLpEMIU0uqekWswrhXnvzoPVHqfvuxUmjL78ilIL5MsnKXZcAhapt1FDRxkT6h8gV3D\nxQ5kRrBvwrLPwnwPilwgK5bJKcH3zlt21wVVAT+yFxrSkOQuhg6U06gQ/mbpobb/4V6w0q6UL7Aa\nMVrTENYRn8VQGaYonPH0vOfJSmaMHZAQjfFyHJ7gnPhiYy9xAEC3gGhqJ9e97R0cue4mdh96HY0d\nB/vKmk7TTKKC3HsQiKIa9Xp9xICklOR5G4iQcgAINJs7kDIYQZmEgCTpEYZh3/O4WTqT1GqjGhbl\nfRRCkGVdet2LaF2g+7rjpVh/QZ5naB0gZR3TXeDcV36Xk3/1JZI8RzbcufdK5Srj6sl9oriPCvxY\nVnJ/7eXQfYkCB1fboU4MIQXCgEksc6knc3fBeDKx9IrLImyQVw4QbAHatqIBad1GiJqbYbOJ4VrD\ng3qX9vmkSZeX/+YxOrOnXKXYlzn2Na3ruPehUlHAbMfVAfbX3YXdW4PFxHUJXDNtOTEvUAouLwp+\n7AZLQznUbhGH5AQ+UddDBHLhjce3sTjWPwPPMzw5uigno5Xj2IVHBX3fWlIMPElhh2qbZUeycYaV\nFs6rdjxiplHse+1dHLztx9h1+HaCRg2DJQiUM45Goy8IWC58IapIqRDCUqlM0Gg0PaJXStYKoIu1\nFYRQCAFhWCOOq8tQtCSZQ0rr0TF3v5RU1Go7UCroC28Mb4JFkbCwcJY8T72QpemXI5xKUoG1EZEM\nWfzuwzz3Z/+W7sICODlwOpm7FgYfTqtRQS3BoHCr+2Uwr7WGL7L6dhU7VKQtB4NJATpxdK4gh3DC\nUX4qqatvM1nFBLURid+l0PzmHIYmyPMFjGmhVIUwrBMEfn4nG5vuNbj4fjBvnrM4e5504SxJa4H6\npNvZL7Whlwknvuenky324IVZwY3Tlj11eGnB7V4vzrnCvwrgzAV4961waJdFFi40kL6SXcZMeomU\nWjlbxuIZDnbAwhnWpBEjd3YwtLq8wakP1zxp2c2oMgPB0V4O7aHKPkqx/5ajvP5N72XfzXcRNaaR\nSiGEJsvmXY1JScIwplaLiaLqyHQBa6veMxhq1QqVSqU/dc0ZiCHPIQi8V8FSq00ThuEyXrzWXRcu\n+bDNWqhUdyBEOEK0HEQPKYuLM6Rpm6IYmtxXuHJEluUEqop89bt87//6V8ydn3M1p4rLZXpeShvP\nYbN2tCXa+FwwK5wXz3yxWw71AJZAgpKD9qSoDI/toG+wKGCu44qvSnqt/grUpUIGwYjxrFcne/n6\nLrC28L1tHQLh/aK1KVmWUBSKMKxhbRWlKki5NorD0vCtT93JUubPv0zr4ov9Xb0kFJ5rCfJ9lhhH\nKXl6Bq5p2v4cmFDAuS4UgeA75+Hth+H+w5aJiiuySl/gRAxynqI0GDEIqYQP40rZgbJ3awjd7rfo\nlNTLfm9Z2Zxph/KY8uZrV39Z6LiCoJYQ1ifZd9udHLzzrey4/ibC5k4ajT19kb/ya5pajMmdAQUh\ncayoVmsjAoBFHvXpF2FYIYriEZTM2hwhNEFZsALieHllPU1baJ33uymN0YShq9cNM5UHxpPRas3Q\n7S54rzNsOCnCSioLM5z/2u9x6bnvkgdgKj7P8d5ZCN+XZQfqV2aIDF5y7EoqkNb0RdSkGHis0ogy\nDWkbJn2bvi08Q0pCIQVJbrncdqjepGfqFwd+FIHse/WlRrQeo9E6ReuUouhiTNrXEQmWMgocCNAF\n26OQgR/OG6JU1XesijUZUX/ESJqSzJ9n9uwLTNQH+cFkCGlhaSWe1Ow9Ryd16IwEdtbg0VcF977W\n8oF9Tg8sFg7mDTwbV5Rwpw+cjafi9OXKys6DAbXMFTSHpkQPMWcGO6M3nDLPyb2uRmpcGNdNYbEL\n7Q409u/l9nf9FDccvZeg0aAwPQ8hK8JAUq/HRFFtRK85DDV5vuhvrCCOFXEcj+QtcVxHmxQQRHHc\nBw4GYI1wiprSxcVh1Bgz9tKQpoue0UC/FSWKJvscxfJ+OWGXjHb7Aq3WrMt1spw8dzSsWOTEr3yH\n1rf/klef/xs3zSR2CX2Se0EtOTRHyZcRyutq8ZC9Jwanvs3IDmmQKDEwvtAbUDmNMtVgLgt273Fx\nsxN8EgTCOl17j25qfFPd/rsQUvXzyvUYj7WGouhSFAlaJ2idulYPIRBSOQb+OBBBDDI13OzUTr8B\nzo0hiVGqPqL5tjT/KYXfjTEknRYzz32TIjFuyrRfmM0KTFahlThPI4EDdbjQdqHcRANuPmipTQuu\nb8B06Hasns+XjG+2XJrDyJLHKUvumg8NSgq9z2v6f2YGzIQSWs79Dct8db/Me3oZtLrOgEU15uBb\n3sXNd/8U09feiAwr3rtAns9hrXb/l4owzGk0GiMFzUolpNvN+sm8y1/Ckbk2YRi6BrUyZ1ty87X2\nVApcJ2xZBB2+J2m6SJZ1XIjm2Q1xPOUlDtIRKbGiKGi3L9FuX3R5TlaQ5TlVcqLTf0X7yYfpXrhI\nTzvIOLduUWsGk7cphXZKKW1/LXPjpRKKfuuRQ9xKVSw16EYP5MB4rO23JmGta1cJ510B1RWtHW3L\nljmsdlB5EYDceQTlN61h5HLl8M2S512KoovWietz8uN2SsNZJwrnP8xarC1cS65JnDGhkKpKGDYR\nIhrxPn0PlGXkvTYXX37O9fCYQUIYSLcgzy8KpgKLso6ecaonOJdYJvfChIIfiSw6gbnEUdojNcpv\nG467jAcRGKK0Gw8WGAaTSgSDRs3ywpe1G2vceMEEx0ju5E5OttMBE1fZe8ebueOOu9lz0xuI67uJ\nopggCAjDkDB0hUtjKuT5nL9hkiAQKKWJ4+GEtoLWtT6LvezgHpks7dEyt3Etz2uMp6k4SNoVR8tc\nxhlYQa+3QJ5nWCPQRqOk64NOkmTEcPI8p9udZ3HRySjrvKCRXkJ972G6z32DdKHtDCZwVKfMs7SF\nLzobMTCaYkgJK9NDA4PNIIwr/P0RPkIIPMtJeeBAlSCBN4qSDa6BuQUXpcTSGYsbhCHIretPSnoQ\nvu4t6Ma1xENefxSVHBiRGxrcoSh6PscxlDNLSk+zCowtlrypGBm0NdArHUCf1hosGlPkFEULkAhR\nxZhwaJKCi6UXZr7PpYsXmag67yO8elG5o3Qzl9BmXh55V8PJtkoBRcflOrke9I+YYAAElOBASTKV\nwtdwGArNRH/Su4OazaiyS4miac8ELwoPvRbQWXTepnHNazh89xu59kffiaw3USpABYJKRVOvNwiC\nsG9EzmgmyLKQPG/1QzQhUqJo50hCW6lMkKZzQ5mX9jWa4YYv4UVf1JIGMIv2us7GGILA5arDYECS\nLNLtLgzlN5ZarU6SJOR5PqL+miQtLl8+i8RS7c2Qf/MPaX//2+7eCMj89Oy0VI7znRol+lgCAnmZ\nJ3qjKfVJdOHLCXYg1dDXSRUDuQglfIuUGEjSOeBGYLyqnNZwYRZ2Tnol5cIRdSPlPic1MPGGD6CC\ngCiKiKJoyAu5+6F1Qp63KfKuMxrsQGGqL2s9otE27Fb6u/i660Cin5yLoZ0wR+vE1wUMaUp/DMmr\nJ79NlrkpCOWwr9xrBDYDf9Fzh1yd78KPHLJMNRwvzvhuYoOnvCsPQ7uGTac5IYYgaTuoYosh2ows\nazRDhuN70Rw4UAwYBUkCbT+fc/eRu3j923+aHTe/gVz3EALiOPICGAqlNEplNBpTvrVjsNNVKnvp\n9YQPs9yUP2OSkTCrWp0gyxZ827UT3Ri+zlIGq5QLNHmeeP6ZIQxj8lwPhdE57dYsSa+HsYKiyAnD\nJr1e1vc4gzpdB909R+MHx+g+9RCt2QuuCTF2IWyW++mNPofpF4bLp994CgPtfMDrK1niSTHIa4cl\n3oQYdI/2dSR90boEcNJBt3kf9VG+XrfQEUzXLYFHFQVumMDULbdTuf6ukTEnSgmMyUiSlp8qko+I\n4pQTGgdQhlhdfNEOPOdyUbkNwXvWJ14pvV6HbrdLr9Nhfva8Y8kKd1GER2CUgaqynFt0tIw4gP27\nHbPWJgOemdEDBkHq+9FC31pgGOrTMYNwrQwr+gqUQ2FeWSjtMwoK5+WSFNrzIMKII++8n4Nv+kkq\nOw4QBKHPTTRaO7kv52nKek0K9KhUdozUaNxzJ93uBa+dZsjzFnHcHPL4EYGKKHyC6jzK4C5JqbyQ\ni+orGpUGVBQJSdL1CKoDFNI07XubJGmzsDjrBTUKrA2wVnmRGFefQ2dUFp5BnvhzOs89ztzllKgK\ndU/E7XnDSa3PBz3VKtEDCD8tBp7n5UWX0E/EHokDZnvu0te9znypn1iOTJVygNL1NRP9RpiZgSGV\n3kf6cE0IS6wsUSzodSzCy+zpHrz2Pb/gowKFEIYsW/CKPLn3QApZwrCU9YvlExr7Px0nkrjUAwmx\ngvHYlQ1wuTLP8CQ5Q7d1mSRJHdOgGOwcWe74ZhXl2ccWpqagUnWFsU7mdznPbGZYmNaHdypyN0LL\nQeu3tB488L0/ZUd1Hzr3O6f2OU+WQ9KBtAvVqV3c9d/8Intf+yaC+s7+7lW6f2dE07i6WY9AhajA\nTalzqkUVomh6pM6g1ATGpM7LCIEuEvK8QxQNFF6iqEneTTyCmHsCbqmj5xe/VBS59nmoM5A07Xmw\npkDJGnlusDbp/6zVukC320ZrS1FoomiaNF0AnRN2z1L5wdcIzn4DOX+ahTnn7XftdL01qfb3oNQq\nLb1MPqjZZMUAHBAWLnXhxKzllh2un8caeP6yC8tunHAL39qBnlufPqUGEHdu3GfkJYPDt5QjBuCQ\nG/rnWsOrFYGxlk4CjQgWL8KRe3+MxrWHgdSL17i5vlJGLvT2fL816fluC5XHrqylNYzEWWMweUHW\nnnN9HoVjyObaabsl2gu+CydPFEVuIWephzbtQG98OOQSyWDDCBnAz1J6OeVyRxsCBfDvY4YQnV7P\nTWWY2n+E23/6Z5k6dDtxdYJabQdRFPdBgTKvkVJ6KHSCNJ1F6y5CKLeDIsizBcIwRqnmSJJaq+1C\nFz20yTC2IMvahGGtn6+ooOp2ZmPIsoQwzBFC9cOwotBIoSmiwm8ozoA6nXl6PbdI4qiCNr0h9keX\n+fnzfYAgCptEvXPo7z2MOPklVHKRHdPu2l/quR2/WnMATZK5ZsXc12JC6wZzB8ohW/1pjz6PUd7r\nT8SCZuR2cyGdx6lGjkVSDb2R+PcsDaEEBUr6VupZ2tp6ao8XAiojKykESti+2nEUWnqZe3+Zw/Te\nnfzoz/4ihW4T49DiIKj4/iYXMaw2bWFY1kOIK6uULjegK+r52itSeYyHxoyxSCFJWvN9KFJb33ef\nOY8yUYXJqmvSynzbca596GUHs5n63sMPgGOoUKqMg7XL15UyBFYOzWBzwwEcQpM4I52+5iZ+5J6f\nYeqGNyCVJAwDwrBAyg6VSp1qtTHCeh6e/BzHB0jTObJsYUjay5Akl1AqGOk7EUISV3bSbr/qi5qL\nBEGt/xqtQYiYokgpigSluigVOwPKLWmSogKJTHKfRzkR/nZrnl7Sxhjp4/l232BarXMUaZsob1M7\n+wz6+a/SOXuKWgzTEzB1wHX5XrzsSgZ+Egudnlvwie97CgPHXavIgdGEHkyQvkcr91LeAkvhuYex\nBwGumxR8q2O5mMLu+pAhDUnNlXqOZe2tKJE8j7wNCLEW6Y2n30MkXTG9JiGuxPzkL/+PiDigUgmJ\nogpB4LyOY54PddSuYETD2teMj+rW6YHs2n48LCBSfs3zlPbCLElvEeNh6yT3EGMAjSrsnICprqVI\n3VCORA8AgX49Z8iQcm+EthTWNO5ClpP7ykjSygE7oZw7kObOeHZed4ij7/x5pg7ejlABURR643Fw\nZ6AExixgrSCKdi2rYg88y26kDNxsTS84WRQ57fZ537xV7fPLlKoQBE16vTm/0cxRqymfv1isDcmy\nFGN6fiqfR9HSnG4vQSmB1p3+kOU8z1lYuEyepyAitM4crcRkmMVXCX/wTdSznydYvEyAu9bxbjes\nbnICGnXH/Ohkbvh3HDkjyLRDOAvjclCTuXAsUl6zIIBLCdQV7AyglbnXzvZgIYN6JKhGlqqX6d6p\nnBGdnoddTafKk+UDelQ+FGkMU3eMFejQJfL9qXI4DySxBAIaFchzgc4tSge867//Rap7r6NSqRJF\nFeI4IopCzy+UQ2jogCy8Re0Mcgh5KGXlV7Aeu7ZhW9ZarLEIqTBGOm0EA0nX7U4TTaeak/lpf6dn\nobHHk0qHEI6+uA0DCogpZa7897kP3/qjacTQiE5vRFkXart386M/+2F2HX4zhhQpc0fkDAOCMPQG\nFCCFRCqJLlokSeGbzCpjVVjjeMo3ms1SaFdhKooeeTZDrb6770ncLlr3XqJNns2CDZGq4j2KJk0L\n8izFmHnC0HiIuUOn00EpS1FU+lPXiiJjYbEFOqNhCvTstyheeYr0le9Qab9CbKDmlWysn1ZZCaHZ\nhKlpd+ytyz6sjhyAk3mFmyj0Sje5q7GUIZ0K3O/me4Jvzkredr1hom6ZT+DsrGBXA853BUpaarFj\nnJ+atVwzAQcm3X1P0gFaZxnkRX0miP8a+DAwUk4jQ5tSDNHlPvWKO+bZnpv+/a6f/Rn23XYX1WqF\nSiWiUokH6JuUzvCGoGlxpZF0dpWIbARpEwRxvAshSiX8DDBD8lRm+diSNSZJUiniWoMsMy5+zt0N\nmGr6RNWHck0Fp1KXhO6seQlfNQRDewChP2HQJ7XGkz1D7duB5SjlXfr6Q1CJ+ZG/+wscuOt9BGFM\nFMdE0TRB4IdwkiHlYMKE9BfcIsjzhIWFl6lUpojjyWVFNVc3qBGGliy75AubYE1CoTVxvGuA6FiL\nMRWSZA6tc7L8PHG8yyNqBWkKSa9Hls0TRu71SdJicbFDGFqSRGF0QWS6cPklKt//Ovn3v03ROoMy\nOc0Y4gqEOx1SqX3OqISgGlom6g6oCZoxrYs5nY5xRhE4I0tSZ0TGc9JC6ShWuYeU08yFbrtjy7cz\nwxNn4R2vgU4h6OSCW3cbTlyCyym0Cl/QxgmF1ALn7bSPMJQcsBb6lQVfTC43R+UBByWdF8p9qBf5\n6KXIwLQF7/qZn+LGt72barXiDajSz12FkAg5qLuttHjHuQXLoKnLUdx8FIJEqQgVxCgVE7gqt1oS\nphQIYXzMnWGtQ4DcV73ko8cjGkIIdJaRJJqJhot/Yz/UN8l8LpK5JHR3BVo57BaDwprxoZseMng5\nBFdr69oMcj8RUfrRi4H/eVSNOfzmd3LTO/9biBtIFY5w0RzMWUdKx/1zYvqFZyqLwVxYC618hiRp\n+Wnk1ZFNxXkYiZRN0vQSedZziFunSxj2qFR29kECBwxE9HottO5Sq4k+GzpJclqtNlLmTkTQFBTJ\nPEEyS2X+Rcyrz6BfeYbuhZOIbpdq1ekDRDsdAKNC13jnJjm4rjIlJRVlqMU9apMhYsrJGS22LVa6\nieWBcnoLhkHBuaTUSB96W+XY8I+/pLhh0nDbDsvfXBDMLkCSWS614HLX5Zrn24LXTFmiGG7c4e51\nOx3kLWYony0XqjGjG3uZs1oDBbZfd6yElumaM8rLs4If/6n3cOO9f5tqvUG1WqVacdO548iH44Hn\nvvkeonFuQPj3tz5jttb9jfKzXB34EHogIkKpaHVxeVcpHyUuOsPJPZUn89/nWKOdyr4t+iBC2eko\nlUQoh1LFyiEyhXauvfDhQeGRuIYnJPYl1kqGgB2a0MGAoiftAOIuC6TWt2fbFG54w53c8XcegPoe\nClUhWsIhG6YbOaNqYG2FwnbJ8i7GJJ5dISkn+HW7swgx54XGmwihlo2otLZJmnUpih7WWjqdHkHQ\nIwwnhuo3ll6vIE07dDo5cTztfpd3kXlCoOepXfou4sIpzJlv0nv5lJPCC12NLJ5ShHsUUey4cqFS\nhDJAqgClIjc0t98ObQlDi6w10fUKl5OAeP48hXFcwyjwUL73Cipy9yO0rp1eCcfI+MoLiiiAayYM\n105C3IN0RnJ2UbO75rzL116Q3LHXUgsttcCRbQtf7A7DARJatiWU4bgxwyguLJld4MYCWXcu1dB5\nM5sK7vnpv8O1b30P9YlpqtUqlUqFKI6d8QQRgRL9utwoh3CwTj3329f0nKEMvobeWOTmYWzXrFVC\ntuUJF756nqNUghAdtJZIUY4JtARRSGOiAbZNryyMmoH0ayncsaMK359zN61ZcbWGsgO07Aw15WwY\nTw61JY/KG1rSgdrkBHd+4L9h6qY3kQYRMYyh6uf9qXhKKfI8H6LXOLVyYxRZ1sKYFIErlbsQTGPt\nIspzAIOgOqID4YypSpr2SJKWT/oXCcMFgsCLlJsMmywSJ5eIdYtq3kX2LpH/4Ankue9RDZL+sLCw\nCuEhiQhCVBAThBWCULmO20ASKGc4UjpdNzEci5SCdjWDjgTfOBXyrecMRyo13rK/QxTA5W7IK/MB\nU0FCHLj6yoIRXOoIqtJgcQqh105avvGK4o0HNKFyLQU765aOERwILG88YMmN5YYJd+96uZdVjj0D\ne6jY2t/0GIhXGgZMem0HYV15KgpXM6xKCIXg9p/8Wfa94R3UJyap1ZzxVCoxlUpEEERDoIEcGm9f\nbu7Ko3MltF1+DcYyP7atpVuIwBMYY4SoAnXfHdlAmzppegkhLlGf3M3CubbTOiiGNMBESZ50cOhk\nxVF5qpHnyYkB21r7REh4wqFlyHgKyBK48abreMPf/Rk6yQJi/klE7RqM2YE1jrSZMdn3OkuZucM7\n1KA/qkpRBGTZIkWRDjYOA8Z2EVwmjGoEQcOFfKUHtjk2aWG7FzHpAjVRULU9YpMSF23E5ZOwcJ6g\nPYPN5px6ZuB2aTXlYGMVVRCygpAu1pZRAyndaHulBLKc4lBi+NLP95Al1uP0u0QsoGbodQuu3Z0R\n5z3O/KBKoxYjhOI7ZxpUTJd9dRdSn18MOT0X8MwFwfte03PJvIGjBwyPv6x49oLklp2GQMBkxbrJ\nGApumHJ5aSdzh9CI3SHlnsGeDXUBDxfsS0yqvKcl6loCRvgQUgqINExM1Lj9J/4hu2+5i+bkZN/z\nVKoxcRwSBKFjGgiXxzpEVxFElaHwq2SQqA1J+W6TMqlPvmXoEqugRqUyRVSZJq5P0uq6UfPaj6mJ\nGciyGhzjuemLbt180Epdthv0L3pJDPVi4oV2gMR73wk/8d55Cr5KK91FJmrk9gJpUUMv5hgbYyv7\nIWwgigQZNbCVHU56N08QRYKt7YKwhpChm+9jMoROkHmboMjJS06bcR2gqIBwsU0cBoRSEekOQTKL\n7J5DLT6P6LQITYsoW4Rex2GdckiOtglBpNyALREiZANkgBAhVlSxouLCMRUighiEQSqBCNTQLCF/\nQcvx9sK6EYehwYbatW+GblTIDRiiSxHXvCYjbk5wdi7k1JzkngMLVCLLhbmYM62IvY2M5y8HhKED\nYiyuK/iOfYbvnpeE0nLbLheq7aw4sCDzpYfp6oDH1htS2PGBhiOg2kGOO8wps3Y0rZZezNJ4ldr9\nr7uRO+67n903HqEx0aRSialVq8RxTBQHhKFjxUdRzRe0I8KwVB+SW2Is2yoqMjCikq6vaEzuZNeB\n63j2+NNUwsEFKncXKZ0RfONVwXRsuX7CEwftANK0ffqG35H87pVpODAFf++d8GPvANloQfYd9mZ+\nLEoOxsQw0SBJm2gbY3VEEdbQucBmMcJWXVOaFtisihAhwliEdnmdAci76CTHFAWKHFn0kEWXiu5C\nMY/IeyjtJGlVMMjhUfQHQclp6cdKRIgwcKPDpR/iKsPB9AYR+RUUDKRUpe+JLscaSIkVxrPa3dQ7\nJwessWQOvqoJRMU4BUmboxKLnoN2L6ZXKNS8ZCEtaKeSaigIJDx3ucJUtaAeGrLC9rXZLifw3CXB\n7bs1e2uCeujqdVUfykXSoX94j1NKU/Ub5cQgt/U6k47gK4YAoiE+o/XMe4XLZwOpuPO9/w8O3/1e\npvcdoFavebStSqVSpVptEMd1KnGNMKp41vqStpBtfGy5rNWwEakwYu+hm90uZEtp3EEXqfYX+IYJ\nS+Jli5Ji0GIwjAaVUkhlH8nRa+FnfhRuPAScATsJYsqvPeMHIJCCTqnL2XIkJzYZEEuFHoiNkA+U\nSvFD5UREX9LHeJ5WySCWMYjq0MAnibMiGQ2mMEjhjaThMnQZuj9Uke8vV35OpRttImQ5+Kac/aH6\nRWGQbkPxhTIrdD8/tLZwSvwSRGRd225NgCrQ86CKHjPz8H+/qIgjy0/thlAL5lJJbl3N5Qdzkp94\nTUGSW15eVLzakhyZdry86aqgHluO1Cxp5gqoBydhMnYonsYhbWWn6YBN7pscS1rVMB/Oo6x9r+M5\nb2Hov09gz3V7ue0dP8m+172BHXuvoVqt0WhMUKs1qdUaxHG1T7UqkeRxjYf/f2FAI4ajBm201cnd\nrsvQx7PGDi6sLtyus6fu/p8Ug52r/74+Hw69t4oi+Ilb4P23Qi2C3ktuB5QdIPWGFPhpzYEfCK39\n4CU/nqdvKGYJqFnCfQaI4OJCQGgM7TSgEWmm6toZGnj3Eg7iMhmCakLQwKoAEURY5T2JDJ3RqNDX\nrv0MVCGwUnrkzFmhFao/x7SE0YWlv+JEScEg9wlZ4QTvhYSKhqrXIA5yLp81fONxWHg14HW74J1v\nKjhYNdRjyaw3wAu9mJt2pggpeOTlCq/bkXJ4h2W66oxjf9Oyp+Fa7/PCIXd7vAB8KQyZeEZCn0VS\nehBf0ymR01IrrwzRtCxpQJ6JYJ0+eajgyN1v5fq73sG+w7exc8811OtNDxZUiON4pP/qh2U8W5oD\njQvlVBBQm9zpksBw0N9ufQMWXqij1FAr23wZ6g0pvVaeuwLa378D3nerm6RwzrN969rN8VF+BhBV\nv+gi70UYFGFtOJh614d6FEMNKUAMM5fr/B9fn+bnfzzn6bMRp1+S/NO/ldJsCIdq2Mi5oDByOtHK\nFe6sDBBBCFHgpnELH54pL7Qt3HAtK33LgwVE4EZCClcXGlZfESVz1rgEzOKH/lrlh+AIV6QJLMli\nwvmXM/a9TpAtKBZeFBx5jeB7rYA9u+DaXcZzpiw7mpo3HxQ8MdPg7usXec/hLg8/X2GqYvhnb+xS\nFMahph5ubkQuCi0lw5JsMNAbr+FWKsGWPVll8Xu418fgWxrMAKIuvCqtTmHfwT3cfu/f5cAtb2HX\nNQepNwaGM1wkDYJx9UvB1X5sqQENQ4flCTand1GtSoQ1fXGPchB02aZQdjCWzNtQuZ2u7Isv1Xfe\n/Rp41w2Ov9VNnKCHVY5+jxwYEX42DDkwAbbuvUyp2u8jJeujJeGLhUIorKogmjF//WQTS8yBQ4Yd\n14TccpMkaE5BoLA+wREqwqoIEUS+munmnzqELPbhmlcGLD2LH8smUP2hwgjptR3kkBKKw3k7l3KC\n0BJPurZdoR1EabAUi9CbM0zuMXQvZMxnir/+riE4Y3nNfkHPBrzldsFNOzT2XIJd7CL86Auh4N23\npnxqJuLRF5u87YYWd+5LSfwArsS6a1lRQ306ZqBrXZhBHqt8ZBFIL4HsQ8s+2moHTh8/YrVsiUhd\nWxK1ZsSt997DwaPvZPehW5jcsXvE48RxPNI2P6qf98Mxni0P4Ya9T3mSlVqT1x59K6eeeIxKfdCI\nVepRW9+UJSzUYj8XMxoyIOV2vx+/HhoFfP8VOBzD5H4neXVhFg4IuFTAZA4T1iv2hFC0gQUIpoCm\nP1vtGTwCRAVPNZagA6ysIqiDrSJEhcIorFY06iGHmwpbRFjt+0kCF5YJFQ+YlmHshBuUjx/LsK2c\n3VGuKCEHjU2lPKfRg0piyUsKLDIPmP9+RjUxTFwTgAkwWc4Lz1r27xLU4gw68PwLMHFQcv3tMYeu\nNcz/IONbJwquvx5EFlEsVNg/mREmqXMh3YTpMOOf/SicOq843w7YXcv7OgVhMOgEzXyrQe49hTEe\nLBHO1I0/XC0cE8SIgVEVdlADsnrQDl4UkPWg1qhy81vfxDWvv5udB1/Ljr3XUas3+kYTx3G/N6tM\nCzYjUbXlBjRsxcOLfyPDh8oTLBvRwjAkqsQcuvUOTj7xWB8QEENkPaNdftSoQbPmx//52lCl6l5/\nbQN+5Fr4vf8Ciy34uQhUy+3Vr3Tghl2uQj3XgvkuLFyEGw868mT3PMTzLman6cIzCqCNE1aeiNwH\niYrzGiqGXoW7ro05/p2A1nzMjmYINkJUfA6j/DyOMvcJY8dTCiouCw5Cj5z5sXrSE860clt6X03D\nDNivwn1vtcDgevy7sxnhbsVEEPD9x7tcv0MxsV/CnKZzEZ46b9h1CG4MLKdmDO+4DV5zVJBeKJjc\nnfOk1Pz6b+e89gZ4/90R4Z4mzFl3kUyK7Xa5tmHYX3XFTyscSVOkkHqwJffG002HNA7MYGZqyRYp\nu4Oj0OcyZtAQNyxEmWROoEUquOH1r+fQ7W9l35Gj7L7uMLVGc5nhBF7XYGlLyQ8j3xkXeW0pCrd0\nFo0zpog9B29y7Qh+VGNJFi0MFEoQVyyV+iBkK6vYKoTXNeCamhso/HdvgS+egGdm4JWX3M2akPCN\nM/D3bneTnS+14PPfkry5bXnfj1lkFVotmAg8BN705XUjsZ0c0Y5ATCLi2v+PvW8Pkus66/ydc+6j\nu6e756GRRpqRZMWWPSMbx3aikaGAylr2LkuxseIUW0vFik1sdlkHp8I/2LHX7B8QEmSoWoyNxKOy\nhRPB7h+sbQmW5SHLsMBCNDIbkk00k+A4cTJjx7Ze/e77OGf/OOfce+7t2z3dMz16QVe1ejRz+z6/\n3/m+7/e9AJKDIBZISLGt7KBNCN5pOpiwXAg4II6rwJGTvg5VBTOWJTWPqzUQk0Aimp5zgHeFRHki\nIVU5XySmTcIgwLeWmthaJGABQ2gz5LbaYOMhqisBytsp6KiNGz8gcOYrAn/7fzy8PRli9zbgf7zU\nxu6dAcK6j+9/P8G/+zEb26c4prf42DXThmg3gTyR55VzQap58EoTvC0nV7d0Dwo/Lm+otyR42n7c\nmdUP4847EZh0eEF1aG2pgjhPWRjtAGjWpXLdedMcdt3+w5jcfRu27ppDwfBzdBMQEzhZJSWXy2Tr\n0EBB0FSdMC2VbSwZISHM8iLS0XwxC42mJosbCNqY3H4jJna+B8vffF0OQXJkfpwlCDgVsHNxmMOi\nqsaHACUBzE0Bu0alBrEDYP/1wBtvy+zh23bK6XJ/ukjwtbLArinJyOVc4NtvAagA+QnZL5m3lPZh\nkN1MNjkgbh44lweattQorgNi5yAYAxu3ML2V4Bvfy2H2jqIEgm3LohrmgFBlqulPpjQNU2kFRI+U\ndlC/SNE872PTeF6mBgFATfYza1QFChMWSJ4CCMBsioIb4PXXmtjzAwVYRQDwsXWbhcp3fPA2AXUs\nFFyO993sYKoQ4Fv/GGD2doaGRXHxHDC3nWDE4qDtAHfdphoLvNVWQ4jbEMIDmA/kczIeU22ifZ6j\nXlXJuUxlEbTlfW55cb9vz9A+vo7rhTKXsaEmMGhiyAvi2UmUANfN7sKWG+exbc8PYnr3LcgXinBT\nwMkiCS4XyxanAJFUclHcNckKgovgnMieBToNgun2TEilPFAjpZ+oYBVNNmJQ7WYZheqHRpAbKeKW\n778HX/3S70AoNk72LxAycTiUsQLbkiaEReQQ2S1loFCUcjjiAM2alN+pceD0eWB+p4xS//lrAn//\nFsG7TYHFCuBzgvE8gIbAuQbFl5ct3DbugzUJSi4H9VuoBi7erk3ghpKvetLaQA4QjII4OaBg487r\nBf7ydQv/BhaI7UhTzXKBvItWYEFYNvJ5V/ozloUgZKCWA8IttC4QeC2K0CHIUSZnENO8zLWreRDN\nEGzMAX+jirotUMyraXHUxuTOAqrvhGg2gVJRBqWsPMHFkGIbZ3BEAL8lcOG7HI5FcOv7GEbKAj80\nz8DrDLQZyI6VXlupgZacOiUCSZpAALwJhG2Z00hEFJ5qKBPL0/0oWNzrTRcy6l4GVHXcaaqpGKFK\nemWQvyMUcC2Krddtx5bZf4HyzPdh2+6bUR6fjEw008fR5r+pcdandVSFm+CpZFKeBIkuBI3+pv7P\nwygYLGvcVOwNBFwEEkCUaKDQON0ZYZRCLssXRCqTlRj/jzWQEETV5cuZoWHYghANAA3ceMc8fP47\nqNWUP6IWfUsNrCZUOqBMyM+iA2yZkNaNFwC+JX9381bgewXghvPAa+8Ac5NAwaFoBAJv1QlePwvc\nOMElMB2gxAXeqlr4+zdcbBvx8eN7PTglB61mDq+9mccNP5QDznKgSST1ZCsVaNkojRO439X8rOLE\nHRd+w8G3XyN46wLBnvfaKDoOfG7DGnXAQhv+BQJmS23UrhHY4zZ8wQHkZLebc204RRvMtiGojYJr\nJfgchwbYMkZxbrGNHBOwJzgsQTCVBywhh6XaJY7Ns0J1geQyzb0O0CaHaPggLdVW1fOUXUYAYUH4\nHgK/At9rIPC57PCqBnNYIwALZCym5cVAybvy+QRhPIFCA4Q6UuPr8u56U/a2IHYOU9fNYXTnHZi8\n/g5M7rgepbFNCW1jmmta43SrAJbCzlPCH8YpQKnaNSFCI02IJ8CU3I6nqoG6Fd3FCXxCJaUCBJbZ\nG5cQqkwMEdWR67Lj+EJER584o1AgJgoIB2MCjAlYDChNjuOWfe/HPyy8ikKOgAkBlicgekitkIE1\ncEmMjZdl2a7KVon7KvgygPq+aeBLy8D1k8C2EofwgO/VKQIBnGsINATQrgO5SYEf/D4Pv/03o/jI\nrQ3YPkHlu2N49cIIzjZC/O+v5XHzDMPkhMo+kAQxCFxsmnZR+CpBvZ7HyGQe4BYC4uIfFwl23VbA\n5iZD2LLRdGwsfjXAzI0Odu6y8U7Fx/g2F6OjIxiFDb/JIdACgQU/EDjrWZh0R2AHAk3PQklpJiBA\n61wDpOGjfIODi0scXsBhq+lsYzsBavM4XT0MJTiCQNVy+BCBmpXJPUk30raKanKIdhPN+ruotxsI\nfCKHVrF4/o7HJA8yMgaQmkwwBZG/c3NS42gKm+RiEtH3gcoFmRHPaR5ju96Hka2z2PSeWzCz+xaM\nlMfgOLZhplmwLKY+KSjlICRUg7QChKHR4JAIAwgiVeDJI9mMza2M5m1AnKlu9oJWTSu79T9MVqSS\n5F7VfiwdPdRNF0DiCjx9Qt1H5MUN7QRINLOGUzkr07I4HMeFmwvgegF+9Cd+AotfelWWE6iBL76n\nGFxbAsgiQNkFxkbkg4Xqz8FDSZO2PFl/TwTw/dtkFrdlE/ihwO5Jjm9WCP72LYatZWDprRC3WALj\nToi2YGhMOyCFNsTrTQhRwDtNCv5NYNqyMH6TC0YYBKcgIQE8ii1bHBRLwHcrFLMTtgxYtih8TiGo\ni4mdBQA2uLBxQxjitcUQ3AfG8nnwC1Q2/waBnRfwbI6gJmCNOBgrOGifC5DbxOCWHFR9jrLMO5ec\nwpgFlqe47nYq0ytCAXecgJRtGakkej6L0bKIypwZQkOgFUK40sMnnpAZus0WSNCAnQPy1AF3fdkP\nXMT9CTyVKkXz0hQLWxIwvlBNFTnQcmN/qNECKueBRgWwR3Zg263vAxvbiokdN2Hbjd8H27ZUhyMC\nx1EEpcXBGFcugi7SpKqYkRodcQmEQM/2U5HlJER/yaIk2VV0dZYt67Bxw0XFwpEEWaBPhBipJKJH\nS5GoSWCEaDkuPQwFbNuB74dwbBeuG2Dmht245Y734rX/92UUC3KMRautakS4nLDsWrImqFAC7KKU\n2bApxwSGRNncDeBCVdLeFxvAZFGgWJb1Inc0gB1jHJ4gON8E/uY1iq9XLFznNPHyq2PY8a/bGL0p\nxI+SEDe9aWFskmBsOwG1CcAsEJ4DAqltBAhalKDZIJKCdlxYdh6TWwS+9ZUQe37IQdhiYDbD1HYH\nExMO6m9zjIyN4O03PHznyzVMbbIwOT0Cd6KIxrkWyiUbpc1lVC42IRyG8q6iHHMPOd06N8p0NzZl\nDci4EBm34sQ8JgCXx5WEhEvbiwWAE0IEBMQnshNlI4SwWyD5NtAmsJsUdttH4HPZIFEpq1DF53w1\nlc9zAd+R7lOjpUATyqG+tbrsqdBoEpS37sZ7fvgDyG3ZgdGtO1HaNAXbduC6uq+erRg1TQzEs1xj\nxrabn0P6aRWV2eQg211KdhsVEF38KtJnmypi9sY2QaTNORF39zQaiwhj57KlU8xU6OG1jHHV2cZB\nGIbIqWHDH3zwP+C/PPY4eFAHbOWYGrN6cqrU2C6rhE01wk+4cRZ2U5UJN3xg82Zg33Vy3uj3zgOz\nmwRu4ALMAsYLwLstghIT2LelgS9fABrnCJxtRcADRnMemi0Xm0ZsORbPVXXnLA9QF4Q6KIxyXGyr\niC6XXU8mZwv41l/4+Os/rOGmW0uYfE8B588KjJYsjO+Q/tK2m3OYaAdwLAcgOVgFghELQNgGsW2M\nTuYiZodGdziMM12je6qb57E4WY8ovt9RKRfCkzlMFgccARJwyTsjkOCzXYgWB8EFCL8OXwi0lenl\nQ/W+1l1HuXQFdQyn7ct7ffEiUL0gFy9hjWN013tx/U3vhzOxHcXJbRgpT0Rmmm07cBwZwpBtkGUn\nV8ayY429CQJD6FchEbQs6oEI/Wy/qsrq+V1DA0nApGhrQrvsQqTqyk2bUtbhMmbJER+WA98K4boh\nfD/E1M5d+MCP3Y0v/tFxuI4kCFyV7WKrzi9WMZ4ZJGTfD9lhR/nE9ZYqDRfy580TMvxi2bJpoxdK\nIIYArp/kuHmrdJZ/fGsd7vmyZCk22xjb7sCr+BBvMpBRGxiHnLUyQoARBkZc7L0N+OZ3lIeNHAAb\nTt7Bnf+yiAvnGMoTLhijmNzsKCJAxn4YKAoFVZCj7ilzcoizUZkBFhhJeULx7aqBeGLsl05V5vKm\nWIqyzAmpbTzpxYtWHaRZA9oVoM0hvBCkVQX8BgJjskJbqPEtftwJtNWMYz/VBnD+vGoIYo2guHU3\nNu/aC3diB/JjWzE+tRN2BBjdHsxRbJqlQCOBw1RuJNEdcig1yKvB+0wRsgooVm2905fFl/Efkg6k\n0hg0xFwRaDZwovZAIru3iZC1GAIElApQxpQW4sjlZFn1j3zkp9A6+zqW/uErEJSAMgHblsmihRFV\nqcqV+V8DwoLKnVRZKDqYJ4hcIQUkU1QakavoRaMtMKHSCQ4pcDEkcC/4KIODEhvW5CiszXmINldN\nzhyINgEJVM79CEG+TOGEKhefuDJTFQ6YZWPTFl304yihdxTIDG0R3V9z8RFGF6TAuJeqFkjOGTfS\nxj2VNtFQn00AdUlF83ZcjxHKG0QEV+1faxCNGkhTphT4XHZDarbiz5ZqXdVsA426nLZ3vipN45ag\nKG69Bduufy8KW3bDGZ1BcWwL8iOlCDAy1mdFoJGMmqPGutDEWJFE1otucEgwAHiGETzt9KNEas7U\nQIFUDZaYOED00NNqNcmAkG5emmpqQVTrKKLKdPXYE/n+0Ycfx9mnfxZe9V1YKoGUC2kqjDuyHEGo\nfDmMyAREv6mmYou4PVJUJUqlJsu5KuCnOvb4HmCVgEJBZYF7FIFXgHNeIXKTDVJ0ZYYqs0FslXcf\nKBMgJHBcpsCjwVJUQLEygOIrgSep+2nWTOhM19AAlG9onZYCSUsCxQQOb8gkMq8tYztBCARN2fyu\n1ZBOTVgDgioQNkG8AEFLMmTNpmTWWmEcIK17QK0BVOrA2QpQ5wTO+C5M3nInclt2wylNYWzqOuSL\nY4kyAhM8shurbn/MUrlqhmVi+Myajk4TBYT0AgxZE1zEalqLrBWEBFYU/zGJg4wMhPjiBbI7acWE\nENGUuCIUdN9sCSL5Dsc2Y/99D+P4bx9Crii1TrUtZS/PgTEHKGyStWiwJCVdr0qzwtf0K4sL7nSu\nptnBxw+k09tqASMFAlZwkCvmALggwgXaNlAhknkr2UDRVjEgAEwKd2ECGHFVUphNEjcvTtQXkeMf\nm2TM2IYhOZs6gDkTKAaUZ4CnHgOINyVIWipA025BtJsggQJRvQ40qxC+BxJWAP8CEIQIAgFPlR40\nfBUkbckxmtU6UKkBlYtApQ2E+XFsvvVfYWr6FvjCxeT2GzEyNqn66DmJIKf51rEbM0/NzFczgZMO\naJoLc7w4c6PDLYz7idT3Sd9mHukqr/2SBd23sWLgpIFEI3tSQGSir3PnIu7hFrFzBILJWI/rEkAw\nCDV/ce7OH8E3v/IPOPVnf4LrtgNjZZkuZit3grtS1LwKULsoH3rNkyM3bCbbPBVyKreOSQ6g4EqB\nCVVv5VZbrq65nEDZ9UFyoap54HF/YM+HqLVAQjXByyeqC4YHh9oo2Q44D0AjgATqTdUtJEo70RSw\nOOKiDaOaTMV8JGi0ltEmWiPWOH5DXkDbN8DjAUETxG8BgQfRqoG0LwJeHcSvAe02eFvNcVUapq78\nmYs14OxFOdvVFy7C/HaUZm/HtsndIIUpbNpxIwrFMhw3l5hKkQaP2WxfN2fRg5F7EQP9DqtGV9Y3\nCSw9GlMu0NlA6wyUrtU0JN3KGTLYtygrgXRhK0QqVkQNzYUo3Ueo+l0WhrCsUHXE8UBoDoy1QGkd\nP/ZTT+DdszV85W/+Gu/ZAWwpAmOq2Z9zQZUMt2WEu6Hm1YACIxaweRSYKEvyQED2cM45siRC8Lj3\nXK2msh5sioKlGDdbdWG0BGCrgUVQoXaVdA0u4LcA4TBQlxlMmX63I/rZjJvF2ihMGxEKXKHhy1RV\nanhDfdakadkOVDJaS16I7ym7tCUT+4KmBI13AfAuAi0PQRNoVoBaUy42588D756VI+CrHtB2x+BO\n3YCx2+fBRncgIHlsvu5G5PJFBZpkpadZQtBL06RHJ64n0bOf0SNyE9YVaEJ01yLdwGUGYhM9DiOW\nOfuMLAkYFo0QlP2xmNH2icWUdWIF6e8m6dSfBDATN4rgJ5/4Zfzur/xnvHriJBpT0v/1PWDrRWCq\nLJnlkMp75hDZ5XSiAGzdJPtsw1LjTBTmtXnnW8pnCoCwKvXHZOCjPOqDli3AEhC2BeLmZJ6bKoo7\n/zZQ2iJgTRD4LY6L3FMCrtgv+Ao8TsoP0tdkaipibKPB1DJAU09qnrAp1UfLh2i3QdpSC4lWE8Rr\nyIRAvyadmkYbQd1HswY0asDFKvDOeeDd81LTNAUQjF2PketvxfjOPWgLB4XxrRjduh2O46rJ39r5\nt9Wno9g0V9HPehpf9/y0KyM7mvTh05A1dOcRiaRSIWJrghACi7F8ogQhvklsKDcl3XstmYcU//yx\nx34RxWIJX/yfx+AwqTkqLdnYfMuYzINzXemmjOVlk/SSorsFMZSCkluCuDI6UClAfoWg0W5hokZR\nrhLkSznYJS5rwt0AGGkDAfBnf+ajavk4cE+Id95g2LnbBmoB4BTkG54iEdyU5tEP0swfZEajBX2S\nhpmGlupRXJPkQMuDaPogrRZIvSZVSvMiSK0BNGrgDR/tdohWU46iPHcBOF8DztaACzWgXZqBGN2F\n0m23Y8SdQG5sCyZ37IabK8B2HOXkkygmY9tMLZimlpGTDGTWAJU0NNOLEzXGhdArpqxgI4GZzMRJ\n9hAk586dE1kAMlv7DuOlu3fqIVB6zGC73Uar1UKz2US73cLXTv01/vj5Z3HhO9/CphFgelwWzO2Y\nACZHZYpPcURmKjgO4KgeGkJFzGsN+dn0VdBV9WBglMngKCvAsi3kHIaCm0OpkEc+78DNOXByLsiI\nha+fdbF4LofrNrvYOuVg6gZX2oajthoNoBuE5DJiOcRg22zDF9JkQVNqH78hgy3NhvLs1YCkRk0i\no1EHmh6a1ZYalylwsSr9mGpTmWSCoO5sBSZ2wxrbheL0HPKbr4OTK4DYFlw3h1y+qGIzdpekTaHG\nfkhqmbJkdgBAEiaazCCwIvCYlgVZKxd8tUJr2AV1/di22tk0bWazBPzWH/gXuOmOffir4/8dr/7p\nMbzxzndhUxnjGZHZNgiYDATmfdmExvakn9RUrZV8nZaiXBqhR9VRgEKoIccUARPwmyHyQRs5T6DQ\nFsi3bdxUAm6aAoTFQVwP4p0WSNGRB27JcgY4alirniOpe9a6kMVOEamgzT1PJpf5TUkM1FtAvQHU\nL0r6udoAak3weh3NC23ULgIXKtIkO1+XCrAWFtHOb4E9thOl627H2MwctoxtBScEtuMily9FIKFq\noi9jRAFIBjxt20kslnFvgZjxEoLHuZEKNImsaB6CI0ysyrEZpxk48k9CQ10yDWQ6Z1oTZWkj/dlu\nt1E//zZe//Jf4bW//WMEb34ZU+PAtilgQvUkKzAZhLdVMnLgxUNv22Fcgqx9I2pTEOrCYjYs2wZz\nRuA4OdgWQc6iyNsMedeGqztdOpZ0uPSMjrwlOwq6jkrehCr8V86oA6DMgFFLAok3VHymKVViU1HR\nzTZQbyCoN+BXW2g1fVQrkuy4UAXO1YGGz9B2d8LecitYeRfyk+8BcUfBiQ0nV4aTd5HLF2HZjhLw\nAIw5ajKbbvckZzPJ4VUUlm0rTeRmdrTRP2vnWgiu+oFzw69IkyIioXzjDBqaCItIlyA7vng1a6BL\nCqAsEOmm73r0uud50acGVOi38c63vopvf+kvsfJ3/w15CJQdac6Vi6oviB4kHBidTZX1pCdBMwZQ\nNQaEUAKbOWC2C8sicC1p1uUYg+3mQJkF27GRL9hwcgTMsWQcyFIsnVA1zYGQDhZpAWXIKPCIJf9f\nuwBRaSOoc3iVAM1KC82qkGBpyqh/pQV4YAhzU2iN3Ah7bAdGpm9EftMuOCNjoFYOlm3BdnIghCuW\nLAcgVOMmC0rwBYQIYVkWXLcAy7Kj7HhJ9Uq/TPo/lsqWdxK+bhYZoGtwOA/BeZiIy/Q217IyVYiR\nbR3P2yGUXpWm32UBkEkemH6Rnv1pgkm/Pc9TwGrDa1RReWcZ777xGr73jf+L1/7uj0HVoFlXWVX6\nHfX+UEHWnOo2Y6tOuZbZG0SZM7alUppAYFsWCnlgxBZwbQLHpmBUTqFqBwRNjyHwQjC04eZCsBEg\nzMtcs6YO/FbUuESWRzO3B6IwA3t8O+zRbRDuKKhbArFdOIUSqJ0Ds2xQwmE7haiFE8Bh244yqwRc\nVw4pFiJQQU432g4IQIilKGknQeBwHkCIwDDPqMoicPt41mqOjggNMIm1PP0EoKKfqDb/2Ib2sr4m\nAJQFIvnJEQTarPMRBB6CwIPn+fD9NoIgjAbpysIrDr/dQqteQ/XsO1j+xlfx1uv/iGb1HVz49tfA\nPR9BO5QTnS055tBlavoaldWWjuplHbVzU40c9RQJV3WsiuZ3qjShpi+zmC2Loli0kC8WEJR3wCpO\nAHYB9vj1yI/vQq48BermQZgLoVZc280rwbWUj0TgOAUl6KFix3JxKAECtiPBwHkAV31fahUOx8kr\nmpkgDOVANEplYqceCGXOeuLcN+IhKtFVzcgx43mrWxKhmhnFU3l+65Gb+LtSs9Irlqi4rACKVzR5\n88PQhxASPJwH4GGIkGtfKUAYhAjCEL4vwcNDCbaQx76UEBw8lLZ74HvwWw00azX4rSZa1QtoNSvw\n6lX4rQZ8rwERtOHVKwjbTbTOfTcCT2FqF9yRMizbBoFAvjgKN1+GUxyHnS/Dcgpgbh7MscGsHIhl\ng1iOnKRghAGYmo4m+0QQFXPJRYOfZDQ9TAg654Gc3erkI+deCB+WlQdjFGHoRX6MrOBsg1JmAFCo\neymbVFuW1ESm0Emt70UT+cy6G0qleTeIBojBFBol07x3zmRCE/VnBpqsX1JLXR6/6pICKDEVTAWj\n9M3WzRoAYkx7i5NPtZ8kTQf5cxjIvwXq9/Lvwvh+iDBMarc47kSVs8sSZSNCO05CxCMe0dkJJh1A\nTAcW9T2UJlOoqF892MmOgBEEHhijsO28Yic5OPeV9om3078jhMqhX4TAtiVgpMYJYFm5aEAUIQRh\n2FJmlgRFGkTapNMLVzovLB46xQZ+ztlgIkPSHAJmN/pOUJGEv3VJaOysqPL6ossiunHxJ49ApHOY\novQhFqf+aJqbc66ArADALXDBwblAEIQQjqSPw9QEOs7jqXSaTZI/EzWtjCj/AUbSougrtSQ9iCsN\nMDNtX3AfIbeiURuOk1MCqQPKPoSw1EQ1V2kfH4IzOO6I4dwLBAFU1rOtph9wWBZTJQN5+H5LAdU2\nKorzCIJWNN9W9j9IjiyUILXAuY8wDBLmlwQ/hxBMaUyrb6GSvpVtgEnGweSnWDOY5NqWThfToA1S\nz4Umcjy7l+is72UNR7vEGkVrGD2WPEuVxxciVhVWIYQSSAGhwGDbFrjSLmFC6yQ1Tpy4qTUOTbCA\nJniyQJTuBWGyVWlAxdnHCggiXoTikYI0yqcLAplP6DiFaLswlH2kJHnAEpMY4s6cDoJAzmLRQi1L\n6D1l3rmRwFiWC99vqUUkAIQAs9yOaLoedxiG7UhrafBy7oPzEJQGA49BlNdlqWkcApTyhHbqmuuW\n1jcEXdN0SEahm1DzkrgezoZ4QlukHECj+rdLCqDeYMlyIuma1WPiZzUSRWskRuWQX2aAIZ5VSg3z\njCZAkvVzVmpROtibPqc0aHTAMQg8CCErU6UGtRPgEUqLUqrjMXrqswSPZAPt6EELQUC5mbApeyZw\nHoKx2NzSzBjnASi1o4XKtnNKEwFccIigHWme5LVSMJYDIT7C0E8xZSIyn9cCpBhMTF2jlhsNJtGV\nS1gXHUEieyju/SaSeZhpM3BQ089a3W/hHT5Ltk2KNajmbs6kSGkrkVDhjJEoascNQEgWyUqo9nT8\nKZ1eNAiQs7RRcn9tWFbcfFIyYbkEAMOwrR6SrQgFTTFLX4lRyabFjSrDDu2tG/1JgZamHKVM+oSB\nD9tmhilHwZiDIPCi+xAEnqLurY7r0tooCNqGFo/9oySQ7DVNgkuDSWvIBDXeF5nXKT/EGBe5Og5E\ngp435ZhSbQb2BpUV7ySOPEfMRpeQWHeFuz7asvvvTAESkXkEQmGpsgr5IEmmNskCTzdavZ/VJyvY\nGIbtyMyS4GFgzE2ATfsVWsuYZqoGc2dQkWSYujRawXVav9ZCmmGzrJyhKS1YFiIQAVAgEpG2Su/f\ntvPgodRGIuM5SD+zrQgSW3WwJWu0NCRwGRMQnIOL0GiamF0FTZL/dDHr1ip/sujTdD/M5qMmpW5x\n7kdN7WRZA1EFb+wKiw6LBGUpV16rZ6/ubqbZsBiYCDyB30EwSPDQxDlw7id8g+QD68ZUiS5amSsh\nE5EJIrVQoITbT4BD0tNckQUaRL5qfmlnPmvKbBDKEIa+sbCmta4A555iHq01Ayl6tpSBgUVaWV4j\nR6ILLtamndYKKqJuv4hyBcOYhZMrGUlw6nGTEW1EissMHDNKzYz+3IP7U8MNBoeSRk79Pg0eKQy+\nWtUQZTOb+4lbgtEMNrNTQ5iUsQYjpbahhfyOUe6MOSrmFoMoDAPFfjpdzFUKy3Ijpi5mUNFhDg8P\nSIi0OMAiVyL2l0TGeZA+tUv/f1/t9IUQej4QrsBXTAZoQbiS0jtkDMXrAKpJJZsA4TwwcsDS2sdk\nvkjGA+4sjc4qZZaaz0YYeLIVcuhFZqQJItnkJYieuzy+1zOAqs00rY3SGQHxWssRhp5RpLl+IGny\nhDHWERZZvWR7PSBZ/byt+AaR/lZwgY4S1+GbRzQyz67EnCipTfwOp1U61VbHKhWzWjCykk3/jGcW\nqMW+G8n0G6Q/yBO9yyll4FSO/tPOPiF2SkPaEXB1cqd24NOxok5t5KjAtd/F0zdM21D2vB4WkEww\nSZZVGEywGbpYBRIDpAOtdspWOr7RXw3HsFWWpmOZMkeu3JR3zj1FBpj0tgClTia1K4y8M10y3xkW\n6GVqioh1S/gKEZGQNOM0rS1NOGmipU05zbYBXsQ+6QbtYeitwq6RyESTgd+wU+Ki9A5teslA6jCB\nlFxIaAaYRGaMaFWJJhhI9i0TNGZj717fJ334+qLvm2CaaVdySnscVDT7nMlryI6LcB6CizAeV58S\nZL2NFN7B7HiZxmOOGjfPh4GQMJFnmPZxInMvVAV0HWSH6Bnr0SDkJDRy6tLLNkndvyACUpo1HSaY\nTFZZTjYfXLP026nHMjuRxrEDGIG8Ac21rACYSDe3owZwrvy0dSlUXqovWSys0iTK+k6QeGJZ5p3Z\noCL7XvAOwEYgQQCh8gcJEakqX6ZMKBJR3knmT8eIbMMci5+bPvfVAqbaJE1mePcWQB30HbZGSmpo\nYpAtPOUriYGB0tWESw8yMjvnqFPpOZ1hdeHT6RQ0CqANyqJdXvDwDOGIxEdRxSTjewHiJEqR6c/F\nwbve+WGmn5U0BXSsjnf4I1oLQTVbl6RB5zlkgQgJEGlNRFbXRjxMLhqrmsMhCOEGSbQxFoh53VIr\nCcOPXyvVHZlwZllvRndSggSEdDLf6j6NtpepoXEorqZXEjykgyHsRv3GAWmS8BuytkuumL1NuOSg\nMyTAJ4kImmIEmRJoElHWkmkjPUDUKeTaTF1NwLU20ik65iLcazGX0+RC2R1zg/soEDUKhERxJdFl\ncewTQP2OmOhpO0YmmjC0GLsqQdMJniymiWYKYtLWN7bO1D4mwya67qtbG2XdRYcLGGaKSPk5DISY\n6Vci05TTz0wCLux49tJE9BWVvRotTCIGVYhQlYj0t+QKEYJAN0Tf6IYkxKgIIIl8zn7cFn1uVlZX\nyRhMYgBkI6IXr/bGESZ4NAFg6tVe8ZI42GcIcqb2CVMLFOnjYad/TdVkhvREaVOYWZTqL1lBDkF4\n5vlrLZnUnrEpLrMbrL4WxcgVoGG279jVqxdRYFkH+DdelkzyLG3aidVNOLMBeLaJsMrB1bTua6Hb\nii6CS9DKxkcv4iNy1k1Dj9Luo2IAYxXM3ob0sH2IGgityZ60GRdrFhprAiNxMut5aRB1M2vie0P7\nWqUJsRJxmv5CJCSlDcgllK8kE52cvdrZKMWKc7jEqjZ458O7ek207uDhPQW2OyslYlIgApzIJEy0\n+da5WHVuB0IM/yebbdLCak6jNoVYCAqQMDqMrpfJMuU0iJL3In3uQd+aKHbiCTgn6L9vQmd9T7oH\n+6V4mcfrHGSsTDjJSqT9nOwhWuke1/8MnqQP0o39QQ8msx8CoftsG9KReZ5Vt8R5Z2P1LI1lEgKy\nVyTvQpT0r4liIoV1jKof1LTWNV6XGkjZYNKpPCRrWqRIqflrS9sknX7Z3YZkMkSxg939wYqogWHy\ne6yrICTpadL13HptowvuTOshGxQkUVcVnzPvIYjEOH/RRUPyDsHqVxvFeWz9m1bJ45p9Dy5PQxHl\nA3VOodM15ZfzBC8NWSCi1lC9HvhqUfNOQkB01T5x3VFsb/demEjPqLkubchm75LbmSaeJomyNFZS\nSFjq+rK0Aona+fbvZ2i5MjU36UFQmV1PTcLBdD8uvZxa2SsVueZ7GifB041CphGr2EuA0gJ76vTf\nY3HpG1hcWkKlWsXhZ55JE7bolmndffXt5TsQ9I4XpUEUfy/WInTNINL1TIMyZvFCHVeG9h5N0vt5\nXg4gdQzYutq1TaVaxaeeeirxu6QAm+ARePmVv8SLx45Hf9s3vxcP3P8RxKUUZBUQpv0mgVMLr+Kl\n48dRqVbxiY9/vIv/Q1YlavoDWIbAiOzYSyeAYJh93QVvcWkJzx89irvv+gDuvuuuHiQKXwNbFqeM\nEbL+xoyXGki0s5/W1f0ql0o4/MwzKJdKOLWwEL2TJodcTavVGp478ls4dfpVLK+8ic/+4i/ggfvv\nR/+TBXi0n1OnT0cC8YmPP4K5uTkAwMz0dAf7ll2egMGBguwp1yIjwTRp8qGraVmpVhP3CwCeP3oU\nJ06exIvH/yh1LhnzdDP7ZvSnjYZJTvVTxj8UAF2r/o0puGeWlhLMk369qLQEANx9110olUqrsGed\nrNup06fxwMP/HovqGFoQtBDuUUDKYt/6B08//kQ2IDKd+C6U+RdPncJHP/ax6H7FWnke++bn8YlH\nHkmmC2VDCP1G83uRDMMiiMQaAT0AgK7N14mTJyPzaXl5uQM8yysrOHHyL7BndlZqrnJxAPDEpttz\nR34LyysrmFP7AQjOLC5G2tAE8iAmWvZDH5IgZJXvA3juyBEsr6xE90S/PnzgAA4/8wz2zM3FpS9a\n/WW91wki0xe/0oFkXYvgWV5ZwZ65uUijnFlc7LD9P/v0r+LRR34an336VwEAc7OzmeBZXlnBmcVF\nLK+sSI0yO4v5ve/H8soKlldWIs0DAAunX8WePXuibecM7VOpVvDnL59AuVRK+REkOsdTp0+jVCrh\nnv37USoWoy1efuUVAMA9+++OzKwTJ0+irLbVIDh1+jQWl5aUD9fJxpnXIoTA3OxNuHPv3uhaTM1z\namEBc3NzKJdKarE5iQcPHox9KWW+SpPvNJZXVrBvfm8KfBJEC6dfjfY9Mz2NPXNzfSwsZuMWMUQg\niaH6+9ckgE6cPIk9c3PYrh7SmaUlVKvVCFAvHj+OUqmEfUp4pAYqJ8BzZnERzx45gjvn57FndhYn\nFhflfmdn8fznfgcvv/IKzix+PRIKCSSKO/fdGe3zzvn56Hw+c+gQKuocTAAtLi1FxwGAzxw6hBeP\nHcPnP/c56Zc9/Ss4dfo09u3di3v2340zi4v41FNPYXllJQJQpVrFEz//FE4tnI4Wgzvn96pcst7X\ncud//RxOvPIXWFxajK7la4uLIIRg3/w8nj96FM8ePhwtHvvUeRJC8btf+AIWlxZRKpUkEXMEePlP\n/hfK6j4/f/T3cOr0Au679wBKpRKeO3wYlWoVv/zpT/cFoDTJMDQNbHb4WSeQrkkT7osLC9i3dy/m\n974/4QcRAlRrVXz+6O/j0Ud+GguR4w/cPHdzAjw/88lPYs/sLB48eBD75ucjX2bf/F4AwAP33x8J\nwX0HPogHDx7ET370o9HxtTA+f/QoTi0s4AG1epuCsbj0dfzMJz+JO+fn8eDBg9EKv7y8jEq1is8+\n/SsR6OdmZ3FGsWEf/tCHEqzjEz//87jv3gMxkVIuRYKy+rUIPHjQvJYDePDg/Xjw4EE8e/hwZI5q\nX0i/nj18GC8eO4YnHnsMT6r3fQfujcDzmaefxuePHsWTjz2Ge/bfhfvu/WDkb5r7GYxkGDbRJRIj\n7f8ZQEqglpeXMTd7I4TgkWBoU+vzR38f9x34ILbPTEcPVD/0NA3+oAKECYq52ZsS2iMmLOIHu6iE\nbnllBaVSCU8+/jjKpWK0ihPlxj/3m7+JSrWK+w5I4X/h2DEAwKMf/zjKpRI+++lfiMBQLpfw4rFj\nidV7bm4On3rqKXzikUciYMtjzPV5LXOxCZm4FkmSPPjRj0bCbgr9qYWFCMij5bIC3r148rHHIs3z\n4rHjeODgwWh/WjvumZtN3O+1ESbD78mxViBdcwA68fLL0cpKiHxgUti/jjNLSzhx8hXcd+BeJeBv\ndvgqLx47huWVFdyzf3/iQWtQSEdaPkhNXWvnWmsvDczl5WV8+MABCCEis27f/F6AAKdOn8aphdPY\nNz+ParWK548exfNf+AJ++dOfxocVoCQVL4/x8slX8Ogjj0TH0Of0kwcPYs/cXLRdDCSCF48d73kt\nN+/ZY4AiFnD9KhWL0bZ3GgDSQJf+TpIFrFSr+PzRo8pnu6uDCZVky/pMsY3RRmsD0jUFICEEziwt\nYo+hJbTGOLO4hOeO/BYePPiRSJgWl77eoYFeeOmlDlC9cOylyH+ZMfyqmGnb3iEoM9PTePLxx2NT\nSv1eO9n6/8vLy3j28GGUSiUc+4M/UKSA/M7yypsR8J54/Oei89TfNTVEBNC984nFoPNajqFSrRoM\nIUldy3RCoLS2is9L+nRJrRSD6OWTr6BSrWJmejqxL30uM9MzQ/JnNjLNrH8gWdcOeGQD/JdPvoIH\nD34k+r1+iMsrK5iZmY60D0AjTaF9gkq1GgniduN7z3/haMfqvLioVtS52cQKvLy83CFwMjvhdLQ9\ngEh7ffhDH4p8n/TrzGIMOm2WaRMqfQy9P3293a/lCwlQEUIS15JmIJdXVhJgSAdZ02zi8oq8/pmZ\nGDzPHTmCqr7XagEZpBd5f0zdEGn+TLKBXLsaSIPnxMlXEloCIJiZmYm2e/D++6PLNoOdadPGNEd+\n6dChyBTZt3dvZBaZK35FmWCmdtCgFCIGjzZ5tOloAs7UEPq8NDN2twkU9be0ttDnvm9+L84sLUWg\n0OcQX8v+yCR7QZmrndfye0rTvBIB1TRNzftjEi8Lp0/jjNLqseY5jlKpHG07Nzcb7b9SreBrqXt+\n5WmjdBxJXFsA0uCR9PQfKjMnvpl6xbvvwL3YN//+TPBopssE2wvHjuFTTz2FRx/5j5GAvXjsOM4s\nLWFmejoCysuvnMRHP/Yx7Nu7NyHgsXDH5tvyygoeeOhhVKrV6LxOnDyJF44dw4mTJ/Gpp57C4uJi\nZBppATZjK3pfplO/vLISCegDDz2MxcWlhAZ48fjxiGzQ1/LCSy9hcXExeS0nT+KBhx6O/CitTU4t\nLODZI0c6zMHnDh/GqYUFfObQITx75AjmjNDB4uISnjtyBGeWFhMEx6Of/NmYyXzoYTzw0EOR2bxu\nGJFLAaSkaUevBfC8eOwP8aF/+xM4tXAaZ5aW8MBDP5UICu6b34tHH/npCDyfOXQokXD63OHD+NRT\nT0VBPr26PvnYz2HP7E2RcN6z/y48+djPJfymUqmMw7/+68qRX4iEO5nCQ6LV9zee+TXsmZ3FfQc+\nhJlpyQR+5tAhPHv4MO7Zvz/ym7Rm2DM7mzCtvriwgJnp6QSAKpVKBNrPfvoXcd+Be+W1KOBVqhX8\np8cfx565OeNa4mNF11IuReeX8Kvm9+I3fu3XUC6VUC6VIpPzhWPH8EuHDmFmZibKPzTPq1Qq48nH\nHkO1Uo3O74nHH+vIdCiVSkMMll6KEpwYSITrkQFXrebpt81WfwmzMQ0+G2k2LUgz0zPR/irVGlZW\n3kwARTvnpukkt61mpMgoJm9hATMzMx2BRSF4x/4AoFqrZ9LApxYWML93b8LESB5XHi++luku1ywS\nmi25bUwWLK+sYHl5OTOmc2ZxETMzMyqbQkb+Ty0sKM1DUue3bNyXYZfRiA3yjYyneLUBKFafHIMU\ncA36cLLqfJKAJH0lnPZ2fsnA3137Mfu5/tXy1wYX8KxuQfE97HYMDFWDDDeLIcXCXU2Fc8nGGnRD\nwaNbEK/PTOjVzZOu6burC1efUza6frebsMU9MgYtmkuCsp9OoMMFUVx9O3xtRK8m8MQtbNdiEw9y\nHGC9w5k2LoV+7efVX8PAzsUnKfiDr+aEZA0LJX0668O7bxvhG9GrCzyDX97gGlYMIBAbBQKxrvNb\n/7mRDG0Rv9ci17FGMfu+rVbWPvyiuGEzdfTKBw9fI3jWYq/zAQUMl1zQV5OnYVjk/Uy3HlywtVkm\nOnzJSw2iYWojeuWDR6zxBtEBjyX6FC6y7n1trNuZJZBZWmU9iwRZkymXrX1EH/sSGzYoer1AotcO\neMiawTOYYG28H9NLVvoDH8kQ2P402CBkxdpMOYLBOhJtLIjWq42uQAD1OziWZNrUawHPMLXP6mAk\n61xYNsLnWvt31tpApH8T7lKAaO1NTeiVB54sdZ7dumK9Pk8sAMPUPpeLfRvMhxk+ybNWTSR6XCdZ\n4wK7PiANcq+tKxM8ZMMvfFBh6hecw10gyRpB1GuqhohKvfu55o3saJOcy5N13mJV0G5EHHMQWboi\nNFCS81+rubFW7bNRJlA3LXm57zYZUJg2Tgt1aqJB93Fper9d0QBaf5rFWvOn+j/uYL6PGJIAbzTS\nhr94rB1E67neywsi+k8TPBujfbrv8spLlxq+zK33OQ7D/P8nBKD1O4KXAjzrsbFXIz022FAjw9xX\nPzEkgvU2U1zfvbo8IKKXDzy4LOAZzNYma9hvr3k7V5qvI4YASJFBXqzXH1oPiDaOobsiALR+8KyP\neel/kRpM4HsPyroyX4Mt2N1oZ3PxEOs2D4eRYrOR5QuXEUBiSOChl/DGDhsQV3cj/3hB6VXysF5T\nbnggukTTGS4VeMQQHuD61PsgpttgxxJXKSTWsqCQjOsmGWbs+rTAcJI9Nx5E9OoCz0aabmvfv7hC\n8dPPGjDouWfvU2QCa73PfThBUnH1jjcZlholWC94BLKLubKYMrJB0e1harPhNeBY23ey8tdEj3t/\neUz2SwEiupHgGcaDJomZM8MQGLIO4VmPMA8TlMMOxooNvHZxxWui9O/1wm++ze3M7enqIOh+kN7b\niiEL/HqA3L8wDV6Ed7l8l+HtY3Azbi3P5fLE/LJBJFb5veh467+nP2k/GiR90F7/HyZ41nvTLiWd\nOTzNvRGgFRusEfsR3Mu/mPY+l9XOUXR8CtFFA5nBqHRgqtf/hxfEGqYfMujY9UutCS47ZNfkqwyu\nhYZlypEBnjnp8jfRxS8WA+yTZGugXhe5mhk3LIEfBnguRQxgsOrOy0FIZCVqiqt6IegEUT9dikim\n/xuXUpAe5BLp8nf5SZMrxGoaRGwwG3T5wLOx/fHIZQFu9rF7xXGGoRG6Cfj6A6y9QUTWRBKt93Ss\nYanX9QmRwEbRx1e2I3+pzzddSk06Fp5BnwEh3dKYuoNoGItKXIx3eV//fwC0VWZuzsA9mQAAAABJ\nRU5ErkJggg==\n",
-       "prompt_number": 19,
-       "text": [
-        "<IPython.core.display.Image at 0x1085d30f0>"
-       ]
-      }
-     ],
-     "prompt_number": 19
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "a, b, c, n = symbols('a b c n')\n",
-      "int_table([x*atanh(a), a*x**n + b*x + c, csc(a*x)*sec(a*x)**2, x*atanh(a*x)], x)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\int x \\operatorname{atanh}{\\left (a \\right )}\\, dx = C + \\frac{x^{2}}{2} \\operatorname{atanh}{\\left (a \\right )}$$"
-       ],
-       "metadata": {},
-       "output_type": "display_data",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAUYAAAAzBAMAAAAZYbwFAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAq4kimRAy73bdZrvN\nVEThti0HAAAFH0lEQVRoBc2YXWgcVRTH/7uzk/3I7my0KoJChpBiRDFb7YNvu4jfDXTpQ/tgIRuo\nIATdhbagYM0oKsFCU20ExQdX64OCaAWhxfoxEYvaBrO+iKKSfRCjIHRRk8bWuN7PSaaZney9ixvP\nwz3n3nt+55zcSe6cCbAJEt1x9SZkVUt5F0bUgE3wPoZ8aRPSKqU8hNG6ErApzvNFjbSRgZwGpY18\nqkMO5vt0ME0mqpPMXNpja+bTwV7XgRIVHUqXseyekjqb1Dl89TSCGP/x66I6nK+qMzqEMbTl23sx\n0WxqwFM5DUgD2YW3qo9pcBT5RJNTxWxM4RtVSPj/rcmpYkVcp4pI/57fpfWf60d1MyRWdElVzliC\nqcpw/94/9Dhl6niigWeUKQZkG3qcKpW52FsxHFWK+5fd9jnL4b7vtI94nuaprQPPebNw4xe+naoL\nt6kNXzPjXqcyJphYiRvWyYJYuUyZh6+632ixd5nr6tTL0yNLults9jurXtKypMG0+bycnpGGK4xs\nTa749Q1VWPdU/WsBsxZ50kXhmxZ6or4ejvmX3hPThCPXZfNyXkaTG1zvfZHo4RybmFz5HcSsRZ5J\n6ZyymWU2A9K8IZ24ljXGPdc9wuFGv6OcfU4dF/gs48jV9bpFnoPS06wwK3NBLqxq68CqTS1Z42/e\ncm+Nm595K2uNGLtyt/OlkBpb5LFcL9hHzIqKVyHvSoA3n7bx2l9X1JgxfuChww6pkY3AHYQwrr1l\nPxAtcHMFkiNzT/IuNXfzeYsaQ/LEbEJue2ohBwyyGOk/eSjRlWSO0e/faYAb56rmP8CHbATOEteF\nXG+D7LrcXITXzYzMUpmh0XZW6SgkuMawPOkqYO1nvc4PLEhWvApFV5JawvkcrZEbJ4FlgI/AE+QY\nLyJ2goSocNNFUDfzKjkBT4JrDMsTrwOkqd1BQvDf6bx4FcquxBoaLtEawYzTrEY+AuRIIw0kHaCH\nnCU1bUiOEJ7wLrbI57LGbNMTAvPwwXmydaAfeIl4lVmMdynAhHUlxkyxzGrkxroasycwWuI1UrNO\nSMaxCHKYoEamRIbY7OyXj8/O9tEFn4TloTVegrlEAF7jTlewvCtJuyg/WJyGww1/jYfIM3AwT86O\nPmthym7mvpepvEKj9RfJEBNx5TmKqVBheeI1GMvINEz5rOcKnBJdySip4ZHSNGxunPY96w+A0Rqu\nJyeUcqUZ1M2UHRJzK4+L4BrD8vRWYa4g4pKm/W0WpFljSnYl8T4MP5wbgc0Nf43kJkhXM9NRfvcw\nU3KiIK5S5O/wp5xYCq4xLE+0QK+Q7wq2uHuMJo8luxLj/cldX+CBK3PMGGte8/2FAh9Jyl/p9Xhk\n/AgptS5MyZHdNTI2cyf/0clacI1heayj5Hqc/PlUHfiKBg16zdD1QInLs4F8Fwa6+RfX1rh95GP/\nZvCMvCS4mBWqE5fEtB2VsqXXkDQ21pbj+Rh9mPLO11tdb8iOBVHGRpbXu7ReOSO2TLe1T8hOpIhk\nI2Rfbnm92V62kqS3UNuyTXhGvIfeNkod4wcRIe+BDYWcN5ctTKl9zcjvkWc3TBPokF5ErJ0acTvH\nEyWmyy6fdmtMLqpnmrfVmU6Iska+4XonGdXZc+oI5jSYDhDa1ymL6MKVOU3gSQ3O6N4/pGh1mQJu\nU66StMPdlH3AceV8kYoy0gFgvDAweFSZjxeUkQ6AJPlaUK+RfBf8z+Vm/f/+du0nm9vtdWpdy6ma\n6NabSqpIt/3/BXDQmsurWvAhAAAAAElFTkSuQmCC\n",
-       "text": [
-        "                       2         \n",
-        "\u2320                     x \u22c5atanh(a)\n",
-        "\u23ae x\u22c5atanh(a) dx = C + \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n",
-        "\u2321                          2     "
-       ]
-      },
-      {
-       "latex": [
-        "$$\\int a x^{n} + b x + c\\, dx = C + a \\begin{cases} \\log{\\left (x \\right )} & \\text{for}\\: n = -1 \\\\\\frac{x^{n + 1}}{n + 1} & \\text{otherwise} \\end{cases} + \\frac{b x^{2}}{2} + c x$$"
-       ],
-       "metadata": {},
-       "output_type": "display_data",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAiQAAAA/BAMAAAAiU84yAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAq4kimRAy73bdZrvN\nVEThti0HAAAKZElEQVR4Ae1ae2xbVxn//LiO33a3ritlJW5oaaCFuaWgIkC5m4Yaukx1g7QCm1ZX\nmpjQNCVb16qIlTihg9Btqluo6BgiV+MvClo8MSBCiLoIaWxEJAU0tUIjRqA1EkhxWJuWPha+87o+\n9/pc25ljO9V6pNz7nd/3OueXc6/POfcAtLp4xlrdgiWXf/QXS65JLW6Q/0KLG7D00s/kll6bWtyi\ngWQrGuC+97ZWpK0pZ2S2JrPFNvoc9Cx2yEWL57qyaKEWEui70JVeiH0zbcPvKLNNc/QlpbZ+8CDs\nLlSL4upoyTMN4Tls2Z7f2Zrni3PAm7ZozmxMWeqVKuW/7drt2ZLDVNVIa7tEK0pezZAoJXDUlips\ntjcva6L7pibleiX5gYvl2rDUR/t/ocxam9uVKAObATBKXralGjbrL5oSCq64JlcryTuXKSiJlQh1\nS+yo4/j71XjDUTUl+8y8u0wJBVfVfpSs/QpKZlKm3kK1icpCYAHJZL+6ZSUl0bwZNzRpivVT8mEz\nVjThS5sVtdBlqPGGoyYlW4bvAzhzaPg7mNKbAPB03nq2G8Ctg1l8tz8e93Qfmoy++tz6NKLTP986\nmMC7sqhGyenhVTzuo2+eKY0YpT8cSarxhqOCEt9xcCWiF+GEG1OGDYBe+InxNYBIHuuiuHLw1RTc\nAoEPdGUQS9yR0cgPFvSMk3KaiGZRUKJdhViaxR2YnzctHYRTDnjDYUFJWwI8c6EsbCMZ2wrYXzgC\nbwBE+7EuClLyBOAkK5wlr9lo4QXQ1NMa1CooiVyEtgSPK0I63685qxqrEZTM4DvjgisL7yPpYgWA\nFLyfiL4iufLiykWvo1YP6wTQkA/spbV85nlSfqSkxJtHXx7X6qWo+f6rAJsCCUpGCwDXfHPaQZKV\nUAJwgFxslARxVMTyjBLChytPjFRFMUoCOswYPK7KxYL5kfzWFEEJmYPNeoaG0qQZbVjB5wjw8bA9\nOBEySuKcEvJfN1Jo+nk6NF4grmZRUILTkh0pHte0cxJCbztpGo0LSvBd4nsnWGDpQgbAj/1FeBog\nmGcQvbJ3SV+BU4I+o6mEpJdFFSVpfBXxuLKpUo7JT6zSolGgoCS6F0J69JdfSZJEbh0iV0L9noz1\nRxhCOTifhFeAU9JVgA2RNKiLghLXpDcu4qqdJLQvL1WoGOyeXmPHGlGnlOyZvxX2dKwCGJmf1zFL\nNAva2LqOwyiGC3jhxdM+a/huWWNE2x8nTxacB/j0c0Jpu3u3Xdtug0Bbud2Ma9eV1Y/E7dCXZ4xA\n2gruxGlCpfLvJ9Va7Znl2z26WsdWwkL3YAEeOkYqewUClgm9iTZBaM/Yk3ziWYjRQSwpTkuySnR4\nR683ILrNUDkgxh4crvwp3v9G5Bc5ANBpSk0WBgplCVeScUmLJqixdtmEhSvOPVXlweOI3slilPlA\nQHb6VBrg1yRGOEWuWLQ8vdV3+UJFd7VWmxdNKDnvh3uirBbJsLutywI2XdxZU5SFV0lsTm+ZD+zu\nl2y1juG1aVL3xDnqSnKhntvZis5qbeRSmZOnCPvfYqjoh63LAjZd+e+AWWeCl46tLdZQJZvRREmW\npK1c/paEvWtR3WkRTq11i/n8piH8kds8+NlDmWgO7jaYl+h7eOWgwZQUFzD0dpKGbxrCOTl1ZV7i\n2pUn0v2savrQRAQbIWOowUXdaZFUaHGIpvnyG1Vh/sUNJwenQEsEf9CWFQ54F/3YnYM5SSlg3zfg\nNfzdRNeUqfXSpek4Gf47DEUomojgbuv7STJdRFF0Wh1SaB8phLN8+Y2GMd4w3DW5F9zgL1omQKLv\nuIH7hKQU8K4MeSWia0+5K8Yekd8GwocmIi0czZBrg4votDoN12oHIGSUlsldbzPrdoATuLBw5SzO\noh/4MeiCpBQwOmHB67FyV1TMU3WKXs0BRxMh5D3IcPmawIqL28v4u5cFJfPWUmQRudZFqqVl8ijX\nXgW6JdOWKaXHR+C1p8bpI/A9iF7BJRlVSvBVaoyuZOtCdmVBBsiNjjqLD9v7Ue2B67j8XZ9kzotw\n7Rkf/759e6kUtqSN5Sh6gOt25KnguQyRIq4+8UNYimvITQyH6+DFSYSp5DA6YbG5eunS9HmSpZ2E\n8hIbLCUfmgi0cTkRs9HxFkgyeXGuYpSoo3FtV4ao2fIbhQmdVEG7jvsPbwSTR8Avt1RQMod7UpJS\nwDhygk6uGLQvg5d1+EcK92GJCPAlMo/jJXjf4TiKOv61gJKYAWCUlsnzk9gMLK/DOT0xZfwKtrI6\nu4q+r4a7QFIKeDnAh5xcMUAQX93/Ev904UMTkege9tjRRJFnoB/uWnZ02WQrKHHp4H6ML7+xXfO8\nyZuG3xorPDDU22nQNvKL6MfOQwZISgF7O4dTOC1RupIIe07fwxk3RwmzpuF3mDqAFZ48Yjr+tWCU\nwN3DT4vlNza0fPKKzTKL6LsJMMEBtllZq+U+ffmSRdb/EpKrI9BISrb0/LaUEiXlm8YvjV6LNatE\nMwoQJ2dqWGkrwHKfGFv2uQenV2i54EfQUMdfnG9/VHgsxn1aDoLLpyPSyMSvQbJWyK7LQmr+nW8O\nrHPlxBRFr94I328SKqM+JWqzxClPoGjDyqsB+n2oHG8GwikphA2RLSkEp3sBf6jiKuWMrkJtWNs+\ncJEZVOUSq85a5QB1aMUWUqwqE2YSHSCkpASnVNVL+CJ4q1Miv+Kqx1xcC0HJI5CuMXBQd6KkxgDW\nbSu101RCjTcDZZT4ihuh1kac150o+WS6thbX8M65s1BbqEZYMUq0sb8OpaqHJ8cGgu1HV0NoxfAY\n/jB1r0n/58Cf9//sf29O/Ml76S/tcZg++SyFK8b6Y0UtVU5UN2mYhXhwakrAjg3oOEpeJ8fvzgHu\nfR7952XtMqndhm8YLQcBBleI581VUHKV2FOrbrn4FguihB4bCOhIST/EMuSj8QncvkrBHdAWxwcv\nFI8eBzeDK7R0sIKOqzwt+0aODWCUxKw7GaRWLG84OzZAKckhJZELJ0+ugt+j3VTybDFaIL9DAyvT\nDC73FkhEh48L2ekebOG0xPodx6mFHGfHBkxKyIISKCV4auSgG8dOHHpHZhnsHOph/N7srGUaV381\niwbqlQ/Oo+qE7NhAQPeTj8OxDNnQYpR4j2c29BJKfEkY/TuF1REQ9RzrWJt11HJFm17NooF6OyWT\nmOtheu5GkRTfJX2FgO5mlMDXAb5IR4lvNtn3TUJJJAPeDIUV3gwK4ENZlZK+tKN/4xV2SnIk5TmH\nvPhF5RXw5gUlMwXcmyLvEvghBPKUkn0QSlLYIUJN8EZ2AKom2wYYLYgScmwAtJc/6GuffezUk+BZ\n3pH8x6XV2KrD4M8Aog91Dn+MwnW1dOL+vXX51+ksKBGHNyqOkjpz1eq+eUO6VtNG2AlKxOGNpUBJ\nI/q5gJiCEnF44yYlEKKTC+SQHN5wjY8/Nf4H59frAqi+gU39YurMD2/cHCXg4Vvh4vDGTUrMkwVR\nfniDULJ5ovsGHvf1N9228UtHSf1Rb+gI2khBbn9crrxXZW/lZdp7kpaquxdNZuX/MRPqh2eBYUQA\nAAAASUVORK5CYII=\n",
-       "text": [
-        "                              \u239b\u23a7log(x)  for n = -1\u239e             \n",
-        "\u2320                             \u239c\u23aa                  \u239f      2      \n",
-        "\u23ae \u239b   n          \u239e            \u239c\u23aa n + 1            \u239f   b\u22c5x       \n",
-        "\u23ae \u239da\u22c5x  + b\u22c5x + c\u23a0 dx = C + a\u22c5\u239c\u23a8x                 \u239f + \u2500\u2500\u2500\u2500 + c\u22c5x\n",
-        "\u2321                             \u239c\u23aa\u2500\u2500\u2500\u2500\u2500\u2500  otherwise \u239f    2        \n",
-        "                              \u239c\u23aan + 1             \u239f             \n",
-        "                              \u239d\u23a9                  \u23a0             "
-       ]
-      },
-      {
-       "latex": [
-        "$$\\int \\csc{\\left (a x \\right )} \\sec^{2}{\\left (a x \\right )}\\, dx = C + \\begin{cases} 0 & \\text{for}\\: a = 0 \\\\\\frac{1}{a} \\left(\\frac{1}{2} \\log{\\left (\\cos{\\left (a x \\right )} - 1 \\right )} - \\frac{1}{2} \\log{\\left (\\cos{\\left (a x \\right )} + 1 \\right )} + \\frac{1}{\\cos{\\left (a x \\right )}}\\right) & \\text{otherwise} \\end{cases}$$"
-       ],
-       "metadata": {},
-       "output_type": "display_data",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAA2sAAABBBAMAAAC9RCFuAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAq4kimRAy73bdZrvN\nVEThti0HAAAOwUlEQVR4Ae1bfZAcRRV/+zH7cftxlw9SgaCZhIChwLgX+QOr1FsDwslHZUWKkAqQ\nSUEFIZYbCEEKjdmcKeqISA4IiApkoaQKI8XdlfItsiKUlXCSxVIEAbMgZZICvQskIULI+t7rntme\n2dns7iW3e3dcV+3Me79+3a+7f/PR028bYHQk3xOjox0TrahrBHofrct8wnhUjEBo76hoxkQj6huB\nwb767CesR8UIrE2MimZMNKKuEYjtIXOtc71RV7HxZhyb/EKVLl3YfVYVi0Zmez4ib+GCdlcjvY46\nXzsv/aRKm+6DxUYVkwZmRw+Rs5sBbmmg09HnahKkDt+oUA+EcqqJZ3Yz3y7R/dSW2wAGm9kKdTya\nIk+q5jXcBvEPVKM5HW2q2mBZ0IYfAel8gz2PKndVaWtNQkB9jmr7F+lN7AHT5nsfacs0sRXNdr3s\ne5PgtO7z4b0b/nI9tcU3fd4qe5s6dAgcUKDQSkVpvFiiTW+889HjcQYE7gSPDrf9i7nZmYgMYeP8\nA5zoaUi04cVtJXxoNjNN0MajPwOCOvj2w1aemvg+An+fnRUnbR1Ze36DtRJtmQZ7HlXuZsBgHmAv\nPM+t8gxB2DEczofkxkRT28+0YXshnW1qO5rsfAb0FgAOStpa+2CpYW8RTUn4E1fCz9qzG60J2vAD\nYEdzL59G99vhbwbswLttj6StIwM76Gnp/xmnPjTGd1lM/QA46KigwaqgDT+3T26w49Hljt9tgUOS\ntqV5OD5m2FqIn9venhJim56U4OrSnH68HI48CdrCeY0nvkde3xit4WmIr4JIUtIWzcY2eR09uRcW\nGSUopH7DleCqkj/lz1U1qsFA0KYtWGfUYDxuTdqLx8Gy2cfBWx9+hvrom37rilsdnb1w7jQFiagP\nTAWvJoYTOF09CknQdhQq+nRV0To0vP4G89qh4ZW0l5qgzT4eNWrpnLvhLhVuKaialGP7WKhu6FK2\nBE3QVhqLOqSNba7GATvsFqGL6lSyguG717lWC3Bx/5nZ05S8CdqUwahdnJlxtY3ap4lRF6NZjFUy\nrDDT8d4I8A7+rDRBmzUU9QhrC67W3Xa0RbfrqEmogmFcPEGdpbSteDl4aRakJURe2N3QWXBCt42A\nVrTfVmbmalMQZ22lXUftbVhOWAVD9dNQKRol8zhVFssIeGl5zSJj4niYEYh96JoZzzngZxw6BJ55\n8xjEKhlGk84CrC/M48lHeSZtvToqE6nOEfDKtS3f1Nn5+IaHctC+4PNYhV/HQ3vXzgTMX/eV9RmA\nOajv2nILBDpnGWwTLBaHEHM1xJK4ni1LopGVfOxNMxAwaducsnJNYYMpjNuzRlf8kaQorr1TShcC\n1y8B6MFlsSsNgGgWb6RV8CxoesvPgz0Ab+DbqA/C8BrE90kbKuZqyCVTZkk11ucvrWFL2rzlU5dQ\nH9c8rg/vHWHvWuWwvQgt+3enQI/2Qa8BECxgPDUL54IXQkMxBHYijXeidgPA3dIGKAUL5YZU8jyr\nJBpZKVxakpG09WasTFN4zRTG8flIL80OMZD0Zw4I7rmJYt+UWgsAM5Eh0MDDF38awbXTjdjeLVuO\nkzZk526IJW+3SrKZPIglGY00QZt/jZrN8qdjTXlbWb/rAnqH2DxOTy/t5GLbYJZ1ou1j0GjVMZgh\nhGi7YPOeFro5pQ3BTFuZIQK08CVKspk8BNnbK/Tc3PqDgYE2WKSr2SxHkmXQOAQ6EkfUqYU5Ls7h\nm8uh5ZO0znowD74DEBvCG6PDoIAdPiQDCej9J9ErbSoa2kuqsT7PPiqUpIO427QBrJtToE8Kg4ys\nkNqInSx/I+ZBqbjcmb9Nya5f3J4UZe7B7+dXATrDOYAsQCQL2ifgyb3SktgIIRzIh3mg/Znv4/KU\ntOGCbob2kqJ+ceS/jHmZF0EbLL5T5nytRxryvymuOFYtNgJywPI3ApU7q3Rx5iu95Z3WtejFvLBK\n5+FHf0/Bb/AvlKEELmQkAbbBa0l9R/ZxOB1N8AMgthoiicECnChtEHU3tJdkM/PQm4f4GaxI2nwf\ny6yYpC0g+jPi8xLTn9myET27OOOrc7hOfUXkiJJvapfxdndXAdo7T0I1joPY3v3vJwpLui6Ym0Xg\nJcTmds9Du9kJaYOou6G9JJuZh8DxU88XsqQNFualLmnzi/O4p63XHJLhnCsskgCsstfmsrglDWo2\ntFco3234osyJDPOClPOYCrTFM45qUN2lQi0FVTPlR0yhdDb9lRCWhunA3a1Vt4sz/LvI8FPIfEY5\nq3jADngzdr2k1WxYKsKSOT6tPEvBR7C829IGZzNtgeN1VkqHZSXRlAJtpsTns2waKY/iWo5Rhgp/\ny55zZAzHQSQFUO5WrdjsnIKFk4pSElc4G8RZzj/8eA6UStgkRzzmElumqtRsqBZSZDNwY/Zso8gT\nd1vYTgnAC0pJKToaEHVaLKHrIudEzcsE/+lnS8NwoD2LtJW5tdVqdk4BPT2KIsU4foQ5G8RZcbmW\nZRYJV/o/iM8+YFPMAmXnmg3LSgrASduTAha0ReytgFCmvJZuOyTjSRb4zUlEm+OZgIgcyX7LkIV6\nHHxLFNUmzUTaLLcStVfrQltoyG5Cmh9/jgZJI/Sgpsr/JKHpo5VChiWWCTUblpVkwEnbL4SZO21B\nR/PJdrUoYB7L3sIhom2RmW2d3Wmrx8GrZl0bsVWWWws1c+nsQlvc5Yb5JZq606ZWhrI5IXDADVSd\ntMnHgTtt75U3LJ5zYM84dKYtkneg5kg6RqkeBxZBRBuYbi1UdehCm22zmrCNX4dnR4NEjm+5Whv+\ng1u3643XJG2+U/dmyLl2gJswf3snnfEh6etcn4fY9M7uHtQX4I8iSwxSHKlS5AgzzMS0eZOmKs+m\nPxwl2lcGL6/vvhmz6nFgEcS04YctJwuVOp1MZwpkdtSEqBH3/29SHvq//eMMwBVd0+J/+snnrt5+\n7xsHCwvXtO8BjqohzAW+UDDLNets3m3SP24RUhLSdlUKJsNgKpzREd+GS2wUWSKQ40gVIkdKFcC0\nxXIqpMj9Yl8Z/ofibi/C9TiwCGLaMLLFyUKlXvGkblaTm9s2ofHvsriei3cndvmzHZmlGdQ8KbwH\nl2BUjWGqcHvFWhuV4aDNtquE7rZraVX0SfCvpAb9EGmiyBKB36U4UoXIkdp4pi3OxVVYyv1iX1mk\nB84mpB4HFkFMGy7acrJQqVc82SaHQZ02txFtjwMcoEX4cCbag+GXHFxD3eyH3RhVY5gqPFix1kZl\nOGmjEIOVIm1x1FuTx4KYL2NcoUPHpRkGMY6Ehq0FlxATfJl3qtyH+eJuCwyh5NvKKBYopX6xrwyr\nP5bAmh2grUUQ05aWdVqo1CuebLQN5mlzG9H2NNG245wt92ejSZzLfBDbCP8l2iiqxjDacJitYsUN\nyRC0tRYx0dCKNzWrqEXaWnAgW3NpYxH2i0d1MIuzbQYxjoQQ0VYWOULcSny3MW0WhILpr1/sKwvs\n19ZQNlZcm4PzBgZ+OjDwB66yRJuCkoNKiTpKW/pKqbdAt5BFWy/1lmiDa73BvE60UVSNYQRbXGah\nCDcyOe828W7znnsMNSLSFqMbq+30uSdxm3Bo0zpegwROwzgS9s4txMS25qHCQ1JuGOoX+8p8XV0G\nFajHgXVf1fCQnG+2Bi9MXcg22sTmtk2QEXcbXTqCtm9c7H0UC/QDRdUYxhzPSjw0Nzlow1gdpa/j\nvxowiXdbuvAIKZiewu15OYws4bst/Z8M+DNo4hJiAjUxbS05FULZ3DDE77bAIXNNsR4Hdtoelg4s\n1OawT9HmCfl9BaIXLM61NoEuaAv2gZaJJtEiPSVwIEG0Yb2dDCMYpJzmJgdtIHpzB0VnmbadCfgt\nvLv8cm4lzrI5akQgx5EqRI7ULjFt3qQKoWxuGOoX+8rijy3HweH4VM0OLIL4bjvcB4C1bs6NEAuF\n9imz2Nx2nklb/BB4U0wbXqX3YKl+oKgaw6ilDa6omQcnbddxY9bA0gJSNHNPIjB5VhbCxSI/U3Zj\nJkWWCOQ4UoXIkdIh/9kHz8EHDtZmS3LD0LLiFN5XBpuLxSQa1OPApO3Mtc9nObLFDkyUFfMQ4WtC\nah6DBMfnNm1ugyWTE8uK017/MIkfpyfEZ16TxwlVFroBlhWPEVG1BScAnAozZE1NPEnafJ2nGNyK\nF2VbdqRKjdJeAm23jnpQ7b7MrylyVL64BXLDkKjlkgJcdnudDmwElS9uzZlleLvPgA0PZLDdWPVp\nXY+Bd92uaXJh1bYRWzSixuP2ixxdrrHcUTWTtC1OdAiezpa1P6d4aenDaQj+Sgu2SuYDioyiN2PX\nhTa3HIzqCvZrlF/HX4sKyvxKDnbJfD5Zbk3Uk4nov4fFl+kaVvkdXP65w7cPTvT0rYF4G5XwDnG5\nYRzmn2IMo9RRLiJpmwpXiYrlXeblvklfvrt46oFa9biKeHM4GqnlHACqs1ToSwbPd4btAMrc4lUY\nH4LITXv/lgJ4C2d/yUAPFKJZfDzmAFOEjySNySRpOwTrRPNl1Nd+iV8wt+sszm4v72MtkSNPoqyc\n/b7SZnfPMchmmA5gitPBIN66K8HT9noxjyue9H0ZwiuxFRsSyJFta4aOYzZF8BsMHyH74CkRqeL5\nE8T1gOHWJV+mHD1dhUKGqpnyTaZQOssNQyVASMN0UO4W77bL8G6bl4j1ALwLsDQVeTABV4IB8T5y\nlUYCx3AKiRn/6sD+B7kXeIliWvHmy6kR7ZTcMDRyPiI66H+GRZfqgCwtxllJKn31RUOngi7fnyeP\nnOtG1OwTO7Xe2bA+y+7ERv61xeLIOpcbhkbQyZldcOHsM2ILugz8SsQXXedD52hP/LUrBf4Ceb2R\nDmM4LczaG3+KXR0XWiivdCNKcowfKgo61kTn31mWGmOtB9Xbi7HBUuLvvXC2BIxJSdtcsLU7lLOp\n40P5h9KNNpJ/pQBjU1T2KnIHto3Nbhy21S2Gle1NoegbBQsdVouGKXzRXm6xYdfHoxbNj7te+f44\n7rpU1qHpZcjYB7469rtQpQdaoYrBYbL/D4l+fQ6QhDaNAAAAAElFTkSuQmCC\n",
-       "text": [
-        "                              \u239b\u23a7                       0                      \n",
-        "\u2320                             \u239c\u23aa                                              \n",
-        "\u23ae             2               \u239c\u23aalog(cos(a\u22c5x) - 1)   log(cos(a\u22c5x) + 1)      1  \n",
-        "\u23ae csc(a\u22c5x)\u22c5sec (a\u22c5x) dx = C + \u239c\u23a8\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500 - \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500 + \u2500\u2500\u2500\u2500\u2500\u2500\n",
-        "\u2321                             \u239c\u23aa        2                   2           cos(a\u22c5\n",
-        "                              \u239c\u23aa\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n",
-        "                              \u239d\u23a9                       a                      \n",
-        "\n",
-        "    for a = 0\u239e\n",
-        "             \u239f\n",
-        "             \u239f\n",
-        "\u2500\u2500           \u239f\n",
-        "x)           \u239f\n",
-        "\u2500\u2500  otherwise\u239f\n",
-        "             \u23a0"
-       ]
-      },
-      {
-       "latex": [
-        "$$\\int x \\operatorname{atanh}{\\left (a x \\right )}\\, dx = C + \\begin{cases} 0 & \\text{for}\\: a = 0 \\\\\\frac{x^{2}}{2} \\operatorname{atanh}{\\left (a x \\right )} + \\frac{x}{2 a} - \\frac{1}{2 a^{2}} \\operatorname{atanh}{\\left (a x \\right )} & \\text{otherwise} \\end{cases}$$"
-       ],
-       "metadata": {},
-       "output_type": "display_data",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAqAAAAA/BAMAAADNvWdJAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAq4kimRAy73bdZrvN\nVEThti0HAAALGUlEQVR4Ad1aDawUVxU+u7Oz/zu7UkBU6hsQ4jMlZcHGNLHmbdA2rxbD+mptSRvf\nNrFWJPU9BBr8QRakzRNrgQBq1chabVJJ07ckKIS2YVttFCRla00DUXxrbVqaNOFhy+NBxfXce+fe\nmXtn2F2e+wN7k50557vnnnvON7Pzc+4AdKZpBzozb9fOOvrbrk2tI4mF3+3ItN076eli9+bWkcw2\npDsybddOmjjTtal1JjHfhc7M27Wzxv/btal1JrH4RGfmbeOsvrntvE0wQvX+zbk2pvh/TfXygmzt\n8Woy8/pStQc0tZcRGqnoP2qq29Y5M9aOlWt7V5LRJ+40aw9oai8j9PsAjzTVbeuc+VJ6HedKMuHh\nOvbN7WaEbgc4nW6u41Z589X9/yrJROoOaGqojFB8/RwqN9Vvy5zVJ1RJpq/Qsli8HFNCtX8joXmv\n7isOC75/VUrr31w2/vjDj+YwOm3W9avlINVktrb3r2cTaspxXamarwgrsjANIh/uy2OMb6Zj4yTU\npUdJex4lSqhJMNYOcaE9+6uR0G8A9OXi28jNSbsAgaLMlErof+TuVms2oflWT9Uc/76icREgmYln\niD/fOETyRLCb8pcP4uWsnY0SCuQ6XmjntFOfy1eM4ttyssQITRZhMKc4k5MJI/3tbIxQfNIYa++1\ne8o5+ooJcoamGKF4HR2DLDq79THSfkbcysnE3pnyVFMayAjFZ+GPTWl4+wfhTQmvoUMVRuhgGWYn\ncnIUcjJJes+SLVqpMUIjZf3BVs7SRN+xIt7ZYR8wQuOFxE6/4l1OZqikdNdQT0l9T0taowojVF+y\nMdfoiM7aaT1nCsFpcwpGz6oyRqLNenTlo0pEcjJbU0q3S135ggUFZdNAjuHG/oxloOzu2vuZwg0K\nBoxQFe0ivSfvTsaQIB0vurTFsxIOJUtNkkPnbv5vAbyOP7lFzsp612kbKu6UAjK011JHZBget/TT\nCtEM1g8j7LduebeLoYPDQuxKQa96sPFrOVVO6FoZhjst3ft+HSfmhkXfcTF01BRiVwqJc+60jDUy\nZhFqlGQYYmUG/EHBmbqM9GoZptiE7vY4gMymO7Z+681T673meD+m9ORmE355/n1lKqxc89Uf5AH2\n0i0ETOynxRbL2J9hwEXgo1HnTaOO9RzTBaH+Nr9H8HDato/jexNpA/CbwjcBEjtgKcBOLvy5oONr\n17N0C/EC2tFiCzcuMeAsHw0BWoI5mkI8IC0XC0JH89jXzS1pnTEmbIVXAaITpJKOhDJhP8AkANtC\nqMKLLZYxuUCS6ksJLMBJVER6A+OEBtY7bIxNv3NoXSL2WXln4UM0I6N3YY4QClR4hhLKtpCs8GKL\nZRwcZ4CJL7dstIMU9gbGl2M4odLyVRzudwzoEnEUSWFtHdlpz2eHKKFMcBHKiy3UmBBKgAoOpADx\nwFuIOsaTntZif8xqsaAfzXIDgEg26dBs/KqWlpWs8LUJwNMpXoKh+7I7Ic8EidBQGeusrNjCjMlf\nXgIgQEswjxXRp48+wGcs78etPSzfxSWyf8updId8LMPy+FV4HB4CGETCvp7bCSYTnnH+5WMF7KfF\nFss4WlIA5optg5O49/MzUBCqvecw0n/vUFohrmyF09o+q3jaYUtciA1reYBQChY+kF4KJhMkQv0Z\nPINJsYUbuwBwttEyGJ/mgCAU6OOpBX+e883Nmrz/8gea7LC+O62apkb6gflzt6Ck7RsZ+BPcPS1N\nhXurM/92LsO2eJvahv2k2MKN4xUFkOYLzp7+OQHYhA6VBKjfPCDk1ggnWuO2hlevF6VLmq9Wevir\npwJ7qTahSXptpTaR6nkv2yZi7Sc07Lyk1cuEF0O4XS8X6u9PCROrfOffeGqmwGoJRt7Z+7RTseQa\nrhol1A4PfUYrHpM0CvkmG7VEO6V8p5cuY6wwtQid7ys6n/FFtyUEnzUt6V6pi9dgnWANV7UJvVSh\n9xandyHbIQmICEOmpEYmJLW2oqWkfh+7/EpYfcUitEJfZJ3mFacCy/lcL0qwqME6ULcr0akSaoge\nIlyq0BuXrJhSATskqft0RlIvb0XpRmnsw5LWqMIr9kn1cGQkDzGL0HBegkUNVncMd7kSQ1RCGyv0\nRk3hQAgZAB6SwKjA3wUt1HHPle1apnFC74ecNEc0I6k8+lBWgkUNNpG3cdWV3aMS2lihVx+2PVgS\niY6H5Op0AmOmU2uHzAgNji/AioqzvZlxaiL6tyUUsyozwCbU7coeohDaaKH3OduDJZHovAn9RE4y\nXliR1DYojFD9wF83iXMvOrIEoj3brwUiBPffMnIAo59JtgBL8OeqwSJmEyq5IkPstvhYv1DqFXoX\nbcLF4sUbP7U5DzBPjEKBfHpHo2MhBfvn5N5e95cHnzp/8thLgXOv9KTg1J5HgMBk1DGyaWvjf3nH\npCfSWAGMZACoED9Iyi2xI6zocgTtXDVYxGxCHY5qiPUKvcZqOAS6Gf1paBvA352OVtBP7zJ4jGlI\nJ8A4C9v/NalPkgBn4HmrFyECFMZhVr3e6aDFsgehoznjHUooFWLDkMwD2wJ8F08R+sGbowZLIrxc\nQusVevEr2dvAD+HxRA6PoJMD+ukdOdwspHUAP4HDWLCcTd7TTSTU2IUDKYyxtvlLMQyUEZqsWm2c\nxP7apglKKBViRUoo3QLggoGPfvDmqMGSIZxQydFNtNj1C9LP/dM9AeoUensITzrgdzfYhsjGauzT\nO0ooCSnx7p49HwSyijaWPj5uVMiVdcOsHINpXZ4PbNfe4wy9aUaQEUoFF6GuGixZaTn8naN0paVu\n2KeuyxGbeoXe90Anj+ShPDF2Eso+vROERi8SA0JoyDTX+/G8TcHA7jMMxoM/TLrb2mxC5+3NspmP\nQnDijkgmDFSQCcXXqT61BktG8TMU/LfN8Iyfey8FaY6svnvJQq82CYlxfKTsy5FP65x/efbpHYmO\nBmbQpTJCaGBX/jos7sRSwTSM/sNaQQtlPINpJSgIDWTxVkQaXt4TE29EMn4myIQeVEqupAZLmiD0\nZrKq6G7C+y6g1ZjB2oVe/SL4Sq9G01shjIQ+5fSH19ChCkbHCIVvA9xFz9DgmfTQ9wihGEogT2G0\nzDmHtkUWhEbSWPenbRX4J14JlPxABZlQfIJx1WDJIEHoDnJWuZvtnVQd6xd6j8CJjDlW2A83ojFO\najd8mtoHJDoW2OkKzKeEws8hUqKEroVYmsIL3Etrtp9WSYLQUJksUZP2yf6HFuT1vR+hwsM9Zx44\ntCZIt9j3Fl7+1BosGSMIXU+eXtzN9n5PmvTWK/QuGnnjQOXuTQO9BTR+iYzgjXx6BxidFZI2fW76\nn+euxd4tEM4Dol/qHbkeCAzHvqhWOLmTFu4FoUiKXRq95IQhSofdzWuwglC83Wa1fnbnsc1QQu83\n4Dq17n2JlUwVGvRhqbdxZbFHGI2PnqKlg9C4Wd9HVLHptYY4yqQvwPJ0X9blKm7qO7Sz8IU7FA8u\nQxAVF6vLn/ewuWKhGH3uoOHNaSTIFyUjjxqsPwXTYYVkZXn3ZYLbYHd1m7tPQeLy4bhH6b6y1bB4\nl1BPPu+4F0mwRw32cfL0v1GyIgp6T1bCKRfuBSiF3mu8bK5YTDvHQ3sNvsLFGnuyFms3dw3WMIP3\nnYWDt9s2TELvg9nYE2kV99TJrV20cE6IV4WwrMDCDD53soH7Rd2UVp58Obs2OPGEYki8h7JDX5P/\nzIpRd6h81SVUrY43IaMN1Sq8vmVzQXFFvBv9T35WgbtR1XdXujGtDuYkfznawUC6ZuqPd00mciL/\nA6gEk16N8pC2AAAAAElFTkSuQmCC\n",
-       "text": [
-        "                        \u239b\u23a7               0                  for a = 0\u239e\n",
-        "                        \u239c\u23aa                                           \u239f\n",
-        "\u2320                       \u239c\u23aa 2                                         \u239f\n",
-        "\u23ae x\u22c5atanh(a\u22c5x) dx = C + \u239c\u23a8x \u22c5atanh(a\u22c5x)    x    atanh(a\u22c5x)           \u239f\n",
-        "\u2321                       \u239c\u23aa\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500 + \u2500\u2500\u2500 - \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500  otherwise\u239f\n",
-        "                        \u239c\u23aa      2         2\u22c5a         2              \u239f\n",
-        "                        \u239d\u23a9                         2\u22c5a               \u23a0"
-       ]
-      }
-     ],
-     "prompt_number": 20
-    },
-    {
-     "cell_type": "heading",
-     "level": 2,
-     "metadata": {},
-     "source": [
-      "Limits"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Recall that the definition of the derivative of $f(x)$ at $x=x_0$ is $$f'(x_0) = \\lim_{x\\to x_0}\\frac{f(x) - f(x_0)}{x - x_0}.$$  Write a function that computes the derivative using the limit definition, using `limit`."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def lim_deriv(expr, x, x0):\n",
-      "    \"\"\"\n",
-      "    Computes the derivative of expr with respect to x at x0 using the limit definition.\n",
-      "\n",
-      "    >>> lim_deriv(x**2, x, 0)\n",
-      "    0\n",
-      "    >>> lim_deriv(cos(x*y), x, pi)\n",
-      "    -y*sin(pi*y)\n",
-      "    \n",
-      "    Note that we must use this trick to take the derivative without evaluating at a point.\n",
-      "    >>> lim_deriv(exp(x**2), x, y).subs(y, x)\n",
-      "    2*x*exp(x**2)\n",
-      "    \"\"\"\n",
-      "    return limit((expr - expr.subs(x, x0))/(x - x0), x, x0)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 21
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "lim_deriv(x**2, x, 0)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$0$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAAoAAAAOBAMAAADkjZCYAAAALVBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADAOrOgAAAADnRSTlMAEJl2Mt1EzasiVIlm7xEe\nOPwAAABJSURBVAgdY2AQMlZhYGAIYxB1YGAOYGAuYGBtYGB7ycCnwMDyimHeBgaWx2DyNRL5GCz7\nBqSS6yVIF3cAA0MUg6wDA4PQ5hYGAON0EpMbNABcAAAAAElFTkSuQmCC\n",
-       "prompt_number": 22,
-       "text": [
-        "0"
-       ]
-      }
-     ],
-     "prompt_number": 22
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "lim_deriv(cos(x*y), x, pi)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$- y \\sin{\\left (\\pi y \\right )}$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAGAAAAAVBAMAAABLWfZ5AAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIs3dRBCJmXYyVLvv\nq2aiBbi/AAABmUlEQVQ4Ea2SO0jDUBiFT0vSpra06uRS6ODmUlCcA4I4CBYHFx0CDq4FQXSRdrEV\nRermg9LgVNBBFxUfoIPoGBEHt+IgTqJgfWGNf7zJvTcWN39IOOf/7rkvLvDfNSBPGNdlx3XkhUtE\nLKFJzficZ5RXTwHBjNCkgj7HjTSoyJs/Im74fbM787fUE79nLrDKu0qKSyYOuB+ZQqAOKEv3qWQD\n6+crCzliYYM+m8py+QQPGEPQHoFRII1joKumPhML1oDptfxDG1y+4QUi5iSi20BfBoYTOALeiMV0\nKKbWmofHB9He7VSPigskcjSiMQ8ncMgCCZ1SUVjweIU8q5Y6KiVAHbet34Ek7RIuF4FwCosUXUb8\nQwrETOrNgg7n8kE2Pf2DWWccqnRIKRCt0aJ1vHN+ywNhS/kis5XBjhQIZQEtDXpcLhfXqu4XnijQ\nX5zTy/Z12b7Z/KTBCu2ernaP1mG8k68AhAg21anoOFx6GlcYMwXk6s5TjIdynkcvdrmWBH/ejA8L\nVC3owggVsFzN+KUgf6kOGWglfAOzz3frF+JlMgAAAABJRU5ErkJggg==\n",
-       "prompt_number": 23,
-       "text": [
-        "-y\u22c5sin(\u03c0\u22c5y)"
-       ]
-      }
-     ],
-     "prompt_number": 23
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "The function you wrote above to compute limits using l'Hopital's rule is very fragile. And even if you try to make it sophisticated, it will still be unable to compute many limits.  Try it on the following limits, and see what happens. Then try computing the same limits with `limit`. \n",
-      "\n",
-      "1. $$\\lim_{x\\to 0}\\frac{\\log(x)}{x}$$\n",
-      "2. $$\\lim_{x\\to \\infty}\\frac{2^x}{3^x} \\textbf{Warning: Be sure to save the notebook before you test this one, and be prepared to kill the kernel!}$$\n",
-      "3. $$\\lim_{x\\to \\infty}x\\sin{\\left(\\frac{1}{x}\\right)}$$\n",
-      "4. $$\\lim_{x\\to 1}\\arctan\\left(\\frac{1}{1 - x}\\right)\\; \\text{Remember that $\\arctan$ is called }\\mathtt{atan}\\text{ in SymPy}$$"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "lhopital(log(x)/x, x, 0)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\tilde{\\infty}$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAABMAAAAPBAMAAAD0aukfAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAMt1URBB2Iqvvu4mZ\nzWa4xGRRAAAAeUlEQVQIHWNgYGBgVDJwAVIgEMbemQBmYCdYA0DiBUDMuvLnBgbWU2c2MDBwCbD9\nDYh1YKhmYEhnYLC/epGBgbmAIYGBge3nA6DKBBCTYT2CufIjWPQpUMH2nwEMfAUMPAwMGQz+Uxhs\nGBjYe84+YGDvn3kAqAZuGwDaSx3BxThQpQAAAABJRU5ErkJggg==\n",
-       "prompt_number": 24,
-       "text": [
-        "zoo"
-       ]
-      }
-     ],
-     "prompt_number": 24
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "limit(log(x)/x, x, 0)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$-\\infty$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAACMAAAALBAMAAAAHCCkxAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIs3dRBC774mZMnZU\nZqvpz9EoAAAAeElEQVQIHWNggAHWABBLAMYF0qzp3xsYWKfNbECIsS3g/hQQ5MAggRDayMBwXlWL\ngYFHgEHIGARMGDYwMHB/vwBUAmRAAYiVjymU/gsojlB1Faix8XsAA68ATB8DJwPDPgb/EoaTcBEG\nxpeTLjAwvi+fgBBigLseAP1wHBzUhNGNAAAAAElFTkSuQmCC\n",
-       "prompt_number": 25,
-       "text": [
-        "-\u221e"
-       ]
-      }
-     ],
-     "prompt_number": 25
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "lhopital(2**x/3**x, x, oo) XXX: Don't run. This hangs the notebook"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "ename": "SyntaxError",
-       "evalue": "invalid syntax (<ipython-input-26-daf458c59400>, line 1)",
-       "output_type": "pyerr",
-       "traceback": [
-        "\u001b[0;36m  File \u001b[0;32m\"<ipython-input-26-daf458c59400>\"\u001b[0;36m, line \u001b[0;32m1\u001b[0m\n\u001b[0;31m    lhopital(2**x/3**x, x, oo) XXX: Don't run. This hangs the notebook\u001b[0m\n\u001b[0m                                 ^\u001b[0m\n\u001b[0;31mSyntaxError\u001b[0m\u001b[0;31m:\u001b[0m invalid syntax\n"
-       ]
-      }
-     ],
-     "prompt_number": 26
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "limit(2**x/3**x, x, oo)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$0$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAAoAAAAOBAMAAADkjZCYAAAALVBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADAOrOgAAAADnRSTlMAEJl2Mt1EzasiVIlm7xEe\nOPwAAABJSURBVAgdY2AQMlZhYGAIYxB1YGAOYGAuYGBtYGB7ycCnwMDyimHeBgaWx2DyNRL5GCz7\nBqSS6yVIF3cAA0MUg6wDA4PQ5hYGAON0EpMbNABcAAAAAElFTkSuQmCC\n",
-       "prompt_number": 27,
-       "text": [
-        "0"
-       ]
-      }
-     ],
-     "prompt_number": 27
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "lhopital(x**(1/x**2), x, 0)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$0^{\\tilde{\\infty}}$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAUBAMAAABhbjCNAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAEJl2Mt1EzasiVIlm\n77s6qyWGAAAAnElEQVQYGWNggILWhAMwJgMDm+A7AQQPD0tah4Fh9i6oAs62vCs8iiwGDAxCxioM\nzAwM/bsZGDIZGMIYRB14GBj4PjIw8DAwBzAwFwB5HOEMDNMYWBsY2H5yOTBozX3IqMDAr8DA8ovh\ntIYDo27dBIb5GxhYPsPtBvF+4+EhVIJM+QNXCbSB6yecB7SdOwDOY4hikHVA8IQ2t8A5ACXSIfGJ\ncN/4AAAAAElFTkSuQmCC\n",
-       "prompt_number": 28,
-       "text": [
-        " zoo\n",
-        "0   "
-       ]
-      }
-     ],
-     "prompt_number": 28
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "limit(x**(1/x**.5), x, 0)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$0$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAAoAAAAOBAMAAADkjZCYAAAALVBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADAOrOgAAAADnRSTlMAEJl2Mt1EzasiVIlm7xEe\nOPwAAABJSURBVAgdY2AQMlZhYGAIYxB1YGAOYGAuYGBtYGB7ycCnwMDyimHeBgaWx2DyNRL5GCz7\nBqSS6yVIF3cAA0MUg6wDA4PQ5hYGAON0EpMbNABcAAAAAElFTkSuQmCC\n",
-       "prompt_number": 29,
-       "text": [
-        "0"
-       ]
-      }
-     ],
-     "prompt_number": 29
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "lhopital(x*sin(1/x), x, oo)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\mathrm{NaN}$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAACkAAAAOBAMAAABA5yhLAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAMqu77xDdmc1mVEQi\niXYYNmHTAAAAuklEQVQYGWMQsndlYFD5VsAAAgiO8CcGBtYGsCADA5wjqb+AgQGilIEBzpEMARoB\nF4VxJLk/I4nCOJIM9RNAauc9vwA0AcoBMtj+AEW5chgqQKJgDojB+AMoyvmRYf8BGAckynD/AdAE\n7nv3BeAcEIPtTwEDT1OAPFgUxAGr5QF6jaOBQV40AKgExAGLMrw3YIh/wLBeWgAoCuIwMKwFYg4D\nBhYFhvtSB6AcBuH/VkBdCgw85u9i+2AcAItCOkbAdyQwAAAAAElFTkSuQmCC\n",
-       "prompt_number": 30,
-       "text": [
-        "nan"
-       ]
-      }
-     ],
-     "prompt_number": 30
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "limit(x*sin(1/x), x, oo)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$1$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAAgAAAAPBAMAAAArJJMAAAAAHlBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAACGjDitAAAACXRSTlMAuxCrdpnvzWYiHG0BAAAAI0lEQVQIHWNgYBBiYGBQ\nnMTAoGwMJBhYSCVYw6ZHAPUxMAAAQGkI1Fjz0FgAAAAASUVORK5CYII=\n",
-       "prompt_number": 31,
-       "text": [
-        "1"
-       ]
-      }
-     ],
-     "prompt_number": 31
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "lhopital(atan(1/(1 - x)), x, 1)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\operatorname{atan}{\\left (\\tilde{\\infty} \\right )}$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAE8AAAAVBAMAAAD1D64kAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAZnaZiVTdIs0yRKsQ\n77sQheylAAABgklEQVQoFaWRsS9DURTGv7aa1z5tI0gkLC9YLNqEoeNL/QHtZmNowvr2Dh4jjTQS\ni4qaRCw6WEQkLxgMFCmLSBrpZCAYBEnDOff28l4xuck553fO+XLuzbnAf49uuCb0urgVi1wIT2W2\nOAYK7PnoMrh8nvlA2zdEzRaeXECBin5DkYjdKutSoGLUUSTiaTPTq54yJZtcOGGnsYtlgM4BE30v\nexkBa9WlYYM7o2SV2iVwWGdsSyA4jSSQRRMWOyLvLJwlu0M8H5mHZlLThu8N2xYLJdwDzyy8BvwW\ngq/HtJhx2so5WSpdYKGEh6aQxvqpFr8gRxB+hLbglIRQQosw9vQlDNkorTpZGBKU8EpOjNXoappI\nV58ZmFwpZGFKUMJberQDDM7cAD3ENqJlpJetJEwJSjhGVybgL+uN9WBCrEer9x/NobJjCSh+7E40\nqIENstwILSnX4M8IrZP79UQtKn//jPrCn1qf6amlPJknybuziO3OvJxzp+38kD+OZrgaQ8Anzrdr\n49xeRX8AAAAASUVORK5CYII=\n",
-       "prompt_number": 32,
-       "text": [
-        "atan(zoo)"
-       ]
-      }
-     ],
-     "prompt_number": 32
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "limit(atan(1/(1 - x)), x, 1)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$- \\frac{\\pi}{2}$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAB4AAAAlBAMAAACno0T/AAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIs3dRJmrdjJUZrsQ\nie92pBgeAAAApUlEQVQoFWNggAHW/0CQAOMxMIR3Fq4SRHBZJrALFCK4QBY3QwIKX4zBAIUfxfAB\nmc/zh+EHMp/dgOEvMp9pAcNWZP4AsYWMQcCEgR8UHP//09AVjKHaDsjGizGw/0Tm5zAw2CPz3x1g\nyEfWoH+AIR6ZD1RrfwBIIAAHSgAzMDBtQMiBWNGoXPYEVP5UBkYBJBGOAAYuZL7w3bvBSNIM9v//\nf2YAABDvJavRuLWzAAAAAElFTkSuQmCC\n",
-       "prompt_number": 33,
-       "text": [
-        "-\u03c0 \n",
-        "\u2500\u2500\u2500\n",
-        " 2 "
-       ]
-      }
-     ],
-     "prompt_number": 33
-    },
-    {
-     "cell_type": "heading",
-     "level": 2,
-     "metadata": {},
-     "source": [
-      "Series"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "The Fibonicci sequence is rexcursively defined by \n",
-      "\n",
-      "$$F_0 = 0,$$\n",
-      "$$F_1 = 1,$$\n",
-      "$$F_n = F_{n - 1} + F_{n - 2}.$$\n",
-      "\n",
-      "The first few vales are 0, 1, 1, 2, 3, 5, 8, 13, 21, \u2026\n",
-      "\n",
-      "The Fibonicci sequence has a generating function given by $$s(x) = \\frac{x}{1 - x - x^2}$$ (see http://en.wikipedia.org/wiki/Fibonacci_number#Power_series for a derivation). What this means is that if we expand $s(x)$ as a power series, the coefficients are the Fibonicci numbers, $$s(x) = \\sum_{n=0}^\\infty F_nx^n$$"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Write a function that uses series to compute the nth Fibonicci number. \n",
-      "\n",
-      "Hint: `expr.coeff(x, n)` will give the coefficient of $x^n$ in an expression. For example"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "(1 + 2*x - x**2).coeff(x, 0)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$1$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAAgAAAAPBAMAAAArJJMAAAAAHlBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAACGjDitAAAACXRSTlMAuxCrdpnvzWYiHG0BAAAAI0lEQVQIHWNgYBBiYGBQ\nnMTAoGwMJBhYSCVYw6ZHAPUxMAAAQGkI1Fjz0FgAAAAASUVORK5CYII=\n",
-       "prompt_number": 34,
-       "text": [
-        "1"
-       ]
-      }
-     ],
-     "prompt_number": 34
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "(1 + 2*x - x**2).coeff(x, 1)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$2$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAAkAAAAOBAMAAAAPuiubAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIpnNu0SrdlQQ3e8y\niWbzIQYJAAAAT0lEQVQIHWNgVDIJYGAQY2D/wcCQycCwnoFh9wSG/AAG+wkM+kAJoMgEIMHzF8Rk\ndgCRKiCCPQFENjEwCjDwKDDwCTBI3b2rBVT8//8vBgBR7Q/Fm5CwxAAAAABJRU5ErkJggg==\n",
-       "prompt_number": 35,
-       "text": [
-        "2"
-       ]
-      }
-     ],
-     "prompt_number": 35
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "(1 + 2*x - x**2).coeff(x, 2)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$-1$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAABgAAAAPBAMAAAAMihLoAAAAJ1BMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAilU6eAAAADHRSTlMAIs3dRLsQq3aZ72YDTSHvAAAALklE\nQVQIHWNggIMwOIuBIfUYgpNejsRh4CCTI2QMAiYMZBsAcxDnrEOzYWwwDQBP9Q53CSxxJQAAAABJ\nRU5ErkJggg==\n",
-       "prompt_number": 36,
-       "text": [
-        "-1"
-       ]
-      }
-     ],
-     "prompt_number": 36
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def fib(n):\n",
-      "    \"\"\"\n",
-      "    Uses series expansion and a generating function to compute the nth Fibonnicci number.\n",
-      "\n",
-      "    >>> fib(0)\n",
-      "    0\n",
-      "    >>> fib(4)\n",
-      "    3\n",
-      "    >>> fib(9)\n",
-      "    34\n",
-      "    \"\"\"\n",
-      "    s = x/(1 - x - x**2)\n",
-      "    return s.series(x, 0, n + 1).coeff(x, n)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 37
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "fib(0)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$0$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAAoAAAAOBAMAAADkjZCYAAAALVBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADAOrOgAAAADnRSTlMAEJl2Mt1EzasiVIlm7xEe\nOPwAAABJSURBVAgdY2AQMlZhYGAIYxB1YGAOYGAuYGBtYGB7ycCnwMDyimHeBgaWx2DyNRL5GCz7\nBqSS6yVIF3cAA0MUg6wDA4PQ5hYGAON0EpMbNABcAAAAAElFTkSuQmCC\n",
-       "prompt_number": 38,
-       "text": [
-        "0"
-       ]
-      }
-     ],
-     "prompt_number": 38
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "fib(4)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$3$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAAoAAAAOBAMAAADkjZCYAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAMom7VCKZRHbdzavv\nEGbh6M2uAAAATklEQVQIHWNgEFIyYWBgTWCob2Bg+sLAP4GBBUwyMIBEgGA1EDNqbQAxGXoKQCTP\nXwZWAQbmfwz3/4JI/gUMnF8ZOB4w1CswMLilLWEAAJ6qEfrOOFffAAAAAElFTkSuQmCC\n",
-       "prompt_number": 39,
-       "text": [
-        "3"
-       ]
-      }
-     ],
-     "prompt_number": 39
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "fib(9)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$34$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAABQAAAAPBAMAAAAWtvJmAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAMom7VCKZRHbdzavv\nEGbh6M2uAAAAf0lEQVQIHWNgEFIyYQACaQYG1gSG+gYgczIDA9MXBv4JDAwchxkYWCDMuMUgVWAF\nChDmagYGvgAQk1FrAwPDDQaIaE8BgwKUyfOXRQDEZBVgYP53iQHEvP8XyPTevfvPDgb+BQycX4G6\nDwOtecBQrwBhMrilLQGytP/nAUkYAAD6ySE1M5863gAAAABJRU5ErkJggg==\n",
-       "prompt_number": 40,
-       "text": [
-        "34"
-       ]
-      }
-     ],
-     "prompt_number": 40
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Note: if you really want to compute Fibonicci numbers, there is a function in SymPy called `fibonicci` that can do this far more efficiently."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "[fibonacci(i) for i in range(10)]"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\begin{bmatrix}0, & 1, & 1, & 2, & 3, & 5, & 8, & 13, & 21, & 34\\end{bmatrix}$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAYAAAAAZBAMAAADK9+SzAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAu90iEJl2MkTNq1SJ\nZu8+uZRyAAADV0lEQVRYCe1YPWhTURg9zXtJk7wmleIgODTWQSgFA1KEgvBcHKS0WVKotRoEBYva\nLA5KoQE3lyrooC4BwSGDZnFxaRRE1EAD6iz+gG4VjWK19Xnffa/p+77vDaEKkuIlP/eefOd857x7\n01eCvoEsOnbEB4aQ6Vj32vjIlghgTpws8n3osjmC7RwZntzBoO76wyqFEi+N5xTBaH2KIXC1JRde\nA2llrr7TVbionnoHIiVzD5M0+22G4GCTIUYZs8zuMOLfaFXacWoUQQ7RBoNcbcn1GkgrRg4LBaWw\nSz11gBPAaapoVu7ZFMHhCg+QtBH5RKuWqvhMkcSRJxRAqgEzQzGtLbm6QYiVnp/oVQqxN0pFBxgE\nFrJUErM2AxDjAdLvkfxOqxZFgCQtUKuesgigtSXXbyCsWF6AA1eVmg7wFZhnZ6GdAIkmoiwAxBGS\nAawfdk+BxfIuDj9+fgMRQJHdI1RbD2CsqgBcUrLEDiidCN8VJMoKDozkqZlSYOlO+9fOMMTfXc5V\nVW4DaQW4CaSyJECNaUpWWIB5TptTymR02Sbfpaizm5SohdYWXPWB20Ba6X5aBg7hLwRwJeiIfaRr\ntbrLkFcXHH5gvYsTwnUbyADAuRJqNECBdZGskB2IbmMstVy2ObZUJEgqh9f85PnagqsbSCtAumkV\nWwHgfokbpElY7JAAM4yE/eqEU6U+YKlEytI2jDWCeEdIcgHdQAQwiuhaG8VGgEFgMcskBUv+GYWV\nwz5CMx2bB3gLHKfaY4oyQWg6QAjXbyCsjDdVgAeVyq87GzeyRzCppstSj8Bwd4AWnQde0KIVYG+W\nFOWAG5SWVnluU5q+OJIL3UB/B4iV3iuIfFHOWjeySNX8gPFMwKw+Qia9qboBSJExVH+coUVnEV+l\nRcOw3lHEugarRmk6gOTqBiFWYg0s1IIBzKMzRYy5mVojv3y9YS4H9z56bGWaFkUcx8nQIis/WaVF\n3flKliK4nJ8CpWltydUNIK3gfv6WcvrMmfaPkGf7Usv9+iQeDPBHRW1p6w6yUsMhVjxD+l8Jb9rw\n3gKvqcDcn26yqC2abiErNRxixXO0hQLE/GsceCsE5t50k0Vt0XSHkEqNF7z+8jWwA/LDTkD+B/jX\nuzSCgc7+XWjwN9UKBtQPwW28AAAAAElFTkSuQmCC\n",
-       "prompt_number": 41,
-       "text": [
-        "[0, 1, 1, 2, 3, 5, 8, 13, 21, 34]"
-       ]
-      }
-     ],
-     "prompt_number": 41
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "`series` is nice if you want a fixed power series, but what if you don't know ahead of time how many terms you want? For that, there is the `lseries` method, which returns a generator of series terms.  This is more efficient than recomputing the whole series again if you determine you need more terms. Here is an example usage (**Warning**: since series are in general infinite, `lseries` will return an infinite generator. Here we use `zip` to limit the number of terms)."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "for term, _ in zip(cos(x).lseries(x, 0), range(10)):\n",
-      "    display(term)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$1$$"
-       ],
-       "metadata": {},
-       "output_type": "display_data",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAAgAAAAPBAMAAAArJJMAAAAAHlBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAACGjDitAAAACXRSTlMAuxCrdpnvzWYiHG0BAAAAI0lEQVQIHWNgYBBiYGBQ\nnMTAoGwMJBhYSCVYw6ZHAPUxMAAAQGkI1Fjz0FgAAAAASUVORK5CYII=\n",
-       "text": [
-        "1"
-       ]
-      },
-      {
-       "latex": [
-        "$$- \\frac{x^{2}}{2}$$"
-       ],
-       "metadata": {},
-       "output_type": "display_data",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAACcAAAAvBAMAAACS3s5rAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIs3dRIl2q1SZEGbv\nMrsbSYq4AAAA5ElEQVQoFWNgQAWs86pQBUC8WQyTMAUNGeQvYIieYFjvgCHIwNC/AIugKhYx1gIs\ngluxiLEE8GLafq+jfQGSWsawwrZpDOf//0cSY1jKsHnDYWQBEDuAIZ+hF11wAUMduhCIfwyLIONf\nBi504Y1sHxiy0AQ5fvMdYExAE+R6FhWajSY26LlCxiBgwsD/Hw4+DIyjGWfqOWDYLM7A9gNDEJiy\n7TEEzyxgqMfQr7+AYT6GIFCr/QIggQZ4v6IJgLhMD7AIzsMixoYtwXcyMAqgq+WdwMCNISgcGjoZ\nXSGD/f//n0GCAFRmOfCpSmWyAAAAAElFTkSuQmCC\n",
-       "text": [
-        "  2 \n",
-        "-x  \n",
-        "\u2500\u2500\u2500\u2500\n",
-        " 2  "
-       ]
-      },
-      {
-       "latex": [
-        "$$\\frac{x^{4}}{24}$$"
-       ],
-       "metadata": {},
-       "output_type": "display_data",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAABYAAAAwBAMAAADnb5cjAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIol2q1SZEGbd7zK7\nzUTvhYErAAAA80lEQVQoFWNggAJeGANIxxfAOez6CDZzPYK9FYmtgGBzCCDYxQwIdlhafgbcTAZ5\nkDlCJqJmBgwc/q4MDOwKHDO4JkDkmRiYP7BugLDZGVgOQFggkssAwZbfwAAyAwg4BOwZmKHs+IZT\nDMIQYYYaoyLlBiib1tR/BKDMKrHccyADtgAxowODfQCQngPELAUMnB8YGJjXANlcyxlY/jEwSNwB\nsnm/M7AB2QogNhBwfgeGBpS9X4GhmAHKBlIKUDbbAQZg4ELETRgYihggbNYEBsEQF5dfzkBTtjEw\nNAIpkF2Mk5TUJkDZnEA/Atkq/5HiESgFAEGkQFKV6+ITAAAAAElFTkSuQmCC\n",
-       "text": [
-        " 4\n",
-        "x \n",
-        "\u2500\u2500\n",
-        "24"
-       ]
-      },
-      {
-       "latex": [
-        "$$- \\frac{x^{6}}{720}$$"
-       ],
-       "metadata": {},
-       "output_type": "display_data",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAADEAAAAvBAMAAAC4bj/EAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIs3dRIl2q1SZEGbv\nMrsbSYq4AAABXklEQVQ4EdWSvUrDUBTH//1Ky21Dg+LHFl/AD1BwEGneoAGJoCAERUonO7uYSXBK\nQSq62Dg4uNSuTr6AQsAHaB/AIaCVOsVzK8WkOe76H+495/87595zSYCE7ra7Ce/bWFQDnuSawuRJ\nyeF9QD+tazzrmeoKT3QDQ56UfXzwJO3gnSeFRjZ5z0xtvm7jYceb7BFmcaOUrKeyHJSg4E/Wy1wg\n36eNVclmbTJ1Hx7HitoRFJa43VfMci3oHN7++jnZhv9lTq1KraEcxhX8pWe8tCzLTF0tGRAX9dh/\n8khTN+agDJExxGZ05l0gj2OgggNgP0pMYA9PHk6MdaCqRRGyNpY9tI1PoOfESGeUVW4GROwYuZSZ\nOkhJQmf/SAQyTveTRFmQ5BojYst4rEyDIoUWOUF37Mr9vknLGVIaTe1qUVIlojZR1OilW1EAl8i0\nZZ0j44jnGJFnV8LwDaJV84EvR7hiRhgZDXAAAAAASUVORK5CYII=\n",
-       "text": [
-        "  6 \n",
-        "-x  \n",
-        "\u2500\u2500\u2500\u2500\n",
-        "720 "
-       ]
-      },
-      {
-       "latex": [
-        "$$\\frac{x^{8}}{40320}$$"
-       ],
-       "metadata": {},
-       "output_type": "display_data",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAADQAAAAwBAMAAACsx0TOAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIol2q1SZEGbd7zK7\nzUTvhYErAAABnklEQVQ4Ed2TvUvDQBiHf2ka2/TDKoiIizEVnYRKBcWlFbuIDoLi4lIRP0CEUqGg\nCLajWxCcFBUcRHAIIq4WRNykgm4F/Q/6ITVFofUubUqOprt4Q/g973N5cy9cAGY5g8sMm2AEeyZi\n4hO8DJtgWu0yERN7v9YZNgH/fmwiJq66z2JMoQGODLzJBjGBS4NvofACe3NDzj85v4KE3M+00SGO\ng+RVc5lWJISwZK1imLUWtHrRUnE/cFjLFJ/HmKUSyp5zLmCpHA9D8ril+X/Fasv1h2a9BRLBTeBG\nfgS6t57rSE94ApxiR+WiyAW4MEJzOlLDX4NXwGdsJfgUcnnFvI5U9WQhhtFeEKhyXcJe0ZEqKQtf\nFO4SibmAV0NbxUBnRxZ9EtyfRL3SraJm4DZqqgj3cJiqe4mqIklSQwETH6Rg7ISg1jNt6NKAtrTR\nP0630e+WORWeMjCKGgILkcj3FDmtUNjXqBKi6NSRNAH0kW2KLwOxgDsgRUa2KXWFI+yq5AfPSdyh\nPKjoSNVAdQMJ/wywuPYGkdwHpYb6a9aPX900isnj4kp0AAAAAElFTkSuQmCC\n",
-       "text": [
-        "   8 \n",
-        "  x  \n",
-        "\u2500\u2500\u2500\u2500\u2500\n",
-        "40320"
-       ]
-      },
-      {
-       "latex": [
-        "$$- \\frac{x^{10}}{3628800}$$"
-       ],
-       "metadata": {},
-       "output_type": "display_data",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAFoAAAAvBAMAAACRacBDAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIs3dRIl2q1SZEGbv\nMrsbSYq4AAACSElEQVRIDe2UMWgTURjHf9ckR3pJmqCIOIjiIojYiAUFCcnWTQOSDII2KKnUDqZ0\nE9SDgOAgCUpTI6gH0qHS4cTJKYLiosUgKLioILhqG1JrQznfvTb0BZKrXYqD3/C/7/v+v7z73ntH\noHd8hkC23NvvcD5NQp7hjp5HUYQEUcuDUK0ixgo+U2155EUigs55EKpVxL8lemtrGwuETfV1Hrk4\nk3miMQ9CtQSd55Ta6Zpr2YmbFXYNVtBH73cl1OYMz+yXasMzT3OF256EalpcV8tN89ebEgqgrWIo\npXf6VP/JZW9kww22Bl5ouY3aOzO+n82MeyP/3e05gR3H3Bgi6vxFbM9I/85bIpnzJsxMnUOrHkmJ\nLHNvXWZHH4BRGasrw+7Bv4SWYJLd6MtQpt9ekyEe1/GljIRCj5g08KU5wFVIErIx4lL0OPp+LsIF\nhS65dM0SnbcWN1KBgqCl+Ar4FzgOpzv+EsUkh92fD1o8SgV/WYGclGiZyDK/4Yvpuu3oK7D4ccx0\ny6TFj1YeKfvSRJa0pqBzrrUeHw5iNGxOijIivH7n6Jq4dFPS6TbqPvVXhgMjFvR9hefvHVNKD5p3\nTxpQM+EhhMrUVqR0nWSvmNJeFHQOvQBhC60lxd1lS+7SFgOsheGIjdnf5Nq30GJzol2RIk4wKE+w\npJygWDYZK7lzR8qEYmFhTUgRtxOIu7dzpr2yeI7jbzKQNt6wM5O5S/AQwbQUTjAnbt405hU6WL1j\nwvR0iqTjiN0OV8VXJWU2e018VVOX6vwBf37U8ArfDb0AAAAASUVORK5CYII=\n",
-       "text": [
-        "   10  \n",
-        " -x    \n",
-        "\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n",
-        "3628800"
-       ]
-      },
-      {
-       "latex": [
-        "$$\\frac{x^{12}}{479001600}$$"
-       ],
-       "metadata": {},
-       "output_type": "display_data",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAF4AAAAwBAMAAABqAtB3AAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIol2q1SZEGbd7zK7\nzUTvhYErAAACYUlEQVRIDe2Wz2vTYBjHv0lM0jbdFhRBvDR0QxARgxsFD8OBBZFdclCvldrDUA9l\njoEyWP8De/DHYCK7CII7BObNgz0ooqeCF5EJRf8At86tm7LV53mSg/A20F6GB19IoJ/vJ2/e93nz\nvhTo3ZwGcOpttXeoUqdSh1W1mmqSQMw60q72OyFVMfmZwD5QgwRCPmB2ElIViz/kqUECEX8sIeyB\n2U95PYIExP43vE5IVUy+8+7aZTVQyNGJ4wVfO7vjZ7rdDSVVgO2lljJczD6bDmPDDPuUSbNxpNG/\nzWbGH8zPhaj2/0TKvQhjAL9U+4hj/XePhfOzo7UB/P/q4VagO1g73MH9G297BedxPp/HXHkamB+/\nTZv4ZoG3/Hu6ZstnYigJj/gpUlTUn9pznHTxDPdCpFv2MrBAx7O2jCuIoCSkG6vQaQNOZVfoaDDq\nMJq4AExirkh+2sNXCIwS8k+sQwf0cKQJvZOewvAmHgI/XBjkP+CtLDBK6Je3Tjd8x2IDxsHIDTjb\n2AHeBOJ/4UxglNCp7bJvN8D97+Y8OFtam3xf/P21QgCBciPzLti3AlgryG4xbYvvsW/v1bAkflsS\nMj3xF+kVn3Fd8bvAuaqosU9nK/c/SVdqfG2b6V/jsfdoyoFAudF6QHyqCDW9w7PalfnWovGT7wuM\nElwtFn9dgk0VoTbUpKqZUs9SVM8P3L/AKGFrFRgm39hErkWrotd5vU4ToPqXePwCoyT2Tfaf4BPw\nCPfpewjsl5Gf9ewXMZSE/LHuDI+Z/o/cCejTGp2mUpUnQli39meASqUVQ0m4/0HaH8rI7cFFVzeG\nAAAAAElFTkSuQmCC\n",
-       "text": [
-        "    12   \n",
-        "   x     \n",
-        "\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n",
-        "479001600"
-       ]
-      },
-      {
-       "latex": [
-        "$$- \\frac{x^{14}}{87178291200}$$"
-       ],
-       "metadata": {},
-       "output_type": "display_data",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAIUAAAAwBAMAAADN86TJAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIs3dRIl2q1SZEGbv\nMrsbSYq4AAACqklEQVRIDe2VTWgTQRTH/5t0t5vdrEbFLxAi3vRQI1ZUPDQnBU9B2IqnBqUWD9J4\nqgqaXHtqUFBDqxmUKoXSrhfBk3gVweBJT+bgQaTQD1v7BY3vzSRpQCOhU0/1wb7973/e/DIzL5sA\nrYRXpqpQK5VNa7yHCRobEk0LWhmwieH06DOsSX3Gp01gpPQZbkyf8Rz6jMFCcbiVFjat4d4ivtG+\n7O7bdy1tXFhOw83ebPoZfx1wUu6ZKC9CI0xYM3ZJA0BTHbSX6aYZ0bQmgKbHSxB6FDfWD0uTMRRM\nYY/eMjDRO9odaDL+T9/qJ7DzOEcnUNlozGz1I/zH+x/1H8E77fs+sE1UFXswCh1JOLcu8m/zd7r2\n3/sKjF19XE2Ny8ojErjU4EU40wJKsYe9sJZwIGe8BSZWCJlBfw6deFZSqYHhBnASpgAyzkBWQCrp\n4TbQhSngLl4MEKNdIDxjJWAdlAkNYWaYAZi05H5isJIe3gtkk3NAj4BFjOg7tM+HM2iblakBAXtR\nmGkyztJFDKmUd1SgeH6N3KRkhFYQmd+eh7ckE1fWY3q1l7RTpiQZrJRHexG8jkAyaDy8Ek/B+ykT\nPa5HpHKMHiI5SpLBSnnwFjBCwHSN8SXF0xdkovL1eP2xkgMm2ZAMVspDqIyngV2sMzrwZ4abxxs6\nsct1BqmqhydkvrpOHeUzpdWVJeP3vUQFjFXgZJ1BqupZGTZrfQH6AD7OVZnkUDWN0/0BnGV+5L2w\nUh4GYcTIPQS1DjuPHdRWm3trz3J9LaJUdgNtdQYr5Xl50P9uzJivMj4DL+nrZSZkqs3nu30Edgp2\nncFKebt8/z6uiFBaMYwT/qUETmG8pFIj5FyB3i+PjgSFD4cDpaTXVan8gFn4Roc5MjeMML1TCYx1\n36F3jtOmxC8/qCMkO/cynAAAAABJRU5ErkJggg==\n",
-       "text": [
-        "     14    \n",
-        "   -x      \n",
-        "\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n",
-        "87178291200"
-       ]
-      },
-      {
-       "latex": [
-        "$$\\frac{x^{16}}{20922789888000}$$"
-       ],
-       "metadata": {},
-       "output_type": "display_data",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAJIAAAAvBAMAAAD6AY4WAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIol2q1SZEGbd7zK7\nzUTvhYErAAADFElEQVRIDe2XTWgTURSFv2Q6mfz0Z/wF3XRIpSIiBC0FF2Lc2EUXDgrdSUOrRbFi\nLCJUBCNCcWcURUGwdSEF3QQEwYU0axdacKFgoVm4b2utqZvG++4ku2IDE3ChD3oy99x7zrzcuWle\noImVKsP1nkITlVuUpM4V4WtqeYuyZtJ2kWjO8Zop3aJGnJL+FjXNpcWp+0y/21zxH6vEac5LSbNC\nL7OnCmuhfUCcukqstsapw2ejNU52tjNcn7b37erPRA79zDDVmw+zJ8eLP0mG20v99lGsZbsUZi8N\nrUNbuXEd9jWZCevQ0HeXCNXphk/cPY7VEqfhwnt2NGxDvd48PNGKf5Wh9vBf/I92oNaq9Y/276++\n7d2XP8g568gluDYyCBpGxhYqvB1Jpz0n3evXMxPp86CgpDPaX6oLVU0ky3GfZ0yWIi/Y6wbhTqw1\n7sl8ZGNwAc2QI1YIQMlExXmKCgOgLU9i2SpizbfPyDeJhgzANPuhjbswiWbiBZyiQkAehWOoUAGS\ns7RtJLJ0rnTNE61qyMs8pyoeHGSfcdJMNCtOCgH5EJZcFSpAR5XYRleO1NqtMtaGhizmuVKBzgzD\nA/SgGftHPppRCMifMOerUAGzEtVuj9SqufO6hoaclq+Um9Beu+Ppntb5uH6YAAwZ+S5OGRUqGI2c\n18z199gM7eaMNOcJpKQQeVZc+eUSZGK1+6BgSHUKhKqWUlhAr50vDBmnBcN1lMFZhvilxTWCzNS7\nmo+CITdzipXVaZX4kddyApRQ1rj8WfMwRbyW10w8x72qgpJXN3l3fWB6ZloUrYKEYpIVkGfCLHQX\n5Fqeap7IukJAmo4XVNhQ2zm2icZekfqOeUwIQ0RcbuVwZmSTGc3cEBxVCEiZgmEzBfZKQ/0Gbsts\nRYvWijnhmpBUjrjLUg6ey3i6mkm6cEIhIGUyD5jJFKEBiDxI9xZ5xI2S9ZhP9XBPOn1RbilOZ/Oc\nRjP2Z2xPISATvvMKFQZAQj5dRfmlNAi94349nK7Vfpk2yHCeHPODDN/GZCoUlHRG+krmJ5YIFX4D\n1xNlQbFLfTUAAAAASUVORK5CYII=\n",
-       "text": [
-        "      16      \n",
-        "     x        \n",
-        "\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n",
-        "20922789888000"
-       ]
-      },
-      {
-       "latex": [
-        "$$- \\frac{x^{18}}{6402373705728000}$$"
-       ],
-       "metadata": {},
-       "output_type": "display_data",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAALkAAAAwBAMAAAC/PMZ/AAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIs3dRIl2q1SZEGbv\nMrsbSYq4AAADeUlEQVRYCe2X34sbVRTHP/k1+TGb3dFStYo2b1qK6YAtCEU3/8GGwmxZQQ2CW0qF\nrlBbWpAGQaQgbKiUGkrtYKlQKE18KYgPruBTkW6gFOlT90FBRDDrtksaK/HccxMzT6WFnYfC3oeT\nc+73nM+dOXNvMoHHHsUVuHbQe+y6RyoonvVxvIIsEcvI+UyGlGJhg9CzbyQW4qMnlpthfHTeW+vE\nR8/Xb/bjo38NO+OjvwSH4qMnPU5sOH3rgecO1hL77tcKZ4INP6uFqrt3wt/wax4CMzjdXFw7kQLZ\nleFCsXxM1GLBDqHbO4Rx8V3vME5s9MX2nzwT16Vz9f1Ls+3Y6JvgzQ488R14+jUzdsNg40f3ie/O\n5g08vAOFucD8JP8Cl+fPw7bTv8Kt4He4eSYIqsXgnbr1rLwz3DqME81yhUIwVx8WarWa6HpbOllf\n4jdhNxc78gp9uJ5oMFPjB9mrC9tIr1tPZZYH97Dxszg98nDOFlrZIKJw9pAsgXMDR/5clLIhqW6m\nx5TPW5Dl3Tpr1lOZHR9JtSryVjbN93DRFqpscyJ4t6/BC2VSC6RXJ66TvZtTehXeZtHQ1VOZBZOt\n8c8hJyv7DV2VsYnASS5pVC0z1aDYS/bJ35UZ6Qyk1axbT2VLV2VXyIXK4glmbaHKNkfyR2Pq1fkv\nwfXKbK9SNKSUuZuXjX7VmKS5XPGsfHT+iJlUhelwcnCtahWVRwiToqO1l1Sbb7B0eWTckVX2aQdk\nWW7pOuKZynv8Qasis0YxIRfWPKuobHOMNhytLpm+dHJMLxvlgwoUusZzfrLeqDK7NFKSK7jnd/Ue\nSvdxe/IS+n9n8iuGOSHtcUrGYzlUz9BN4zL/jpSv4DvcQajK2GjR0EyVcNcvIXTzSP6BA5DoMCme\nbANehL/a6qk86ZORh24UHDHXpWNtVcYmSpd8t/fZsWMPjkpJbpVcg6dafaW3GhQGoaGLZ4i5VXmP\nz6+iMadIPL8E+ZoqYxOl57TvoKcp43MbvpX7SQljRph/y5nx1JOTkvHlbJqzZ5RiQ3baj3LiPFXG\nJkrnN660ZeIGvM6VTmJPMOc7bWaqsCiMQ6RlZxjPyg0+92y8JQi+4JOQT62isjVRfP642cH7B+e4\nPPsxKfly8TnVfEXm7rTl/3vzdN16KnP77IdDZXowWCN9vCmyKYwYSYhz/AcfkpFQNTd5DQAAAABJ\nRU5ErkJggg==\n",
-       "text": [
-        "       18       \n",
-        "     -x         \n",
-        "\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n",
-        "6402373705728000"
-       ]
-      }
-     ],
-     "prompt_number": 42
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Write a function that computes the number of terms of a series expansion of a given function are needed to compute the given value near the given point within the given accuracy. For example, in the expansion of cos(x) near $\\pi$, suppode we wish to compute $\\pi + 1$. Let us see if terms up to $O(x^6)$ are sufficient (remember that due to a limitation in SymPy, when computing the series away from 0 with `series`, we have to use a shift)"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "a = cos(x).series(x, pi, 5).removeO().subs(x, x - pi).evalf(subs={x: pi + 1})\n",
-      "a"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$-0.541666666666667$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAALoAAAAPBAMAAAChJ8gEAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIs3dRBCZdjKrVIlm\n77sGqe+vAAACHElEQVQ4Ea2UMWhTQRjHf8nz2qZJ06Lg4BScXISCDhU7ZHFuFgeRmk5KGsVgoaWD\nEHBwtFARMkjfUuiWgChihkbBOYqLgsMDcXIpqa2gw/O7u753Z3ijH+R39/5/7v8u310CJ6XurLf1\nNP8+90aGqS3Bd/ncbL4G9arf9mBF44zZznnU7Pd7st5WUFULejYTx1oMIrh1BLkFtuFMuzDvwYgO\nmc4wjmO9Q1tr8EDP8g3ZKzyMuNGR9KDHebhKvuLBiA6Zzkso6CBbV2BpTqZWyr2LYFLShzXRSjLx\nYEXjjNmeIw0w25SVUsfwJJTRphfzkU2/KBL5D/8AIzo423PgVEuvNZX7I+n6sbCxWYW3Sfro8XrI\n7IWNVQ8Y0cHZniPHZpM1Tbp8G8o19RPVOklXhwMWqS8SDByM6ODZngirGekiPadIkh7Dfq1+QPHI\nQWnxegrPdk4NdSBRpy/pupx2RqT99l6afigHG9bnKf12UFrcTeHZzgmZrEhUUvpUB/LwTdKv9ZJ0\nRhLUmq1Q+uVgReOM2Z5DsJVEyyg3sjsn4ye4f67T2fnSMjdSXjYMy3rvDnoHw9Ah06G+4qWvwQsU\niCY/H2YieyO7uu/Tuu8OGNEh02FJktIKQvUZ6e1Zpj+KmKSXe+or/GB54MGIDpkO3ZU0W/6omptt\nliOmbnekQcWd48HEvdFdaDSqMPHsqQ8rGmfM9hxzit4L/v/0L9iNQMEYAVEuAAAAAElFTkSuQmCC\n",
-       "prompt_number": 43,
-       "text": [
-        "-0.541666666666667"
-       ]
-      }
-     ],
-     "prompt_number": 43
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "b = cos(pi + 1).evalf()\n",
-      "b"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$-0.54030230586814$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAK8AAAAPBAMAAABgoIKoAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIs3dRBCZdjKrVIlm\n77sGqe+vAAACyklEQVQ4Ea1Uz2vUYBB9SZr9kex2V8UiXiyCYD1IxB7UCu7Fg6cuCILIuksPW60W\nFwVL0WLw4KWHriDiHkpzEm8NFqq4YKOgVxUV9GRAvejBtnZbrAtxZr40f4FzSN7MvPfyZfJ9AeIw\nR6+7DPVX2jO6ZZqQSqb93APOTFwA+ka+AdPtH1AdRTzXHqN8se1CEPCdTUidhFEyj3CSjyKfbkYI\nqfShZwMYxGlXa+KWp9Uw3FAdRawhFWCHm3UgCOc7JGZ1EteAq5zoF5/ybSqEVJY8/EbaQbo/W4ax\nbG+i4KiOEHMBTAdD0PsVOtsSY1IncRQYLlKWlYr2MoRU5tnYaKJnJf8R2TVLjKUjRJsm5uTYTBCQ\nZszqJNaBGY8yZWzrIeIKjaJQQ2ZT7yC1RgQahXSEaP0p2w39LZUFxcas3grtLxk3KMtOTJaAF3q4\nVdGb2OMjQ5OGwcsZgOoo4q/uDRT2T4wBjGJjUhNUIWT+ar1lcw1mIzb2MT0AMaYHY4Ye8LipjH0h\nIhUdQvU4jECQMma1cqVrYkx4FjYSY6Q/JMYHmT5VSrizwOvbkVddht0RpIxZDWw/zDGoXo+FwJL7\naMuYh/OlHI8iFXI330m4S26uhjedqoPcpiBlzGpmquAPEhD8SsYnfW5JZRcNL+CP1wUm6cVc9HZV\nh4mlfBlat9CP3IYgMTZFHduCN9d8kbL3wJXdrdbc5wZXdkZlMqbtZq3AqmFbtcPGwmVisUKK0V5e\nsSAxtkSdGNNxWIAJOkDYS8W8HJAFrAIninRAbAd3aLPQ4owVPiALipintdy1eMaC1ChEnRgbnvkJ\nNK0+WO+UsVRuoof2wzFUXG2oveikAwz7kI4QrX2wfPxEJVBIHRBeVhLmpUkXlRCZeotWYc+tB1Kx\n6iMe/YSePIARRZGDh/UD9NNhriKeqtMWTt2/Byg0vnpZqRPj/w3+AWrzIIzvy1iMAAAAAElFTkSu\nQmCC\n",
-       "prompt_number": 44,
-       "text": [
-        "-0.540302305868140"
-       ]
-      }
-     ],
-     "prompt_number": 44
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "So the expansion is accurate up to two places after the decimal point, i.e., within `0.01`. "
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "abs(a - b) < 0.01"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 45,
-       "text": [
-        "True"
-       ]
-      }
-     ],
-     "prompt_number": 45
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Note, with `lseries`, we do not need to worry about shifts"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "for term, _ in zip(cos(x).lseries(x, pi), range(10)):\n",
-      "    display(term)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$-1$$"
-       ],
-       "metadata": {},
-       "output_type": "display_data",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAABgAAAAPBAMAAAAMihLoAAAAJ1BMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAilU6eAAAADHRSTlMAIs3dRLsQq3aZ72YDTSHvAAAALklE\nQVQIHWNggIMwOIuBIfUYgpNejsRh4CCTI2QMAiYMZBsAcxDnrEOzYWwwDQBP9Q53CSxxJQAAAABJ\nRU5ErkJggg==\n",
-       "text": [
-        "-1"
-       ]
-      },
-      {
-       "latex": [
-        "$$\\frac{1}{2} \\left(x - \\pi\\right)^{2}$$"
-       ],
-       "metadata": {},
-       "output_type": "display_data",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAFoAAAAqBAMAAADBpFHwAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAuxCrdpnvzWYiRFTd\nMollB7CEAAABv0lEQVQ4Ed2TPUjDQBiG36ZNamy0gg5iB7O5+Tt1suiioNRBcfIHcVLBHxDEqZsU\nHAoi6uakgyIOgoMIziIiiKM0qF2l6CKCxO+S0MvFKpfVG+7e78lzafL1AiBiQn4orSFspac3hA1k\n/7ldamQvKPmWqqkuydtGQf+St7VT5VPeBhJvYey4BYwtruZoD1CbcZZqU80+o8/+S/f+IpAnqK6x\n/HDFXwRynOoTPHIay/D8I9F961IX3ZxrJs8/kjINzbbLnB/yWCWlAmySav0lfTYq8inbtt+Bkkix\nRnU7NnMLAleHz3bzBeBcoMAc1RayuBT4EQZjJOPApfRD7uOzQ2Ciy6E7N2xcO7khypaik/nEbGCW\nAzfpnQYLQXueQTqUClv5UHNJVnhPUuHNlPKxMvoqxAkdZvKOwoZIWY8SH5FpPSPyISQtIsEOHgNK\n09PrgChTYyMjhNY9vD3e4iSNNeq3Qf+8M/ROZE9ZEg+ke7Ey12fcGDVhlJ3414lt8/ZpM4i6rd7y\nSLUl7cH4G1TXDnbDtyt2xwuDfcvSo2hJqyQuh5HVhjB2fxg5MYI9ef+Bjp60rd++lq6kbYM+NGn7\nG0/gY7SgevO+AAAAAElFTkSuQmCC\n",
-       "text": [
-        "       2\n",
-        "(x - \u03c0) \n",
-        "\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n",
-        "   2    "
-       ]
-      },
-      {
-       "latex": [
-        "$$- \\frac{1}{24} \\left(x - \\pi\\right)^{4}$$"
-       ],
-       "metadata": {},
-       "output_type": "display_data",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAHcAAAArBAMAAACwWwo1AAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIs3dRLsQq3aZ72ZU\nMonLrI/bAAACDklEQVRIDe2VP0gbYRjGn8ufSy5eTNpJyXJLJ5dA7VoyOjg4lNIxS6l00DhIOiqC\nFkQMnWodjBRDx4QWupVMrUshW+nUmzQuIiIRWyS+X87c3ftqNLmsfYfkfX7v85Av33dfArB6ztRg\n4mVrML/f/ao4RBjx/2H/Zt7sLYEG2TBTbu4g4blhwqtDhJPfhwiP6iJsfDjddrdwyu1uNF+I1GTY\n70oW/Ir3RgP60l3hUJ4HmLJgbm1dVBnzi7d+IftvBDTxnf2eil/I/jWBr+d1ibs6YnW7296j9duo\nywybFtZc2H/vkk6z0263z4HREsdChWg35vC5+pFxY2M/U0sDpsWwFIkcYGMTP9lgGstxyiJSdvDD\nx6omAVrQdZ3QJJUD8ljseFwLqZmYQkll6V0qDHySBq0QVuiecKJOHu0SuvJ6ZVRTSnSX7Q1YF63S\n4xs/wSqjmM+nGkRGLI6FosMw/0XL2hLnK0jZRO45qkgW+ouD43WexQSiJUKhHL2wGn/3TOlfDtxl\nMyHU48lKK2CzTuSJQ9Wz37OachLLI0zHF99zBnddSd2S4UQFsTMg88gZ0EJ6ViwtR6EWDArb12GM\nSYOnN7zW68ItjKS7YQ/31/2xMYugYcrZQcPGDMxG0PCauv8Bw2YJD34Ui3/f9LdB3PWb7hGRPU77\nU9rT46Ns0HCYfoQofNj2/q76+9SArisQh4Bog/FyCAAAAABJRU5ErkJggg==\n",
-       "text": [
-        "        4 \n",
-        "-(x - \u03c0)  \n",
-        "\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n",
-        "    24    "
-       ]
-      },
-      {
-       "latex": [
-        "$$\\frac{1}{720} \\left(x - \\pi\\right)^{6}$$"
-       ],
-       "metadata": {},
-       "output_type": "display_data",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAG8AAAAqBAMAAABPfhiMAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAuxCrdpnvzWYy3YlE\nVCLumKMEAAACRUlEQVRIDe2UP4jTUBzHv0mbpknzp4OjYJa7QYeLOLnooQU9B1tEETnQ43AS/DcI\nLkLmU44sLi4XEBc9IUhvytLhJkEIeIvbDYpOWu4U7rie9ffy2qYpSa/p7I+S93vf3++Tvvf7vReA\nm2D1nJyDeGI6UDxzfjoQqP8Hk00SFy8PhFzFkd216cANnJoOvD/A8vXROKzdHqB59qgc4FUfvPHw\nidP3adwc8kfcF4DRgRmOyHyq2KlyJEousA9zPjVDtlJlLj4CnsFspWbUUtWe+Bz4jI/pGcvpMldn\ngfLitdQMjVaTbUKYGZN8qlzz3Nb1ZMadbre7C1QaSXloJjugM7Xi3BvSAGlh68fqNqBnr6fUAnzU\n8SUBfsLVInHQlrhM/58wUlmtLZyO4t/fMluP/GqBDUo7mqQ9eJPujoYMW2XSGLAUUtzYh5hEJcdk\nQn+pyWA0ExxgtdjGhWRszjJdUsrZxaGC63vCkjGfBK/A9EkZ0w7Ng3jsQxB/V/gLnkJokCe3+FR5\nEwQBvt08DszUbnHtAR/Sn3TkIitTM3YNG/UQ6zjJNgHQOc62Zi9UsQC7YEFtFz0U+cbHXSuRp9Be\n6eeWllHoqDa0v9HraAGZVtiOQ5uQdyB1zAaUQ65+jYOj3kIsiFXmqzu/fCi/Y/loTwpZzprPwIOj\n0+OMuch9jNzgJQZK1QjMtdTXDLxIt4mKs8f8CU38Q4l6Az+pHTpvx2SkxsCX7D54qHiTMVGWTqDx\nLtjw8B6zbg6Q7UulA+thpnl2cu4fXiCRCxxGVLkAAAAASUVORK5CYII=\n",
-       "text": [
-        "       6\n",
-        "(x - \u03c0) \n",
-        "\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n",
-        "  720   "
-       ]
-      },
-      {
-       "latex": [
-        "$$- \\frac{1}{40320} \\left(x - \\pi\\right)^{8}$$"
-       ],
-       "metadata": {},
-       "output_type": "display_data",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAJUAAAArBAMAAACDTNd5AAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIs3dRLsQq3aZ72Yy\niVR4peFTAAACwUlEQVRIDe2UPWgTYRjH//eRyyVN0tTBWhGMiIiTBxZcqs3o5g0iOvVAHFoQIiJZ\nhCYKNlohsYOk+EFFqQ5CU3UTIauDJiJKHII3OhRatZSUttbnvZiU95I7cjGjz3C8z//5P7+7e7+A\nduEz2qldacpYz1hKcrJnLCD7n+VpQb3PV1/mrsMbvLPSuNgz1lmIPWNdKQ72jLV3/V7PWOrRkfas\n2YUjBXvllF3YyV/T8FFo1NhR3EehhHM9UIQSg9jyeqcO0XCqkB6DoEPtmJVxQeEtcAB+t7dx3fNc\nZksmgPHqR5vomMoxxxIVfKZb1V4LlAGhcvl7ni8EtikSCOd42T1ji3QJrwpPeFv+Q/rNABCJ8bJ7\nFowDZWSxxNlkU42mSZHn6vKuYyyG0c8+t22skLE/Dhi4arUIB60WUmimkKBniFk6DsYCnrf4B6GR\n5o0VNKlF2IRio90H+6TGP9qKDqmvACyqK7jJ15U1bJLSF+Nl94xWPbLhmxNSvE3VsEWKtz0ha1DO\nfalO8yh2ns+TJMbpwQfdBUr+VhGh6mcTGJo5Q0cj86Duecxb+YzOkD0kHVJcGcEQ5BqEBLImhnGh\naNno+DpHpbV0W8cN4Dq+mfjFjr20QvOhxiyjaLT6GwpdXvYQXuo4DpyOLjNWcB7+VSkB+Yflo890\nDH+0pRQWdawDJZM2TA3iGgKr/TmEfteNe1r8TeFOc9QcLIq6QCtcStHCWF8hre0vI1RrGjofKKm/\nrDLeH7baSmXGYhvIa4TRZEF9yroPoVvWUoOVIsyCAQR0i9XFPyplYllzX9gHjNH5m6KrhuZ+g9Ae\nI5JMTj5L0Z5Y3r1tMFYkhwHaE5H6nvBIQ9Daq5/wExiN4h27GTSENa8Yy08syVReYBryFoQT1a8a\nTmKi2A0rPLleUB5OFRGZnTEh0X2tYbxyrRvUv/f8AbPRzoUQwhp7AAAAAElFTkSuQmCC\n",
-       "text": [
-        "        8 \n",
-        "-(x - \u03c0)  \n",
-        "\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n",
-        "  40320   "
-       ]
-      },
-      {
-       "latex": [
-        "$$\\frac{1}{3628800} \\left(x - \\pi\\right)^{10}$$"
-       ],
-       "metadata": {},
-       "output_type": "display_data",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAKAAAAAqBAMAAADGyk2gAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAuxCrdpnvzWYyiVQi\nRN3cr+EFAAADD0lEQVRIDe1VS2gTURQ9mfymmemkiAtRxBGhgptExF2Fwbb+KG3A1k9dWKQbEaXW\nTUWE2YibogERwU0HsRSCSBYVcdWAiC5ECoIuBDOgC60fQmox2pZ434vYeZPfJOnSCzl597xzz7x5\n784MUBYbypjWiO351urd1Tv2rLMhAv8N3ZvccN7sHrZ1AKneCpdr0rDtqI2A1R4vd2zSEIoNLYkK\nLdKCYUzHl3Vd4ZSOj+tqmK1kGDz280T5VYhpNyrSjJTnCWgPK6+wWtmtahPEnywZxjI4V0Plmhp3\n5c40TAmtMJTEipOuOQ4YNaZlixtSH1J3e4yQXkMojUCdWTLQ01tLJRq8FVNXtsWVe0iHSaPe75od\nFLWni8XiIjAtsl6yCRLtwg3zgiAOHp59MZkBHgusp+Q8qSwM4Imgfoe+QIaYN2ssLblu5Ei+Sj8d\nu3nh8+8svvFxh5/9TfFxQ8AMgVF3jRrXGNWEIX8E1F+QRMugGWWE45bF+erZJpqaDOSwX5TE9GiS\nmOsi6yWjxlAKvhHVEMX9iFrENNE27wFp473UIdEPE/AliLrqoO+mqM2l6VQSz45vpV5LnfoL0mBv\nEhyYOpQhqBb06P0LNYGsgVdJv63GMZBGAkGzBNq89BkcmJg9/1UjYqxNRZYRtbGA8Jhfh5aTTUg2\nB/QDB0vA1bVeXzvX/KAwQ5l9rEJn4F+NxMmQAz4A2QwHLn/qKHIPu0Qia4RHiAnnEVxVFvWIwQFL\n1K9pDlzuPl+HR4B1jiMuIXq5h44C0PLYVjgCDupvMuxjYDi0HoZtM3HEPkEzSTtlIVj8Cg7c8AEz\ntDy4CJID87EcImwbLwLX7hTTHFowDOVjNuRlWlgH5ARu5jlww77Gb1lNwleIjkH+AXTTUetQCxz4\noZjsUEzhfuolsTwZ+vgKlQRedpJ+kANrmznWNnOZeh7CPC1OW1H4Ht6m90mIqrs4sJ5+WAKhoF4S\nMJG1sBmdprqQmraVcSgWB2hp6WwJ6nmI84+GrtBx7N0HjT4FNl4PUUdykIa76eXAoJH4A6F8EmVH\ndtj7AAAAAElFTkSuQmCC\n",
-       "text": [
-        "       10\n",
-        "(x - \u03c0)  \n",
-        "\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n",
-        " 3628800 "
-       ]
-      },
-      {
-       "latex": [
-        "$$- \\frac{1}{479001600} \\left(x - \\pi\\right)^{12}$$"
-       ],
-       "metadata": {},
-       "output_type": "display_data",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAMcAAAArBAMAAAA+rYEMAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIs3dRLsQq3aZ72Yy\niVR4peFTAAADZUlEQVRYCe1VXUgUURg96+6Mu+4vPUUSLoFQSbSRFZHEPvpUC0H01kSEJchuSG0P\nQqZQSoISmJZJG2EEha7UazQvkj01EJRBSxM9aBD5U2hlun337pTddpxtfwqCPpiPPee795y597tz\nF8gRB3PUS1E+Nl8KFWuNhvhfMIHzv4l1G8TqP7BdY4C397T42iaoqJU8bgYu45KJrEgVZYI3wDZU\nqaJkNiraZBjRcLasyBRtAkwromQ2KoHJlmxVkXFdnRsQGQHVC0gA9xminsAbE/i8gcdivkslOWby\nIG9ZcUKZImIBBQmRiUPzqAKfL+iwmsBWQCZj7ycVq2E5a7esRjQC67f2YySdthqVs+YIWg2RdKvq\nb9dcGmCbODnVL864nk6nF+hU9Yh0gagsCTThXvKmMN/VNVU5GgB8QYEuFFSEAQ3deCcI7MM5J3nA\nkVih12xnUQvQIvMJUvCHAQWnuNYPGUKRckZ5Znih2MRMgNu/ythidkaVyKRCJy3bV8hMcyVcST8D\nP2/XSjHvXxI1ftQ5g/PizKjiV4lxB0W6QESH1LcoJWyt4vx2+DViSnSEHSHIh56lLooeqIHUQ1RZ\nmJJJPIJndyqVQsNgC3Ci45qRICk0uGnwJeT+TvU7SdQNelYNulZMYwfcdIoXbMNYF0AtjqqZJB9W\nqMF1aIY9LNchQzIBy1t8wtQCziF4SS4mJVAecYbgDPIkx88Sa9ewAe1AGzjJFayuejnIh2Slymp4\nqWGqPwjvvD0GxyxPQLcCPKQHu4D9AYMkaItRWiXKA+YFrZrx9YhG4Pzo74FnmaeMyWZW+ww80Q2S\n4bUsmUeXOe0OMBM5AraSxSoNnk88ZUzmxjt12xKZtBqkuUgu9jiYiUuHKwGJ6y8xPRKm7ZI/JLGH\nm2gGmUvOvK5xkygtpgZvs0zo/+3VEbaSokx8Kjdpozdwd4wv800xdoavhHr/uujtagI3oQNE4Z1n\n7V3kyegJmbSyxicNko/LN03G41/OQCYdirIgHVQfO8K+2YzJATLR6Q2m2RFmZKExRBc0mThnURWm\nT84b4iljMk09UehjfMo+Rm+oUAuATHzMZCc2AnvRqGYS/xglTb4Duy7fNSqFujxPD1AfaPaLXp2u\nwYkWI10Z2ZQE+vrCkAcvqAZZqMkfm/cNx+U5CyYfG4QAAAAASUVORK5CYII=\n",
-       "text": [
-        "        12 \n",
-        "-(x - \u03c0)   \n",
-        "\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n",
-        " 479001600 "
-       ]
-      },
-      {
-       "latex": [
-        "$$\\frac{1}{87178291200} \\left(x - \\pi\\right)^{14}$$"
-       ],
-       "metadata": {},
-       "output_type": "display_data",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAMoAAAArBAMAAADLUwq8AAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAuxCrdpnvzWaJVN0i\nMkS9ILV6AAADrUlEQVRYCe1WTWgTWxT+OvnpJJm0WYm4sPfBQxEXjYobETpQRKRKIxp/kYiLtxB/\nUBBd6SwUXQgGtEhQMAtFXKUgD3y8nw74+56CBRHBjeEpCrqwtoh/0Pidm7bTVDuMSQkKnsWZ757v\n3PPNnXvuZQAfa1E+5ExRRkcTVIwlXU1QAXp/qnxjX/woXyyZ4sJa/RfX8FqS6/qpUFK+Mg2rIE4V\n40IzVMKdzVB53BSVvL9Kdu8Bx3ffgDZ72gSzTIr7Yrr+KtMW8IgHHvwCbWOEKr+iYZX9X9T2AnJM\nqHIpm9vkBetBYdtnlpnXKsB95ZMVgIr6zTe2wzr71obZtSxAKZ+UFz4cMMeXDU5uZuq/3f+tsGun\n5CqVygjQVxute3SI90fevBaV28qzyJqLd066wGUv1BDaA8QQHooP1lR5idVhiuC5F+Xi6rMh1hjl\nWhBK6Wq3/xT7R+NUSB5PNG7cUQWI2lMLWemEhGZKZacUuz8IJU/PIk67DCZ9MY+rA80Gr6lehFXt\n3E7VLjt1vDZa94i9WnJm4caUAj1ozzM0U538Cvhl1YIzzhSVQ2jJMHR4UnhBYQuSvxcKBaBFjSGj\n0FeEld1XhrH09CCTyeDmxrlsqfUrBquOUURduumMN4xnGUQck808AvkvrqIIsAnXEf6IW0VrF2uT\nsdLoLSJRNv6uOqkgF+K0FrM9ynRg9McUkNb/xRrhBLAQi4EBzAIWQTMhhcQQeoCVVadL+N388z0R\nxNKiwjPMD9OreJQFnRaV3xS6yu+AC3wFMtEdCI3iKvDa1U7XuD6p0lS4fFIgPqL00p4xxlo0otJi\nnMERhdz/bxgta6Z1GJFRvOVhK2onqbBs/fiaC8t+TljH+1XERopOqwhqqRzNS8KAkrU44/qJYesD\nVVaLs4UPbpHKX0yOFOm0ika5Ty7HyQ/YAHTY4ypP8lrlvKjot2BOQDv2qFIEOiVbqwgytx35yEdr\nCvOdeM4eV9mHelXMDE4NS+PQtIqgY+xoBawlPLqG/Tu2ylRVpY4vFuVJeA/pnbFagnbwDnQQTktw\nvMeAbg5k4x3tNBfUzWPiehicWFURJKc2YuMSLJfRg2NMPIN78jYl6eSSMMEt6gLL0TahohGPe8hN\nZuTCda1RFpNv+RA4KQfyXNUxGtzi+xHPIz6hotFlhSu4WyhsRY9qtVmMKtYfhb5+JIrG7qoLLiGZ\nT7Nb2LPcGuj/Yo3almaLGKhUPiGWlf8dYRK86/phbO7mbSnu+7PPCp1DTSYOx48AAAAASUVORK5C\nYII=\n",
-       "text": [
-        "        14 \n",
-        " (x - \u03c0)   \n",
-        "\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n",
-        "87178291200"
-       ]
-      },
-      {
-       "latex": [
-        "$$- \\frac{1}{20922789888000} \\left(x - \\pi\\right)^{16}$$"
-       ],
-       "metadata": {},
-       "output_type": "display_data",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAPsAAAAqBAMAAACHPjAfAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIs3dRLsQq3aZ72ZU\nMonLrI/bAAAEFUlEQVRYCe1YTWgUZxh+Zn9mZ/Z32pM/0AwFS8GCWyrtpcpCD3oQ3EMRKYUOFRE9\nmJWixUNhYqCmlHRXoSXxZ7NSkB4URuxBKdShHmoPbZaKoKeMFDQ5dE1sukYSs32/d0wna3YXJzsh\nIL6HZ/P+PO+T+eZ7v28TwI/t8lMceO3eeuAtfTTc9/mqykN5Ke/jbQVc+uIs/i1ALn/tb3mCe/o7\nnwGh6thqyeM6MIGDqyl/wZ84gpz765DmBk74+wWCe/e0+Kl53PQlr556ePp5CdvbF/4oUvT008jY\n7au6yqQK7elqlXK09Z4gY7av6ioTMjrQdcqR/FvI5DpUdZMa6ET+mZIk/ys+6FTVTe58J/IB4LVN\nQ0iUv+tU1UUuonciR+1O2QByqgNI44duDDX3Gmk0Go+AdKk5HLgXskAn6mXr+6bO6uCN9Zc0IKk3\nhYN34jnAQRG/N7XegT6F1BGpeOFX3xG2GaCFCcaot5goA4dZ5X8B8vIxEUpNcmLlwB3oH54VkAph\nEVpx+bhNKtITyELNM9XKCGfx4nvJAH+K0ta7pEziy+aevUamSpGE3hwO3KPRSs5GK5LZ3LkfGYci\nKz54kSzk3fdqz36X24hoieRDOYIltvbkh8D+gbPAvvIXALsMN8u1miPXJmzIR+/T6h2snVkM8tBX\nVTC4bNH43JLuiwJ06C41qYCijc3YU5UuYJ3Grhu7RgNZUIHTWGdL1LgE1VoE4Zy8BQzM5s7iVmlr\n460yMQPhSSULRY9WEMuzy4B7QAw/AXvwEWiYExbkrAfoB465wGzuHTL4oyXIeqtw/Dxi0+ECIlMZ\nHek6uwx0fuFv3BfyD4EHRrpA8h7gPWCnxsBs7k3L1tZiWqtUqA51OlNCaq43D2WaXQYqjpgYPYJx\n+V+gmEs+MtKmB3gMjNkMzHZ7r3E/WuFgq6CIhes9DlIz4uln2V2AvUC0ccXhp7fwyew38ECaJ/k+\nASazRaPl2ZgjGsyrFURnqMOYswC00zHyj4ZTJGtCbbwND1j+rpB32VS6TNsAlpc34jchv0G0ESBP\n0lF1dtMcPrWSIyau/tmwPQhMXs2z/AwSA7fn6PnypMyg6MBVJBoGrgwW7UQJ1+oesHxfAIt/nG5K\n2nritafp/xjkPgXa0aBvbz0WBR4YcQPSrAe89Syx9awFtiD6tmQJr5BQcoqYIR3CdQG9JcgVWgmT\nMq9DHFpDHojBGxWDN6otsKnAv90Rt1QW6awyhZ4chOsCdpb4GI1pRY3+NolrwCEPxInzlwvM9i/M\nDGlrbSKL93GgqryLN8GuG8Moyf9i4A/0GyETyTeQdDxA2JYvusDsZcqH6WTPYv843TYT39pg143R\nW6WT5+iwjfTwx9R92zANogdy+ThdOQJcth/9/wDcHM89tyP61wAAAABJRU5ErkJggg==\n",
-       "text": [
-        "         16   \n",
-        " -(x - \u03c0)     \n",
-        "\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n",
-        "20922789888000"
-       ]
-      },
-      {
-       "latex": [
-        "$$\\frac{1}{6402373705728000} \\left(x - \\pi\\right)^{18}$$"
-       ],
-       "metadata": {},
-       "output_type": "display_data",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAP4AAAArBAMAAACqSyj+AAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAuxCrdpnvzWaJMiLd\nVET4aMmqAAAEhElEQVRYCe1XXWgcVRT+dnZ2Z/ZnNnlRFNRMwaYEhCxGfbBgF5JQS4WsNEsbUdr6\n4IN/yVZE8UEHURR86KoNMkXpgIgIlYzE4k8rHRGhrdoMiPiYBUVfhC7bVhObdD3n3l13V5Jh0t0l\nKJ6HO+ee75zzzZx777m7QFiJmGE9e+KnDGwqvzKyY1P5gYn/+XuyscIm/Y/VP9kPvDTuhv36bu+/\n5B4PqqvQS4SVLtff8BAxMROWvdvfD+KPnktlN5M/NV0wN5MfO1ec0PyF6aet0M7kmMmt662XCaL6\nx/zj1XWdOgXeDUjwgOTfBjwb4NUZdCggXJP8HwH3Bnh1BKm5gHC9JOqvubg9wKsjKG4GhCsHkHrr\nck6Zst0Ar46gXwOjbw5EuwFOUZLPRr8Yz7Uli9VIqOfMtll7MaGNrZT0M3GvLfnkh7tfPUmWH9us\nvZg8CSSgVgynNXnGV93dbPilaeWKdFkqlP0qfT+i/YLnk29ZzrMeAVUfmOOhp0L8QDz3T455eGzq\nPf8TTHPagcnPpuwDF6e1/k2sq9oNgO5OQDXbsipV/MmGV9qsvZjQCVu0rsfH7blVD8ts6f35+w3Y\nsmvoiNXOr1m4ji3Pt5iVWduhKd1XW8foYjqx9xYgab/u4/iUbZeElvzatm0Jay+m3pFIqlAsA0P2\nQ/VAEa1MjnMy2nqueKw9UP9tyikn6tHsS+A8bnPoF9GEjxPIXMJhOpZZoemkXRQw4rVaSSLzUFeB\nPGKWRDga6bJyTqTmK2ZdSeRaoLPQZgD1IGhx1JmoiXQFx3ys4A0gKrWECWQFDG3PUUiErq4F6BYU\nTyASvg/YKXMH3b/bWuj1qph8WkQ6i8yV+MOIXsUi89MXHJVagpqZI2B6IxKBPGJiRzmRJX6BSPgr\n4IIrEs6Lce1he4tZOyAmpSL68kiualXEuHdQ/eu/oYSGnyUs+QXygon9ZeOimciJQDHgMvUWXyRM\n5cRjrUF1Wqx9z43RDtLdIk6XkGTWNFdEy9Kwhf2ERn8UJBwdGy03ECyYGFjaJREBp+h0zeUIDy/D\nZ5C2cCskP5/OOSrvB09xBnqxuhbzBcsyIqbC5WEESfKO1b6RCPMvC34K34AMV5Co0oo2+YscrdIF\nplQaGoapmTIBG+5qIFo/8PL7NV8g18zvQV+la/Lv+scoK8m0SaehofGmZgJeHhxz6sj9tG55HK4K\nRAzXUP++GeiXhkD8vIOWgFGi+BwYsJDONjTQvpbwTcRfFghUguMmUksCkTDvP4tfMrRE+Pu/Hxn5\n/Q6iM67AyOOkUqONZWE4j7qmUF4JPw7sdxkBfkDKHaTnpEAkTO+56IbmZkdDrD8g+k/Cw3vAa/iD\neouLC8QitQzxU4MhmEzP0BmnRzIP3eU2u10gEqb+8/aG6IEbMWhRyEHgOww6qbP2rEd/CzK01RaJ\nRWoG8QuYOrPxmERO2faDMA7BKEmEo5H2lUc3yB+78x6KeLO2D1uP3I00tXoPRmGvL1dSarwvBIxk\nYYQ+mdd4oVZbAX4q0FHkQDkoU6MOuf575C9+Ztihp/kcUAAAAABJRU5ErkJggg==\n",
-       "text": [
-        "          18    \n",
-        "   (x - \u03c0)      \n",
-        "\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n",
-        "6402373705728000"
-       ]
-      }
-     ],
-     "prompt_number": 46
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Hint: to get the exponent from a term like `3*(x - 1)**5`, use `as_coeff_exponent`. "
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "(3*(x - 1)**5).as_coeff_exponent(x - 1)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\begin{pmatrix}3, & 5\\end{pmatrix}$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAADwAAAAaBAMAAAAZJyJqAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMARDKrEM1mIu+Zdrvd\niVTWGHL+AAABSklEQVQoFXWSPUsDQRCGn1wuuXwn/oIErEVBFMHmGusExMJGUtgJco2F2NjZCB5o\nk8pAmiAWgq1IsBG7IFiqtZ0Jh2kkcW5zMZsLN8V8vM/M7g4ssECEdX3dWImgLPpgy47CmaaQdVh6\nfwy1JPatD3gG6xTLpew3apYajeTmFqRd8kOKHY1Jmrh8FV+1SZUozOO46s7VWVZJ+PAxTt/RVnhb\n+amL37RKkPxmTTTjLbx71jZ7EPO4VyNt6Q3Zhoz12VVqygtB+Kxg9XiR1Stkf2bxg+AS5tDHVW8O\nn8O140/Lm4s1cgNsfd6FHTm2zyZk6pS75q+OjymcycsH3Ir61djDvHA0bjRWpZS9yxMxpuOxmK9R\nrAQ8OembxkSTeDcaVx2MToCbQdTCgeThj6LhJ8mPtHo2TbpSFyaXzzKpTpRyOKcHwlUU+Nf/AKUL\nQ2ycOKYsAAAAAElFTkSuQmCC\n",
-       "prompt_number": 47,
-       "text": [
-        "(3, 5)"
-       ]
-      }
-     ],
-     "prompt_number": 47
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def series_accuracy(func, expansion_point, evaluation_point, accuracy, x):\n",
-      "    \"\"\"\n",
-      "    Returns n such that series terms up to and including (x - expansion_point)**n \n",
-      "    (i.e., O((x - expansion_point)**(n + 1)) are needed to compute func at \n",
-      "    evaluation_point within the given accuracy.\n",
-      "\n",
-      "    >>> series_accuracy(cos(x), pi, pi + 1, 0.01, x)\n",
-      "    4\n",
-      "    >>> series_accuracy(exp(x), 1, 10, 1, x)\n",
-      "    23\n",
-      "    \"\"\"\n",
-      "    # Make sure to compute as many digits as needed. evalf defaults to 15, so this\n",
-      "    # is not actually needed for any of the doctest examples.\n",
-      "    digits = max(15, round(1/accuracy) + 1)\n",
-      "    real_value = func.evalf(digits, subs={x: evaluation_point})\n",
-      "    expansion = 0\n",
-      "    for term in func.lseries(x, expansion_point):\n",
-      "        expansion += term\n",
-      "        series_value = expansion.evalf(digits, subs={x: evaluation_point})\n",
-      "        if abs(real_value - series_value) < accuracy:\n",
-      "            return term.as_coeff_exponent(x - expansion_point)[1]"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 48
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "series_accuracy(cos(x), pi, pi + 1, 0.01, x)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$4$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAAoAAAAPBAMAAAAv0UM9AAAALVBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADAOrOgAAAADnRSTlMAMqvdu3bvImbNiRBUmeNE\nfywAAABBSURBVAgdY2BgYBACYgYGExDBmgIiK6aAyAUgkqMARG5lAJELQCSPAIjcxQAiDykpPVMF\nSjCAdUHIRe9ugEQYGAAZ5A24Epj20wAAAABJRU5ErkJggg==\n",
-       "prompt_number": 49,
-       "text": [
-        "4"
-       ]
-      }
-     ],
-     "prompt_number": 49
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "series_accuracy(exp(x), 1, 10, 1, x)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$23$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAABMAAAAOBAMAAAA/Njq6AAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIpnNu0SrdlQQ3e8y\niWbzIQYJAAAAjUlEQVQIHR3MMQrCMBiG4beUEocgpYOgOEh1cnEprnoDc4SuTt5AghcwN+nk5OAJ\n3FyD3qFDpSDxT5ePZ3j5SMrKoP3LwgT1pSDr4AgNb0sPd8fJXAfuHBvDECCBg7QWoH/w3EaR7mXU\nLXIVh4dUqoY5HD5wIZkGF6kXjPNWbnJm3q85k8lNE0LPqFxa/n51I/Ad/d+pAAAAAElFTkSuQmCC\n",
-       "prompt_number": 50,
-       "text": [
-        "23"
-       ]
-      }
-     ],
-     "prompt_number": 50
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Calculus Solutions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from sympy import *\n",
+    "from IPython.display import display # This, with init_printing(), will let us \"print\" to MathJax\n",
+    "init_printing()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For each exercise, fill in the function according to its docstring. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "x, y, z = symbols('x y z')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Derivatives"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Compute the following\n",
+    "\n",
+    "$$ \\frac{d}{dx}\\sin(x)e^x$$\n",
+    "$$ \\frac{\\partial}{\\partial x}\\sin(xy)e^x $$\n",
+    "$$ \\frac{\\partial^2}{\\partial x\\partial y}\\sin(xy)e^x $$\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAALsAAAAVBAMAAADsqILHAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIpmJdlTdRDKr72bN\nELv8JKevAAAClElEQVQ4EZWUPWgTYRjH/5eP5prmkhtcMjXQjA5B49dQiDWCUj8yFBEH6SyIAaOD\nSyOIWgcTqWAXS/zARYonFh0ceqsY5LSbQ6niooPUjxCjQ3ze3Pu+vrm7SPqQXP7v8/x//1zeuxzQ\nq/ydw1VXbeE4NBR2luKlgOAK770ImGEQBB8Vw2sRoP8QCtDrXIeq/5pSKZDsMRFEfROO2HehgIQj\ntC1E36eE+roBlN7QhUVGAkXRwzOu3soOCQVS236qFrbDqoPrZdl7z9WM7AADIPip9YPZSQ5q12VC\nzJYyyS+8Gq9A0kfCQ2kTUyYfx6ZX7HQHN+9fOVagVigHaPlbM1kgnHEtIl6BkJ7YBS07VULl5RE/\ndcLUOIt1YBafgTeW0SZjwgLW8Nx6BERtWlOJeAXS27hRvepgwdjACFn6Ka0NedtddJBj8V+An2SM\nl0Hr4zhJv7hBayoer0KJDaxWHwDj186CXcB+avTxyv4eySadQ2DxX934FMU7WGJTfdP18HgVGs/R\nt7eAVObJ7Sq5+qlUxgXZ0djdrXvigYds0ovf3myeaTZf0VKF5ixgjPYyZa+d67BZmQGCShXYyq3L\nGGsp8b3nhPYLhm9zVKhGZx9lZ79oYrVEW0BvSCpeAOjVK/rpWSU+aQFPI5s4SqdnSwcTKjRiAxbt\nfe1CAaEC0E9FbLwz4dYpBx+UeLobo3+SDY0Ykr3ie69CegsR85KJj9FlJCnJQ+0oEu7W+eKB8nz3\n7nx38fTvDO3ILIxPkzunaZgouw4eDwVCOrsX+sI+K5Yv7iFXAOWyvuM92Ql6KMihR/gpj0EsxYMM\nyPNWRYz+8+mnBpjlo9WwBziC2kNTWp3jo+LiB8V5e8NT2zhKf+YtlEL9BQUbv+UNIjg4AAAAAElF\nTkSuQmCC\n",
+      "text/latex": [
+       "$$e^{x} \\sin{\\left (x \\right )} + e^{x} \\cos{\\left (x \\right )}$$"
+      ],
+      "text/plain": [
+       " x           x       \n",
+       "ℯ ⋅sin(x) + ℯ ⋅cos(x)"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
-   "metadata": {}
+   "source": [
+    "diff(sin(x)*exp(x), x)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAANsAAAAVBAMAAAA9T4a3AAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAEImZIkR2MlTdu+/N\nq2Z6CBlbAAADt0lEQVRIDZVVT2gcVRz+ZndmZ7N/h+gpvUwMrhYshGBXCi0OFoqXsIuHYFHoNCtb\nsU2zB1trS8iCEGk9uIo3QReVHFqU1D+lXnSKN0nLGtRgvQxFC17arZo2IGn6e/9m3m63rX0k+77f\n977vfe+9eTsLxC0xM7UaVw+HSr/MNB7OgdF8+/wgi+Xr7J96oXDCuZxtqkLrpzSMPmc1F+qjEZ6L\nEAPJQbuwcEmJ7L8VAuxOjO92Fj19NMIXIsRB0FvK6l/FWv8oBOScGBMKeiqcwKCVp/xe1RVZPqrT\n9pKtSi2irjjRKyev7O5TcHvHeZXV/IzYIjULsmfdfCJIaKWCZxUQvXLyylh8a7pvZs6/3OtBpikI\nPW7k1fKolJlvRHoriCAH5DTGXFQc7C49rYYmJ56EWa41MXXtEOMm6P+5medrvpQmxoVSxZkTNU8w\nsA5fDSY3cPyro6/5RCVdwCz9vFDG8ATMGyBnwupiFukPsFta7DWcaLzpYMVoY4hxdOcMt/BRtiWk\nSAeMBVTcSc+UC8AI0MLnwI+hsUYKdtOH8Vf4Ldx9SHWZ81iyhdOoVPEMm4Jaro3rjS+BypH3wJ/H\nN6A+1U03hBTWkhDKOHMt/m7sdejpU9wZ4CaJslVQPYu37eYOZNrM6WR9Gvr9Wt0Tk6DiAtY6UBz/\n/tcG42idBvJtSCnsLmOj3eW/u/qKIGj+jQNgcadFXJHiHFxm/nMo+tz5rmPfgvZd2RcCBYooBsMf\nb7B52LGAFgVwqYjbubz84fLyRSKL4/Qhm7F1s9MXB0oC0jcw3+DOnUgt8a1Ly7xLo2x3qx6uN4nk\nL7ZKg9bJpaAj4U0eJq06aq+jsK7F8feaeYs2lwxwkA6NnD8g02ErSEnTUACE9OzmX/SR9AF8Qbv1\nZpFyhBSFgEhqMo7tm/54I6qsxWVC4A+6IvuRG2c0c+4CHd8hGOqLYK8j5b3k4dP0WWQ8mmWMTjE8\ngz1Syq4zbzIuFeARTzB4x8FnWhwp07czSyatu2PdphtHzpH6sx4S5bp0AJPlJ2CvbAutUv1xRu4l\nzfRwKZRS5KpCKuMwVvcFAbxQn67Obf40t7l66j+a2mrBWBx97DDdlcUavVSFc6tSD+6zXswzqXoV\nqbh49C70dcwkWtyZbxn8LsQD/ajgSkZKS7Ls+S3rN4n6iqJ/w5YmQM4hN+Mq8h79BckLqRHcQzaA\njn6A3scndKLkTNe3D9D1UJOyEtK81zN438LsyOGFGj3w/+mkm6W1Axp+INyjK8h5B3tD6kfMGMmO\nAAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$$y e^{x} \\cos{\\left (x y \\right )} + e^{x} \\sin{\\left (x y \\right )}$$"
+      ],
+      "text/plain": [
+       "   x             x         \n",
+       "y⋅ℯ ⋅cos(x⋅y) + ℯ ⋅sin(x⋅y)"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "diff(sin(x*y)*exp(x), x)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAWEAAAAVBAMAAABlFUKHAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMARHYyq80Q75mJZlS7\n3SINk/qdAAAEtUlEQVRIDdVWW2gcVRj+Zid730yWgBSRkmFbNanSrBrwwUtWC9JKLSu4RaSFeZEa\nKLIqFi9Y12gfgohjlJIghbXgQwXNEhFflIYi1BuyL1YUxEHyoPiQxMRaGzB+55yZzGVnd/vqoZ3z\n377v+/dcZgL8n8bsfbvLgGZeW8/DwbJcMej1sjUzmH0v6MTaHTIBqax1MN0CJmKBMqj/4+f0im/T\nejXk9XDC9BkuUc8RI+NLaXhMgA93Z9Cu+Lmk5du0kiGvhxOhr/YoFakYmaDUvyxJmKKwy7D8eMk3\nhZWzlZ9y1NztGaU/5xY+2QUQI+NJEaHXdSBtdcFGwifCfqqu/LwZjke9KP0xt2AxWuj6MTKeFDCZ\nrWaB67pARdi4YzupRbfzG5Xq13GUvtBSuC4dx8q4UsDxW6ZPAzPbTQG/7/5j1EzN2VixoO05W13e\nwN3P3X6ryZIMT4Exe2hxGlMzMC4DcwrndaxyrNk/38JvpdclniWCPkibbSic1/HyzLswpkdbGP7g\nRmZiZaSUMTPqKKi8fcpM2bmf0u2stopx/h6gjS+AI83UGtPJJjCFD5svwR5BYhX4hEEOr2OV48YV\n9Wf0SxiwJR7icodo8+5euR3ra7izfI+FA6klDJIu2YyRkVKfO0YDcjylJvHMspV8+a5MG98COy3Y\nouOLwJ/MpYugP46P9dYbKCwBOwTC71jm6B9Bbj1tw1iXeID0IVqtLmFwO04uYaH8PLBy2yXWdZER\nUsYavDcjF9A4+rMYxRQGlgArbYoe0xu7IDpm86LjIXZs4SBXDE9jyORiMsjhrbHMkUq8wUdawBWJ\nB0gfotVXJczreMXmJ2yT9I2X7y8zEysjpAZeOLtXIQWlP9gscN7S16lzZqsS6Rhslj1exiTJBU2m\nVjv6bK1Woaly0K7SWigCf0m87Ji/3mRU0cqOT9VqP9RqjzA40uSLki0MVad+2aAvOu6QEVJDDZGQ\n40XPEPNKmQt5Cok6cC9ym4GOxdeRe80Fy1RxM+3IqVA5yK/kedZuSDwg6QO0kVMxaXMJxBrvc7BA\nWKyMkBLb6o6vPYM/1hlHwsKjKFQgtm060HGhCXzEG3cTkg0RxvsK550KlQO+Jw3Psb4m8QDpQ7S5\nqsIxLcYg3SbP8eQNJjImECsjpMQ28Z8Y7ltKmOebF/Er8Jrcq08tfBfomG+l/NVC3SBxRW59+O3m\n5ijdwl7tJAoNiZf0IdrI203fRMLZ4eDL/AkUHN7SOBkhlajiCebF2Kkm8Tw+NjXb5FR60wGuL40V\nJ7YemNja99nfDV6PNlIXTs/v4QG/MCq+7g/zP4e7xm6OB2f/WBkT8w9KPPOkD9EmixLm3TwsT78N\n/cA7TW229BYzsTJSaq5kKiTSjmsEpjMB2zNPegYXos2+68r3ToWfDVtpx/cFbb+vdIyMJ+URBf7O\nUKGBdip0G93Ccx7gIRxrsWtT+Zo7K6/zuU3v0s66JcOdpTISI+NJbSMOb1vKGLQLdiQk3KTlBn/E\nV7Qed72+k0evaFPVPoAYmQ6p5QhHvvRKJCJdo+JGF0eLtA65Xt/Jo1e0A04fQIxMhxSv/zUNvkX8\nkSj7dm8rTL+rdzGzHTJRqf8AxgZl5oJxoIQAAAAASUVORK5CYII=\n",
+      "text/latex": [
+       "$$\\left(- x y \\sin{\\left (x y \\right )} + x \\cos{\\left (x y \\right )} + \\cos{\\left (x y \\right )}\\right) e^{x}$$"
+      ],
+      "text/plain": [
+       "                                         x\n",
+       "(-x⋅y⋅sin(x⋅y) + x⋅cos(x⋅y) + cos(x⋅y))⋅ℯ "
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "diff(sin(x*y)*exp(x), x, y)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Recall l'Hopital's rule, which states that if $$\\lim_{x\\to x_0}\\frac{f(x)}{g(x)}$$ is $\\frac{0}{0}$, $\\frac{\\infty}{\\infty}$, or $-\\frac{\\infty}{\\infty}$, then it is equal to $$\\lim_{x\\to x_0} \\frac{f'(x)}{g'(x)}$$ (we will not consider other indeterminate forms here).  \n",
+    "\n",
+    "Write a function that computes $\\lim_{x\\to x_0}\\frac{f(x)}{g(x)}$. Use the `fraction` function to get the numerator and denominator of an expression, for example"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAD4AAAAaBAMAAAAd0vJXAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMARDKrEM1mIu+Zdrvd\niVTWGHL+AAABRUlEQVQoFX2RPUvDUBSGn7YxbdMP9Re04K4uurjcxalIBadu2QXp4qJo+wu0os4G\numhRWnARBAkOiltWxf/QWgRBRDxpSUksNwduzjnv857LvTfAPLrwfJBc1mEWfLKutNxyBK1qMTxD\nuhnD25BtxfCqIjMXw/M2SzGYbI9L4Qftwysn4jNePRoKc8AKGJ75lHEjvJAY0IXEJ7dQwBoUyxG+\nmHW5l7cbUpN5Ur0IBZVx+JbLf/DiE+n+RV/JLMbvmDfKqKjhHKs5mt8Cs97FUlFHjZz8t/SQNejb\nd+xh/IR3OKVky/m/uIbKzcabjXFcDxkqnQtp5f6liZgIc3gXUNhkthwYzKCQnHKNI0kzDilP8ijC\nPO/lfL1aJ+mOKThBIbnYOfG7bVkPfqGJR9F3NUxksyWf4uQAU8b9kbIzpQfCWVDo8x9x5EPeMJ02\nngAAAABJRU5ErkJggg==\n",
+      "text/latex": [
+       "$$\\begin{pmatrix}x, & y\\end{pmatrix}$$"
+      ],
+      "text/plain": [
+       "(x, y)"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "fraction(x/y)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You may assume that the only indeterminate forms are the ones mentioned above, and that l'Hopital's rule will terminate after a finite number of steps. Do not use `limit` (use `subs`). Remember that after taking the derivatives, you will need to put the expression into the form $\\frac{f(x)}{g(x)}$ before applying l'Hopital's rule again (what function did we learn that does this?)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def lhopital(expr, x, x0):\n",
+    "    \"\"\"\n",
+    "    Computes limit(expr, x, x0) using l'Hopital's rule.\n",
+    "\n",
+    "    >>> lhopital(sin(x)/x, x, 0)\n",
+    "    1\n",
+    "    >>> lhopital(exp(x)/x**2, x, oo)\n",
+    "    oo\n",
+    "    >>> lhopital((x**2 - 4*x + 4)/(2 - x), x, 2)\n",
+    "    0\n",
+    "    >>> lhopital(cos(x), x, 0)\n",
+    "    1\n",
+    "    >>> lhopital((x + sin(x))/x, x, 0)\n",
+    "    2\n",
+    "    \"\"\"\n",
+    "    expr = cancel(expr)\n",
+    "    expr_num, expr_den = fraction(expr)\n",
+    "    expr_num_eval, expr_den_eval = expr_num.subs(x, x0), expr_den.subs(x, x0)\n",
+    "    indeterminates = [(0, 0), (oo, oo), (-oo, oo), (oo, -oo), (-oo, -oo)]\n",
+    "    if (expr_num_eval, expr_den_eval) in indeterminates:\n",
+    "        return lhopital(expr_num.diff(x)/expr_den.diff(x), x, x0)\n",
+    "    return expr_num_eval/expr_den_eval"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAAgAAAAPBAMAAAArJJMAAAAAHlBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAACGjDitAAAACXRSTlMAuxCrdpnvzWYiHG0BAAAAI0lEQVQIHWNgYBBiYGBQ\nnMTAoGwMJBhYSCVYw6ZHAPUxMAAAQGkI1Fjz0FgAAAAASUVORK5CYII=\n",
+      "text/latex": [
+       "$$1$$"
+      ],
+      "text/plain": [
+       "1"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "lhopital(sin(x)/x, x, 0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABMAAAALBAMAAABv+6sJAAAALVBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADAOrOgAAAADnRSTlMAECK774mZMnbNRFRmq1T9\nspUAAABoSURBVAgdY2BgFGAAAgUgZjR5EsDAmJwWwMDAXMDxUkByAYMqA0MTA8O+idMZGLgVGBoY\nGDieHACqbAAxGewQTJPnYNGDQAVBTwQYeBQY2BgYehnWeTFsY2BgupZ5gIHpnksCUA3cNgA/fhaR\n13z6xQAAAABJRU5ErkJggg==\n",
+      "text/latex": [
+       "$$\\infty$$"
+      ],
+      "text/plain": [
+       "∞"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "lhopital(exp(x)/x**2, x, oo)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAAoAAAAOBAMAAADkjZCYAAAALVBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADAOrOgAAAADnRSTlMAEJl2Mt1EzasiVIlm7xEe\nOPwAAABJSURBVAgdY2AQMlZhYGAIYxB1YGAOYGAuYGBtYGB7ycCnwMDyimHeBgaWx2DyNRL5GCz7\nBqSS6yVIF3cAA0MUg6wDA4PQ5hYGAON0EpMbNABcAAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$$0$$"
+      ],
+      "text/plain": [
+       "0"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "lhopital((x**2 - 4*x + 4)/(2 - x), x, 2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAAgAAAAPBAMAAAArJJMAAAAAHlBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAACGjDitAAAACXRSTlMAuxCrdpnvzWYiHG0BAAAAI0lEQVQIHWNgYBBiYGBQ\nnMTAoGwMJBhYSCVYw6ZHAPUxMAAAQGkI1Fjz0FgAAAAASUVORK5CYII=\n",
+      "text/latex": [
+       "$$1$$"
+      ],
+      "text/plain": [
+       "1"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "lhopital(cos(x), x, 0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAAkAAAAOBAMAAAAPuiubAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIpnNu0SrdlQQ3e8y\niWbzIQYJAAAAT0lEQVQIHWNgVDIJYGAQY2D/wcCQycCwnoFh9wSG/AAG+wkM+kAJoMgEIMHzF8Rk\ndgCRKiCCPQFENjEwCjDwKDDwCTBI3b2rBVT8//8vBgBR7Q/Fm5CwxAAAAABJRU5ErkJggg==\n",
+      "text/latex": [
+       "$$2$$"
+      ],
+      "text/plain": [
+       "2"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "lhopital((x + sin(x))/x, x, 0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Integrals"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Recall that the mean value of a function on an interval $[a, b]$ can be computed by the formula\n",
+    "\n",
+    "$$\\frac{1}{b - a}\\int_{a}^{b} f{\\left (x \\right )} dx. % Why doesn't \\, work? $$\n",
+    "\n",
+    "Write a function that computes the mean value of an expression on a given interval."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def average_value(expr, x, a, b):\n",
+    "    \"\"\"\n",
+    "    Computes the average value of expr with respect to x on [a, b].\n",
+    "\n",
+    "    >>> average_value(sin(x), x, 0, pi)\n",
+    "    2/pi\n",
+    "    >>> average_value(x, x, 2, 4)\n",
+    "    3\n",
+    "    >>> average_value(x*y, x, 2, 4)\n",
+    "    3*y\n",
+    "    \"\"\"\n",
+    "    return integrate(expr, (x, a, b))/(b - a)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAA0AAAAqBAMAAACabMzBAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIpnNu0SrdlQQ3e8y\niWbzIQYJAAAAk0lEQVQYGWNgYBBSdmUAAsYEhvoGIM02gYHrA5Dm3snA9hVIM/9kYALRQMD1E0Kf\nvwChTSAUkwOELoNQHAoMgiDWIQaGh0CKce3dSwuANNf///9BNIUAaAoQgBxIZaAPNPYbAwNTTbvc\nQwEGhgiGQnYgBQQObGCKMYELTDM94AfT8yfwHwAxqhj4wcFhx8CiwMAAAMBWJoZo6bROAAAAAElF\nTkSuQmCC\n",
+      "text/latex": [
+       "$$\\frac{2}{\\pi}$$"
+      ],
+      "text/plain": [
+       "2\n",
+       "─\n",
+       "π"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "average_value(sin(x), x, 0, pi)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAAoAAAAOBAMAAADkjZCYAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAMom7VCKZRHbdzavv\nEGbh6M2uAAAATklEQVQIHWNgEFIyYWBgTWCob2Bg+sLAP4GBBUwyMIBEgGA1EDNqbQAxGXoKQCTP\nXwZWAQbmfwz3/4JI/gUMnF8ZOB4w1CswMLilLWEAAJ6qEfrOOFffAAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$$3$$"
+      ],
+      "text/plain": [
+       "3"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "average_value(x, x, 2, 4)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABUAAAASBAMAAABGPIgdAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAMom7VCKZRHbdzavv\nEGbh6M2uAAAAnUlEQVQIHWNgEFIyYYAC1gSG+gYom+kLA/8EKJsFiQ0UgqsBslcz8KopMMRfYGBg\n1NrAwMT+gaEfrKmnQIRtAoMxmM3z9wJPA8MPBgZWAQbmfwz+Fxg/MjDc/wtiZzFwHGBg4F/AwPmV\nYRkD8wYGBo4HDPUKDNkM9Q+Aet3SljAwXO7IDwCbAyY0YUzuCbxHYGxOBWYFGJulIx3IBACniyOJ\nEYNBrwAAAABJRU5ErkJggg==\n",
+      "text/latex": [
+       "$$3 y$$"
+      ],
+      "text/plain": [
+       "3⋅y"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "average_value(x*y, x, 2, 4)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Write a function that takes a list of expressions and produces an \"integral table\", like\n",
+    "\n",
+    "1. $$\\int \\sin(x)dx = -\\cos(x) + C$$\n",
+    "2. $$\\int \\cos(x)dx = \\sin(x) + C$$\n",
+    "3. $$\\int e^xdx = e^x + C$$\n",
+    "4. $$\\int \\log(x)dx = x(\\log(x) - 1) + C$$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def int_table(exprs, x):\n",
+    "    \"\"\"\n",
+    "    Produces a nice integral table of the integrals of exprs\n",
+    "\n",
+    "    >>> int_table([sin(x), cos(x), exp(x), log(x)], x)\n",
+    "    ⌠\n",
+    "    ⎮ sin(x) dx = C - cos(x)\n",
+    "    ⌡\n",
+    "    ⌠\n",
+    "    ⎮ cos(x) dx = C + sin(x)\n",
+    "    ⌡\n",
+    "    ⌠\n",
+    "    ⎮  x           x\n",
+    "    ⎮ ℯ  dx = C + ℯ\n",
+    "    ⌡\n",
+    "    ⌠\n",
+    "    ⎮ log(x) dx = C + x⋅log(x) - x\n",
+    "    ⌡\n",
+    "    \"\"\"\n",
+    "    C = symbols('C')\n",
+    "    \n",
+    "    for expr in exprs:\n",
+    "        display(Eq(Integral(expr, x), integrate(expr, x) + C))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAOkAAAAuBAMAAAA/9CPcAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAq4kimRAy73bdZrvN\nVEThti0HAAAEHUlEQVRYCcVXXYgbVRT+ksnMZPMzG+g+iAoZlgorimZLER+UHVSKD5aGfWiFCk7x\nWRKoFRW04/pDKMIWoQ8V0aAvKuKu+NClIDsvfbCKm6daQdihiLYoNNG6lv6t59w79yYbEsUuyRyY\nOd/57rn3u/fO/UkAaanpSozG6XbOlcYpJ7XMjQPu+FWz9fFrAhMJzC8w10xirItJrGCsJjFU3EhC\n1fojCdXszSRU838moTrZTkK1Fg5UdQJJ56KBxf+TvBjnf6HqLXaPppqrSOCQgnti8NsLiunzT3/5\nRHN3H9cXWkoj48cl5UCnXPY0xBkFCwoMWXXpV4Cf6fk3K1RVaRiDo5FiYGqEbKBwzpXI+UsxW7z5\nDbWY/o8V2dBVPpLI3NT90EUEbM2adcmnj/eWa1w4QtCJczTbBzhH2gHpin8rAnjI1/h3jfC1hAWv\nS/WgfS0KjMFlKs0JFUKe02ly4gPx4mfvGOWSdWpPY4Xpx+jZ9fqjbwbAToKYXbjcUgTHygxR3fRV\nLLwxNd3C7sZeOMc+CYnJuNSxmR3nnyQ5D2yFK8KZy5hAvoTCaTwbEXMWMN3cezZN608UOoexWlUE\nMt8JK1FB5hq9+q0WWS9aJ5ByDwLUAApNYB6fNl8GiiHFwKRcms4JpFk1X8dkQPRr1C1k20Uf+JVC\nuoOf0gTF2iYGraNvkduwXRgbl6pwKdWOQH4R5/QKmIurHb3DF6rLUvUWjRWpZaqCGj1l4F1NMKlM\nnmxi8T9yku0Dmky+T+iD4IrdeZsTJyOgirsYWm1+Y0k6zH/Y6VOlPgacwarXYVI/YoJJZbaoToPo\nMYdnfSkCbpj3bpYIsyrwEr9i1X0hB7AqWGrxDMdjfZXJOZ+6yDNsXEWxTQOSBDJiVCeXKSUldrHH\n2drE3bneAjrPIccf0CZM883nQbzH1jyRXQyQCXpUTwO5yiKypPo5TfZNpMJzihAV4pd1lUCasnrt\nfapM39W6dR6gdYt8E/g428ZbxIcicZP7QWvrCPKVHlXaLuvNU3iYinjnnMWPnqsIzte21ILzuI4k\nqLXwBq36vPdDFV8RlfZQvJavG4HaOcZmhWga+UzjAavc2V/uPL/Kx/wl4ODC/EyT4Pf0zDZ+WYkU\nQXHXrLun9nYjiYypBR+Hpu/EhcZCRJRzHObKPdPHCBY4Ru/RxLEyW3aGQnUiqpLb8Yd1JXkiZq9r\nYgtQZz7NSbCl4LaC+MynujOifopXwyA7o8hnFNiG1zedGYpWJjaGNDar+B0KbMMbpbhySn64ob+a\neMGxZX3htvnivcAmjio6eEIRjfm17o5ZUMg9GCWhupaEaDJ/rcRVOPbh5oZt15H2JFUfafNDGre9\nIQUjpWv+SJsf2Pj98hfUwLLRkWv7uxff6FT6W951n99PjT7+B1zw9sIQfJxvAAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$$\\int \\sin{\\left (x \\right )}\\, dx = C - \\cos{\\left (x \\right )}$$"
+      ],
+      "text/plain": [
+       "⌠                       \n",
+       "⎮ sin(x) dx = C - cos(x)\n",
+       "⌡                       "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAOkAAAAuBAMAAAA/9CPcAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAq4kimRAy73bdZrvN\nVEThti0HAAAEH0lEQVRYCcVWXWgcVRT+diezs9mf2UBTKVpwCBVSKpqWPvRFdlARHywNFaxQoRME\nEfqwgapYQV1TlVCh6YMiig+LviiISfEhoogj2AftYvZJCwoZRGgLQjfabkOadj33zrnzE7MhDevM\ngdnznd/vzp07ZxbwJTMyxihJtas6lCSdz6V3jljJs+Ynk+cEBlPYX6DaSONeZ9I4wfgujVvFahqs\nub/TYM3fSoO1+E8arJV2Gqw1d31Ws+77C9768TvyXubsL1TVTI/RNKESHmNgztvKFddPn3u0sT/u\nIit6SnOKY8DhvHvrDNao88ouKVBpKRTT2VeAP+laI+a10FEaV9hl8LqnPDGdryuzYDG6GtSqkND6\nj+TO8pF8MhKJZE8H7o99pHcj0SAIGIFbn2T37kg4hKUXCZucczH0R5FI8eWIr8o3lCOu/wrNbxn+\nELoi6FCLDM32PRFW7bkgyXQDWBTZtDc8ELXhkRb2Tx+EefpTl/wP07XvjYferAO7CELb8cAtaKPb\nLj4urFA0Wa87vodZRY+9Szj+wvPv1CkwYFG9X5q1yQZK/NBrXu6l3HvIWEeBs+T/iZ6YVfjQIPy7\nyLs0VryOw/iscZKMgaaUIQFXRFQJs8oe54ALDf02hUoNqNKyK1MrPBAvoNAxLGidK+OwKPIabQPy\n7bJDhGRqKxhwKTCDX8iKyGBstDGr7EGs88Ay5RoeVCkfgKpfpYlvwFXa9GvG0tsEQWvUkZkTsEZX\npo1BC+O4Rzii4o82nV3MKnsQ6zc+a8WDKs21Zeasr0yxUbMUXdV3d4cIi52BURe/grUyh2Me6Zfp\niokh6+UGPNFsvt9sfk9h2SPOyqXMesiVTeQkWWwBS8+iIDb9VeGuOrRGucPVOhYJax3aAXqYH0iZ\nI5i5LhJt8UPC9yp7hKwG9eVS3uEFW2QDHwEFeq6521QojunXZI/NIE+sn5N5rIWdZeeTfBtviexQ\ncsuEs5QlhVllj5C12AC4tODKvK5YB0mthVPmCRTtX8fxJdn0uiw25nHAh3QMy+9myyvFSa1OnqjM\ntmA+ohzMKnuErFkbqpQgidYdE4rA8JSDiZG78cf0lEf2FeDo1OHRBsGf6dJ2nDl+Rv/qvpHTZMQk\nt3P4YOBgVtFjort9onvXbzdsmlxnoUpLnsjtNZpg8GroaEyKxM0Js65NPhE4/ImYvxk44iCY+cjW\n45GNrMvrB3nmU3BUJmSW188DzqvAMwpsXQdfOt2VTQY7vXrtVYFtCmxda0Ncm/GfW+9/Teqw5p2t\nswWVBxjJsUcvjBtEEgSLVoJkAdWDXgATBAsJcoVUqyFMDsnPanJ0zFTo+br+n0vJ3MGM7d86DLt/\nvTbfqeZsPrdfmff/989Xv1pv0GfhqfDDt0Fan0P79jh97riJdv8CeDoMOFAR3oYAAAAASUVORK5C\nYII=\n",
+      "text/latex": [
+       "$$\\int \\cos{\\left (x \\right )}\\, dx = C + \\sin{\\left (x \\right )}$$"
+      ],
+      "text/plain": [
+       "⌠                       \n",
+       "⎮ cos(x) dx = C + sin(x)\n",
+       "⌡                       "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAJ4AAAAuBAMAAAArYb09AAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAq4kimRAy73bdZrvN\nVEThti0HAAACn0lEQVRIDbVWPWhTQRz/5eM1rzEfHUQHhwSxWLDQtHRwkQQqflEwONRBhzg5plAH\nB6WvwSGgEFEc1ME3u9jNbk0nUQLpIIJTM4gKDgY/aqHWePfu7t1F48s7OG+4+///v4/3v1zuJQAb\nkcMFHplZjhTHzBgxF2v7Yt6kn71o0g0YNbpboOia7a9h9nSxbrY9/DTrN/LFrJ+9Z9Zv31ezftmu\nWb9qU/pFVz4ekJlOJJUN5XqMR1ZvMpdP1wa7Wbf3n4uV/sakMudItJNyRfKPUzrqInPaJwkyIJXL\nHVlFVtyVzHelKsPLD0g8xUiW4HqwUFq9sqTjKiosi95VqjJ8QckfWJ52ZB2+Mv1DVke6k8izNFWS\nZRnFvU9hlhVUP6mMius2OzFnrb2ued1O1z5vYmblxC1HetGo2KTzAp0A309VIvWNo/fBnwtklrBe\ntvLJRwm66/kWHRuUdt6lMx/CL60ogSw/yGIHpwSTvBHnEYXdTVdEia1PCkou/FQl2QK/bgef1n1y\nDrgHC5FVRe2FPW8us7LwU5XAsy5D+ba9ZBfWLxIkHAbJeZmGXtPxVuvljVZrjOSqknwkTcoBdthC\n59gO0l2LtF4BbeXsQzoeUyRH8ziNyBD9KUpSbZcoBlwHbBbB2kOk+SZZaMCmemVUHZKM84LwU5QE\n6W0y+A6sOU7EK7wt5bfc5zguKnxNksN7V+CJ8FOViPU4HD1T98XT9fdrnUu1CxOuX+LBlY2T/Ply\nv6oS6vX4UzwkF/310ezdvlQnyTgD2JH+0xnA0CuNbuvxh7H/56/HsGeHwbfyYVjhOVOd8NwwzHYY\nkgZHvJ01JEHUmOE/Q0nDX7/IYlD3+liipK8JUlQrQaguNolDupJAfnthKRDXBWeOVXQlQfzfXemX\nZqu0dL0AAAAASUVORK5CYII=\n",
+      "text/latex": [
+       "$$\\int e^{x}\\, dx = C + e^{x}$$"
+      ],
+      "text/plain": [
+       "⌠               \n",
+       "⎮  x           x\n",
+       "⎮ ℯ  dx = C + ℯ \n",
+       "⌡               "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAR8AAAAuBAMAAADjKADCAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAq4kimRAy73bdZrvN\nVEThti0HAAAEvElEQVRYCc1YXWgcVRg9u7Mzu9m/LI0PVgsZQ5SAgpvShwhKFpWah0pDBCNYyoRC\nwaddrIIK6hqirL4kFvypD7rokygmC6JVkK6CD0po4kupWMg+iG2p0FRrDG3a9dy5987uTneq5mXn\ng9n7fed8371n7r1zZ1hAWmQor7yQNMPjuZAokTLMjWk7VIISpVDJAfrCtWDAeDVkMzQfsmcMJ0I2\nQdgKmSDrj5AJSlwLmaDUnyET1L8eMkHFendB2bLEk43u/LbQc6rqs5tUz8uDeuY7X86Mjvcq58Iz\nGvG1T9Qeru7xYW5o7bI7YUu/FGJOJ9EeDZZl9GY7SP97Hae1E7D7oy8Av/LqYv63UnpSJ9W1c2P7\nckNitU4qUdZx0pZe9i+NdLTmDxwlqp6MxzoopPSMKLji0R96nt8xm0q1T1DcuxmzJGuiC/5aN04/\nyyarck53pvgFiVRp09q5oc38rSCfoN9bmd9IN11oQW3e/lUGhuJuLihb9+pSoqqrRfWbg4L2VB4F\nfpqrvM7MB3ntfuWBuTIwTBejsxdXNSBibYZbbzoyVoKMkYHTE0Q4Q8bE3Coyt05UOL8xm9IlFS2Q\nbjM1FJH0ZQXXYL2FiM2d8m6U0I+AaSffi7OfMwyzR3BiUgOILbuWIxG7wh/PlKApfFx9niAFPTWJ\nHbg42Ve2OVYVUFSmTrplXs9Av352aojbMDZSC3hEJL7EnYrEesYBzjLkR9M+DxC8tr6Og14JsjGP\nU8ygoKdZ63yFWIlhvAEoSm86osL0UHTHdYc1cE1wObKAnSLlOmcIkSXhFnkNAkc9QIDa5EFvqlAJ\nmsTtLpDKZXm//YWdYLd0GoCirHXG9x8T9j49PRTdRcEIq2GxAWxZG+aLIqQg3lJZ/ApBV2EKRAIC\n1BZ368V0YN/y8jvLy9+6zHPubyqXZFV/vehMrxIQggCXcgWJSJvX8/66gmpYY9ElY3bWEYiratzh\nHYklMzaRWec0SAAx99aOLTEv4p5OBVFCUzPEpedNiyXLiBnKjY3cJdi4UCUp35J5PQMrBZFKc/eQ\ndV2/ur4Gkvl5JCjoU07pNUTqpzQgC+Svtck2yizXlKCPEut4lYDcQ8WGenWlqoCiknU3X/+09dwU\nqoXVxJOUKmS/OJwXIZ/1teqXGJMuH7qfC7YGBO/Z4iqyD+lICspcSZWMMjEKOpvH57hw+JDIiBag\nKbrt1urZaLrDAzPNAcwM3QZ80GyK5PPAk7NTI1W6J3mNVn473tAA45ZZu27h6aVMCjKP3zn0BhFr\n8FLe2nFHFX3NpjhdsgvQVLqhKmTT6tk7qDV/oIGDRxnElVAuV0lz/96qJfMlmidhnrcJHvGIwFdH\n4qqXI51P2PzCS79SOdFlyfyX33Ndk5JLQIYXWq/Uka6JBCObPuY+B+CGbvv8OODL+P+h8Ta3U5V1\n3ueHWQ/qpW/Dx5hDlWFHYKOaGNDO9tupkdm9otrIqT4i+aDOgr+o3ceEZQknqHYb+JiqeS2wtlgP\npHpDrNm9GTdw1HsbgVRviJXeDBs86lYw1RPGCNs/DUn/MdSTaWkbNFJqC8LgxgthUNGmoei0Bb13\n71Hf4r1XohSsPN76QAmFqN13O6HQoUX8A0JEKJn2S4DjAAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$$\\int \\log{\\left (x \\right )}\\, dx = C + x \\log{\\left (x \\right )} - x$$"
+      ],
+      "text/plain": [
+       "⌠                             \n",
+       "⎮ log(x) dx = C + x⋅log(x) - x\n",
+       "⌡                             "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "int_table([sin(x), cos(x), exp(x), log(x)], x)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now use your function to compute the integrals in this Mathematica ad.  Remember that the inverse trig functions are spelled like `asin` in SymPy. \n",
+    "\n",
+    "The ad below probably has a typo, because one of the integrals is trivial to compute. Include what you think the integral should be, and see if SymPy can compute that as well."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAANAAAAEECAYAAABZfLr5AAAACXBIWXMAAAsTAAALEwEAmpwYAAAK\nT2lDQ1BQaG90b3Nob3AgSUNDIHByb2ZpbGUAAHjanVNnVFPpFj333vRCS4iAlEtvUhUIIFJCi4AU\nkSYqIQkQSoghodkVUcERRUUEG8igiAOOjoCMFVEsDIoK2AfkIaKOg6OIisr74Xuja9a89+bN/rXX\nPues852zzwfACAyWSDNRNYAMqUIeEeCDx8TG4eQuQIEKJHAAEAizZCFz/SMBAPh+PDwrIsAHvgAB\neNMLCADATZvAMByH/w/qQplcAYCEAcB0kThLCIAUAEB6jkKmAEBGAYCdmCZTAKAEAGDLY2LjAFAt\nAGAnf+bTAICd+Jl7AQBblCEVAaCRACATZYhEAGg7AKzPVopFAFgwABRmS8Q5ANgtADBJV2ZIALC3\nAMDOEAuyAAgMADBRiIUpAAR7AGDIIyN4AISZABRG8lc88SuuEOcqAAB4mbI8uSQ5RYFbCC1xB1dX\nLh4ozkkXKxQ2YQJhmkAuwnmZGTKBNA/g88wAAKCRFRHgg/P9eM4Ors7ONo62Dl8t6r8G/yJiYuP+\n5c+rcEAAAOF0ftH+LC+zGoA7BoBt/qIl7gRoXgugdfeLZrIPQLUAoOnaV/Nw+H48PEWhkLnZ2eXk\n5NhKxEJbYcpXff5nwl/AV/1s+X48/Pf14L7iJIEyXYFHBPjgwsz0TKUcz5IJhGLc5o9H/LcL//wd\n0yLESWK5WCoU41EScY5EmozzMqUiiUKSKcUl0v9k4t8s+wM+3zUAsGo+AXuRLahdYwP2SycQWHTA\n4vcAAPK7b8HUKAgDgGiD4c93/+8//UegJQCAZkmScQAAXkQkLlTKsz/HCAAARKCBKrBBG/TBGCzA\nBhzBBdzBC/xgNoRCJMTCQhBCCmSAHHJgKayCQiiGzbAdKmAv1EAdNMBRaIaTcA4uwlW4Dj1wD/ph\nCJ7BKLyBCQRByAgTYSHaiAFiilgjjggXmYX4IcFIBBKLJCDJiBRRIkuRNUgxUopUIFVIHfI9cgI5\nh1xGupE7yAAygvyGvEcxlIGyUT3UDLVDuag3GoRGogvQZHQxmo8WoJvQcrQaPYw2oefQq2gP2o8+\nQ8cwwOgYBzPEbDAuxsNCsTgsCZNjy7EirAyrxhqwVqwDu4n1Y8+xdwQSgUXACTYEd0IgYR5BSFhM\nWE7YSKggHCQ0EdoJNwkDhFHCJyKTqEu0JroR+cQYYjIxh1hILCPWEo8TLxB7iEPENyQSiUMyJ7mQ\nAkmxpFTSEtJG0m5SI+ksqZs0SBojk8naZGuyBzmULCAryIXkneTD5DPkG+Qh8lsKnWJAcaT4U+Io\nUspqShnlEOU05QZlmDJBVaOaUt2ooVQRNY9aQq2htlKvUYeoEzR1mjnNgxZJS6WtopXTGmgXaPdp\nr+h0uhHdlR5Ol9BX0svpR+iX6AP0dwwNhhWDx4hnKBmbGAcYZxl3GK+YTKYZ04sZx1QwNzHrmOeZ\nD5lvVVgqtip8FZHKCpVKlSaVGyovVKmqpqreqgtV81XLVI+pXlN9rkZVM1PjqQnUlqtVqp1Q61Mb\nU2epO6iHqmeob1Q/pH5Z/YkGWcNMw09DpFGgsV/jvMYgC2MZs3gsIWsNq4Z1gTXEJrHN2Xx2KruY\n/R27iz2qqaE5QzNKM1ezUvOUZj8H45hx+Jx0TgnnKKeX836K3hTvKeIpG6Y0TLkxZVxrqpaXllir\nSKtRq0frvTau7aedpr1Fu1n7gQ5Bx0onXCdHZ4/OBZ3nU9lT3acKpxZNPTr1ri6qa6UbobtEd79u\np+6Ynr5egJ5Mb6feeb3n+hx9L/1U/W36p/VHDFgGswwkBtsMzhg8xTVxbzwdL8fb8VFDXcNAQ6Vh\nlWGX4YSRudE8o9VGjUYPjGnGXOMk423GbcajJgYmISZLTepN7ppSTbmmKaY7TDtMx83MzaLN1pk1\nmz0x1zLnm+eb15vft2BaeFostqi2uGVJsuRaplnutrxuhVo5WaVYVVpds0atna0l1rutu6cRp7lO\nk06rntZnw7Dxtsm2qbcZsOXYBtuutm22fWFnYhdnt8Wuw+6TvZN9un2N/T0HDYfZDqsdWh1+c7Ry\nFDpWOt6azpzuP33F9JbpL2dYzxDP2DPjthPLKcRpnVOb00dnF2e5c4PziIuJS4LLLpc+Lpsbxt3I\nveRKdPVxXeF60vWdm7Obwu2o26/uNu5p7ofcn8w0nymeWTNz0MPIQ+BR5dE/C5+VMGvfrH5PQ0+B\nZ7XnIy9jL5FXrdewt6V3qvdh7xc+9j5yn+M+4zw33jLeWV/MN8C3yLfLT8Nvnl+F30N/I/9k/3r/\n0QCngCUBZwOJgUGBWwL7+Hp8Ib+OPzrbZfay2e1BjKC5QRVBj4KtguXBrSFoyOyQrSH355jOkc5p\nDoVQfujW0Adh5mGLw34MJ4WHhVeGP45wiFga0TGXNXfR3ENz30T6RJZE3ptnMU85ry1KNSo+qi5q\nPNo3ujS6P8YuZlnM1VidWElsSxw5LiquNm5svt/87fOH4p3iC+N7F5gvyF1weaHOwvSFpxapLhIs\nOpZATIhOOJTwQRAqqBaMJfITdyWOCnnCHcJnIi/RNtGI2ENcKh5O8kgqTXqS7JG8NXkkxTOlLOW5\nhCepkLxMDUzdmzqeFpp2IG0yPTq9MYOSkZBxQqohTZO2Z+pn5mZ2y6xlhbL+xW6Lty8elQfJa7OQ\nrAVZLQq2QqboVFoo1yoHsmdlV2a/zYnKOZarnivN7cyzytuQN5zvn//tEsIS4ZK2pYZLVy0dWOa9\nrGo5sjxxedsK4xUFK4ZWBqw8uIq2Km3VT6vtV5eufr0mek1rgV7ByoLBtQFr6wtVCuWFfevc1+1d\nT1gvWd+1YfqGnRs+FYmKrhTbF5cVf9go3HjlG4dvyr+Z3JS0qavEuWTPZtJm6ebeLZ5bDpaql+aX\nDm4N2dq0Dd9WtO319kXbL5fNKNu7g7ZDuaO/PLi8ZafJzs07P1SkVPRU+lQ27tLdtWHX+G7R7ht7\nvPY07NXbW7z3/T7JvttVAVVN1WbVZftJ+7P3P66Jqun4lvttXa1ObXHtxwPSA/0HIw6217nU1R3S\nPVRSj9Yr60cOxx++/p3vdy0NNg1VjZzG4iNwRHnk6fcJ3/ceDTradox7rOEH0x92HWcdL2pCmvKa\nRptTmvtbYlu6T8w+0dbq3nr8R9sfD5w0PFl5SvNUyWna6YLTk2fyz4ydlZ19fi753GDborZ752PO\n32oPb++6EHTh0kX/i+c7vDvOXPK4dPKy2+UTV7hXmq86X23qdOo8/pPTT8e7nLuarrlca7nuer21\ne2b36RueN87d9L158Rb/1tWeOT3dvfN6b/fF9/XfFt1+cif9zsu72Xcn7q28T7xf9EDtQdlD3YfV\nP1v+3Njv3H9qwHeg89HcR/cGhYPP/pH1jw9DBY+Zj8uGDYbrnjg+OTniP3L96fynQ89kzyaeF/6i\n/suuFxYvfvjV69fO0ZjRoZfyl5O/bXyl/erA6xmv28bCxh6+yXgzMV70VvvtwXfcdx3vo98PT+R8\nIH8o/2j5sfVT0Kf7kxmTk/8EA5jz/GMzLdsAAAAgY0hSTQAAeiUAAICDAAD5/wAAgOkAAHUwAADq\nYAAAOpgAABdvkl/FRgAAv9BJREFUeNrU/XmU3dd134l+zjm/4Y41YAY4AKRAQuIgkwJlDaZE+knR\n4FB2EktO6HbiKN2hYrcT97O0Vi9bK89Wr5bc3ZH8nuN+K4nciSy3bTqW7I4tilLLUgyKjGiJhEjJ\nJEQCEEVwQGEq1HCn33TOeX+c87tD1a1CjVDeXeuiClW37v0NZ5+993d/93eLNF20bPihgICr+zBA\nG2sLQKzyuo2eVgMhom0/C2tbQL6GF679jISIEaJ2heuyFceeg+1gMVv6WUKUXycBeZXXlcbazrrX\nTWCt3cRCtv5ExVU8UeGfFqxd5+naofewY97X+kUdXgUD0oAevXZ2I6Zvx9yT7T72wh//+o5WrPif\n8n3xG7K4Kucx+tkpUKzbcIONHaj1T+09wdX2QmroGJYfmt2UB0qB6lW4YcYveMFG7MWO/cXVMqDc\nG9DQZjZyHnasldghT2PNwOOMWJAIrrrxuHWcDF3DdRnQpi6l30XVVfZCEdAbPVk7fNk3cwOKMQti\nezYBa3PAugVlBwtqY0GBuUrRQHnP7ZJrbdccRpfnN+485VUIn5cfTzK0ma07hDMbvIjl1wJr5VX2\nQuXOZ65wYdYSuo1778wb6XbeNPxCdLuxRbD2cHql89j+0MdFHIU/Vrsld3LwnxBrr3b4VnqfjW28\nweYP1iJEjrVX2wvFfqHbZZm23RSwYLG2uApAgl2yA9t1/e3WgSYbWXB6aPMS6zB2Me4q9DdDQXyV\n1xBY213HuWxpCGeHnoXfTa+mF4pGjWfLQjhYEzq2ZeHQuJ9tZBGZq2RE2l8ftcZrbddg5HZrMooN\nhevppq5bsHnjKRPD9Cp7IQmEYNOVIu1NLOrshwuEbBjYuRrXPt8Gj2eBGCHUD8H7LAVDrkoIZ5fk\nQaUXyrc9dxh9VLD0tsErmCFwZDvzOMvqCJZlOcq10vfmKuzg2iNwFiHMKhnNeo3ZIETM1az9uFpW\nAsIuOWZxtQxoqSeyCJFgbXgVvVA8BCZsRfJphxZKhhDbCWfbMZvRSr+HUfzaLskhylx0uwEEQ4lS\nuvxNjD1mhyoO0MXyZ+Pf0yLE1QahADpYCrDSXbv+6dirYUDLjWfghTK/sK9WGBcD3a0JKfp5lEGI\nYpuPfTUPJEaMxV6RcXG1kCvjoXexiuHTR9KGjWxlgNH48C28aqZjbTaEvLnN1yI2VD8Its54Si/U\nxdroqnkhIaqegiE2nkcsQ+7MVciDVH9hCWGXFEjtOs/F+lLCdl/zHGvNGnIVu/Zjt1z18M1tuMOs\nA/vDCOGGq7bDRqSBhKtRzXeP0F8Is8qOw0g4sbZdqvBx/nbdWNGvpYwe1xJvZAc5kF0GBw+DOME2\nG5DF2qwfdo072hVTolXvi4KrWDy1NvXgwdJ8c2PAyCYMyIz1Ru7i9oDKVfJCyhtra3SxL/Eqg5su\n1njh9FWrB42GbGVIMewNV9vdr074Zq3xfLGlOdgqlmNXD15L8EBcNQOyWNv191UuyS83tlY3aEDL\njWdQmS4JmT2gdjWCOG+si6xenBwXt9tVESfn5rfn5vbDIDsMBKx2XHbV7zfGKNlI/rPSdRVjDHo1\nTpwdiiCuTrjvjr+zyia6oUKq2bA1l387ajzl4uv6hb39sa0QIdaG/gJJtqa2on0etF2bgBxC0Ta7\ngEokazsfZbFcrnBd18+JA+XbL65W+Fa2waghe1kPzWuLQQRrxwEK5SPzXqh+FS5N4MO4dMt2sxKy\nFVeXWbIBgy9vfLitRmRt5vIxsXXnJ0TgAYSrhbwNvE+5dEV5QmJj4fCGc6BRrzNsPGaJF6peBS8k\nfKglV1mIq+U7Sy6cLdGYctdV23RT7YaT15UBne3KHdI+lLH5e+W+Xi3jGXgf7QxGjNmm7Jpwj+UG\nJGUda8cbhENJzOjPrfX2a1fxPiXKlCDE1fJCkX9mG9jRl/LpbN+AXMK5PQYkRIS1vY3ZzFIoYVs9\npR0CENaGZo5DPYVgaF1JhKhfJePJMKY9MH9/YGLEpkvPtL4LKZfvZN5I+sbDCFBgx9J4lj6H/669\nzbvjYDG6YpxZ92K05XPpr0zpgbbrIdfmXIaP0a60bW0fD3G4A3WtpYBxryuPvwx+rhb6Zu3i2HXh\nVzXWbuoOLrkVyzo6bf8Gjg/VVtseha/4JlfJUa8DtFjBaEZfUjKPr1KeY5cb9Jq6bqz1XnK7DGjr\nr4GU1atkPCnG9K4YhYz2jq39GbgFVww7awa8qqUh2zjkZdx+aJftAEJcDUSugoNF05U/y66vi9/a\n3F+LrV+cAomxW26G27IIr7RLr7egKkTjqhiQMYtLooiV7uWGmQjRkAGVZEA7lOTadVjm4D0GHkt4\nD7T9uZCDswOsTcf0269joQ291qE32lf6t/qAw62zHru9BrQpI15Sm5My3p7rOdbwk1WMZfT/1l4Z\nJJGq6gEQiRAS6WLncEzItlrBcSUmsR2Kc4cNS2DtAlejYi5EdbRIuYZQbeWwTnr6iuaH/lglH3In\nHmzTIjQYk2/piUhZ52poNxizCDZf4eaPr1etxUWMnIv7ZsAnGzCuVvM+jAnprpSM5R6H324DqvuF\nb9dnNCsambn6BnQF4GD8Y7t6l7K1ZmJrDlyvRvHU2p6j7Xif0t/Y7WoXXazzJsnSgCQulBNj2MB2\n/Da45JYup9CM81qLV8ELqf65bBZEGHjV7QISgvGehc1ow231Qsy28P0tUlbY3kZFt+lp3fYo6nIa\nkd1s2a2/EVSGM+1wKJRbyWhWWoj2CsZTZpI51ravkhda0UuvPaTrAwnZtixSIdTakbYf0sOYbOUL\nOTYqWSXwsQYp69tOO7I2cYzrVT7H2tVSk7VsVSFCVByVR/Qz7ooHFAqWw9ErUWtLMoQdC7sshQeF\naCNEc1tjYEENgwQxRrhwRTbKSso+glJ4YutvvPDX3m5isVgcp0wO3cetBxDEsqsmxvxXrHqcQiqk\nrGzLcQ7fPK3L2qNaHRhcVoEWVzw2IVwRuMzjlqyIssOTJeHZGqr44ySLxuiyOVRrm72QUD5UWE/C\nsZJ3Ej6EM9ti6lvlybZjV3fFU7uqb7FDYdG452AZWd8iv73om6v7dLhSyWSjXt+1oNf6KOKYT4lG\nULnlrs6ugszZkTBp/OuMN6DtZSdcuc5gGS4Sr3ZB3WLIt+EYNwhjj4uO7PYsRjbZJjG0DSNldZuV\ndyxaL2zuaK+wUzgPWhlxOWMeNbByldxmZeO5cn4hgeQqIHJl4XaFfG4duZBz9+l2mPm6jGUlRG6r\nVEKX5z+pn8CwFbDi9lN3Bt5nHR2mdhQY6P/XxWoglCsRiBAhKz6/FlcyIAl9qHEt4dtSr3OlpMx6\nL7R98LAQEilqjKUqbaAuZGzKtqf6S4zli198hH/8wf+Rd7/nn/Af/+ThFf/ItQVsRwiXew+0+X4l\nt3NvL/u6KOaX3CKxhiOzA2RuaAGPqg6V+XttWQF4lYA0RohsCVt4dbHwtT8k2B7W9jZM6Th+/DjH\njh2j3W7TarU4e/YsBw4c4OjRo9x///0uIZR1bLHoEsN1GM3yMxVYk27TbZdjZx3963/9Wfbt282/\n+Bc/z8MPP8Kjjz7Jz/zMT6zi1eUWG49xJNJNm4/tC4dsJ/pmjFtPo6DA+o7eLoNKBn8vRIyUy+tX\nwerhRc0jUHrF9Guj84VcatXyieX64uJPf/rTPPTQQ3zyk5/k5ptvHjGqj33sYxw7dowPf/jD3HTT\njQgRDI3iuHL4u/KvjefFbW0Y4o5vVELr0Uef4KmnTvCZz/yvANx55y0AtNsdGo06K9zjrd7P13bd\nrmiIjimv1GDxtVotms3mlh6t1vMuwe83yI3b9MW6wug+tUcEK7InrrAlBEMewq6Cvq2/hVoI6avF\n62Nqf+pTn+LBBx9cZjwAR48e5ZOf/CQnT57kIx/5CO1218esdk1h2pqS6i2Pk5bflK9//Un27du9\n7Of/4T98nqeeOrGOq7zJ8A09BKJc+Tm+BGQRIkSImFarxcc+9jFOnjy5xd6ni/ERwjAquBwZGvfD\npVQ0uyQzEUhZWzH8XINPjX1CfiVh8PXd1jLGdBy5tSWqx48f56GHHuK+++5bZjzl4+abb+b++++n\n1Wrx6U//rkNMtqSgyhZzwgY3aOnj0UefWPazP/mTh3n44UdWiBXUlodwxmRDU+jWDw6WvTYg+yWF\nhx56iGPHjm0D8lb2+4jxx7OuavUonVSIECkbq7iYNcToQjR8NT5jfJF0HcazpEhZVo3Xkgs99NBD\nANx7772rvu5973sfDz74IA899BD/9J9+kFotwpicTqfLt4+f4G1vfyMADz/8CO12h7e97Y3s3798\nx2+3O3z960/SbnfYt28399xz96qf22q1eOSRR/ohytGjR9m/f//Ia06ePMnx48f7HvPGG3egh9Zp\n6WHa7e6Itzk3cxGAU6dexFpoNGq0212sNShVJwgmOXDgwLLPK49reNcfft3x48c5efIkN998M0eP\nHh26t24G0GOPHeemmw7RaNT40pce4fDhQ/2QsjT2c+cu0mjUedvb7hoNMS0IqVCqzszMDGfPnu1f\nA4BmszmyES69NittkktzH2OSNRl3/5iWRW8rxcESpSZXDfPUv/yX//I31pT0Y1nbKAixrjzDGWGO\nlFdmJ3zsYx8D4Fd/9VdXfV2z2eTP/uzPyLKMI0dex8GD1/A//8//H/63/+3f8/VHn+TNb/4R/tW/\n+j949tnTfPWr3+CrX32ct7/9jTSbg5t/6tSLfPzj/5Y777yFRqPOb//2Z5mZOc9b3/r2sdXqmZkZ\nPvjBD3L06FF27tzJn/7pn9JqtfqLstVq8dGPfpSTJ0/ylre8hSzL+M3f/E1mZs5z6603EkURjz76\nBP/pP32Vc+cukmU5585d5NlnT/Hss6c4deoM7XaXdrvL6dMvIgRkWc7v/M7v8/DDXyOKIm6//fZ+\nbvGzP/uzvPWtb6XZbJJlGY8//ji/+Zu/SZZlHD16lJMnT/Kxj32MZrPJsWPHePDBB9m1axc333wz\n1moefPAP+Y3f+G2+9rXHufXWm/id3/l9vva1b/C1r32Dn/u5n6Ld7vAbv/GvaTbrHD58iM997kt8\n7WuP87a33UUURf1lKWVEEEzx4IMPcubMGWZmZti/fz9Z5lrvDx06tOK1OXv2LLfffjtxHK+4oIpi\nDmPSDQAUYvDvMhaFS0uCYGIZcFDe+/LrGg2oVL7MgWJDQ6xWZgKJfr/NajDn8ePH+cpXvgLAP/7H\n/3hN4d7MzAxHjhzhtttu4e67b+Gb3/wuly/Ps3//bn75l3+en/iJe4jjkG9+8ztEUcQb3nCLN4aL\n/Mqv/C/8D//Dz/PmN9/BwYPX0GjU+IM/+HNuu+11HDhw7VhgI45jfumXfolDhw5x11138dBDD/Gu\nd70LgI9+9KOcPXuWT3ziExw6dKi/u/7xH38OLNx5560cvP4a3vGOt/KHf/jn3HrrTXziEx/hHe94\nK+94x1vJ85ynnjrBRz7y3/FzP/dT3HrrTdx00yHa7Q4nTpzmfe+7r2+sx44d46GHHiKKIo4ePUoc\nxxw6dKgPvLz44ot85CMf4Zd+6Zd43/vex7333stDDz3E888/z0//9E9jbcZrX3uAVqvNiROnabe7\n/NRPvpObbjrE4ZsOcucdt/CRj/wmb3rTHXzgAz/B/n27ufPOW/gPn/k8zWadW2+9yec+AqUmkbLC\n0aNHmZ2d5fjx4zzwwAO8613v4tChQ6temwcffLDvjVbyPloveOBNbMiAypLPsNgJuIKplFPLNsul\nBrQOs5UIMeEKrOvp4rJXgLlteTG2r19IiBgpIhoNt5sMw8Hl96dOvTiSb7TbnX5I9dRTJ2i3nRzs\n889/b+xnzMzMcPLkyX54sn//fj784Q/3F/Tx48c5evToCPrk4Hb4k899iZlzFzd09m9721G/YXx7\nZPMYDnnLn91zzz00m80+3F+GwmUoNTMz4zc7jTFFPxy7445buPttd/H+D7yXD37w/XzpS49w6vQZ\nf32e5amnnmVm5sIgBPXJpUCg1OpNlFe6Ng8++GD/uJbC7EXRwhjtgJgtXToCpabW5NXW6fciEM1l\nrm4l73PFJH2k87PwyinjHwcOHBiJldf62L9/v4Oe11HEe+qpEzQadf7jf3yYr3/9CU6edMb1T/7J\n+3m7z5+WPu69915arRYf+tCH+NSnPtUPVYaPd/gcyscb3nDHisDBlbN1y+HD17N//96+0bRaLWZm\nZrjvvvtotVp9Izp+/Djve9/7+tfkk5/85EhuOXxNlzYRHj58cOTj+8bz9Am+9GVnTKdOn+GDH3w/\n73//ewdtlDK6Yufpatdm2KMuN6AEYzougoHlPT927WmGHSlgG5SaWHO5Ilj/bt7AUXF6q8LYV/I6\ndtkJGaxtAY2x7nj//v3s37+/v9NfKcEsb8yRI0e8S167Ac3MXOTOO2/hN3/zI8sxsxUMsVywJXjx\n0EMP8eEPf5j77rtvc7CtXbbTsFT25e1v/zH+43/8s35h+d5772X//v089NBDHD9+nPvuu4+ZmZmR\nazYzM8Mf/dEf0W63+wm7M0KLMcWqe+u5cw7Q+PjHP7zqoSt15VrPRq6NtZaiaA/NFloPYDAeNBjw\n9Wqrom6b9EDlkUwyOhpifSHbSoLkTr+rtSq6ttKOtPSmlAl86QUcDWNtTXaNRt2HbeP4emZFYun9\n99/PH/7hH3Lffff1a1bDnqhEocY9+nUfO25rHN9xM4DuX9P3MseOHeOee+7pn/uxY8c4duzYMuP5\n0Ic+BMCv//qv94+3DN/KKQwrPcpQ+NFHn1x1naxFeWct12YpsmhtgtbtNbVFLIOyVysoCIe6rYfw\nuqHigdNgm1xev7lSNX/V3wt/81YelnXfffexf//+fj1opceDDz5Is9nkgQceWAKCXJniDoPK/5/8\nyZfGQsLjDKhECJvNZt/zlAujzDXKMGvU252n0ahx5x23LLvLaytfKO655+00m00eeeQR9u/f388l\nyg3nt37rt0ag/2PHjtFqtcaWA1z+k62alB8+7JL/z33u4THQf9d7n7Uxr1e7NmfPnu2XA0aRtwVG\nmNPrcearIMVSTqwrUtmwAQ1CuRoDgfnV283XpmZZ1oV6K8LTv/Ebv8H+/fv59Kc/PdYTPfjggxw/\nfpxf+ZVfGRPmyX4IsNpx/czPvLcPJvzrf/1ZnnrqBI8++gQf//i/YWbmvF9gy1G/4UXQbDb7N79M\n2GdmZvrI0jBS+MEPvp96o7am9fDlLz8yEkYJJALBPffcQ6vV6htNueE4j9EYuRalgT300EO0Wi2O\nHz/e9wDHjh3j3Llzqx7De997D/v27eb06TN89KOf4tFHn+Spp07wO7/z+z6XsyjVWHGhlpvfzMzM\nFa/NAw88MAIuGJOidZcR+YEROsT6TKlcvELEKDWxbjtYM4w9PpQLgJ4XYhfrDNlW8lLG7wa1se+5\nc+dO3vWudxHHMb/7u7/L8ePHmZ2d5ZlnnuGzn/0sAL/2a7/G7bffPhKyfPrTn+aRRx4F4MyZsxw+\nfIhWu8snPvFvOHfuIufOXeTy5Xne9KY72LlzioMHD/DUU9/j2WdP8bWvfYPTp8/wz/7Zz3L48PUI\nES5Dl1qtFr/7u7/bX5DHjh3jE5/4BDt37hxJiD/72c8yOzvLmTNn+L3f+z0eeOC/493vfiMgeOqp\nE/zv//vvDx3PAgcPHqDRqLNz51T/OP78z79Ko+HgYoFAqjp5bjl58uSI143jmNnZWY4cOTKyi998\n880888wzPP744zz00EMcOHCAe++9l0ceeYSZmRkOH76eL3/56/z5n3+VLMs5ceI0WZZ7eBqiKOTW\nW2/i1KkXOXHiNI899iTf+tZ3eMc73sp733sPIAnDHcs8UAmlnzx5kq985SvEccztt9++4rX50Ic+\nNBJeAuT5xWXcwZX9yvj2Y7H0d8Idr5TRmjb5ka9pmtrhXXm95FBj5rB2ntU7UtdkOSPRfhDsW5N6\nS5nvrFYvGL0B5zCmu+a6QQlv33T4UH8olJRVwnD/shi8rLYvrbAvNbQycT569CjWatL05TXN92m3\nu5w69eIIEwAkUbS7X+1fmi/MzMzQaDTGkjdPnjw5EvKdPfsqu3YF6KK9ZrHtc+cu9kGXcsdUqkEY\n7hmbo5TnP+5eLb024+o+aXpuTXHb2ozJUU9VMEEQ7Fhj5LXFBgQGYy5gTG9wwdbldeyYaXIGKRsE\nwW62nuPVIs8vsSYa89jWBkeOjKK9W8LMttaQZWfHhoVruXZSRoThnnXH7uOPpSBLZzCb6b61hija\niwq2lm0NkKUzaNPb0N+KZcYkhu7lgTUzGTZRSF05jRJicoD3r9l4BiL2S7TyPVO7sy3sZ+fV1ibq\nvuIAeqtXDCOu+sPCVs5E0maTw5VFiJBb3zhnTBe9iZ6swb0UfUMHQRju3FSfktyaRVlFiPraxQwB\nrFhiOKOzQq3Fs2ztFhvQKoIja9RlGyBV/7U87BYZULapMSmuCFndhpH1lqIYP2Fho4Zk+1y3yqbe\nb8viI8cbqqzxQi/1OqWo93A4JzCms+5+oTUhJ6qxouGsba3aLfVAbsHZjf7xFslE2S3ZFLZDtkrr\nLlpvxToQ/bRDysoVmdZX1YBc38f0WqK2FXZNO+SVhi/e/DaEcV5wZCSEXIvVD8tz5evul1n5pm7s\nNrjDkWyFVJS1XkTRig2/gRTRluRio2/rdd625FqX2gZqLEr4QzYgtzClnBy/m65aJ7JYK8ZMqxYY\nMzzfZauO0wnj2TVd74HhjCrh5P+V5EFyy3IgY5INv5XFIlW8Jih4fcfUc3WfLfNqFqWamw7dtsWA\n3OKcRBCzstLnEnc6kjeNm89iMGarvVDJErarG84Stf5Rwy5gCwyoVLq0P2RtXzcKxGzwb8sIpMJW\nCjRYa9C6tUWe3t1YKSsEwdSWHec2GJBEqunBvmTHj4Uo3bNdpuFlx+xCmdf72srjLJnCdlXDWfle\naMyWeCCx6Vk5W5FzuKa0zSzMcMt29YEBJWjdWS6guwkAKQynt1TccVt0hspQbsWakhVDult2FEQY\ns8Cs1WjdYisROYfG1QciEms1nCHX4ThxP0zXYbdsMbj8h409KbUD4i00HktRtNz92SKnJmVjrDTV\nZh7bJFQsEKKJED1fy5ErhHN2FcNZvhsZ0/XyQltzjG7HnO8bztLH6dNneOqpE5w+/SKHDx/iAx94\n75IwLsNas+FFPDMzw7Fjx3juuWd5zWv28YEP/MQPzRSdCunGHo89dpwLF9o8/fQJ7r//fo4ePcqx\nY8eYmZnh+PHj/Z+t1/sURXvLED1XcJ7elgx0e0xIhCg5TTm4a3XjWX02peh7ofaW7vhSOtRoterV\n6dMvrkDb9x5ok/H52bNn+frX/8t6gaRBn9AW5RqbA0Qkjz7618sY1WW36UY8a54vbOVq3DLU7aoZ\nEIAYak4aX2RdaVQkYzyW8PpfvS01cueFxifPhw8f5D3vuWfl22wKP8l77Y+Stweuz+VKCkOrzxhU\nW7IoNsv4uOeeu7n33h8f+dm999575XNbxRtq3XVMtU3vESXqtj1T8bZ7bDZSTnvOmB2DwomVvc+y\n4qbrWnWojNmynckZ0AbrMP3uzbU9jh07xm/91m+tYikrG8z41ENsiQFpnWzimorlhelNPvJ8bh2b\nyOqbjxTxtoRuV82AXLJeus81ijOu0rW61ewEKWOf/NoNnJvAmGTNBNyPfexjIx5o6a2wdr1rZmtC\nuM0wEFwX59bt7q7uk6x+DdZgTNZnBsE2hW5DIMK2iSsPLdIaxtS95sEVFsAVu1adFxKickUS4HBr\nd9nEVfaXHD9+vN+V6TxkQrvd67cvjLYMjH+cO3eJxx77CkpNcNddb1xVp2FY9KP8fvT17h6cOn2G\np58+QaNRWzF8PHfuIo895vKyN77xLbzudW9Y8bxLoGJpuFgKKh49epTrrlubATz99AlOnz7D4cMH\nueOOW/y9rW6haLwlz+dXtIxxMcz4H7pfBMH0lhr3WAOytr3hCQnreSi1w2th50OOT4yELmua1SME\nRnewasIL049frKUewQMPPNDXSSsff/RHfzTSDSllhT/+48/xuc89TLvd5YMffP8VDehLX3qExx57\nkve//728+OI8H/rQh0ZauZeGbqU003DPy7ABnTt3kY9+9FP978+du8iXvvQIv/3b/6+R9/ryl92k\nhg984L2cPv0Sv/iLH+5/bimu32q1eOCBB/pGcvbs2b4Yy7333suDDz44Ysi/+qv/PXfffeeKG+nT\nT5/gM5/5PG972xt59NEn+MxnPs8//+f/iPe85+1bukCLor0uzpsdbzdYLEpWCIKJbV/XcjBycXvr\nGc7VT4/3wevpH/J8uX5f/JjH0aNH+52Zx44d48CBA3z4wx/m3nvv5Z577uGP/uiPlhh3jb//93+S\nf/7P/9GaDuHRR5/kM5/5PL/6q7/AnXe8jn/wD/4e9913H5/+9KfHhmj33ntvX+fswIED3H///dx/\n//0jTW7nzl3kV3/1F/j4xz/Mv//3/wt3330Xp703Kh+PPTb43DvuuIUPfOBvc9997+1/7tGjR/mV\nX/mV/nm/733v45Of/CT/7t/9O/bv38+DDz7IF77wBX7lV36l/3OAz33ui6saz0c/+ik+8IGf4P3v\nfy8f//hHaDRqfO5zXwLUlhlQqfO2Ucb18IoSCFQwuekC9Vo+VZYojBPz2G5AoY6UzdGEdQPDrgaI\n3Mq7Vbk4m80m999/P/fddx+//uu/PrYz06mihn21mSs9PvOZz7Nv325OnXqRp57+Hk8++eQy77Le\nx5133k6jMfCob3ub05877TXYhj/39OkXefrpEzz11LPLPrc8v1LaqvxZqZVw77339l9z8803c+ed\nr+f06RdXPK59+3Y7YcW77wKcIs/hw4c4d+4igapvWZ1G646/n5sf5qWCJkFQ3/b1rHWHwAl5GC/w\nrtbckrBRxCYIdniD9cov4zptxxmVGI15LQKtF1bcAcsbe/To0VVvcl/jWNX7yabjpy1p3fU724wP\nr/bt283nP/8lDh8+xMTEFAcOHOCBBx7gyJEja5j0LJZ97/KIQWvCsEi7EKIf1vU/9zUHaTab7N+/\nf+Rzx7330s8Wy4ZQseLC3bdvDx//+EdGQsjSqFWwfGS9GNNeIa7QcuHyWhcFbS6fsggREUXT2zbM\nqzwPZ/C9kongIGJjFv3i2T4jEiIgCKbI84sre5rVvNAS+NWxEzYfRjhyqRgfFwx9O+OnJLz3vff0\nmQNCKKrV67cVjBn53Pf/hGM/y4hKZf+GQxUXCVzZ/587d7GfH9555y0cPnyQp58+gVLxlu3kRveW\n133WfTlLMZOQ7XwY0+uzJOTgiN0EBmMWriist/lQruFVK+2GjcefikdttgpuD8cazmhouFxU0LV4\nb5YxLFaO/y00h8QMR2tjG99p18LlO3fuIr/8y/+TBxt+YQkyuBVFXO00rq3BLpnNs976j1I1gqCx\n7caT54NOaTkYYz+g1jilne00IuEVIKNRjbZVssOV60IZWm+Mqb004R9W0lzpnh0+fIhGo+4pPk8M\nXdhslRrPGg1ohcVigdcMfe5jjz0x8tuNfq4jkK6+Mh977In+DKWlYd9G8p+leaLWPbTujdRqNlL/\nEUIRRTu32XhSZzxDm6UUY/ThXc//whb2YYw74aivgG9XMZ4rbz4bY2rffPPNnDx5so/InTx5kocf\n/ktgIJ6+0qMklf7O7/w+n/vcwzz11Am+8IUv8KlPfWrVxdxsNvvQcqvVWvG1dg2f+/nPf4mnnnqG\nhx764hU/d+UFkXMlFYsyF/vSl9wwsqeeepZz52b7SN9qkrzjHh/60Id44IEH+MIXvuCQt3xxXQjb\neCuzhOGubUXdrC0oigXntYf2DfXRj374N+zQbPVB72UBZH5X3p7YXsrYd3Zm68uFxsTyrh/FdUN+\n4Qtf6EO7J0+epN1uj+ifgROdP3bsGI8//jh/+qd/ShzHHD16F8eOHSPLci5fXuDcuYt85jOf90Ot\nzvRzgFtvvYkoCvnWt77D00+f4D//52+Qpikf/ei/vOLw3OPHj/OFL3yBmZkZZmdn+exnP0ur1eLU\nqRcAuOXWm/nylx8Z+Vwh4JZbbuKWW24ijgef+7WvPUaWZfzar/0azWZz2Xk3m02OHDnCpz/9af70\nT/+ULMt45pln+nN5Pv3pT/Poo98C4MSJU9x6603LhhgfPnyIEydO8a1vfYcvf/nr7Nu3i3vueTuP\nPvo4Z8+e5ciRIzz00EMj7x9FEY888siynx05cqQ/eOzd7343112329F2NpPwW00QThJFk9u2Tq01\n5PksWrtBXs7zOmBE9HpnrbUGrPHGbHwsbrynqHnBELlNB5eTZTOjbOB1qpliDSooxfzWd5zlbJoy\nvHjllRc4eLCx5pvx1FMn2L9/N/v376dave6Kf3fy5EkajcaycR5FsUiSnF8z7eSpp57hmmuu54Yb\n7tjwjpokFzxp88rX7PTpF9m3bzf1Ro1KZQ8XLrTGjiRZSwg3MzPDTTfdRJK86hflRhe+8UDKgW3z\nPs54LrvrJOSQAclRAyoRmQEyY3GTCNy8FCmnts3CtW6TZef7I8rXX9J1+VsU7dt0Yc/agqT3Cnbd\nBT1JpbJ/w01lRdEmSc6ueSG4+1KjWj2wsaVnEpLkPMYUg9HwV7zKFiUj4sreTWsfuPM9vwnjcask\njvduK3CQZZd9iuA0yIUc9kByta1n0Kej9eKqY0e2AkJWqr5usu1wAj7on98cU1uIsrpu131Dr65W\nnEDKje+6xhSeSS7W0XhqvHDIZmFix3kTm9roDEEwccUJeFtjPGMGcg2wa8tqU+bc4sQPc21v22LY\nbMOTQKKLrWBqC1RQ34DEscWYdFOf62DhK085L8cnbuZ6GZOzPtqM9ZvL5nPiomhjdLYceVzjDmqt\nRakKUTS15Rp0g2NcQBet5ZfejtY35JUOdBiuLIrLXph9e1C5IJhmw+qTAiyGPN+8F3KdquF61hbW\nWoxON3H+EinVeFR5I70wV9i9N+ItBw2Im/U+C9jV9CdWPV83vDgMp7atYFoULfJ8ftVZwHa4DjTY\nbe0VT74oLm1bjUipssBqNrwItW5vgaZ2gFK1KxvisqY3s0njXV9T3cY9gcGanPUVYUvlnXCTi7O9\nzHhXdUJLfmEtBEGdYBvE610+3iXP51Yf2dNXlVrxCtpVojpDnl/YFiMSQhIE05uTugXfT283cRzl\neEJ7RcMZFVs0GzbeMjFd62bsjnFji3n92t4Wx7zeXL7hEK1Fv2GLNe1NdsmuL2W4bQVTY1KybNYj\nwmJZvjNOTVeO/aUdHdS6fCBwTpFf2hZlTikjL3y30UhOoPXqTO21h3HxaC60guEMby7rafFeiuIJ\nT41Zeyeq2OBCKbymnVjH9ZAEQXVT19T1+6TrPu7haxFFO7YFsra2IE0v+o1Frh6RLQcRlrimEeMZ\nAzJYgbGJD+e23oiUaq6uHLqGcGpZX/26DSj0CbNZg+F4sMWYDedBQsjNFRTXCXasN/mWMt7UwnX9\nPu2N57hYwnBiWyBrZzwX/HWRS+OKZVYznBvJK0fky0MLnz5hTMeLv2/1CBLpJ4YFa4Rlli9urctZ\nmpvA9YYER9aSw1vMhodTWbtelEBsqLhtrXUI3LpE5MWm+2u07qB1b4Ne0yJlQBRNb8uGkmWXPB9P\nLIm0GArj7LL8Z5kHGj85YbUbK9F6kaKY23IjckJ4U2xsipwLp4pifpPH4MTS1z71SG54+JYzBrWO\n67hRSWCPwK3LA8lN5T/WFuR5qz/UaiOPKNq5DaGbJU0voIvuUDF5BUDNjsHh7JphGDHyR8t3l3nf\nELW1jyCYdL0+1q7TeNwxG71xpvYgD4rWhay5BD3fkAFJIdc5WFZsYDGbdechQbA54RCtE3TRgw3V\nrTRhOLkNBVNLls1TFJ2RlOUKguhjtpYx0Nx4L7R6IlsUl7bFiKJoB4gl9RF7JeMpf6d9n73dhBFV\nkFKteTlbs/Hxj1tY6lkFQMjWaXh2U+FbH3nb2NEiZYUwnNjygmmWzY/kySM9VuO8zQp3S1prPfxq\nVzCklexoNF50YuCXtmGWT0QY7lhmMWtdbFonFMXGvVAQ1BGEq3uG/sEILBsf/7ieRSJgQyGNMesd\n47g54RCtexRFdwMG4KDuMJza8plDRdGmyBeWsU0srBquW2uX5EPDHsiWL7BjKllX3u1LbYU8v7Bp\nCHn5InaoXBlK2XUsM2sLX1zdaHE2QMpw9Yr5kutjTLEBKtA6c5o+K3h9AILW6Xr6RAiDjQuHWGvJ\nsrk1k1WXXttA1bdcHETrHml6CWOLFaWD7VqS7tKArDVYYzFDKJAZw0xYviDGJ1nGaPJ8q9kKot/r\nbtcZDAix+bqQVDW/iOzY07dL9qSNT69bX2i10XxkrS7IYlBBbcOJv9M6SDcwXc4iZEAU79jSNhpj\nMtL0AtbmrpFzc5fS3W1jJMZqSkNa271aWctAULa+zm5pjcgVWCc2tChLzbGNeqEgaCDKPGwNNSFj\nNmpAdh0v2wiAkC1pV1n5aa0TLdm4cIhL0u2GN8ytDd2MyX37Rg4Mcurx93DNLhpZTte21nkhY8yK\nxjF2pxzLWhCeU3R5C4XgHSrn4vH1vWfJkduoFyr1n4f7lVaVHzbFBg1IsSZgVAikWP/ics1ra0Ax\nrEvgA1Vjo8Ihed4eyrfWQbe2FqVqRNHWqYpaa8awDEYuJ+MDrNUcSp9MKoAmUOnnQANQwa6uUrzM\neEaBBa0XyfPLW4YtCSGHWLh2nRfRUhSLGzZopWqsddqGBbRefwgrpVoeKm5FtFfuwmX+s8qkuZFz\nDqobzH8849raNVjqaJogREAc72SrmjettSTJ+VWLuNauYiPL4rySRy5QqoZ0Hsep5PRHHl7xLi3p\nHLXLSED9fEDrBV/Q3BojkrJKoJrruZe+f0ZSFJ0N9+woVVtzPO6mNuQb9752DSe0kZxklXNfEsB5\n+H5j4VuetwZI5Jr6fQa/iOLpLWjYG3ieLJtdMwPC2rXcDOujoQmiaIczIGOMq6rKCZRqjqGVjHmT\nAQV5iU7ZcmPL88sUxSJb9QjC6dXZ0isk+u7mbsyYhSjn4KxJAt8DCRtRNRJr2q3XC2G7HqBiTc6n\nbFjbCEzukNgr5JtjDsB1mDa2tE0hz+bXzMwXq1z54bUOiiiaIgwnyhDODuBrnBG5xjax+pDgde2M\ngjyf27JCqxDCU9rVFY1nybJD6+66JgCM5mD1NRuB24HXm6spjw6tIhBn3fVf7+J27AO7js2isqHw\nbSnjek0Gi0WIkDie3rKCaZ63yPqim2vwPqt5f+HFdoQkjneOgFkjBjQwogZBsMJQrCUM7bXv5Zos\n27pCq5QxYTi5SgC78rHl2dyGP9PpENg17cTrpfSU+tgrJ/abg3DXmsEpGaPU+jtPnfdpwxrGXi49\nrSia3jLUrSi6pOnFNfUdrWhEQ+vKmFL9Z++yovJYA3KLpU4QlGJ140ADMXSAawtrBka0NYXWIJhC\nqurynp0roGTaJBtiarudee1eaD27/loc+sgIj3XWR9xE8TUJDiBVZUOCJUVRMq7Xc2yGIGj2Q6LN\nPrTukSYX/PR0saHLPuIsrEWpiDjeOzYnlEsNZ9QTVbzWWtUhc2NZCesjPxqTeXg73/TFcqGcL7YN\nMSiu2HZg7QY1tUtav1nTsa150Q6BLksNY5wDEoJ1J9rlHNTy/pa579KnRSJljDHLX7PSZuuuabEB\nPQpXa4rjrREHMSan1zuPtXpTBdjh+CpQNS9XNv56B+NGYow+Y6JoN3l+yYvwObhaiHWOhrSDu+8E\numeJoj2bnl+pVJUo2kGaXhwZRbKaRyoXt9addTdoKRWhVNWpyojVjFRgTT4yKuXKIWLg86DBWYgV\nDLm8P+VCHmeo5c+0zimKHGPMyN8sRZ7cbquwNkRrPXK9lh+rHHmfPO+S5+2xxNuVz18QRVMbCheX\nn6trigPTZz6IVfGZKxXE3GYZx7vHjnApvwYOe7/SPJuAMNwDzHqdLNYRuo1bxK6wmeeKKNrNZjH/\nIGh60mJ79GRX8UjWaoq85ecCrefznbST1sl4RU87uDrGI3Hr2yTsWCMY/t5a0NoAesQbjPvq6l9d\nsmwUFVwmJONzW2urFIUBslWNZ3gxuVrLPFprhLDeuJcvtuH3stYSRU2iaGpL4Ope74IPmcfs2WN/\nsIIDsBYEhOHEmupRaw50hZBE0S7yXK46XnFty8ItRAdtS4+obdyInDL/FMYkGKNHyIur5UKF7hGs\n0wu5PKgGzK96ggNGRrLm5Nh61ZmSDbLUEFyYUr6vRetsmdGUfzvMKEnTNlmWYH25YiVjQwjiGIRI\nxp73sBEMfzUmpdeb91p1om9gQvgBaqL8+eBvXIfp1DLptI0YT5Jc9LnXFYKfFX8weC+3zqfX3P26\nzkxREIY7EUJ5hsGGLGck5i+KeYRQhOHm2nWlrBIEU2TZ5TVnZ242TXtdRdJBGFdxXkiIlTimQ+gX\nq3qV4f9rbSkKs4pBuMJ3lhUjhrb0Ofx3abJIlrf7bdwlLX/kOPohJGRZe1m4stTrDIxC0uudx5gU\nKdzrBr+X/v/0vwrh5HErlWmMUd5DjzfOtTyy7HJ/I15zFjEaqY0YTxzvJgzXXovaUI+sU81R5Pms\nhyzFGkO38UaU53MIJEE4uSkjCsNJX+dZW+VZCMdOCILeumjzTqGzgi66DNei7NjkPR3RGBv2DMOL\nvFz4eW7Isxx8e0hZ5DZmOPm3QLef6C99j6UG1O0uUBS9Ie9jxuZNStUxprNq/rI0R7Y2J0kuI6Xo\nC69L6QxLSomSwz9TCCmIwgZQIc9zlFJ9Ax02yivnT46smmULbETlp1+lssLXoQIqlT0Ewfp6nzbc\nZB4ETYSQZNlFN3BIiA0Yz9DFyC8jZLCp1l3hC11Jcg5j1sYCKNVilFpP27LoV+rH9iqOJNc94tj0\nd/yli3vp91nWI0nSIaMw3lC88WiLRWFtp280A+Px/9emb3zGZPS68xR5D1MUCNyxCOuSbZN2sEWK\nCGvE9T1kYYbNewhjQAXgQQEZNxxC53McqQKElKTpQJlJKTlkCN6AVGlMCqUkSgWEYZU0zVBK+ZBY\n+deqfk51pXmvRd4hTS/7nGUzcLUTLKlU9ngVJq6OAZU7VhwH5NkFtMkGJ7ku43EL0vGWLhFFYlMd\nkFJWCIIJsjUWS50XahMEzXXtPkpWkCry8DDLvMrAG0CStFGqsgwSLr/XWve/7/VS0rTX9zrGFBhd\nGpDGGIuQIVq3B3+nC4zRLscpMihSTJGCUEhy8vYrhKZDIDSRtMhAosiphAmKi1iREQmBKqqIQmGS\nDqGZQwqwVqFtjAl2o4NJtIkwYRMT1NAWlJAYVaEnanQThTYWpYRnsEtvHAKlXHhYr++m18uRUhME\nAUEQoJQaMaLSe8m+9xr1SEXRoZdc2LDxjK7hmEpl74b5d5uWOZEyJoz2YrMLI3pj6+7HFAJjCrJs\nljgONlWVDsNpH8qla/RCljxf9F5Frun1CIUQIcZ0HGTdz1lsP9wqx8ZY2yEIWGYww19dt6gmTRN6\nvZ6f3qYx1qIL7bQWTAFZAkVBLs8RmIyQLlXTQtoeoegQ2nlCfQlVdFC2i9IL7GpexprLLhdRIIIB\nhiokkAMdYM6Db2XEqYYi1LKNaOnXUh8+jLkcvp5cTFBUdmGCmF50gHZ8PXlQp0cEqoaU7loHQUAY\nhiil+oa01KBKYyo9kpTSAxYX3YeLzaK3dSqVzU22ExcvXrTDFt+PXZVaVzLnPMgFr4Kz8ROzxiBV\nhUpl36ZOzF3os2sv7Fmo1g6s6MbHJf553qLbveB2/z56NvAUxhiKQqNUnTCcpiiKESMaNqDy2evN\nkfYuokwOukDkPao2IzYdItOizllq9lUi5phuXIJ8DptmiAKEXnLlAyAceiq/sRXOaEQGpP7/Zqgy\nUSpsBf45rDVo/OuHjcj/vS1AFIPXlpfeBrBQfz3diTvIG4foNG+jF++hEDFKKcIwXPYcNqQgCHxI\np+n1ziGE2QRyZ/spSKWye0MF1xFofqsMqDSiPJ8dYl6L9Z+bcG3hYdj0hdaNV5SzbI4sm13bcVhQ\nQY1qdd8gxVzChyp/VoZgWme022cxpofW9BP8gXFYiqLAGkWlupeiKNBa9w1Ja43JU0zeRnQvELRO\nEuVzRLKgGlmq5gKxniHkAvXaJYRHuoT12E2J38ih7/3/bSAgiiAMQQSIIoReAmkChXEWIhRIgxUW\nIS1Wag89CxDGU4aCwRtnKWjrPssugbXK4xguD1rv3bT/Wrh02Raw2LiF7p63sLjr7bQqN6IJiKKI\nKIrGGpMQliK/jLXZANWTYp1r1LdMRNPE8Y4Nb/TbZkCDhXvJ14rWYURL8iZrtS9m7d1UgS1JzlEU\nnfHE2DF1mGp1f98LlYYy/P3SMKzbPUeWtSgKjdZmxHi0LigK930Y7sYWGbZzAZucRxRtAptTVSk1\nfZFq7wdUzMuo4iL1uIMKU1dDCQZyataCMH3wEqslaRIhIklYBWljUBIbWAgFiDrkMaKroKcgy0Bq\niAWEAQQKG1oItA/VvCvRGnKD0AqbG0ThaVJFCnkKOnNWobwVSTMwngJMBjZ3RmML98S/xHpvZrR7\nOxNAZ/dddA+8k870XXTCa1BBQBzHxHHsjSigKOaxNiGKQgRiBLBgLWyPfp1rx6YVTrfdgNwYlAVf\nk1kD5Wcs6OCqimE0vSk1fmMSet1z2FUYwsMVfqUqVCr7RzzNSnmLy1kW6XTO9/9fFNobk6YockTn\nEjJvE8uQsPsKTfMqNbFIVS4SZWeoB5dRIkFKEPEgZLIKkAKhhYNaTYQwTj87N4rjp6sc2BVRdGP+\n03dC3nir5G13hSAlBBaKENpAS7swDQWRhIrEVgNEJNzrJC7ukv4CFAabaURmIbWQ9SDtDaSAhXcj\n5N6AANuFJMF2CpI29HqQZyAFBAqUhFCBUsN1F3eLtYaicPYoFbSvfSeXb/onLFQPEUURcRwDHaRM\nCILIeySH6gVqFGQQUqxiPJJqZQ9BuHlt7atgQB5qLFpk2aWhAHsdxjMCCkxtyoiybI40nV12Pksr\n/e4piKLdSFlZ0WiKouiHY3me02q9Qp6n6DzFtmcRJifsXCaa/x5NNU+1qqiJDpX8NM3ovIt2Ym8w\nXgbBShwwgcISAVUQMcKGYBWWEJSLlf7ikZCujfjJvxUQVRUzswG1qZBdO0MoJCQa2y4QnQK0cqs4\nCrCVECoCEVgIrUua/IBpjIDCQqEhLbCZhaRApBkUPg4LLHjDs2gwBqEtJD1YbKMXE9qdHlk2uN9C\n2n6EZ4X7GGH7sgsI6aO/ofxKa2gdfCftW/8pC9E00KMSV4jiiDiOPAChUCrwtabl7IfRBR9Qqeza\nMomsES4c2/gIgiZSBk5KyBQroib2CtSFPF9AipBgg5R3V2DteYFFMZLXlFDzoMZiKfJLhNHuvuEU\nRUGe5/3cpTSgLMsoki69+YvYxVdQrz7BRDHH1FSTqpontGeZMK+g2gVhA+QkEAORMxgrJIjQ/6CK\nkCHWhghqIGOsCEAEWAIQAlEPaF8O+O55w99+S0D9UAXCgOtfI6BQ0HbGQ5aBiKARQBA5AwoEIpI+\nVNNYaRwh2O/ObgSQAZGDTRHKJzqRhsS5ChtpiC0i0g6uKzLoFZAH2LyGtYJqJaAe5yAs1qQUhSXT\nkBWQ5aCNsxPpUy1jPT2ptLIyGjz1VWrPfBVx83to3fGP6GiLNg6trFSs59LRd9kWgyoRu/IeC2c8\ntdq+DbenX3GNr18AcP0UmzjeQ5rOLh+rcSW5rCFPkWWzIMSGWn5LMRJdpL6t2Y4YjtbGjSYxhkJr\ntE4IMgFUyLLMf35GUeTkWU6RZ2QLF8gv/oDs2S+za1Kxo55TCy8Qc4F6e5aoArICqumcCSHYEFAS\noWKEiEG4ijwidMmAUAgityhUjJAhiBARBs771AJalyQiKmjsjWEicgmSkJD7WCiTQAURK4hClxMJ\n6fIoT5RE+XBHWe8B/T0pLIQFeZbw8qWCCQrOtzTXTMDUFIggg7CAUDsjTy026SKsRMgIEcUoU6AC\nDTIj7/TIiy6GAqlcWhbiPIwpbdc/tXb4hPXonS1h9L/5MuHZk6i3/zKdiWv76GalEnlAYGBEfSIr\njhgbyCqV6u4tVzYdMaCimEP2t8btM6JKZR9pen4Zf2wtfUWO2azJsjk/ZnDt9Pfh3iYp6+T5HMYO\nAQJ6kPznRRme5VibodSU8z5Jj3ThPLpzGd2Zo/Ps11CtS+zb22Bq6lUaxXmavbYDvaZA1JxToeIN\nR7lkQKiqj90aIF2Ihghc3kLgvAYheMNBRqBCh6SFChpgpgwiLugEMUzWIFXQ05B5j1ETICJsECBU\n4Nq/jQ/TBBAICIwzGuWfwlFaEM4Dyarg/PmUlpFkheFiIJk6HLiQT+YumigKhNGIWEI1AJWhbA9D\nwee/Lbk0X3D/kRaVyNLJUsd5UxphXS5UgnjaQpKALhywYBgYkcDhIGrhBXp//j9R/fFfoHvNHSzt\nkCqNqETnDIYwdDD1ZiaZr9EDJeR5gbUThGGD9XUTrscLBMTxXrJsliJvOcrGspESq8V3roiWJOd9\ng1N0RaNZCjtLNYE2LYqi66YU+IQ/zwvyIYg5ywqKbBFJG9NtU8x8j+TE/02tEtMIDDvFWWrxi0z2\nNPU61CdA1YHaIEQjEtggQqgYZIgQVWc0QQSiCipy2bUKnKHIyHsilwMJobBSIeIA4tA9JyT7hGLn\nnoTkcgjdyIVXPeXeb6paKty7ekxiXXIhwEpH4iS0fsP2eLPwLgHrELpAoHbAjXslc4nh5glDGgvs\nTomQBkyEyHLophRpApUqaneMyFNsoZBCc8thwde+mVNUDHFDErQKjC7QpusL3AajB0ZSDSGQkBeQ\nZC7c66PjBlQM9WyWzmP/hsrNP0565z9Yds+dESkf4k1Tqexa81CAjSG8BXneISgDTzcoK0OISa94\nsz1G5Pp/pK8VXQGhG/FSThHF6Iw0vUilsndZoXVp3WaYe1YCAFI2yLIFitzlMXmRk+cOMcvSlDxJ\nyHsdigtnUBdOo84cZ2J6mslgDnnpBZoB1JtQ2wnVClQq3uNUgEqAjRWEMYQ1hKphRex07GTovE8Q\nue+VR8xUACrCyhBhJdYIIMCGASKOoBE79CwKIQpQdcENB0I6HYudkYi6hFB6L+XeU7cL9CsFUR1o\nuM8QgYJIOQMPpasF5b7yKrWvhHpgwYTYMOD6/ZbLPU1gLGLat/YnGRgFVUXr1RDTMuy8EcgjRKqg\nSNgznbGrKckqNZJ6RKVaoDopYRqAiUAsYnoFRQFp4dK2SEKlCrFyP8v8U1tn63EMoZ2l99TnkaYg\nuevn+vHJMLk1jncQe0ngtfS6bQwc65LnCy7UH4F8dZc8z4EmSm280HSlfCSKdvmWiFUGc62EzgmF\n1l3viQ4s67AcNpxh9GxQxLQURUynu4AuNEmakyUdsoV5Oi9/DxbOo85/j+k4oBJoZDRHPPcCU9PQ\nuB4qNYhcCQUReSStGmCrMcQNRFx1W6bw+YsMPFAgfYhW8eGaK3A6IEG5cAu/0MPIeZxKCHEAgQ/p\nCrdN72wYXpqx2CxC7PSFTolLLLAksyFpTzF9wEWIyBBiidWSZBYKJI0aiJp2BpNLkouahTnLnkMh\n53+Qc6En2XFTQDOx5LMZNgJRFKB9+B0HTO8LSRZT99k7BPQspJLKtKJZEzz3suXsCcEdBwW37jcQ\n5pw9F/OdVyZ54+4WnQQqoWGqVpBk0MugXnEpIxbSHBJvYNJHbdFO6D37nwgjycLtP4ubJOjg7Fpt\nF0Ew0c9thzl0W+N1NFk6R6E7WOvePxgsbCc+aExBni8gREEYTm8LeuG0DKaRMiDLLjlNbnEl4xn+\npfQq+xeIY9fROs5wSqMp4eYsy9BakySQJIb23AWS+VnaLzyDmTnFhJmjUY2IwzZx8iLTE9A4BPVp\nt6YD4aIu4QuZRApbiaBSR1RjUFUIXMgGoUvwjQQT4lZg7Mlo5e8DkN5oKjFUIlfgLL1JEA7yoqSA\nTgZdy45ayKshFLJKVIkcjFUYn40HJAuCYEIidoT98My0JL0FCZWAF58vuOGwoLHHVzRjQyCg/UqG\neEZTf03I4ddZwp0QYeCaEEwBufLom+ClZ1POvKg5PaPY/4pm976AG6+rMj0ZEExHzFjJDVHAG2/O\n+Kvvaq7ZI5iaEFTzhMsvxPyfz1Q4OJVycLrD3r0FWRtOnA95+6EcqyGzbpOqWzi7AGdbMF1xKVvU\nhOzUI+zYdZC5A3ejVEC1uhuo+ihDjmysW+GFiqJDls15eWTZR/qCURrNwOVp3cWajCCcIAgmt8Eb\nCa+vJb1Sj14XN9BavIiFJQx3LTOcEnLOsqxvOGmakqUpnbnzzL96mrnnv0H+gyfYv2cXVdmiYl9l\nMuwyuQ/qUxDWfdTl17LyG411GD2iugMRVb3HiH0e4wlkVrkajA7AVhw8LeSAWiDc60UcQi1y3iYK\nfJLv8yIi0BLahYOLtYQ4YPeegGBGk6QBUcn4FPhKpWSumxPXYyYbFZdodCzd8wVqd0R1f8z+Toaq\nSWes5b2owv47u8w9u8DOAzX3e4oBWU7kEBXu2NDoHa54dW2gsHlKqjQ6Vw6GtrCvXmHPPsXNtyge\nO1Uw07FM7YHpWPL+ewv+338Rcd2ejNtuTCm6UKQSZSQvXAi5eUfO7CLkuYsY8xwuzMFlXEQrBNSC\nWcQjv0/tp27G1vZgTECWZX0CarmOncaD3VTHa5rOuhGVPuUYbsgLxlDR+qC8RXtBxB5huGNbvFEQ\nNJAyIEkuODFyVmdzDxc/nbEsUhRusrfWA+MZ9jhpmpJ023RmzzL7wrPMPf9NWs89xqHDr2Fyd07N\nfptde53RRJFLS4LQpSuq5gxJxeXFUYig4rbBaNItqKDikngReXqydLB0HoGNwUhEIZxBWV81lYHz\nOjUBkXU1GIXnrsXOxWU5tApIA8fIjCKoBsSTFisz5tuSiczD0UL5PEvRmFAY43lAQY1UF7SDDjv2\n7oRqTPPAHGG9DtQ9Sc1VMGu7JS+LHguzkh21ijegwDNPe277zxWEBTfcZLjhJkHyfYW5LKkdLiA1\nkOUYC1FsaFYFaEE9lkyHnvotQuI9KUf2G76/2OCN+xdJF1Ie/k6Dr59U7FCav33IsKdq6PYs/+VV\nQWws1VAwX1h01Tnj5+Zgd2WW1/7FJ9j1j36PXq/XJwCUXmeYyb0xNk3Pl1+yEVracOauPvzhX/gN\nwWjvuoMDB0Q9a3O07vjfRVuemAkR+H6ZFGOLsd5uqeEMs52zrE2eW4yRzliShDRN6fV6dNuLtF4+\nwaVnH+Glr3+exZNPsLeec+3ujF2V73Pt3jZ79jokKMSFDWEEQdPF29GO4QJojK1MIao7IJ7wZM2K\nC9uUD7+EcuBASTUQkQvhjHDeCIkNQ0QlcI7Kagc11/zfy8gZS0fDnIYsgqDqwzvl6D1WcHFGkquA\n/QdjqDYgrLnXNZpEVUWrZ6nu3OkEUHpuRk91zzTWwJmXetR21AmjuI+6ZonGmIKwIlAXclQkcG1Z\nTs8PW3imgnWZfeGMQ6QCOwcq9EIiRqKN4NWzlkC43xc5HL7BooSlKATzc4LuvOWlWcm1kWJqUnPN\nNT2uPVjwg/mAC5HizbfkLASC4y8rDu40CAQ93yy7tw7PXoD5DJrJIr3Lr9B43T0Ib0DDPUXLNBrW\nRP8qPHvlkhdiGRX+HWUilMU1xo/47v/fN7wp1fOzWypbakRSxlQqB7ySfmcETl9K6NTa9MmaZZim\n9XnclImQNE1Jkx75wlnmnnucV5/8S3R7kT37JpnYNcN02KLR8EajQXUhqIFqQDDhjEbtAFX3u3sB\n5AHYSYRt+N6AMhyTPjD3bADpmQUmcAmTlSAFVgaIyPcIKD9PQxnSuYDzZwMOvL1KqCIXji1qmNfO\nY1UrUI+doRoHScndEZPXdJlvG5ja4YolQ5FDuEMgZnJMT0MkCISiQYHNnMxWI4jIFjTVuovirTG0\nXu2gapbpayaZ7Qnal1Omd4Z99NPlcAEob0wmh0ygqmCv897FSDAFsYAfOWI49bLmlQW47XUQVQLQ\nlqST8VdPGN58WDKfK/7kW01+8R2KnZOXeWvcZcddOTccTIknLQtnQvadU/yd9xZkieW5Z+BvvueA\nxQMTzoCCCM799X9mx+1fQdz23pFWiDIfWo8XKooOaXIZbZIrdgLYMgeyy4bwrQQvCz9nJyUIJgmC\niS2dICaEolLZQ5bNkuftZV7HyTmNAgRZ5sK1NE0o8nmwdYr5c/Re/Q6vfPvrtM6/yjUHJmhOzDId\nvUg9djUHUbicO2hCOA1q0n0Nm+5JRTjUa1FBGoFtgKw7KDhSrrovJEhJ0hVceElwYKckmHTAQGk4\njlEZuMp/gSt2aOHylUqA2BWTfl9i2gJiS3EmQ+gAVa/DdAzVpgcTYveewhlJY7pgbi5FJwGqhK0c\nSQahqkztyMjaGZXJBmpyisvtFpdPF9xweII9NzTIM+HdaoEQMLl/CpQrwEzeMAnWM67xEldSeIi7\n8NJBnjYQWoKmT5Uy018+O3db6g2BLQKqymIzCVZQrcPdd2p2VAVva2pu2m+QoYReE20h0IaFS5I9\noWFfrUCIgAuJ4MB1ljv3walCokLD2e8LmoF1m+AkXH7yz6m99h0kSbKsMa9sG7+y15knzxacwEgf\nwVt9QkkwvidHrMJXk76INIsxXZ8bVbY0nIuiPVgr3YQzO9ADKBkDha/d5Hnez3WSXg+9cI5s5ntc\n+u63mDt3jl17dnFg/yWmojNUfJ6d5+7ca3WIpiHYCbLpvI+quUiMXGDbEtGLsHkMso4IfT3GBmAU\nwrh+mvkLIX/8RUgWLP/sHymCHcLXVyzahohcIQX84PmcuXOGN9wWIqZCaFTRYUw3DeiiOfblFKYM\nE3nAHW+uUd3XHHizvscbaGfvmoo5nSYstlOmq9GSxhxFbd8ktt2BJIfKBJPXVmnkEhkFvl4iBt5F\nWIJa0xtMRqACz6PxTTylcRoPlYvQIQXSuJBTu4qnlaHj1wkLRUQlcO9vc4Gwheu5Uoa9O0NINJPV\nnMlrUseisAIlYq7Zm7jTzKDRtFyz2/CVx0Punss4fCNMThp2HxQceFUiLmt0Dpc7wHe+zfTrvwh3\n/FS/pygIghEvtFIYl+dt0nTOS06LIeNZzZl48cV16ouOWJ/WPYw5RxBMEoZTW4LUlScahjuwVtLt\nXvQ5zwCOTlNH7EzTzCFr7TmKV4+zeOKbzJ69THNqkhv2LTAVvkoUuDphljvHUKt7hG3KhW2y7tHn\nwG3AMnPsfNFzzAARhdho6EKaAIrAEdtsTF0p9lcsRilEy7cASIUtFM89ZTjzXI87DgnaLUFYC2Ay\nhIk6RTfkO9+2nD5bEIaSOFTceVeTiekKlb5BlF5l6TYmUFMhKIVI7FAnW9lKqpBBBSYqjlhKjpIV\nVDzcedcn0zDaWlo+9dC9LttTS/q0cnC88hQgo32eh6MJ+QkSWAfJiSBwncHWIIx2by+FK8gaX8PS\n7tirkXHhgXEds+85mvIXT4S8cEFx+DrNoSnozMHtN1mkgqkWVH4Af/I4qC8/yBtufSdZFveNaDUv\n5PrFZimKNsYUK0RTqyuYBitHd2JNhmStR+qKDlG8c1MshuFcxxXCGgRBQa93gTzPyHNNljmjSdOc\npNuiOP886QuPM/v8SaLJneyZmGdK/IA4dOsgT51XqVahNum8jqoNqGYy8Euu642nB0JLBydXnSqN\nsAJrBCIL3I0WvrmlKghrLoGOrCCqKRcWWQmFZecUfLdr+PKTkp//uxHqhtiBC1WBlIYdRxQ//qMx\nu7Sk87KgudfnTctunhkyDhcFBHHMtTtiHEAkh4KJsgdbukVeqTB+1pMZ+r8e9BI4N+Of2v8sc0TV\nYqiRh9KQfKFWSYS1WKM99075Wpc3ssC3p1rtEEcrHVWJ0P0ssCUHCkzPnXriIub3v9nrqGvodmF6\nwnLDLssfHBP8vR+zvOMOeEVD5wcv0v7eI9R+5G/32fNBEPSLqsNeqCi6JMklJ9GMWCUVWd0WAoYi\nNofGDVEj+rzW1fWNsRZjM9L0HEEw5ccwyg0bzwCiLhyzWEyT9F4lzXrkeU7S69F79RT5979O+srf\nkKsdTE4V1LKniPzGWPQcIhw3IJ5yX5UnAeALolKCzEG0wXZceB9IoKLpphZtIppTEnSIMJHLe6TF\nBhahLFlLM3vGcuaspBJbRNMTMlOD0IJ9Nynu1iGPfE2wmIZMV3xPjwC5Q3LDHle30fOK2QWNXCio\n7wiHFq9cYkRF31hCBfUpSdI1S/qt5NBz2BCHPc24x7DHsUM/04P3Ff5zxND3/YHHjgokhMRKiZCe\nn2ctKO1aj1BYoRAycOGe8SFgULgWVoEzOhP68NF//II/nRhqyqFwWQjX7oGvPy245X2WN7wBLu6C\n5MRfULnt3SO1wLId361hTZLMk+eLXhxGruoqRuW0xdCXMTmQHQsnrF0D2wltXEbrLlG0c006W8sR\ntoHAhmshKEhTg7F1er1FurNnSb7/BNnpv6JSCYknJwjmn6UmjKs/CudVohpEDUdLCyIf4Bi3fmXg\nmRcdMF3XcKmEK8sQOuZ03gv5mxciDAFvuCmgMel3X49UL1yE587A7p2SyZpkqirJL2aEoXHoGQoK\nwe6m4sCU4OTzhjdcbwmVgZ3GQcEYUBrZgB23CcKa77PpexvNQBpHDn0NEVISNy3FZe0SflHmP8WQ\nEYgluZEc+n6coRhG5HYIBscRaLfrFL5HuxRmKHWmbZ/OMhgsbI0L77TBFqbfv4cxCOtCXXIXCrv+\nBf/Zoga0HeI3zDdO4eZ97s9qMfy377G8cME1zZ56CeIq7LFPk559jvDQjxDH8YhkmCt3zPnBAHJs\nXWfpD0Z+N8YZydXjvbVNdrLLkLoeSTJDll1edczhSsbj8pyUNE3pdDquntNJaJ95gfnH/5Ti+a9Q\n21klzU4h2t+jVjWoBogmqJ0Q7nZwtAhcdCAzl/8LH8rLDMxlSM5Bd9axXVzhVLhai1FMVhW3HTCc\neCXk//prQb5oEYWEQmBzwXdPCNqp4NARQb1q2BFqQm2gZ7C5wUpN2rWEHcNb7oBT53P+88Mp5N5w\nMl94TN1imthniSIfQ9rEPRl+ZkO5iUvua7Eh6+XorIvTpWoPfW0DPf93mf+bce+ZDtgG5P5nwwal\nB3Ugo93TakaUQ4Rv1BPDK8p6xK5wXXRlGKzVoB0V48K5klpS1pdy6Z7FkkjTgCwPM3XEiNdeA40G\nvPUmqOXQ2An62T/wQFPuPVFGt3uRdnuGokjG1xmH1/ESnzHScmOXhXC2rwu8/E2v3G4wriGvZMKW\nA16jaHqZWOLSfMcY0z/h0oCSJCFJErpzl7jw1MPMPvF59lyzG6YWSTtniDz9rOxBk57+LrM+aQAR\nuXtx5pLk2l2GaQ29eVfGSArnoaY9QdR5+Ig8j8mLClM1eNMNmj98Mua2l+DOIy72W2xJvvOi4e43\n5kitmV8IyEOLsQLbMagJQeus4LHjOXfcHLL/TsFblSQMBDQMdAqHYikx6GWWajQK6y9Iz1IQeogZ\n4DyDUQW91GDy3AMES3KgvncRSzyLHOQxrvoxBCIM50P5gGdXFIOmHV2Azl1R1RgvtePRN+xQ5Clc\nbQgQtmS3CN+7E/jOOTno9bb498PlUKYY8m5LUje83WsXUbzmBjjkBqkTn/0rZnvz5HGFJFkkz3OC\nwBBFMdZK1/q0pphtfCbk9Ek8CheGO4Ee1qZjfNeVPdCArbDED3nGpdZd0jT3U8im+8blULyBoGAJ\nSed5PsIkWHj5e1x66i859+QXOXjL9STZU0SRQ9CEHqwV4TfZ/s88AhxW4eV5wZeeUPzDuwwt4TZ/\noeDFVsidUwWBcjep1ZU8OxNz/JUq104p7rvNcvOOnEas+JuXJXfeaiE0tOYt7W7AdENhWpbLLcuC\nEDz+hOVH32q9qoHmpusFU9dYbKK58bBwMWQv9yBE2R1qB4m5Ko3Fb7VlohZ41EtI32ynQQRUAsuO\nwNFnBrdXDxmGXBLCjfuZHELePGzdNxLtO131wIByH4fp1L2uP8/FuFAtc3/j7ofFFtZ53cI6dR/t\ni5pWYa1AWOmdkTckG7t8yNZd8da0Rnd+y6gWXc3zEwWoCefAD98IaedJ5sM3obWgXouRsuo1AuUV\nOZZCjDckOxz8GmcfgevUrCJE4Wf/ZH6nWBsO19cxRizXibYDhneWzQ9x6ioj8lClvkCWZX3j6Swu\ncOnE13nxr/5PlBDsf02dXvdpKk23jnTer/u5ml6ZgwaeIOBbqrFAx5J1LC+fkxzea6jW4AezAedb\nEc04J8vhYivkmy/V2FkreOplSUVZhE2pNwJu3hnywoKkV+RUlcIEiksJvPyqQXYEU7GhXQjCHYaw\nqqEL8YTk8G7fYtmx0DOefW37Omx9dqrwoUxRohthP58oEa5+56oy7sRDCLVkwhpEUnj0asgohkGf\ncoX1d7alT+1csi58oVcPWsSLIQMyvhZkXShnbeF1FfyKKgpE5t8j09g8R+TufW2RQ547GNs6gxXW\neGPJ3Gfb/socCh+jgRLQUhwkcXuRjcD6znjrI4kdnb/gYu0WNwTAREPglO23fq8pN1km+e7ONwgb\nRNFkicJJpKz4pD/FmEWE0Gx6si2DOTmOJtGjKM6iVBOlJjHG9guhwxy29uIcM9/6Aqe/8gfsuPYA\nsX2ePOsRNr2XT0H4DVB6JLXkVYgYbNVdVJlDMu94kEGgONOCO25wYMNL84peLtDG1RoffrbGVFXz\nhmt6fPVUk13NAtlsQVDjNXsqvDAfsdCGasOwZ1pzcIflC0/AP7jb8oG/Zcgt7JguiZ9+p+v6+KJs\nn5YOyRAydItDaawqfB9QmX0HzlMhfSjnk22pXX5GAbkALen1BDOLcLCwrq278NtzaXxllCaXGJAQ\no8G+Mc5Icu0Wf2EGelNOMdKrgfhwU3vEDTFQSvTvYfPceaC0QOQFpM44RGmM1mBNmZNphHUiJs6r\nSp9jAXTdTRZyELZJRr+XQ1FX4FutcF5onzrOjFokMTFFYQgC17ovpR3Z+NdQ7hwRkAyCKnG8oz/F\nPFgajklZIwwbWNvDmBZGZ15TTawcwvUnd6+ILPQHErtwbRZrWwgxMUIA7fV6LF6aYebbX+X5r/wB\nBw7twXafdry0ykDbTyUuwinXpvB6z8RuJwoD95qZS4K5jmBX07B/ytBOJYEEYwUvzkbsqGuyDF6d\nl7w0J/nxm9sEAVhtUCrDCo2goFLNaYQx0kc4lcDwT348p4tgx3SOCvwC7Sksxvf7KM8VkghZOKMo\n60fCLxIRIgJfoJS2j6tbESCUJ6UqXwEOFIvnJQuzgmuvV4hJQedlizYgyRzUa8wSA5GDMFzYQRG0\nfI0t8w7vZbR2xmOs/1p49Mz/TpdeyLrvMd64cqwxCG2c0Rjr2AVZDlmB1Zo8014ov0AXmZveR0Fg\nC5RwG1wQCIRKvRqj5xiWDIhhFVQ5pDlR8WIt3ltI5aITWRjq9lVa+Q4/qcP6sTBXNp7RbMQghUKq\nmDieJghqI38brNZmIESTomhRFC2McUNqBWIkPFhN1ccuec1AsROKou2pOjWKQtHrpczPnOHZL/4+\nl049xf5DDaR+lsoeZxzGushF9NwiVt5ojKeblTmPNHDpvODpFwXPnpfccZ3lxj0wVdF893zESwuS\nayctuRa0eoJmBeYSSZZn3DCtudALuNQRnF+ImZ3N2bXXrS8lLLWqcYiE0dRrOXVhIHF31ElQhQgp\nsGVYJgIPV3tPROHzGA9NS+t3ghLFkq4gKQOsclA1UrnqvlG89D3Dn39T8/bbFLccDpg7Z7n2Jokq\neo4BUYZkYtjbeDjZTb9y1X9KpoBvqDM+v9EuV7G5L4Yaj6CVYZz24iRaO/lR7RG5IkMUPlwtCmxR\noIuCQhdordDakBc52hjyQmNMTqFdCK9sSmAzAhUSR4K40iMKc5Twa60kO5sh9maIa1utDlhOfXCy\nlD7uwMTCE5xt3tIXuhwI/q8lOTFIqZCyThSVeiErFFJX79dpEgRNimIRrTtoL8jR70VfIfcZj7ZZ\n37OTk2WOktPrzZNllu7leZ77yh9z6QfPs3tvD+xFgimfEntwwJaIrGfSGNdZjHL0NGQB52YFf/U9\nicVy72HNzXstUsLeJvxYraCuDNrAdLXgfEsSKTcrZ7YjOb+geGVRUpiCM5cVCu2Inzm8/toeVdmF\nrkeIyoKiDLEidGtWuuRfCOsKhkaDcMVDh3CU7dve4KQnnKJcCKeUFxkpcyQ1BCtaXnvQEih4eQ56\nC5IbbxSEoYVF64q8S4N2n+1a6wZbubqM39G1NxyjnXCi9vUaoxHah2lFgShy9/vCexZtfL6isdpg\nTY7ROaYQGK3IjG+dt4a8kORaoE2KtplDKbVBW4PVvmPUpkhrECiUNEShoVKBalwQR5aw3CR9u1TZ\nr0js8AakB47KLuYyGskgnD2LmmCkFlTKma2867uZtkHYIAwbV5xWt2bNnyCYQKkGWnUpijZat72I\nnRxrRHaE6TpqPCWfzSFtGe2LL/HMFz9HZ3aBieZZZKVNWHV5rSjrjSWqiotCtHXaGPOpE5qZtNBL\nodOx3LbPcN20ZaLqXqMsvHaXoVYxWNfVzC17U545W+HsLFw34UrIH/5Cg394V87/8+0L1OowXc+Y\nvRDS7Xb50UMdVJL7loWKo+TIyDM3fFgk6UPBQgQ+Xrfek4gBBC2VC+sC3w4hLDZXCCWwSntD1N7Q\nLMJvv4EUvPag5LXXea9SGOyC9Uwfj26WMJLPUdwGVkp+miFvUwwhbVkfKBDaGZQ1BSYr0HlKkRfY\nQlOYAl24HixtIC8suYHUWLJCoq1CW+s09qzAGIU2BiNyLyXmQkbflYHE9plLQkiUMCgBcQT1qtdH\nqLh9JPKNun3Wkhpavdlgxpv1YKWQsHP+e4TkGBO7fcMbkVLLwzhXyhGE3tuEYX1NMNq6RLOEkARB\nA6VqaN1wXqno+rH3473PaA+P9swCZzzdbkLn4lme/8s/JW23qckTVJoFQei8jRUDyNL6TVDFbn2F\nCl6dgy8+K3nXLZaduy3tDlSk40pFgaPlxMrrqIce5PLvd2TasLNa8NdnFPfdpvkXb2uzmEiOHtRM\nNvxJ9KCa59y2e54qxnkfGXr4WfswzdP8hWcAWM8VsulA4KxU4aHwaJpX5JGFVyfRCOlaJPo6bVL1\njccOY6uWAZJl7WBMjvWUK+wg7NGFY0GbFPIeFAloi80LTG4pcicUmeWaIjfkWeGkvnJNWhiKHHIz\nUMcxZf3Xpze5dp3maQG5cTFUWQ/Vw8m+z00C6QxGDlGpRClPJ43T0PYyc40eNGNoNqBec02OVAY1\nvz47yb+/8CSOUmTV4RtdItOlq6v9EM6YpWmHu15uYviEn1S4dlL0hlTnhg3JhAlZdtmLLQxB9UO9\nPIM2BGc8SZLQ7SYsnn+Fl//LQyzOzhMV36G+0/egeeUkz3Rx4bYviwRefcko16QZSJhdgG+2BS9d\ngh+7wVKrOImCwIu1G+FuqvB1wUxCI7a86fqCb74ccGSv4fUHXGXcaMjaDi2WOKk3lMGm5c3KHAvE\nhP7OJc6QrN8abTp0B8VAsFAWQ3WcwhuVb1CTmfdKJYO5vLdOKMRNZPDJu8FX+J0BizKPwSJM5g1L\nYwuNzlJMUZDlBUWuyfKMXmpJcuillm4POokrTWUZpOkAiEvK+qkv45QSvAUBWii0lRgVkA9AOfop\niwDjicZFnpMmmStzCXe/qhWIY4EUllA5owmkb5GSUI2gFkI9hGYH9pQMk/oA0QePbg8TrHN/C8pw\nvzDExWXaaro//rL0NiWkFwZ1onhqzcPVtsSAhg1JqRqVSgWte45nZLI+jDEcumk9aD9I05SF86/w\n8uNf5OLMWar6u9R3ulpaUXjE11+Ewq+JoGQKGE/yDeH6aTgwDU/8QBIKw+lZyY17NAf3eYBBesPx\nUrLa3+SSYfb2w5pqDE+9Kgml5tqGL8mUoNWgvcbnOGCldTYhMw+1+m3WeoMyws8wjTBGYKxBYN0I\nQRm5XVcZH6b5XnvpjaysgfQTZyc5jLW+n8aHQibDGNcVqo1L6q11ox7TQtPLXTjb6zkhn8WeGw3U\nS6HVcwbTTb2Hj0O0it2M1F0HiWo1wuYOJib3ENQaBJUGQilUWCGsTRLGDVBuNmy3M0uvM481hqjS\nJIir6CIlS3q05y8gZYAKYnqLs6TdRWyRo3WB6nV4+utfodDaSUpId38jH15XA7c51gKYTlyUKWJo\nVZzaVyOAWA8iYOnBROkDAVH4iQ85yKyHjfxcWuuvJwqlqlSrO5ahalfVgEY9Up0gqHt0bY6iSLBW\no7Vrvc6yEjhIaS/M88Ijf8biubME6Q/4/rylmgtu2udgWeu9TuFj2zgayElZPzeqq0GmUI8NSSb5\nqTssDz9neKUtEJF1+XI2xACxA/DLdxsQCHjrIU2764wmT3wJxn9OwVDtUpU6zsKT6ZwemkUirPJj\nHSW5gUJLCu0n1VmNFYpQCZSySJk7JV/pK/pGYsVA2FD4rdwaJ2esPVxsrcHYglwXZIUlzayreZae\nQkMnhW4PFtowu+iFfAKXthnRoLrvCFOvv4U9e64lmphEVZvIqI5QEiElhdGEYZ1abeeyadxlyUII\ngTWabm+WRmUHjZ27loyBqRDUGoTNKYpCY22Mal5H0OtirCtZqOf+EjKDUdDquOusvPEEofNIldAJ\nrWoJsge9BcfErhfQ6Dp1nnrsDCoqSe4enSX35S1AmNRPEHQhrlQR9fo+KpWJEfWeH6oBLYW/laqT\npnMkyQLGtCmKzBtPRq+bMPvCCS6/+H2iYA5DwsVE8Jpp64rSPTe/qewcjn3KUfjSQBzC2Xn4/NOK\n1+03vGa3pVGx7NwB1++DCy1BnlnXcuJLIKYkksp+Xu9oWKlbt00fOeU99/+0BMR8MhoypAlnLbI/\nnkNgrKQoDHlRuPBHW/Lcok0Xi8Ra6eHQwhmO15+2aEdjwWk5Y1wtzehyajduPqrvAs8LJzTYKyBJ\n3ffdnvta8lITDbK5h/p1R5i4/g6u338T1em9BNUJRBAjpXIpZdEhSeZQKuyLbggBSgXU63tQKhor\nxFFqrfV6l6hVFZZGP68YkRTLc5RyUJnWiiRJMFYQk3Pqq5/l1HeeRFY9z7RkMfnkPzNwqS0ojGWq\nDgsa5gQ0JUzkMNWBiRo0I2hWoFmFWgWqsVdKTiHKPPik8EVbgZQVKpXd1Os7CYKt66DecgMqdyIp\nG0RRhTwPMeYyWdYh6fVoX77Iy098nSgusN0FFgW86bAlFi73EL53C+uaqQrPWwy9XsdfnYJLPTiy\n1/DyZcnr92ky63Q4Du6Av3lJMDML1zUHuZIeHp1hXfuJHGKLFLafbjij8+WX0MsblOFfUDZkethU\nG0tWFG4BZ9ol23qAFAscNOTe0/Y15dwsK4EVRX+nLGuVeVmbtC5Rb6dOsbObuDCsa9z/USETB49Q\n23MzE/sOUt93kHByD1Y4UmutNkWlMrls5hNYer2ESmWiL41cepZ6fRdR1BjxOsPqntZa0vSyK/+E\nNW/oJYu+8B7H0W+iuEaeg9YJUgoqs6f56wf/v8zOt1BVZ+yJp1+VSq9SOECim1l6OSymcGER9rVh\nYsoBCjtqMFVzhtOMYUcDphuuYbJed1IWJnUbno0c0hfHO6jV9qxrCvsPzYCGjUhrjRAVhJgECtJk\ngXPPPgm6h+28Qk8JRGEJc2ckNnc7rbXOYJKiXKhwoSPY2bBc7AhyC3ccsMzMGXIB0xOCF87BgYZl\noQenZgQ3NC25H+cprAfJKBNc9zNjBgx947su+qpUPrVR2su8+eMoScaFH8OT5a7onucu2dZmkGs5\nHGAU4C8HTGGcd9Ha/V2JbvUS6PRcONbzxqMDQXXvQSauv5nrbj7K9PW3UpnYhQyrICx5toDWKSoI\nHPc0iGk09hEE4bKR8UXRwVo3Bb00DikhihrU63uXhWvDj15vDkipVCpDsmKFR80dvKlUSBg2vMxY\nQlXknHn43/LcXz+KiRwQkOSe/2pd3qPKGi/ufK0P6YQAUwjStqWrIUkE8xWYjC07Gi7E6/bc30xM\nQiJhSjuwsRK6jhCZO/rNdmhkb7kBjRuL6NoTCnQhWXjlVWZPfY/u5b8hjmBh3rKj6nYMUy5C3xW6\nkEI7c239L807adddXcGtuy3PzgiM11GeS6EeW554Ad53i+BfvMWwfwK6uW/bN6MMF1M2TxZDRXgz\ngENLpE964y2BMu0J0WU+leb+eHO38HPjK0C+UF+2vJR9ZsYOxnnkvqhfWLeY2j2X6Le7zmhkNWDi\n+tuYPniYm29+A5Wp3USNaeLqTsIw7nsT51E0SZIAoddDE4RhlWZz1PuUm0e7PUe9XnXytH0NwIBm\n8xqkDMYaDkCSzGNthzAIMdYihHZsaiH8VPIcIUKiqE6WaXSRUJw5zqP/4RN0kpyg6RZ6mg007eMy\nTPbhWzdz11WbQVlN+ZlhNQtCWzIDF7vOM7fr7j53gV2h680zCUwWvsi6CLmaXBaG/lfvgYZHIfaJ\not0OJ//Lw+S9F4lFwXwXvn9esPM6i9EOQsWzWXILpy/D6Ytw8y7BfAq37LY8dwkqO6CdWopYUKtZ\nnnxB8IbrLDfWJYcnDXHome6eT1nG2CXLxfohbNrXMawv6okhMEx7TqO2HmWWg24CYwfeJ/HeJ/Nj\nSI0ZGI0dKDw54zLeU3nyai91yX6r5+7C5PW3cO1b7uLa2+6msfsaZBTR680hpEApQRTVaDQmCcNo\nZASntRlSxiOqnPX6bqrVxognkVKSZYtEkfKjYcpCoqVe30sc11fs9UqSRbJ03oEcUmCL4SHKOUWR\no3WAUg3SNMfOn+HFL36GU48/ivaMgV7mIgqtB9xaMSBikPlrUphBmOvuiQt9tR7049rQcWdnuq5l\nMHXNv5hkABLpEMIU0uqekWswrhXnvzoPVHqfvuxUmjL78ilIL5MsnKXZcAhapt1FDRxkT6h8gV3D\nxQ5kRrBvwrLPwnwPilwgK5bJKcH3zlt21wVVAT+yFxrSkOQuhg6U06gQ/mbpobb/4V6w0q6UL7Aa\nMVrTENYRn8VQGaYonPH0vOfJSmaMHZAQjfFyHJ7gnPhiYy9xAEC3gGhqJ9e97R0cue4mdh96HY0d\nB/vKmk7TTKKC3HsQiKIa9Xp9xICklOR5G4iQcgAINJs7kDIYQZmEgCTpEYZh3/O4WTqT1GqjGhbl\nfRRCkGVdet2LaF2g+7rjpVh/QZ5naB0gZR3TXeDcV36Xk3/1JZI8RzbcufdK5Srj6sl9oriPCvxY\nVnJ/7eXQfYkCB1fboU4MIQXCgEksc6knc3fBeDKx9IrLImyQVw4QbAHatqIBad1GiJqbYbOJ4VrD\ng3qX9vmkSZeX/+YxOrOnXKXYlzn2Na3ruPehUlHAbMfVAfbX3YXdW4PFxHUJXDNtOTEvUAouLwp+\n7AZLQznUbhGH5AQ+UddDBHLhjce3sTjWPwPPMzw5uigno5Xj2IVHBX3fWlIMPElhh2qbZUeycYaV\nFs6rdjxiplHse+1dHLztx9h1+HaCRg2DJQiUM45Goy8IWC58IapIqRDCUqlM0Gg0PaJXStYKoIu1\nFYRQCAFhWCOOq8tQtCSZQ0rr0TF3v5RU1Go7UCroC28Mb4JFkbCwcJY8T72QpemXI5xKUoG1EZEM\nWfzuwzz3Z/+W7sICODlwOpm7FgYfTqtRQS3BoHCr+2Uwr7WGL7L6dhU7VKQtB4NJATpxdK4gh3DC\nUX4qqatvM1nFBLURid+l0PzmHIYmyPMFjGmhVIUwrBMEfn4nG5vuNbj4fjBvnrM4e5504SxJa4H6\npNvZL7Whlwknvuenky324IVZwY3Tlj11eGnB7V4vzrnCvwrgzAV4961waJdFFi40kL6SXcZMeomU\nWjlbxuIZDnbAwhnWpBEjd3YwtLq8wakP1zxp2c2oMgPB0V4O7aHKPkqx/5ajvP5N72XfzXcRNaaR\nSiGEJsvmXY1JScIwplaLiaLqyHQBa6veMxhq1QqVSqU/dc0ZiCHPIQi8V8FSq00ThuEyXrzWXRcu\n+bDNWqhUdyBEOEK0HEQPKYuLM6Rpm6IYmtxXuHJEluUEqop89bt87//6V8ydn3M1p4rLZXpeShvP\nYbN2tCXa+FwwK5wXz3yxWw71AJZAgpKD9qSoDI/toG+wKGCu44qvSnqt/grUpUIGwYjxrFcne/n6\nLrC28L1tHQLh/aK1KVmWUBSKMKxhbRWlKki5NorD0vCtT93JUubPv0zr4ov9Xb0kFJ5rCfJ9lhhH\nKXl6Bq5p2v4cmFDAuS4UgeA75+Hth+H+w5aJiiuySl/gRAxynqI0GDEIqYQP40rZgbJ3awjd7rfo\nlNTLfm9Z2Zxph/KY8uZrV39Z6LiCoJYQ1ifZd9udHLzzrey4/ibC5k4ajT19kb/ya5pajMmdAQUh\ncayoVmsjAoBFHvXpF2FYIYriEZTM2hwhNEFZsALieHllPU1baJ33uymN0YShq9cNM5UHxpPRas3Q\n7S54rzNsOCnCSioLM5z/2u9x6bnvkgdgKj7P8d5ZCN+XZQfqV2aIDF5y7EoqkNb0RdSkGHis0ogy\nDWkbJn2bvi08Q0pCIQVJbrncdqjepGfqFwd+FIHse/WlRrQeo9E6ReuUouhiTNrXEQmWMgocCNAF\n26OQgR/OG6JU1XesijUZUX/ESJqSzJ9n9uwLTNQH+cFkCGlhaSWe1Ow9Ryd16IwEdtbg0VcF977W\n8oF9Tg8sFg7mDTwbV5Rwpw+cjafi9OXKys6DAbXMFTSHpkQPMWcGO6M3nDLPyb2uRmpcGNdNYbEL\n7Q409u/l9nf9FDccvZeg0aAwPQ8hK8JAUq/HRFFtRK85DDV5vuhvrCCOFXEcj+QtcVxHmxQQRHHc\nBw4GYI1wiprSxcVh1Bgz9tKQpoue0UC/FSWKJvscxfJ+OWGXjHb7Aq3WrMt1spw8dzSsWOTEr3yH\n1rf/klef/xs3zSR2CX2Se0EtOTRHyZcRyutq8ZC9Jwanvs3IDmmQKDEwvtAbUDmNMtVgLgt273Fx\nsxN8EgTCOl17j25qfFPd/rsQUvXzyvUYj7WGouhSFAlaJ2idulYPIRBSOQb+OBBBDDI13OzUTr8B\nzo0hiVGqPqL5tjT/KYXfjTEknRYzz32TIjFuyrRfmM0KTFahlThPI4EDdbjQdqHcRANuPmipTQuu\nb8B06Hasns+XjG+2XJrDyJLHKUvumg8NSgq9z2v6f2YGzIQSWs79Dct8db/Me3oZtLrOgEU15uBb\n3sXNd/8U09feiAwr3rtAns9hrXb/l4owzGk0GiMFzUolpNvN+sm8y1/Ckbk2YRi6BrUyZ1ty87X2\nVApcJ2xZBB2+J2m6SJZ1XIjm2Q1xPOUlDtIRKbGiKGi3L9FuX3R5TlaQ5TlVcqLTf0X7yYfpXrhI\nTzvIOLduUWsGk7cphXZKKW1/LXPjpRKKfuuRQ9xKVSw16EYP5MB4rO23JmGta1cJ510B1RWtHW3L\nljmsdlB5EYDceQTlN61h5HLl8M2S512KoovWietz8uN2SsNZJwrnP8xarC1cS65JnDGhkKpKGDYR\nIhrxPn0PlGXkvTYXX37O9fCYQUIYSLcgzy8KpgKLso6ecaonOJdYJvfChIIfiSw6gbnEUdojNcpv\nG467jAcRGKK0Gw8WGAaTSgSDRs3ywpe1G2vceMEEx0ju5E5OttMBE1fZe8ebueOOu9lz0xuI67uJ\nopggCAjDkDB0hUtjKuT5nL9hkiAQKKWJ4+GEtoLWtT6LvezgHpks7dEyt3Etz2uMp6k4SNoVR8tc\nxhlYQa+3QJ5nWCPQRqOk64NOkmTEcPI8p9udZ3HRySjrvKCRXkJ972G6z32DdKHtDCZwVKfMs7SF\nLzobMTCaYkgJK9NDA4PNIIwr/P0RPkIIPMtJeeBAlSCBN4qSDa6BuQUXpcTSGYsbhCHIretPSnoQ\nvu4t6Ma1xENefxSVHBiRGxrcoSh6PscxlDNLSk+zCowtlrypGBm0NdArHUCf1hosGlPkFEULkAhR\nxZhwaJKCi6UXZr7PpYsXmag67yO8elG5o3Qzl9BmXh55V8PJtkoBRcflOrke9I+YYAAElOBASTKV\nwtdwGArNRH/Su4OazaiyS4miac8ELwoPvRbQWXTepnHNazh89xu59kffiaw3USpABYJKRVOvNwiC\nsG9EzmgmyLKQPG/1QzQhUqJo50hCW6lMkKZzQ5mX9jWa4YYv4UVf1JIGMIv2us7GGILA5arDYECS\nLNLtLgzlN5ZarU6SJOR5PqL+miQtLl8+i8RS7c2Qf/MPaX//2+7eCMj89Oy0VI7znRol+lgCAnmZ\nJ3qjKfVJdOHLCXYg1dDXSRUDuQglfIuUGEjSOeBGYLyqnNZwYRZ2Tnol5cIRdSPlPic1MPGGD6CC\ngCiKiKJoyAu5+6F1Qp63KfKuMxrsQGGqL2s9otE27Fb6u/i660Cin5yLoZ0wR+vE1wUMaUp/DMmr\nJ79NlrkpCOWwr9xrBDYDf9Fzh1yd78KPHLJMNRwvzvhuYoOnvCsPQ7uGTac5IYYgaTuoYosh2ows\nazRDhuN70Rw4UAwYBUkCbT+fc/eRu3j923+aHTe/gVz3EALiOPICGAqlNEplNBpTvrVjsNNVKnvp\n9YQPs9yUP2OSkTCrWp0gyxZ827UT3Ri+zlIGq5QLNHmeeP6ZIQxj8lwPhdE57dYsSa+HsYKiyAnD\nJr1e1vc4gzpdB909R+MHx+g+9RCt2QuuCTF2IWyW++mNPofpF4bLp994CgPtfMDrK1niSTHIa4cl\n3oQYdI/2dSR90boEcNJBt3kf9VG+XrfQEUzXLYFHFQVumMDULbdTuf6ukTEnSgmMyUiSlp8qko+I\n4pQTGgdQhlhdfNEOPOdyUbkNwXvWJ14pvV6HbrdLr9Nhfva8Y8kKd1GER2CUgaqynFt0tIw4gP27\nHbPWJgOemdEDBkHq+9FC31pgGOrTMYNwrQwr+gqUQ2FeWSjtMwoK5+WSFNrzIMKII++8n4Nv+kkq\nOw4QBKHPTTRaO7kv52nKek0K9KhUdozUaNxzJ93uBa+dZsjzFnHcHPL4EYGKKHyC6jzK4C5JqbyQ\ni+orGpUGVBQJSdL1CKoDFNI07XubJGmzsDjrBTUKrA2wVnmRGFefQ2dUFp5BnvhzOs89ztzllKgK\ndU/E7XnDSa3PBz3VKtEDCD8tBp7n5UWX0E/EHokDZnvu0te9znypn1iOTJVygNL1NRP9RpiZgSGV\n3kf6cE0IS6wsUSzodSzCy+zpHrz2Pb/gowKFEIYsW/CKPLn3QApZwrCU9YvlExr7Px0nkrjUAwmx\ngvHYlQ1wuTLP8CQ5Q7d1mSRJHdOgGOwcWe74ZhXl2ccWpqagUnWFsU7mdznPbGZYmNaHdypyN0LL\nQeu3tB488L0/ZUd1Hzr3O6f2OU+WQ9KBtAvVqV3c9d/8Intf+yaC+s7+7lW6f2dE07i6WY9AhajA\nTalzqkUVomh6pM6g1ATGpM7LCIEuEvK8QxQNFF6iqEneTTyCmHsCbqmj5xe/VBS59nmoM5A07Xmw\npkDJGnlusDbp/6zVukC320ZrS1FoomiaNF0AnRN2z1L5wdcIzn4DOX+ahTnn7XftdL01qfb3oNQq\nLb1MPqjZZMUAHBAWLnXhxKzllh2un8caeP6yC8tunHAL39qBnlufPqUGEHdu3GfkJYPDt5QjBuCQ\nG/rnWsOrFYGxlk4CjQgWL8KRe3+MxrWHgdSL17i5vlJGLvT2fL816fluC5XHrqylNYzEWWMweUHW\nnnN9HoVjyObaabsl2gu+CydPFEVuIWephzbtQG98OOQSyWDDCBnAz1J6OeVyRxsCBfDvY4YQnV7P\nTWWY2n+E23/6Z5k6dDtxdYJabQdRFPdBgTKvkVJ6KHSCNJ1F6y5CKLeDIsizBcIwRqnmSJJaq+1C\nFz20yTC2IMvahGGtn6+ooOp2ZmPIsoQwzBFC9cOwotBIoSmiwm8ozoA6nXl6PbdI4qiCNr0h9keX\n+fnzfYAgCptEvXPo7z2MOPklVHKRHdPu2l/quR2/WnMATZK5ZsXc12JC6wZzB8ohW/1pjz6PUd7r\nT8SCZuR2cyGdx6lGjkVSDb2R+PcsDaEEBUr6VupZ2tp6ao8XAiojKykESti+2nEUWnqZe3+Zw/Te\nnfzoz/4ihW4T49DiIKj4/iYXMaw2bWFY1kOIK6uULjegK+r52itSeYyHxoyxSCFJWvN9KFJb33ef\nOY8yUYXJqmvSynzbca596GUHs5n63sMPgGOoUKqMg7XL15UyBFYOzWBzwwEcQpM4I52+5iZ+5J6f\nYeqGNyCVJAwDwrBAyg6VSp1qtTHCeh6e/BzHB0jTObJsYUjay5Akl1AqGOk7EUISV3bSbr/qi5qL\nBEGt/xqtQYiYokgpigSluigVOwPKLWmSogKJTHKfRzkR/nZrnl7Sxhjp4/l232BarXMUaZsob1M7\n+wz6+a/SOXuKWgzTEzB1wHX5XrzsSgZ+Egudnlvwie97CgPHXavIgdGEHkyQvkcr91LeAkvhuYex\nBwGumxR8q2O5mMLu+pAhDUnNlXqOZe2tKJE8j7wNCLEW6Y2n30MkXTG9JiGuxPzkL/+PiDigUgmJ\nogpB4LyOY54PddSuYETD2teMj+rW6YHs2n48LCBSfs3zlPbCLElvEeNh6yT3EGMAjSrsnICprqVI\n3VCORA8AgX49Z8iQcm+EthTWNO5ClpP7ykjSygE7oZw7kObOeHZed4ij7/x5pg7ejlABURR643Fw\nZ6AExixgrSCKdi2rYg88y26kDNxsTS84WRQ57fZ537xV7fPLlKoQBE16vTm/0cxRqymfv1isDcmy\nFGN6fiqfR9HSnG4vQSmB1p3+kOU8z1lYuEyepyAitM4crcRkmMVXCX/wTdSznydYvEyAu9bxbjes\nbnICGnXH/Ohkbvh3HDkjyLRDOAvjclCTuXAsUl6zIIBLCdQV7AyglbnXzvZgIYN6JKhGlqqX6d6p\nnBGdnoddTafKk+UDelQ+FGkMU3eMFejQJfL9qXI4DySxBAIaFchzgc4tSge867//Rap7r6NSqRJF\nFeI4IopCzy+UQ2jogCy8Re0Mcgh5KGXlV7Aeu7ZhW9ZarLEIqTBGOm0EA0nX7U4TTaeak/lpf6dn\nobHHk0qHEI6+uA0DCogpZa7897kP3/qjacTQiE5vRFkXart386M/+2F2HX4zhhQpc0fkDAOCMPQG\nFCCFRCqJLlokSeGbzCpjVVjjeMo3ms1SaFdhKooeeTZDrb6770ncLlr3XqJNns2CDZGq4j2KJk0L\n8izFmHnC0HiIuUOn00EpS1FU+lPXiiJjYbEFOqNhCvTstyheeYr0le9Qab9CbKDmlWysn1ZZCaHZ\nhKlpd+ytyz6sjhyAk3mFmyj0Sje5q7GUIZ0K3O/me4Jvzkredr1hom6ZT+DsrGBXA853BUpaarFj\nnJ+atVwzAQcm3X1P0gFaZxnkRX0miP8a+DAwUk4jQ5tSDNHlPvWKO+bZnpv+/a6f/Rn23XYX1WqF\nSiWiUokH6JuUzvCGoGlxpZF0dpWIbARpEwRxvAshSiX8DDBD8lRm+diSNSZJUiniWoMsMy5+zt0N\nmGr6RNWHck0Fp1KXhO6seQlfNQRDewChP2HQJ7XGkz1D7duB5SjlXfr6Q1CJ+ZG/+wscuOt9BGFM\nFMdE0TRB4IdwkiHlYMKE9BfcIsjzhIWFl6lUpojjyWVFNVc3qBGGliy75AubYE1CoTVxvGuA6FiL\nMRWSZA6tc7L8PHG8yyNqBWkKSa9Hls0TRu71SdJicbFDGFqSRGF0QWS6cPklKt//Ovn3v03ROoMy\nOc0Y4gqEOx1SqX3OqISgGlom6g6oCZoxrYs5nY5xRhE4I0tSZ0TGc9JC6ShWuYeU08yFbrtjy7cz\nwxNn4R2vgU4h6OSCW3cbTlyCyym0Cl/QxgmF1ALn7bSPMJQcsBb6lQVfTC43R+UBByWdF8p9qBf5\n6KXIwLQF7/qZn+LGt72barXiDajSz12FkAg5qLuttHjHuQXLoKnLUdx8FIJEqQgVxCgVE7gqt1oS\nphQIYXzMnWGtQ4DcV73ko8cjGkIIdJaRJJqJhot/Yz/UN8l8LpK5JHR3BVo57BaDwprxoZseMng5\nBFdr69oMcj8RUfrRi4H/eVSNOfzmd3LTO/9biBtIFY5w0RzMWUdKx/1zYvqFZyqLwVxYC618hiRp\n+Wnk1ZFNxXkYiZRN0vQSedZziFunSxj2qFR29kECBwxE9HottO5Sq4k+GzpJclqtNlLmTkTQFBTJ\nPEEyS2X+Rcyrz6BfeYbuhZOIbpdq1ekDRDsdAKNC13jnJjm4rjIlJRVlqMU9apMhYsrJGS22LVa6\nieWBcnoLhkHBuaTUSB96W+XY8I+/pLhh0nDbDsvfXBDMLkCSWS614HLX5Zrn24LXTFmiGG7c4e51\nOx3kLWYony0XqjGjG3uZs1oDBbZfd6yElumaM8rLs4If/6n3cOO9f5tqvUG1WqVacdO548iH44Hn\nvvkeonFuQPj3tz5jttb9jfKzXB34EHogIkKpaHVxeVcpHyUuOsPJPZUn89/nWKOdyr4t+iBC2eko\nlUQoh1LFyiEyhXauvfDhQeGRuIYnJPYl1kqGgB2a0MGAoiftAOIuC6TWt2fbFG54w53c8XcegPoe\nClUhWsIhG6YbOaNqYG2FwnbJ8i7GJJ5dISkn+HW7swgx54XGmwihlo2otLZJmnUpih7WWjqdHkHQ\nIwwnhuo3ll6vIE07dDo5cTztfpd3kXlCoOepXfou4sIpzJlv0nv5lJPCC12NLJ5ShHsUUey4cqFS\nhDJAqgClIjc0t98ObQlDi6w10fUKl5OAeP48hXFcwyjwUL73Cipy9yO0rp1eCcfI+MoLiiiAayYM\n105C3IN0RnJ2UbO75rzL116Q3LHXUgsttcCRbQtf7A7DARJatiWU4bgxwyguLJld4MYCWXcu1dB5\nM5sK7vnpv8O1b30P9YlpqtUqlUqFKI6d8QQRgRL9utwoh3CwTj3329f0nKEMvobeWOTmYWzXrFVC\ntuUJF756nqNUghAdtJZIUY4JtARRSGOiAbZNryyMmoH0ayncsaMK359zN61ZcbWGsgO07Aw15WwY\nTw61JY/KG1rSgdrkBHd+4L9h6qY3kQYRMYyh6uf9qXhKKfI8H6LXOLVyYxRZ1sKYFIErlbsQTGPt\nIspzAIOgOqID4YypSpr2SJKWT/oXCcMFgsCLlJsMmywSJ5eIdYtq3kX2LpH/4Ankue9RDZL+sLCw\nCuEhiQhCVBAThBWCULmO20ASKGc4UjpdNzEci5SCdjWDjgTfOBXyrecMRyo13rK/QxTA5W7IK/MB\nU0FCHLj6yoIRXOoIqtJgcQqh105avvGK4o0HNKFyLQU765aOERwILG88YMmN5YYJd+96uZdVjj0D\ne6jY2t/0GIhXGgZMem0HYV15KgpXM6xKCIXg9p/8Wfa94R3UJyap1ZzxVCoxlUpEEERDoIEcGm9f\nbu7Ko3MltF1+DcYyP7atpVuIwBMYY4SoAnXfHdlAmzppegkhLlGf3M3CubbTOiiGNMBESZ50cOhk\nxVF5qpHnyYkB21r7REh4wqFlyHgKyBK48abreMPf/Rk6yQJi/klE7RqM2YE1jrSZMdn3OkuZucM7\n1KA/qkpRBGTZIkWRDjYOA8Z2EVwmjGoEQcOFfKUHtjk2aWG7FzHpAjVRULU9YpMSF23E5ZOwcJ6g\nPYPN5px6ZuB2aTXlYGMVVRCygpAu1pZRAyndaHulBLKc4lBi+NLP95Al1uP0u0QsoGbodQuu3Z0R\n5z3O/KBKoxYjhOI7ZxpUTJd9dRdSn18MOT0X8MwFwfte03PJvIGjBwyPv6x49oLklp2GQMBkxbrJ\nGApumHJ5aSdzh9CI3SHlnsGeDXUBDxfsS0yqvKcl6loCRvgQUgqINExM1Lj9J/4hu2+5i+bkZN/z\nVKoxcRwSBKFjGgiXxzpEVxFElaHwq2SQqA1J+W6TMqlPvmXoEqugRqUyRVSZJq5P0uq6UfPaj6mJ\nGciyGhzjuemLbt180Epdthv0L3pJDPVi4oV2gMR73wk/8d55Cr5KK91FJmrk9gJpUUMv5hgbYyv7\nIWwgigQZNbCVHU56N08QRYKt7YKwhpChm+9jMoROkHmboMjJS06bcR2gqIBwsU0cBoRSEekOQTKL\n7J5DLT6P6LQITYsoW4Rex2GdckiOtglBpNyALREiZANkgBAhVlSxouLCMRUighiEQSqBCNTQLCF/\nQcvx9sK6EYehwYbatW+GblTIDRiiSxHXvCYjbk5wdi7k1JzkngMLVCLLhbmYM62IvY2M5y8HhKED\nYiyuK/iOfYbvnpeE0nLbLheq7aw4sCDzpYfp6oDH1htS2PGBhiOg2kGOO8wps3Y0rZZezNJ4ldr9\nr7uRO+67n903HqEx0aRSialVq8RxTBQHhKFjxUdRzRe0I8KwVB+SW2Is2yoqMjCikq6vaEzuZNeB\n63j2+NNUwsEFKncXKZ0RfONVwXRsuX7CEwftANK0ffqG35H87pVpODAFf++d8GPvANloQfYd9mZ+\nLEoOxsQw0SBJm2gbY3VEEdbQucBmMcJWXVOaFtisihAhwliEdnmdAci76CTHFAWKHFn0kEWXiu5C\nMY/IeyjtJGlVMMjhUfQHQclp6cdKRIgwcKPDpR/iKsPB9AYR+RUUDKRUpe+JLscaSIkVxrPa3dQ7\nJwessWQOvqoJRMU4BUmboxKLnoN2L6ZXKNS8ZCEtaKeSaigIJDx3ucJUtaAeGrLC9rXZLifw3CXB\n7bs1e2uCeujqdVUfykXSoX94j1NKU/Ub5cQgt/U6k47gK4YAoiE+o/XMe4XLZwOpuPO9/w8O3/1e\npvcdoFavebStSqVSpVptEMd1KnGNMKp41vqStpBtfGy5rNWwEakwYu+hm90uZEtp3EEXqfYX+IYJ\nS+Jli5Ji0GIwjAaVUkhlH8nRa+FnfhRuPAScATsJYsqvPeMHIJCCTqnL2XIkJzYZEEuFHoiNkA+U\nSvFD5UREX9LHeJ5WySCWMYjq0MAnibMiGQ2mMEjhjaThMnQZuj9Uke8vV35OpRttImQ5+Kac/aH6\nRWGQbkPxhTIrdD8/tLZwSvwSRGRd225NgCrQ86CKHjPz8H+/qIgjy0/thlAL5lJJbl3N5Qdzkp94\nTUGSW15eVLzakhyZdry86aqgHluO1Cxp5gqoBydhMnYonsYhbWWn6YBN7pscS1rVMB/Oo6x9r+M5\nb2Hov09gz3V7ue0dP8m+172BHXuvoVqt0WhMUKs1qdUaxHG1T7UqkeRxjYf/f2FAI4ajBm201cnd\nrsvQx7PGDi6sLtyus6fu/p8Ug52r/74+Hw69t4oi+Ilb4P23Qi2C3ktuB5QdIPWGFPhpzYEfCK39\n4CU/nqdvKGYJqFnCfQaI4OJCQGgM7TSgEWmm6toZGnj3Eg7iMhmCakLQwKoAEURY5T2JDJ3RqNDX\nrv0MVCGwUnrkzFmhFao/x7SE0YWlv+JEScEg9wlZ4QTvhYSKhqrXIA5yLp81fONxWHg14HW74J1v\nKjhYNdRjyaw3wAu9mJt2pggpeOTlCq/bkXJ4h2W66oxjf9Oyp+Fa7/PCIXd7vAB8KQyZeEZCn0VS\nehBf0ymR01IrrwzRtCxpQJ6JYJ0+eajgyN1v5fq73sG+w7exc8811OtNDxZUiON4pP/qh2U8W5oD\njQvlVBBQm9zpksBw0N9ufQMWXqij1FAr23wZ6g0pvVaeuwLa378D3nerm6RwzrN969rN8VF+BhBV\nv+gi70UYFGFtOJh614d6FEMNKUAMM5fr/B9fn+bnfzzn6bMRp1+S/NO/ldJsCIdq2Mi5oDByOtHK\nFe6sDBBBCFHgpnELH54pL7Qt3HAtK33LgwVE4EZCClcXGlZfESVz1rgEzOKH/lrlh+AIV6QJLMli\nwvmXM/a9TpAtKBZeFBx5jeB7rYA9u+DaXcZzpiw7mpo3HxQ8MdPg7usXec/hLg8/X2GqYvhnb+xS\nFMahph5ubkQuCi0lw5JsMNAbr+FWKsGWPVll8Xu418fgWxrMAKIuvCqtTmHfwT3cfu/f5cAtb2HX\nNQepNwaGM1wkDYJx9UvB1X5sqQENQ4flCTand1GtSoQ1fXGPchB02aZQdjCWzNtQuZ2u7Isv1Xfe\n/Rp41w2Ov9VNnKCHVY5+jxwYEX42DDkwAbbuvUyp2u8jJeujJeGLhUIorKogmjF//WQTS8yBQ4Yd\n14TccpMkaE5BoLA+wREqwqoIEUS+munmnzqELPbhmlcGLD2LH8smUP2hwgjptR3kkBKKw3k7l3KC\n0BJPurZdoR1EabAUi9CbM0zuMXQvZMxnir/+riE4Y3nNfkHPBrzldsFNOzT2XIJd7CL86Auh4N23\npnxqJuLRF5u87YYWd+5LSfwArsS6a1lRQ306ZqBrXZhBHqt8ZBFIL4HsQ8s+2moHTh8/YrVsiUhd\nWxK1ZsSt997DwaPvZPehW5jcsXvE48RxPNI2P6qf98Mxni0P4Ya9T3mSlVqT1x59K6eeeIxKfdCI\nVepRW9+UJSzUYj8XMxoyIOV2vx+/HhoFfP8VOBzD5H4neXVhFg4IuFTAZA4T1iv2hFC0gQUIpoCm\nP1vtGTwCRAVPNZagA6ysIqiDrSJEhcIorFY06iGHmwpbRFjt+0kCF5YJFQ+YlmHshBuUjx/LsK2c\n3VGuKCEHjU2lPKfRg0piyUsKLDIPmP9+RjUxTFwTgAkwWc4Lz1r27xLU4gw68PwLMHFQcv3tMYeu\nNcz/IONbJwquvx5EFlEsVNg/mREmqXMh3YTpMOOf/SicOq843w7YXcv7OgVhMOgEzXyrQe49hTEe\nLBHO1I0/XC0cE8SIgVEVdlADsnrQDl4UkPWg1qhy81vfxDWvv5udB1/Ljr3XUas3+kYTx3G/N6tM\nCzYjUbXlBjRsxcOLfyPDh8oTLBvRwjAkqsQcuvUOTj7xWB8QEENkPaNdftSoQbPmx//52lCl6l5/\nbQN+5Fr4vf8Ciy34uQhUy+3Vr3Tghl2uQj3XgvkuLFyEGw868mT3PMTzLman6cIzCqCNE1aeiNwH\niYrzGiqGXoW7ro05/p2A1nzMjmYINkJUfA6j/DyOMvcJY8dTCiouCw5Cj5z5sXrSE860clt6X03D\nDNivwn1vtcDgevy7sxnhbsVEEPD9x7tcv0MxsV/CnKZzEZ46b9h1CG4MLKdmDO+4DV5zVJBeKJjc\nnfOk1Pz6b+e89gZ4/90R4Z4mzFl3kUyK7Xa5tmHYX3XFTyscSVOkkHqwJffG002HNA7MYGZqyRYp\nu4Oj0OcyZtAQNyxEmWROoEUquOH1r+fQ7W9l35Gj7L7uMLVGc5nhBF7XYGlLyQ8j3xkXeW0pCrd0\nFo0zpog9B29y7Qh+VGNJFi0MFEoQVyyV+iBkK6vYKoTXNeCamhso/HdvgS+egGdm4JWX3M2akPCN\nM/D3bneTnS+14PPfkry5bXnfj1lkFVotmAg8BN705XUjsZ0c0Y5ATCLi2v+PvW8Pkus66/ydc+6j\nu6e756GRRpqRZMWWPSMbx3aikaGAylr2LkuxseIUW0vFik1sdlkHp8I/2LHX7B8QEmSoWoyNxKOy\nhRPB7h+sbQmW5SHLsMBCNDIbkk00k+A4cTJjx7Ze/e77OGf/OOfce+7t2z3dMz16QVe1ejRz+z6/\n3/m+7/e9AJKDIBZISLGt7KBNCN5pOpiwXAg4II6rwJGTvg5VBTOWJTWPqzUQk0Aimp5zgHeFRHki\nIVU5XySmTcIgwLeWmthaJGABQ2gz5LbaYOMhqisBytsp6KiNGz8gcOYrAn/7fzy8PRli9zbgf7zU\nxu6dAcK6j+9/P8G/+zEb26c4prf42DXThmg3gTyR55VzQap58EoTvC0nV7d0Dwo/Lm+otyR42n7c\nmdUP4847EZh0eEF1aG2pgjhPWRjtAGjWpXLdedMcdt3+w5jcfRu27ppDwfBzdBMQEzhZJSWXy2Tr\n0EBB0FSdMC2VbSwZISHM8iLS0XwxC42mJosbCNqY3H4jJna+B8vffF0OQXJkfpwlCDgVsHNxmMOi\nqsaHACUBzE0Bu0alBrEDYP/1wBtvy+zh23bK6XJ/ukjwtbLArinJyOVc4NtvAagA+QnZL5m3lPZh\nkN1MNjkgbh44lweattQorgNi5yAYAxu3ML2V4Bvfy2H2jqIEgm3LohrmgFBlqulPpjQNU2kFRI+U\ndlC/SNE872PTeF6mBgFATfYza1QFChMWSJ4CCMBsioIb4PXXmtjzAwVYRQDwsXWbhcp3fPA2AXUs\nFFyO993sYKoQ4Fv/GGD2doaGRXHxHDC3nWDE4qDtAHfdphoLvNVWQ4jbEMIDmA/kczIeU22ifZ6j\nXlXJuUxlEbTlfW55cb9vz9A+vo7rhTKXsaEmMGhiyAvi2UmUANfN7sKWG+exbc8PYnr3LcgXinBT\nwMkiCS4XyxanAJFUclHcNckKgovgnMieBToNgun2TEilPFAjpZ+oYBVNNmJQ7WYZheqHRpAbKeKW\n778HX/3S70AoNk72LxAycTiUsQLbkiaEReQQ2S1loFCUcjjiAM2alN+pceD0eWB+p4xS//lrAn//\nFsG7TYHFCuBzgvE8gIbAuQbFl5ct3DbugzUJSi4H9VuoBi7erk3ghpKvetLaQA4QjII4OaBg487r\nBf7ydQv/BhaI7UhTzXKBvItWYEFYNvJ5V/ozloUgZKCWA8IttC4QeC2K0CHIUSZnENO8zLWreRDN\nEGzMAX+jirotUMyraXHUxuTOAqrvhGg2gVJRBqWsPMHFkGIbZ3BEAL8lcOG7HI5FcOv7GEbKAj80\nz8DrDLQZyI6VXlupgZacOiUCSZpAALwJhG2Z00hEFJ5qKBPL0/0oWNzrTRcy6l4GVHXcaaqpGKFK\nemWQvyMUcC2Krddtx5bZf4HyzPdh2+6bUR6fjEw008fR5r+pcdandVSFm+CpZFKeBIkuBI3+pv7P\nwygYLGvcVOwNBFwEEkCUaKDQON0ZYZRCLssXRCqTlRj/jzWQEETV5cuZoWHYghANAA3ceMc8fP47\nqNWUP6IWfUsNrCZUOqBMyM+iA2yZkNaNFwC+JX9381bgewXghvPAa+8Ac5NAwaFoBAJv1QlePwvc\nOMElMB2gxAXeqlr4+zdcbBvx8eN7PTglB61mDq+9mccNP5QDznKgSST1ZCsVaNkojRO439X8rOLE\nHRd+w8G3XyN46wLBnvfaKDoOfG7DGnXAQhv+BQJmS23UrhHY4zZ8wQHkZLebc204RRvMtiGojYJr\nJfgchwbYMkZxbrGNHBOwJzgsQTCVBywhh6XaJY7Ns0J1geQyzb0O0CaHaPggLdVW1fOUXUYAYUH4\nHgK/At9rIPC57PCqBnNYIwALZCym5cVAybvy+QRhPIFCA4Q6UuPr8u56U/a2IHYOU9fNYXTnHZi8\n/g5M7rgepbFNCW1jmmta43SrAJbCzlPCH8YpQKnaNSFCI02IJ8CU3I6nqoG6Fd3FCXxCJaUCBJbZ\nG5cQqkwMEdWR67Lj+EJER584o1AgJgoIB2MCjAlYDChNjuOWfe/HPyy8ikKOgAkBlicgekitkIE1\ncEmMjZdl2a7KVon7KvgygPq+aeBLy8D1k8C2EofwgO/VKQIBnGsINATQrgO5SYEf/D4Pv/03o/jI\nrQ3YPkHlu2N49cIIzjZC/O+v5XHzDMPkhMo+kAQxCFxsmnZR+CpBvZ7HyGQe4BYC4uIfFwl23VbA\n5iZD2LLRdGwsfjXAzI0Odu6y8U7Fx/g2F6OjIxiFDb/JIdACgQU/EDjrWZh0R2AHAk3PQklpJiBA\n61wDpOGjfIODi0scXsBhq+lsYzsBavM4XT0MJTiCQNVy+BCBmpXJPUk30raKanKIdhPN+ruotxsI\nfCKHVrF4/o7HJA8yMgaQmkwwBZG/c3NS42gKm+RiEtH3gcoFmRHPaR5ju96Hka2z2PSeWzCz+xaM\nlMfgOLZhplmwLKY+KSjlICRUg7QChKHR4JAIAwgiVeDJI9mMza2M5m1AnKlu9oJWTSu79T9MVqSS\n5F7VfiwdPdRNF0DiCjx9Qt1H5MUN7QRINLOGUzkr07I4HMeFmwvgegF+9Cd+AotfelWWE6iBL76n\nGFxbAsgiQNkFxkbkg4Xqz8FDSZO2PFl/TwTw/dtkFrdlE/ihwO5Jjm9WCP72LYatZWDprRC3WALj\nToi2YGhMOyCFNsTrTQhRwDtNCv5NYNqyMH6TC0YYBKcgIQE8ii1bHBRLwHcrFLMTtgxYtih8TiGo\ni4mdBQA2uLBxQxjitcUQ3AfG8nnwC1Q2/waBnRfwbI6gJmCNOBgrOGifC5DbxOCWHFR9jrLMO5ec\nwpgFlqe47nYq0ytCAXecgJRtGakkej6L0bKIypwZQkOgFUK40sMnnpAZus0WSNCAnQPy1AF3fdkP\nXMT9CTyVKkXz0hQLWxIwvlBNFTnQcmN/qNECKueBRgWwR3Zg263vAxvbiokdN2Hbjd8H27ZUhyMC\nx1EEpcXBGFcugi7SpKqYkRodcQmEQM/2U5HlJER/yaIk2VV0dZYt67Bxw0XFwpEEWaBPhBipJKJH\nS5GoSWCEaDkuPQwFbNuB74dwbBeuG2Dmht245Y734rX/92UUC3KMRautakS4nLDsWrImqFAC7KKU\n2bApxwSGRNncDeBCVdLeFxvAZFGgWJb1Inc0gB1jHJ4gON8E/uY1iq9XLFznNPHyq2PY8a/bGL0p\nxI+SEDe9aWFskmBsOwG1CcAsEJ4DAqltBAhalKDZIJKCdlxYdh6TWwS+9ZUQe37IQdhiYDbD1HYH\nExMO6m9zjIyN4O03PHznyzVMbbIwOT0Cd6KIxrkWyiUbpc1lVC42IRyG8q6iHHMPOd06N8p0NzZl\nDci4EBm34sQ8JgCXx5WEhEvbiwWAE0IEBMQnshNlI4SwWyD5NtAmsJsUdttH4HPZIFEpq1DF53w1\nlc9zAd+R7lOjpUATyqG+tbrsqdBoEpS37sZ7fvgDyG3ZgdGtO1HaNAXbduC6uq+erRg1TQzEs1xj\nxrabn0P6aRWV2eQg211KdhsVEF38KtJnmypi9sY2QaTNORF39zQaiwhj57KlU8xU6OG1jHHV2cZB\nGIbIqWHDH3zwP+C/PPY4eFAHbOWYGrN6cqrU2C6rhE01wk+4cRZ2U5UJN3xg82Zg33Vy3uj3zgOz\nmwRu4ALMAsYLwLstghIT2LelgS9fABrnCJxtRcADRnMemi0Xm0ZsORbPVXXnLA9QF4Q6KIxyXGyr\niC6XXU8mZwv41l/4+Os/rOGmW0uYfE8B588KjJYsjO+Q/tK2m3OYaAdwLAcgOVgFghELQNgGsW2M\nTuYiZodGdziMM12je6qb57E4WY8ovt9RKRfCkzlMFgccARJwyTsjkOCzXYgWB8EFCL8OXwi0lenl\nQ/W+1l1HuXQFdQyn7ct7ffEiUL0gFy9hjWN013tx/U3vhzOxHcXJbRgpT0Rmmm07cBwZwpBtkGUn\nV8ayY429CQJD6FchEbQs6oEI/Wy/qsrq+V1DA0nApGhrQrvsQqTqyk2bUtbhMmbJER+WA98K4boh\nfD/E1M5d+MCP3Y0v/tFxuI4kCFyV7WKrzi9WMZ4ZJGTfD9lhR/nE9ZYqDRfy580TMvxi2bJpoxdK\nIIYArp/kuHmrdJZ/fGsd7vmyZCk22xjb7sCr+BBvMpBRGxiHnLUyQoARBkZc7L0N+OZ3lIeNHAAb\nTt7Bnf+yiAvnGMoTLhijmNzsKCJAxn4YKAoFVZCj7ilzcoizUZkBFhhJeULx7aqBeGLsl05V5vKm\nWIqyzAmpbTzpxYtWHaRZA9oVoM0hvBCkVQX8BgJjskJbqPEtftwJtNWMYz/VBnD+vGoIYo2guHU3\nNu/aC3diB/JjWzE+tRN2BBjdHsxRbJqlQCOBw1RuJNEdcig1yKvB+0wRsgooVm2905fFl/Efkg6k\n0hg0xFwRaDZwovZAIru3iZC1GAIElApQxpQW4sjlZFn1j3zkp9A6+zqW/uErEJSAMgHblsmihRFV\nqcqV+V8DwoLKnVRZKDqYJ4hcIQUkU1QakavoRaMtMKHSCQ4pcDEkcC/4KIODEhvW5CiszXmINldN\nzhyINgEJVM79CEG+TOGEKhefuDJTFQ6YZWPTFl304yihdxTIDG0R3V9z8RFGF6TAuJeqFkjOGTfS\nxj2VNtFQn00AdUlF83ZcjxHKG0QEV+1faxCNGkhTphT4XHZDarbiz5ZqXdVsA426nLZ3vipN45ag\nKG69Bduufy8KW3bDGZ1BcWwL8iOlCDAy1mdFoJGMmqPGutDEWJFE1otucEgwAHiGETzt9KNEas7U\nQIFUDZaYOED00NNqNcmAkG5emmpqQVTrKKLKdPXYE/n+0Ycfx9mnfxZe9V1YKoGUC2kqjDuyHEGo\nfDmMyAREv6mmYou4PVJUJUqlJsu5KuCnOvb4HmCVgEJBZYF7FIFXgHNeIXKTDVJ0ZYYqs0FslXcf\nKBMgJHBcpsCjwVJUQLEygOIrgSep+2nWTOhM19AAlG9onZYCSUsCxQQOb8gkMq8tYztBCARN2fyu\n1ZBOTVgDgioQNkG8AEFLMmTNpmTWWmEcIK17QK0BVOrA2QpQ5wTO+C5M3nInclt2wylNYWzqOuSL\nY4kyAhM8shurbn/MUrlqhmVi+Myajk4TBYT0AgxZE1zEalqLrBWEBFYU/zGJg4wMhPjiBbI7acWE\nENGUuCIUdN9sCSL5Dsc2Y/99D+P4bx9Crii1TrUtZS/PgTEHKGyStWiwJCVdr0qzwtf0K4sL7nSu\nptnBxw+k09tqASMFAlZwkCvmALggwgXaNlAhknkr2UDRVjEgAEwKd2ECGHFVUphNEjcvTtQXkeMf\nm2TM2IYhOZs6gDkTKAaUZ4CnHgOINyVIWipA025BtJsggQJRvQ40qxC+BxJWAP8CEIQIAgFPlR40\nfBUkbckxmtU6UKkBlYtApQ2E+XFsvvVfYWr6FvjCxeT2GzEyNqn66DmJIKf51rEbM0/NzFczgZMO\naJoLc7w4c6PDLYz7idT3Sd9mHukqr/2SBd23sWLgpIFEI3tSQGSir3PnIu7hFrFzBILJWI/rEkAw\nCDV/ce7OH8E3v/IPOPVnf4LrtgNjZZkuZit3grtS1LwKULsoH3rNkyM3bCbbPBVyKreOSQ6g4EqB\nCVVv5VZbrq65nEDZ9UFyoap54HF/YM+HqLVAQjXByyeqC4YHh9oo2Q44D0AjgATqTdUtJEo70RSw\nOOKiDaOaTMV8JGi0ltEmWiPWOH5DXkDbN8DjAUETxG8BgQfRqoG0LwJeHcSvAe02eFvNcVUapq78\nmYs14OxFOdvVFy7C/HaUZm/HtsndIIUpbNpxIwrFMhw3l5hKkQaP2WxfN2fRg5F7EQP9DqtGV9Y3\nCSw9GlMu0NlA6wyUrtU0JN3KGTLYtygrgXRhK0QqVkQNzYUo3Ueo+l0WhrCsUHXE8UBoDoy1QGkd\nP/ZTT+DdszV85W/+Gu/ZAWwpAmOq2Z9zQZUMt2WEu6Hm1YACIxaweRSYKEvyQED2cM45siRC8Lj3\nXK2msh5sioKlGDdbdWG0BGCrgUVQoXaVdA0u4LcA4TBQlxlMmX63I/rZjJvF2ihMGxEKXKHhy1RV\nanhDfdakadkOVDJaS16I7ym7tCUT+4KmBI13AfAuAi0PQRNoVoBaUy42588D756VI+CrHtB2x+BO\n3YCx2+fBRncgIHlsvu5G5PJFBZpkpadZQtBL06RHJ64n0bOf0SNyE9YVaEJ01yLdwGUGYhM9DiOW\nOfuMLAkYFo0QlP2xmNH2icWUdWIF6e8m6dSfBDATN4rgJ5/4Zfzur/xnvHriJBpT0v/1PWDrRWCq\nLJnlkMp75hDZ5XSiAGzdJPtsw1LjTBTmtXnnW8pnCoCwKvXHZOCjPOqDli3AEhC2BeLmZJ6bKoo7\n/zZQ2iJgTRD4LY6L3FMCrtgv+Ao8TsoP0tdkaipibKPB1DJAU09qnrAp1UfLh2i3QdpSC4lWE8Rr\nyIRAvyadmkYbQd1HswY0asDFKvDOeeDd81LTNAUQjF2PketvxfjOPWgLB4XxrRjduh2O46rJ39r5\nt9Wno9g0V9HPehpf9/y0KyM7mvTh05A1dOcRiaRSIWJrghACi7F8ogQhvklsKDcl3XstmYcU//yx\nx34RxWIJX/yfx+AwqTkqLdnYfMuYzINzXemmjOVlk/SSorsFMZSCkluCuDI6UClAfoWg0W5hokZR\nrhLkSznYJS5rwt0AGGkDAfBnf+ajavk4cE+Id95g2LnbBmoB4BTkG54iEdyU5tEP0swfZEajBX2S\nhpmGlupRXJPkQMuDaPogrRZIvSZVSvMiSK0BNGrgDR/tdohWU46iPHcBOF8DztaACzWgXZqBGN2F\n0m23Y8SdQG5sCyZ37IabK8B2HOXkkygmY9tMLZimlpGTDGTWAJU0NNOLEzXGhdArpqxgI4GZzMRJ\n9hAk586dE1kAMlv7DuOlu3fqIVB6zGC73Uar1UKz2US73cLXTv01/vj5Z3HhO9/CphFgelwWzO2Y\nACZHZYpPcURmKjgO4KgeGkJFzGsN+dn0VdBV9WBglMngKCvAsi3kHIaCm0OpkEc+78DNOXByLsiI\nha+fdbF4LofrNrvYOuVg6gZX2oajthoNoBuE5DJiOcRg22zDF9JkQVNqH78hgy3NhvLs1YCkRk0i\no1EHmh6a1ZYalylwsSr9mGpTmWSCoO5sBSZ2wxrbheL0HPKbr4OTK4DYFlw3h1y+qGIzdpekTaHG\nfkhqmbJkdgBAEiaazCCwIvCYlgVZKxd8tUJr2AV1/di22tk0bWazBPzWH/gXuOmOffir4/8dr/7p\nMbzxzndhUxnjGZHZNgiYDATmfdmExvakn9RUrZV8nZaiXBqhR9VRgEKoIccUARPwmyHyQRs5T6DQ\nFsi3bdxUAm6aAoTFQVwP4p0WSNGRB27JcgY4alirniOpe9a6kMVOEamgzT1PJpf5TUkM1FtAvQHU\nL0r6udoAak3weh3NC23ULgIXKtIkO1+XCrAWFtHOb4E9thOl627H2MwctoxtBScEtuMily9FIKFq\noi9jRAFIBjxt20kslnFvgZjxEoLHuZEKNImsaB6CI0ysyrEZpxk48k9CQ10yDWQ6Z1oTZWkj/dlu\nt1E//zZe//Jf4bW//WMEb34ZU+PAtilgQvUkKzAZhLdVMnLgxUNv22Fcgqx9I2pTEOrCYjYs2wZz\nRuA4OdgWQc6iyNsMedeGqztdOpZ0uPSMjrwlOwq6jkrehCr8V86oA6DMgFFLAok3VHymKVViU1HR\nzTZQbyCoN+BXW2g1fVQrkuy4UAXO1YGGz9B2d8LecitYeRfyk+8BcUfBiQ0nV4aTd5HLF2HZjhLw\nAIw5ajKbbvckZzPJ4VUUlm0rTeRmdrTRP2vnWgiu+oFzw69IkyIioXzjDBqaCItIlyA7vng1a6BL\nCqAsEOmm73r0uud50acGVOi38c63vopvf+kvsfJ3/w15CJQdac6Vi6oviB4kHBidTZX1pCdBMwZQ\nNQaEUAKbOWC2C8sicC1p1uUYg+3mQJkF27GRL9hwcgTMsWQcyFIsnVA1zYGQDhZpAWXIKPCIJf9f\nuwBRaSOoc3iVAM1KC82qkGBpyqh/pQV4YAhzU2iN3Ah7bAdGpm9EftMuOCNjoFYOlm3BdnIghCuW\nLAcgVOMmC0rwBYQIYVkWXLcAy7Kj7HhJ9Uq/TPo/lsqWdxK+bhYZoGtwOA/BeZiIy/Q217IyVYiR\nbR3P2yGUXpWm32UBkEkemH6Rnv1pgkm/Pc9TwGrDa1RReWcZ777xGr73jf+L1/7uj0HVoFlXWVX6\nHfX+UEHWnOo2Y6tOuZbZG0SZM7alUppAYFsWCnlgxBZwbQLHpmBUTqFqBwRNjyHwQjC04eZCsBEg\nzMtcs6YO/FbUuESWRzO3B6IwA3t8O+zRbRDuKKhbArFdOIUSqJ0Ds2xQwmE7haiFE8Bh244yqwRc\nVw4pFiJQQU432g4IQIilKGknQeBwHkCIwDDPqMoicPt41mqOjggNMIm1PP0EoKKfqDb/2Ib2sr4m\nAJQFIvnJEQTarPMRBB6CwIPn+fD9NoIgjAbpysIrDr/dQqteQ/XsO1j+xlfx1uv/iGb1HVz49tfA\nPR9BO5QTnS055tBlavoaldWWjuplHbVzU40c9RQJV3WsiuZ3qjShpi+zmC2Loli0kC8WEJR3wCpO\nAHYB9vj1yI/vQq48BermQZgLoVZc280rwbWUj0TgOAUl6KFix3JxKAECtiPBwHkAV31fahUOx8kr\nmpkgDOVANEplYqceCGXOeuLcN+IhKtFVzcgx43mrWxKhmhnFU3l+65Gb+LtSs9Irlqi4rACKVzR5\n88PQhxASPJwH4GGIkGtfKUAYhAjCEL4vwcNDCbaQx76UEBw8lLZ74HvwWw00azX4rSZa1QtoNSvw\n6lX4rQZ8rwERtOHVKwjbTbTOfTcCT2FqF9yRMizbBoFAvjgKN1+GUxyHnS/Dcgpgbh7MscGsHIhl\ng1iOnKRghAGYmo4m+0QQFXPJRYOfZDQ9TAg654Gc3erkI+deCB+WlQdjFGHoRX6MrOBsg1JmAFCo\neymbVFuW1ESm0Emt70UT+cy6G0qleTeIBojBFBol07x3zmRCE/VnBpqsX1JLXR6/6pICKDEVTAWj\n9M3WzRoAYkx7i5NPtZ8kTQf5cxjIvwXq9/Lvwvh+iDBMarc47kSVs8sSZSNCO05CxCMe0dkJJh1A\nTAcW9T2UJlOoqF892MmOgBEEHhijsO28Yic5OPeV9om3078jhMqhX4TAtiVgpMYJYFm5aEAUIQRh\n2FJmlgRFGkTapNMLVzovLB46xQZ+ztlgIkPSHAJmN/pOUJGEv3VJaOysqPL6ossiunHxJ49ApHOY\novQhFqf+aJqbc66ArADALXDBwblAEIQQjqSPw9QEOs7jqXSaTZI/EzWtjCj/AUbSougrtSQ9iCsN\nMDNtX3AfIbeiURuOk1MCqQPKPoSw1EQ1V2kfH4IzOO6I4dwLBAFU1rOtph9wWBZTJQN5+H5LAdU2\nKorzCIJWNN9W9j9IjiyUILXAuY8wDBLmlwQ/hxBMaUyrb6GSvpVtgEnGweSnWDOY5NqWThfToA1S\nz4Umcjy7l+is72UNR7vEGkVrGD2WPEuVxxciVhVWIYQSSAGhwGDbFrjSLmFC6yQ1Tpy4qTUOTbCA\nJniyQJTuBWGyVWlAxdnHCggiXoTikYI0yqcLAplP6DiFaLswlH2kJHnAEpMY4s6cDoJAzmLRQi1L\n6D1l3rmRwFiWC99vqUUkAIQAs9yOaLoedxiG7UhrafBy7oPzEJQGA49BlNdlqWkcApTyhHbqmuuW\n1jcEXdN0SEahm1DzkrgezoZ4QlukHECj+rdLCqDeYMlyIuma1WPiZzUSRWskRuWQX2aAIZ5VSg3z\njCZAkvVzVmpROtibPqc0aHTAMQg8CCErU6UGtRPgEUqLUqrjMXrqswSPZAPt6EELQUC5mbApeyZw\nHoKx2NzSzBjnASi1o4XKtnNKEwFccIigHWme5LVSMJYDIT7C0E8xZSIyn9cCpBhMTF2jlhsNJtGV\nS1gXHUEieyju/SaSeZhpM3BQ089a3W/hHT5Ltk2KNajmbs6kSGkrkVDhjJEoascNQEgWyUqo9nT8\nKZ1eNAiQs7RRcn9tWFbcfFIyYbkEAMOwrR6SrQgFTTFLX4lRyabFjSrDDu2tG/1JgZamHKVM+oSB\nD9tmhilHwZiDIPCi+xAEnqLurY7r0tooCNqGFo/9oySQ7DVNgkuDSWvIBDXeF5nXKT/EGBe5Og5E\ngp435ZhSbQb2BpUV7ySOPEfMRpeQWHeFuz7asvvvTAESkXkEQmGpsgr5IEmmNskCTzdavZ/VJyvY\nGIbtyMyS4GFgzE2ATfsVWsuYZqoGc2dQkWSYujRawXVav9ZCmmGzrJyhKS1YFiIQAVAgEpG2Su/f\ntvPgodRGIuM5SD+zrQgSW3WwJWu0NCRwGRMQnIOL0GiamF0FTZL/dDHr1ip/sujTdD/M5qMmpW5x\n7kdN7WRZA1EFb+wKiw6LBGUpV16rZ6/ubqbZsBiYCDyB30EwSPDQxDlw7id8g+QD68ZUiS5amSsh\nE5EJIrVQoITbT4BD0tNckQUaRL5qfmlnPmvKbBDKEIa+sbCmta4A555iHq01Ayl6tpSBgUVaWV4j\nR6ILLtamndYKKqJuv4hyBcOYhZMrGUlw6nGTEW1EissMHDNKzYz+3IP7U8MNBoeSRk79Pg0eKQy+\nWtUQZTOb+4lbgtEMNrNTQ5iUsQYjpbahhfyOUe6MOSrmFoMoDAPFfjpdzFUKy3Ijpi5mUNFhDg8P\nSIi0OMAiVyL2l0TGeZA+tUv/f1/t9IUQej4QrsBXTAZoQbiS0jtkDMXrAKpJJZsA4TwwcsDS2sdk\nvkjGA+4sjc4qZZaaz0YYeLIVcuhFZqQJItnkJYieuzy+1zOAqs00rY3SGQHxWssRhp5RpLl+IGny\nhDHWERZZvWR7PSBZ/byt+AaR/lZwgY4S1+GbRzQyz67EnCipTfwOp1U61VbHKhWzWjCykk3/jGcW\nqMW+G8n0G6Q/yBO9yyll4FSO/tPOPiF2SkPaEXB1cqd24NOxok5t5KjAtd/F0zdM21D2vB4WkEww\nSZZVGEywGbpYBRIDpAOtdspWOr7RXw3HsFWWpmOZMkeu3JR3zj1FBpj0tgClTia1K4y8M10y3xkW\n6GVqioh1S/gKEZGQNOM0rS1NOGmipU05zbYBXsQ+6QbtYeitwq6RyESTgd+wU+Ki9A5teslA6jCB\nlFxIaAaYRGaMaFWJJhhI9i0TNGZj717fJ334+qLvm2CaaVdySnscVDT7nMlryI6LcB6CizAeV58S\nZL2NFN7B7HiZxmOOGjfPh4GQMJFnmPZxInMvVAV0HWSH6Bnr0SDkJDRy6tLLNkndvyACUpo1HSaY\nTFZZTjYfXLP026nHMjuRxrEDGIG8Ac21rACYSDe3owZwrvy0dSlUXqovWSys0iTK+k6QeGJZ5p3Z\noCL7XvAOwEYgQQCh8gcJEakqX6ZMKBJR3knmT8eIbMMci5+bPvfVAqbaJE1mePcWQB30HbZGSmpo\nYpAtPOUriYGB0tWESw8yMjvnqFPpOZ1hdeHT6RQ0CqANyqJdXvDwDOGIxEdRxSTjewHiJEqR6c/F\nwbve+WGmn5U0BXSsjnf4I1oLQTVbl6RB5zlkgQgJEGlNRFbXRjxMLhqrmsMhCOEGSbQxFoh53VIr\nCcOPXyvVHZlwZllvRndSggSEdDLf6j6NtpepoXEorqZXEjykgyHsRv3GAWmS8BuytkuumL1NuOSg\nMyTAJ4kImmIEmRJoElHWkmkjPUDUKeTaTF1NwLU20ik65iLcazGX0+RC2R1zg/soEDUKhERxJdFl\ncewTQP2OmOhpO0YmmjC0GLsqQdMJniymiWYKYtLWN7bO1D4mwya67qtbG2XdRYcLGGaKSPk5DISY\n6Vci05TTz0wCLux49tJE9BWVvRotTCIGVYhQlYj0t+QKEYJAN0Tf6IYkxKgIIIl8zn7cFn1uVlZX\nyRhMYgBkI6IXr/bGESZ4NAFg6tVe8ZI42GcIcqb2CVMLFOnjYad/TdVkhvREaVOYWZTqL1lBDkF4\n5vlrLZnUnrEpLrMbrL4WxcgVoGG279jVqxdRYFkH+DdelkzyLG3aidVNOLMBeLaJsMrB1bTua6Hb\nii6CS9DKxkcv4iNy1k1Dj9Luo2IAYxXM3ob0sH2IGgityZ60GRdrFhprAiNxMut5aRB1M2vie0P7\nWqUJsRJxmv5CJCSlDcgllK8kE52cvdrZKMWKc7jEqjZ458O7ek207uDhPQW2OyslYlIgApzIJEy0\n+da5WHVuB0IM/yebbdLCak6jNoVYCAqQMDqMrpfJMuU0iJL3In3uQd+aKHbiCTgn6L9vQmd9T7oH\n+6V4mcfrHGSsTDjJSqT9nOwhWuke1/8MnqQP0o39QQ8msx8CoftsG9KReZ5Vt8R5Z2P1LI1lEgKy\nVyTvQpT0r4liIoV1jKof1LTWNV6XGkjZYNKpPCRrWqRIqflrS9sknX7Z3YZkMkSxg939wYqogWHy\ne6yrICTpadL13HptowvuTOshGxQkUVcVnzPvIYjEOH/RRUPyDsHqVxvFeWz9m1bJ45p9Dy5PQxHl\nA3VOodM15ZfzBC8NWSCi1lC9HvhqUfNOQkB01T5x3VFsb/demEjPqLkubchm75LbmSaeJomyNFZS\nSFjq+rK0Aona+fbvZ2i5MjU36UFQmV1PTcLBdD8uvZxa2SsVueZ7GifB041CphGr2EuA0gJ76vTf\nY3HpG1hcWkKlWsXhZ55JE7bolmndffXt5TsQ9I4XpUEUfy/WInTNINL1TIMyZvFCHVeG9h5N0vt5\nXg4gdQzYutq1TaVaxaeeeirxu6QAm+ARePmVv8SLx45Hf9s3vxcP3P8RxKUUZBUQpv0mgVMLr+Kl\n48dRqVbxiY9/vIv/Q1YlavoDWIbAiOzYSyeAYJh93QVvcWkJzx89irvv+gDuvuuuHiQKXwNbFqeM\nEbL+xoyXGki0s5/W1f0ql0o4/MwzKJdKOLWwEL2TJodcTavVGp478ls4dfpVLK+8ic/+4i/ggfvv\nR/+TBXi0n1OnT0cC8YmPP4K5uTkAwMz0dAf7ll2egMGBguwp1yIjwTRp8qGraVmpVhP3CwCeP3oU\nJ06exIvH/yh1LhnzdDP7ZvSnjYZJTvVTxj8UAF2r/o0puGeWlhLMk369qLQEANx9110olUqrsGed\nrNup06fxwMP/HovqGFoQtBDuUUDKYt/6B08//kQ2IDKd+C6U+RdPncJHP/ax6H7FWnke++bn8YlH\nHkmmC2VDCP1G83uRDMMiiMQaAT0AgK7N14mTJyPzaXl5uQM8yysrOHHyL7BndlZqrnJxAPDEpttz\nR34LyysrmFP7AQjOLC5G2tAE8iAmWvZDH5IgZJXvA3juyBEsr6xE90S/PnzgAA4/8wz2zM3FpS9a\n/WW91wki0xe/0oFkXYvgWV5ZwZ65uUijnFlc7LD9P/v0r+LRR34an336VwEAc7OzmeBZXlnBmcVF\nLK+sSI0yO4v5ve/H8soKlldWIs0DAAunX8WePXuibecM7VOpVvDnL59AuVRK+REkOsdTp0+jVCrh\nnv37USoWoy1efuUVAMA9+++OzKwTJ0+irLbVIDh1+jQWl5aUD9fJxpnXIoTA3OxNuHPv3uhaTM1z\namEBc3NzKJdKarE5iQcPHox9KWW+SpPvNJZXVrBvfm8KfBJEC6dfjfY9Mz2NPXNzfSwsZuMWMUQg\niaH6+9ckgE6cPIk9c3PYrh7SmaUlVKvVCFAvHj+OUqmEfUp4pAYqJ8BzZnERzx45gjvn57FndhYn\nFhflfmdn8fznfgcvv/IKzix+PRIKCSSKO/fdGe3zzvn56Hw+c+gQKuocTAAtLi1FxwGAzxw6hBeP\nHcPnP/c56Zc9/Ss4dfo09u3di3v2340zi4v41FNPYXllJQJQpVrFEz//FE4tnI4Wgzvn96pcst7X\ncud//RxOvPIXWFxajK7la4uLIIRg3/w8nj96FM8ePhwtHvvUeRJC8btf+AIWlxZRKpUkEXMEePlP\n/hfK6j4/f/T3cOr0Au679wBKpRKeO3wYlWoVv/zpT/cFoDTJMDQNbHb4WSeQrkkT7osLC9i3dy/m\n974/4QcRAlRrVXz+6O/j0Ud+GguR4w/cPHdzAjw/88lPYs/sLB48eBD75ucjX2bf/F4AwAP33x8J\nwX0HPogHDx7ET370o9HxtTA+f/QoTi0s4AG1epuCsbj0dfzMJz+JO+fn8eDBg9EKv7y8jEq1is8+\n/SsR6OdmZ3FGsWEf/tCHEqzjEz//87jv3gMxkVIuRYKy+rUIPHjQvJYDePDg/Xjw4EE8e/hwZI5q\nX0i/nj18GC8eO4YnHnsMT6r3fQfujcDzmaefxuePHsWTjz2Ge/bfhfvu/WDkb5r7GYxkGDbRJRIj\n7f8ZQEqglpeXMTd7I4TgkWBoU+vzR38f9x34ILbPTEcPVD/0NA3+oAKECYq52ZsS2iMmLOIHu6iE\nbnllBaVSCU8+/jjKpWK0ihPlxj/3m7+JSrWK+w5I4X/h2DEAwKMf/zjKpRI+++lfiMBQLpfw4rFj\nidV7bm4On3rqKXzikUciYMtjzPV5LXOxCZm4FkmSPPjRj0bCbgr9qYWFCMij5bIC3r148rHHIs3z\n4rHjeODgwWh/WjvumZtN3O+1ESbD78mxViBdcwA68fLL0cpKiHxgUti/jjNLSzhx8hXcd+BeJeBv\ndvgqLx47huWVFdyzf3/iQWtQSEdaPkhNXWvnWmsvDczl5WV8+MABCCEis27f/F6AAKdOn8aphdPY\nNz+ParWK548exfNf+AJ++dOfxocVoCQVL4/x8slX8Ogjj0TH0Of0kwcPYs/cXLRdDCSCF48d73kt\nN+/ZY4AiFnD9KhWL0bZ3GgDSQJf+TpIFrFSr+PzRo8pnu6uDCZVky/pMsY3RRmsD0jUFICEEziwt\nYo+hJbTGOLO4hOeO/BYePPiRSJgWl77eoYFeeOmlDlC9cOylyH+ZMfyqmGnb3iEoM9PTePLxx2NT\nSv1eO9n6/8vLy3j28GGUSiUc+4M/UKSA/M7yypsR8J54/Oei89TfNTVEBNC984nFoPNajqFSrRoM\nIUldy3RCoLS2is9L+nRJrRSD6OWTr6BSrWJmejqxL30uM9MzQ/JnNjLNrH8gWdcOeGQD/JdPvoIH\nD34k+r1+iMsrK5iZmY60D0AjTaF9gkq1GgniduN7z3/haMfqvLioVtS52cQKvLy83CFwMjvhdLQ9\ngEh7ffhDH4p8n/TrzGIMOm2WaRMqfQy9P3293a/lCwlQEUIS15JmIJdXVhJgSAdZ02zi8oq8/pmZ\nGDzPHTmCqr7XagEZpBd5f0zdEGn+TLKBXLsaSIPnxMlXEloCIJiZmYm2e/D++6PLNoOdadPGNEd+\n6dChyBTZt3dvZBaZK35FmWCmdtCgFCIGjzZ5tOloAs7UEPq8NDN2twkU9be0ttDnvm9+L84sLUWg\n0OcQX8v+yCR7QZmrndfye0rTvBIB1TRNzftjEi8Lp0/jjNLqseY5jlKpHG07Nzcb7b9SreBrqXt+\n5WmjdBxJXFsA0uCR9PQfKjMnvpl6xbvvwL3YN//+TPBopssE2wvHjuFTTz2FRx/5j5GAvXjsOM4s\nLWFmejoCysuvnMRHP/Yx7Nu7NyHgsXDH5tvyygoeeOhhVKrV6LxOnDyJF44dw4mTJ/Gpp57C4uJi\nZBppATZjK3pfplO/vLISCegDDz2MxcWlhAZ48fjxiGzQ1/LCSy9hcXExeS0nT+KBhx6O/CitTU4t\nLODZI0c6zMHnDh/GqYUFfObQITx75AjmjNDB4uISnjtyBGeWFhMEx6Of/NmYyXzoYTzw0EOR2bxu\nGJFLAaSkaUevBfC8eOwP8aF/+xM4tXAaZ5aW8MBDP5UICu6b34tHH/npCDyfOXQokXD63OHD+NRT\nT0VBPr26PvnYz2HP7E2RcN6z/y48+djPJfymUqmMw7/+68qRX4iEO5nCQ6LV9zee+TXsmZ3FfQc+\nhJlpyQR+5tAhPHv4MO7Zvz/ym7Rm2DM7mzCtvriwgJnp6QSAKpVKBNrPfvoXcd+Be+W1KOBVqhX8\np8cfx565OeNa4mNF11IuReeX8Kvm9+I3fu3XUC6VUC6VIpPzhWPH8EuHDmFmZibKPzTPq1Qq48nH\nHkO1Uo3O74nHH+vIdCiVSkMMll6KEpwYSITrkQFXrebpt81WfwmzMQ0+G2k2LUgz0zPR/irVGlZW\n3kwARTvnpukkt61mpMgoJm9hATMzMx2BRSF4x/4AoFqrZ9LApxYWML93b8LESB5XHi++luku1ywS\nmi25bUwWLK+sYHl5OTOmc2ZxETMzMyqbQkb+Ty0sKM1DUue3bNyXYZfRiA3yjYyneLUBKFafHIMU\ncA36cLLqfJKAJH0lnPZ2fsnA3137Mfu5/tXy1wYX8KxuQfE97HYMDFWDDDeLIcXCXU2Fc8nGGnRD\nwaNbEK/PTOjVzZOu6burC1efUza6frebsMU9MgYtmkuCsp9OoMMFUVx9O3xtRK8m8MQtbNdiEw9y\nHGC9w5k2LoV+7efVX8PAzsUnKfiDr+aEZA0LJX0668O7bxvhG9GrCzyDX97gGlYMIBAbBQKxrvNb\n/7mRDG0Rv9ci17FGMfu+rVbWPvyiuGEzdfTKBw9fI3jWYq/zAQUMl1zQV5OnYVjk/Uy3HlywtVkm\nOnzJSw2iYWojeuWDR6zxBtEBjyX6FC6y7n1trNuZJZBZWmU9iwRZkymXrX1EH/sSGzYoer1AotcO\neMiawTOYYG28H9NLVvoDH8kQ2P402CBkxdpMOYLBOhJtLIjWq42uQAD1OziWZNrUawHPMLXP6mAk\n61xYNsLnWvt31tpApH8T7lKAaO1NTeiVB54sdZ7dumK9Pk8sAMPUPpeLfRvMhxk+ybNWTSR6XCdZ\n4wK7PiANcq+tKxM8ZMMvfFBh6hecw10gyRpB1GuqhohKvfu55o3saJOcy5N13mJV0G5EHHMQWboi\nNFCS81+rubFW7bNRJlA3LXm57zYZUJg2Tgt1aqJB93Fper9d0QBaf5rFWvOn+j/uYL6PGJIAbzTS\nhr94rB1E67neywsi+k8TPBujfbrv8spLlxq+zK33OQ7D/P8nBKD1O4KXAjzrsbFXIz022FAjw9xX\nPzEkgvU2U1zfvbo8IKKXDzy4LOAZzNYma9hvr3k7V5qvI4YASJFBXqzXH1oPiDaOobsiALR+8KyP\neel/kRpM4HsPyroyX4Mt2N1oZ3PxEOs2D4eRYrOR5QuXEUBiSOChl/DGDhsQV3cj/3hB6VXysF5T\nbnggukTTGS4VeMQQHuD61PsgpttgxxJXKSTWsqCQjOsmGWbs+rTAcJI9Nx5E9OoCz0aabmvfv7hC\n8dPPGjDouWfvU2QCa73PfThBUnH1jjcZlholWC94BLKLubKYMrJB0e1harPhNeBY23ey8tdEj3t/\neUz2SwEiupHgGcaDJomZM8MQGLIO4VmPMA8TlMMOxooNvHZxxWui9O/1wm++ze3M7enqIOh+kN7b\niiEL/HqA3L8wDV6Ed7l8l+HtY3Azbi3P5fLE/LJBJFb5veh467+nP2k/GiR90F7/HyZ41nvTLiWd\nOTzNvRGgFRusEfsR3Mu/mPY+l9XOUXR8CtFFA5nBqHRgqtf/hxfEGqYfMujY9UutCS47ZNfkqwyu\nhYZlypEBnjnp8jfRxS8WA+yTZGugXhe5mhk3LIEfBnguRQxgsOrOy0FIZCVqiqt6IegEUT9dikim\n/xuXUpAe5BLp8nf5SZMrxGoaRGwwG3T5wLOx/fHIZQFu9rF7xXGGoRG6Cfj6A6y9QUTWRBKt93Ss\nYanX9QmRwEbRx1e2I3+pzzddSk06Fp5BnwEh3dKYuoNoGItKXIx3eV//fwC0VWZuzsA9mQAAAABJ\nRU5ErkJggg==\n",
+      "text/plain": [
+       "<IPython.core.display.Image at 0x1085d30f0>"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from IPython.core.display import Image \n",
+    "Image(filename='../imgs/Mathematica-ring-a.png') "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAUYAAAAzBAMAAAAZYbwFAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAq4kimRAy73bdZrvN\nVEThti0HAAAFH0lEQVRoBc2YXWgcVRTH/7uzk/3I7my0KoJChpBiRDFb7YNvu4jfDXTpQ/tgIRuo\nIATdhbagYM0oKsFCU20ExQdX64OCaAWhxfoxEYvaBrO+iKKSfRCjIHRRk8bWuN7PSaaZney9ixvP\nwz3n3nt+55zcSe6cCbAJEt1x9SZkVUt5F0bUgE3wPoZ8aRPSKqU8hNG6ErApzvNFjbSRgZwGpY18\nqkMO5vt0ME0mqpPMXNpja+bTwV7XgRIVHUqXseyekjqb1Dl89TSCGP/x66I6nK+qMzqEMbTl23sx\n0WxqwFM5DUgD2YW3qo9pcBT5RJNTxWxM4RtVSPj/rcmpYkVcp4pI/57fpfWf60d1MyRWdElVzliC\nqcpw/94/9Dhl6niigWeUKQZkG3qcKpW52FsxHFWK+5fd9jnL4b7vtI94nuaprQPPebNw4xe+naoL\nt6kNXzPjXqcyJphYiRvWyYJYuUyZh6+632ixd5nr6tTL0yNLults9jurXtKypMG0+bycnpGGK4xs\nTa749Q1VWPdU/WsBsxZ50kXhmxZ6or4ejvmX3hPThCPXZfNyXkaTG1zvfZHo4RybmFz5HcSsRZ5J\n6ZyymWU2A9K8IZ24ljXGPdc9wuFGv6OcfU4dF/gs48jV9bpFnoPS06wwK3NBLqxq68CqTS1Z42/e\ncm+Nm595K2uNGLtyt/OlkBpb5LFcL9hHzIqKVyHvSoA3n7bx2l9X1JgxfuChww6pkY3AHYQwrr1l\nPxAtcHMFkiNzT/IuNXfzeYsaQ/LEbEJue2ohBwyyGOk/eSjRlWSO0e/faYAb56rmP8CHbATOEteF\nXG+D7LrcXITXzYzMUpmh0XZW6SgkuMawPOkqYO1nvc4PLEhWvApFV5JawvkcrZEbJ4FlgI/AE+QY\nLyJ2goSocNNFUDfzKjkBT4JrDMsTrwOkqd1BQvDf6bx4FcquxBoaLtEawYzTrEY+AuRIIw0kHaCH\nnCU1bUiOEJ7wLrbI57LGbNMTAvPwwXmydaAfeIl4lVmMdynAhHUlxkyxzGrkxroasycwWuI1UrNO\nSMaxCHKYoEamRIbY7OyXj8/O9tEFn4TloTVegrlEAF7jTlewvCtJuyg/WJyGww1/jYfIM3AwT86O\nPmthym7mvpepvEKj9RfJEBNx5TmKqVBheeI1GMvINEz5rOcKnBJdySip4ZHSNGxunPY96w+A0Rqu\nJyeUcqUZ1M2UHRJzK4+L4BrD8vRWYa4g4pKm/W0WpFljSnYl8T4MP5wbgc0Nf43kJkhXM9NRfvcw\nU3KiIK5S5O/wp5xYCq4xLE+0QK+Q7wq2uHuMJo8luxLj/cldX+CBK3PMGGte8/2FAh9Jyl/p9Xhk\n/AgptS5MyZHdNTI2cyf/0clacI1heayj5Hqc/PlUHfiKBg16zdD1QInLs4F8Fwa6+RfX1rh95GP/\nZvCMvCS4mBWqE5fEtB2VsqXXkDQ21pbj+Rh9mPLO11tdb8iOBVHGRpbXu7ReOSO2TLe1T8hOpIhk\nI2Rfbnm92V62kqS3UNuyTXhGvIfeNkod4wcRIe+BDYWcN5ctTKl9zcjvkWc3TBPokF5ErJ0acTvH\nEyWmyy6fdmtMLqpnmrfVmU6Iska+4XonGdXZc+oI5jSYDhDa1ymL6MKVOU3gSQ3O6N4/pGh1mQJu\nU66StMPdlH3AceV8kYoy0gFgvDAweFSZjxeUkQ6AJPlaUK+RfBf8z+Vm/f/+du0nm9vtdWpdy6ma\n6NabSqpIt/3/BXDQmsurWvAhAAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$$\\int x \\operatorname{atanh}{\\left (a \\right )}\\, dx = C + \\frac{x^{2}}{2} \\operatorname{atanh}{\\left (a \\right )}$$"
+      ],
+      "text/plain": [
+       "                       2         \n",
+       "⌠                     x ⋅atanh(a)\n",
+       "⎮ x⋅atanh(a) dx = C + ───────────\n",
+       "⌡                          2     "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAiQAAAA/BAMAAAAiU84yAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAq4kimRAy73bdZrvN\nVEThti0HAAAKZElEQVR4Ae1ae2xbVxn//LiO33a3ritlJW5oaaCFuaWgIkC5m4Yaukx1g7QCm1ZX\nmpjQNCVb16qIlTihg9Btqluo6BgiV+MvClo8MSBCiLoIaWxEJAU0tUIjRqA1EkhxWJuWPha+87o+\n9/pc25ljO9V6pNz7nd/3OueXc6/POfcAtLp4xlrdgiWXf/QXS65JLW6Q/0KLG7D00s/kll6bWtyi\ngWQrGuC+97ZWpK0pZ2S2JrPFNvoc9Cx2yEWL57qyaKEWEui70JVeiH0zbcPvKLNNc/QlpbZ+8CDs\nLlSL4upoyTMN4Tls2Z7f2Zrni3PAm7ZozmxMWeqVKuW/7drt2ZLDVNVIa7tEK0pezZAoJXDUlips\ntjcva6L7pibleiX5gYvl2rDUR/t/ocxam9uVKAObATBKXralGjbrL5oSCq64JlcryTuXKSiJlQh1\nS+yo4/j71XjDUTUl+8y8u0wJBVfVfpSs/QpKZlKm3kK1icpCYAHJZL+6ZSUl0bwZNzRpivVT8mEz\nVjThS5sVtdBlqPGGoyYlW4bvAzhzaPg7mNKbAPB03nq2G8Ctg1l8tz8e93Qfmoy++tz6NKLTP986\nmMC7sqhGyenhVTzuo2+eKY0YpT8cSarxhqOCEt9xcCWiF+GEG1OGDYBe+InxNYBIHuuiuHLw1RTc\nAoEPdGUQS9yR0cgPFvSMk3KaiGZRUKJdhViaxR2YnzctHYRTDnjDYUFJWwI8c6EsbCMZ2wrYXzgC\nbwBE+7EuClLyBOAkK5wlr9lo4QXQ1NMa1CooiVyEtgSPK0I63685qxqrEZTM4DvjgisL7yPpYgWA\nFLyfiL4iufLiykWvo1YP6wTQkA/spbV85nlSfqSkxJtHXx7X6qWo+f6rAJsCCUpGCwDXfHPaQZKV\nUAJwgFxslARxVMTyjBLChytPjFRFMUoCOswYPK7KxYL5kfzWFEEJmYPNeoaG0qQZbVjB5wjw8bA9\nOBEySuKcEvJfN1Jo+nk6NF4grmZRUILTkh0pHte0cxJCbztpGo0LSvBd4nsnWGDpQgbAj/1FeBog\nmGcQvbJ3SV+BU4I+o6mEpJdFFSVpfBXxuLKpUo7JT6zSolGgoCS6F0J69JdfSZJEbh0iV0L9noz1\nRxhCOTifhFeAU9JVgA2RNKiLghLXpDcu4qqdJLQvL1WoGOyeXmPHGlGnlOyZvxX2dKwCGJmf1zFL\nNAva2LqOwyiGC3jhxdM+a/huWWNE2x8nTxacB/j0c0Jpu3u3Xdtug0Bbud2Ma9eV1Y/E7dCXZ4xA\n2gruxGlCpfLvJ9Va7Znl2z26WsdWwkL3YAEeOkYqewUClgm9iTZBaM/Yk3ziWYjRQSwpTkuySnR4\nR683ILrNUDkgxh4crvwp3v9G5Bc5ANBpSk0WBgplCVeScUmLJqixdtmEhSvOPVXlweOI3slilPlA\nQHb6VBrg1yRGOEWuWLQ8vdV3+UJFd7VWmxdNKDnvh3uirBbJsLutywI2XdxZU5SFV0lsTm+ZD+zu\nl2y1juG1aVL3xDnqSnKhntvZis5qbeRSmZOnCPvfYqjoh63LAjZd+e+AWWeCl46tLdZQJZvRREmW\npK1c/paEvWtR3WkRTq11i/n8piH8kds8+NlDmWgO7jaYl+h7eOWgwZQUFzD0dpKGbxrCOTl1ZV7i\n2pUn0v2savrQRAQbIWOowUXdaZFUaHGIpvnyG1Vh/sUNJwenQEsEf9CWFQ54F/3YnYM5SSlg3zfg\nNfzdRNeUqfXSpek4Gf47DEUomojgbuv7STJdRFF0Wh1SaB8phLN8+Y2GMd4w3DW5F9zgL1omQKLv\nuIH7hKQU8K4MeSWia0+5K8Yekd8GwocmIi0czZBrg4votDoN12oHIGSUlsldbzPrdoATuLBw5SzO\noh/4MeiCpBQwOmHB67FyV1TMU3WKXs0BRxMh5D3IcPmawIqL28v4u5cFJfPWUmQRudZFqqVl8ijX\nXgW6JdOWKaXHR+C1p8bpI/A9iF7BJRlVSvBVaoyuZOtCdmVBBsiNjjqLD9v7Ue2B67j8XZ9kzotw\n7Rkf/759e6kUtqSN5Sh6gOt25KnguQyRIq4+8UNYimvITQyH6+DFSYSp5DA6YbG5eunS9HmSpZ2E\n8hIbLCUfmgi0cTkRs9HxFkgyeXGuYpSoo3FtV4ao2fIbhQmdVEG7jvsPbwSTR8Avt1RQMod7UpJS\nwDhygk6uGLQvg5d1+EcK92GJCPAlMo/jJXjf4TiKOv61gJKYAWCUlsnzk9gMLK/DOT0xZfwKtrI6\nu4q+r4a7QFIKeDnAh5xcMUAQX93/Ev904UMTkege9tjRRJFnoB/uWnZ02WQrKHHp4H6ML7+xXfO8\nyZuG3xorPDDU22nQNvKL6MfOQwZISgF7O4dTOC1RupIIe07fwxk3RwmzpuF3mDqAFZ48Yjr+tWCU\nwN3DT4vlNza0fPKKzTKL6LsJMMEBtllZq+U+ffmSRdb/EpKrI9BISrb0/LaUEiXlm8YvjV6LNatE\nMwoQJ2dqWGkrwHKfGFv2uQenV2i54EfQUMdfnG9/VHgsxn1aDoLLpyPSyMSvQbJWyK7LQmr+nW8O\nrHPlxBRFr94I328SKqM+JWqzxClPoGjDyqsB+n2oHG8GwikphA2RLSkEp3sBf6jiKuWMrkJtWNs+\ncJEZVOUSq85a5QB1aMUWUqwqE2YSHSCkpASnVNVL+CJ4q1Miv+Kqx1xcC0HJI5CuMXBQd6KkxgDW\nbSu101RCjTcDZZT4ihuh1kac150o+WS6thbX8M65s1BbqEZYMUq0sb8OpaqHJ8cGgu1HV0NoxfAY\n/jB1r0n/58Cf9//sf29O/Ml76S/tcZg++SyFK8b6Y0UtVU5UN2mYhXhwakrAjg3oOEpeJ8fvzgHu\nfR7952XtMqndhm8YLQcBBleI581VUHKV2FOrbrn4FguihB4bCOhIST/EMuSj8QncvkrBHdAWxwcv\nFI8eBzeDK7R0sIKOqzwt+0aODWCUxKw7GaRWLG84OzZAKckhJZELJ0+ugt+j3VTybDFaIL9DAyvT\nDC73FkhEh48L2ekebOG0xPodx6mFHGfHBkxKyIISKCV4auSgG8dOHHpHZhnsHOph/N7srGUaV381\niwbqlQ/Oo+qE7NhAQPeTj8OxDNnQYpR4j2c29BJKfEkY/TuF1REQ9RzrWJt11HJFm17NooF6OyWT\nmOtheu5GkRTfJX2FgO5mlMDXAb5IR4lvNtn3TUJJJAPeDIUV3gwK4ENZlZK+tKN/4xV2SnIk5TmH\nvPhF5RXw5gUlMwXcmyLvEvghBPKUkn0QSlLYIUJN8EZ2AKom2wYYLYgScmwAtJc/6GuffezUk+BZ\n3pH8x6XV2KrD4M8Aog91Dn+MwnW1dOL+vXX51+ksKBGHNyqOkjpz1eq+eUO6VtNG2AlKxOGNpUBJ\nI/q5gJiCEnF44yYlEKKTC+SQHN5wjY8/Nf4H59frAqi+gU39YurMD2/cHCXg4Vvh4vDGTUrMkwVR\nfniDULJ5ovsGHvf1N9228UtHSf1Rb+gI2khBbn9crrxXZW/lZdp7kpaquxdNZuX/MRPqh2eBYUQA\nAAAASUVORK5CYII=\n",
+      "text/latex": [
+       "$$\\int a x^{n} + b x + c\\, dx = C + a \\begin{cases} \\log{\\left (x \\right )} & \\text{for}\\: n = -1 \\\\\\frac{x^{n + 1}}{n + 1} & \\text{otherwise} \\end{cases} + \\frac{b x^{2}}{2} + c x$$"
+      ],
+      "text/plain": [
+       "                              ⎛⎧log(x)  for n = -1⎞             \n",
+       "⌠                             ⎜⎪                  ⎟      2      \n",
+       "⎮ ⎛   n          ⎞            ⎜⎪ n + 1            ⎟   b⋅x       \n",
+       "⎮ ⎝a⋅x  + b⋅x + c⎠ dx = C + a⋅⎜⎨x                 ⎟ + ──── + c⋅x\n",
+       "⌡                             ⎜⎪──────  otherwise ⎟    2        \n",
+       "                              ⎜⎪n + 1             ⎟             \n",
+       "                              ⎝⎩                  ⎠             "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA2sAAABBBAMAAAC9RCFuAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAq4kimRAy73bdZrvN\nVEThti0HAAAOwUlEQVR4Ae1bfZAcRRV/+zH7cftxlw9SgaCZhIChwLgX+QOr1FsDwslHZUWKkAqQ\nSUEFIZYbCEEKjdmcKeqISA4IiApkoaQKI8XdlfItsiKUlXCSxVIEAbMgZZICvQskIULI+t7rntme\n2dns7iW3e3dcV+3Me79+3a+7f/PR028bYHQk3xOjox0TrahrBHofrct8wnhUjEBo76hoxkQj6huB\nwb767CesR8UIrE2MimZMNKKuEYjtIXOtc71RV7HxZhyb/EKVLl3YfVYVi0Zmez4ib+GCdlcjvY46\nXzsv/aRKm+6DxUYVkwZmRw+Rs5sBbmmg09HnahKkDt+oUA+EcqqJZ3Yz3y7R/dSW2wAGm9kKdTya\nIk+q5jXcBvEPVKM5HW2q2mBZ0IYfAel8gz2PKndVaWtNQkB9jmr7F+lN7AHT5nsfacs0sRXNdr3s\ne5PgtO7z4b0b/nI9tcU3fd4qe5s6dAgcUKDQSkVpvFiiTW+889HjcQYE7gSPDrf9i7nZmYgMYeP8\nA5zoaUi04cVtJXxoNjNN0MajPwOCOvj2w1aemvg+An+fnRUnbR1Ze36DtRJtmQZ7HlXuZsBgHmAv\nPM+t8gxB2DEczofkxkRT28+0YXshnW1qO5rsfAb0FgAOStpa+2CpYW8RTUn4E1fCz9qzG60J2vAD\nYEdzL59G99vhbwbswLttj6StIwM76Gnp/xmnPjTGd1lM/QA46KigwaqgDT+3T26w49Hljt9tgUOS\ntqV5OD5m2FqIn9venhJim56U4OrSnH68HI48CdrCeY0nvkde3xit4WmIr4JIUtIWzcY2eR09uRcW\nGSUopH7DleCqkj/lz1U1qsFA0KYtWGfUYDxuTdqLx8Gy2cfBWx9+hvrom37rilsdnb1w7jQFiagP\nTAWvJoYTOF09CknQdhQq+nRV0To0vP4G89qh4ZW0l5qgzT4eNWrpnLvhLhVuKaialGP7WKhu6FK2\nBE3QVhqLOqSNba7GATvsFqGL6lSyguG717lWC3Bx/5nZ05S8CdqUwahdnJlxtY3ap4lRF6NZjFUy\nrDDT8d4I8A7+rDRBmzUU9QhrC67W3Xa0RbfrqEmogmFcPEGdpbSteDl4aRakJURe2N3QWXBCt42A\nVrTfVmbmalMQZ22lXUftbVhOWAVD9dNQKRol8zhVFssIeGl5zSJj4niYEYh96JoZzzngZxw6BJ55\n8xjEKhlGk84CrC/M48lHeSZtvToqE6nOEfDKtS3f1Nn5+IaHctC+4PNYhV/HQ3vXzgTMX/eV9RmA\nOajv2nILBDpnGWwTLBaHEHM1xJK4ni1LopGVfOxNMxAwaducsnJNYYMpjNuzRlf8kaQorr1TShcC\n1y8B6MFlsSsNgGgWb6RV8CxoesvPgz0Ab+DbqA/C8BrE90kbKuZqyCVTZkk11ucvrWFL2rzlU5dQ\nH9c8rg/vHWHvWuWwvQgt+3enQI/2Qa8BECxgPDUL54IXQkMxBHYijXeidgPA3dIGKAUL5YZU8jyr\nJBpZKVxakpG09WasTFN4zRTG8flIL80OMZD0Zw4I7rmJYt+UWgsAM5Eh0MDDF38awbXTjdjeLVuO\nkzZk526IJW+3SrKZPIglGY00QZt/jZrN8qdjTXlbWb/rAnqH2DxOTy/t5GLbYJZ1ou1j0GjVMZgh\nhGi7YPOeFro5pQ3BTFuZIQK08CVKspk8BNnbK/Tc3PqDgYE2WKSr2SxHkmXQOAQ6EkfUqYU5Ls7h\nm8uh5ZO0znowD74DEBvCG6PDoIAdPiQDCej9J9ErbSoa2kuqsT7PPiqUpIO427QBrJtToE8Kg4ys\nkNqInSx/I+ZBqbjcmb9Nya5f3J4UZe7B7+dXATrDOYAsQCQL2ifgyb3SktgIIRzIh3mg/Znv4/KU\ntOGCbob2kqJ+ceS/jHmZF0EbLL5T5nytRxryvymuOFYtNgJywPI3ApU7q3Rx5iu95Z3WtejFvLBK\n5+FHf0/Bb/AvlKEELmQkAbbBa0l9R/ZxOB1N8AMgthoiicECnChtEHU3tJdkM/PQm4f4GaxI2nwf\ny6yYpC0g+jPi8xLTn9myET27OOOrc7hOfUXkiJJvapfxdndXAdo7T0I1joPY3v3vJwpLui6Ym0Xg\nJcTmds9Du9kJaYOou6G9JJuZh8DxU88XsqQNFualLmnzi/O4p63XHJLhnCsskgCsstfmsrglDWo2\ntFco3234osyJDPOClPOYCrTFM45qUN2lQi0FVTPlR0yhdDb9lRCWhunA3a1Vt4sz/LvI8FPIfEY5\nq3jADngzdr2k1WxYKsKSOT6tPEvBR7C829IGZzNtgeN1VkqHZSXRlAJtpsTns2waKY/iWo5Rhgp/\ny55zZAzHQSQFUO5WrdjsnIKFk4pSElc4G8RZzj/8eA6UStgkRzzmElumqtRsqBZSZDNwY/Zso8gT\nd1vYTgnAC0pJKToaEHVaLKHrIudEzcsE/+lnS8NwoD2LtJW5tdVqdk4BPT2KIsU4foQ5G8RZcbmW\nZRYJV/o/iM8+YFPMAmXnmg3LSgrASduTAha0ReytgFCmvJZuOyTjSRb4zUlEm+OZgIgcyX7LkIV6\nHHxLFNUmzUTaLLcStVfrQltoyG5Cmh9/jgZJI/Sgpsr/JKHpo5VChiWWCTUblpVkwEnbL4SZO21B\nR/PJdrUoYB7L3sIhom2RmW2d3Wmrx8GrZl0bsVWWWws1c+nsQlvc5Yb5JZq606ZWhrI5IXDADVSd\ntMnHgTtt75U3LJ5zYM84dKYtkneg5kg6RqkeBxZBRBuYbi1UdehCm22zmrCNX4dnR4NEjm+5Whv+\ng1u3643XJG2+U/dmyLl2gJswf3snnfEh6etcn4fY9M7uHtQX4I8iSwxSHKlS5AgzzMS0eZOmKs+m\nPxwl2lcGL6/vvhmz6nFgEcS04YctJwuVOp1MZwpkdtSEqBH3/29SHvq//eMMwBVd0+J/+snnrt5+\n7xsHCwvXtO8BjqohzAW+UDDLNets3m3SP24RUhLSdlUKJsNgKpzREd+GS2wUWSKQ40gVIkdKFcC0\nxXIqpMj9Yl8Z/ofibi/C9TiwCGLaMLLFyUKlXvGkblaTm9s2ofHvsriei3cndvmzHZmlGdQ8KbwH\nl2BUjWGqcHvFWhuV4aDNtquE7rZraVX0SfCvpAb9EGmiyBKB36U4UoXIkdp4pi3OxVVYyv1iX1mk\nB84mpB4HFkFMGy7acrJQqVc82SaHQZ02txFtjwMcoEX4cCbag+GXHFxD3eyH3RhVY5gqPFix1kZl\nOGmjEIOVIm1x1FuTx4KYL2NcoUPHpRkGMY6Ehq0FlxATfJl3qtyH+eJuCwyh5NvKKBYopX6xrwyr\nP5bAmh2grUUQ05aWdVqo1CuebLQN5mlzG9H2NNG245wt92ejSZzLfBDbCP8l2iiqxjDacJitYsUN\nyRC0tRYx0dCKNzWrqEXaWnAgW3NpYxH2i0d1MIuzbQYxjoQQ0VYWOULcSny3MW0WhILpr1/sKwvs\n19ZQNlZcm4PzBgZ+OjDwB66yRJuCkoNKiTpKW/pKqbdAt5BFWy/1lmiDa73BvE60UVSNYQRbXGah\nCDcyOe828W7znnsMNSLSFqMbq+30uSdxm3Bo0zpegwROwzgS9s4txMS25qHCQ1JuGOoX+8p8XV0G\nFajHgXVf1fCQnG+2Bi9MXcg22sTmtk2QEXcbXTqCtm9c7H0UC/QDRdUYxhzPSjw0Nzlow1gdpa/j\nvxowiXdbuvAIKZiewu15OYws4bst/Z8M+DNo4hJiAjUxbS05FULZ3DDE77bAIXNNsR4Hdtoelg4s\n1OawT9HmCfl9BaIXLM61NoEuaAv2gZaJJtEiPSVwIEG0Yb2dDCMYpJzmJgdtIHpzB0VnmbadCfgt\nvLv8cm4lzrI5akQgx5EqRI7ULjFt3qQKoWxuGOoX+8rijy3HweH4VM0OLIL4bjvcB4C1bs6NEAuF\n9imz2Nx2nklb/BB4U0wbXqX3YKl+oKgaw6ilDa6omQcnbddxY9bA0gJSNHNPIjB5VhbCxSI/U3Zj\nJkWWCOQ4UoXIkdIh/9kHz8EHDtZmS3LD0LLiFN5XBpuLxSQa1OPApO3Mtc9nObLFDkyUFfMQ4WtC\nah6DBMfnNm1ugyWTE8uK017/MIkfpyfEZ16TxwlVFroBlhWPEVG1BScAnAozZE1NPEnafJ2nGNyK\nF2VbdqRKjdJeAm23jnpQ7b7MrylyVL64BXLDkKjlkgJcdnudDmwElS9uzZlleLvPgA0PZLDdWPVp\nXY+Bd92uaXJh1bYRWzSixuP2ixxdrrHcUTWTtC1OdAiezpa1P6d4aenDaQj+Sgu2SuYDioyiN2PX\nhTa3HIzqCvZrlF/HX4sKyvxKDnbJfD5Zbk3Uk4nov4fFl+kaVvkdXP65w7cPTvT0rYF4G5XwDnG5\nYRzmn2IMo9RRLiJpmwpXiYrlXeblvklfvrt46oFa9biKeHM4GqnlHACqs1ToSwbPd4btAMrc4lUY\nH4LITXv/lgJ4C2d/yUAPFKJZfDzmAFOEjySNySRpOwTrRPNl1Nd+iV8wt+sszm4v72MtkSNPoqyc\n/b7SZnfPMchmmA5gitPBIN66K8HT9noxjyue9H0ZwiuxFRsSyJFta4aOYzZF8BsMHyH74CkRqeL5\nE8T1gOHWJV+mHD1dhUKGqpnyTaZQOssNQyVASMN0UO4W77bL8G6bl4j1ALwLsDQVeTABV4IB8T5y\nlUYCx3AKiRn/6sD+B7kXeIliWvHmy6kR7ZTcMDRyPiI66H+GRZfqgCwtxllJKn31RUOngi7fnyeP\nnOtG1OwTO7Xe2bA+y+7ERv61xeLIOpcbhkbQyZldcOHsM2ILugz8SsQXXedD52hP/LUrBf4Ceb2R\nDmM4LczaG3+KXR0XWiivdCNKcowfKgo61kTn31mWGmOtB9Xbi7HBUuLvvXC2BIxJSdtcsLU7lLOp\n40P5h9KNNpJ/pQBjU1T2KnIHto3Nbhy21S2Gle1NoegbBQsdVouGKXzRXm6xYdfHoxbNj7te+f44\n7rpU1qHpZcjYB7469rtQpQdaoYrBYbL/D4l+fQ6QhDaNAAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$$\\int \\csc{\\left (a x \\right )} \\sec^{2}{\\left (a x \\right )}\\, dx = C + \\begin{cases} 0 & \\text{for}\\: a = 0 \\\\\\frac{1}{a} \\left(\\frac{1}{2} \\log{\\left (\\cos{\\left (a x \\right )} - 1 \\right )} - \\frac{1}{2} \\log{\\left (\\cos{\\left (a x \\right )} + 1 \\right )} + \\frac{1}{\\cos{\\left (a x \\right )}}\\right) & \\text{otherwise} \\end{cases}$$"
+      ],
+      "text/plain": [
+       "                              ⎛⎧                       0                      \n",
+       "⌠                             ⎜⎪                                              \n",
+       "⎮             2               ⎜⎪log(cos(a⋅x) - 1)   log(cos(a⋅x) + 1)      1  \n",
+       "⎮ csc(a⋅x)⋅sec (a⋅x) dx = C + ⎜⎨───────────────── - ───────────────── + ──────\n",
+       "⌡                             ⎜⎪        2                   2           cos(a⋅\n",
+       "                              ⎜⎪──────────────────────────────────────────────\n",
+       "                              ⎝⎩                       a                      \n",
+       "\n",
+       "    for a = 0⎞\n",
+       "             ⎟\n",
+       "             ⎟\n",
+       "──           ⎟\n",
+       "x)           ⎟\n",
+       "──  otherwise⎟\n",
+       "             ⎠"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAqAAAAA/BAMAAADNvWdJAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAq4kimRAy73bdZrvN\nVEThti0HAAALGUlEQVR4Ad1aDawUVxU+u7Oz/zu7UkBU6hsQ4jMlZcHGNLHmbdA2rxbD+mptSRvf\nNrFWJPU9BBr8QRakzRNrgQBq1chabVJJ07ckKIS2YVttFCRla00DUXxrbVqaNOFhy+NBxfXce+fe\nmXtn2F2e+wN7k50557vnnnvON7Pzc+4AdKZpBzozb9fOOvrbrk2tI4mF3+3ItN076eli9+bWkcw2\npDsybddOmjjTtal1JjHfhc7M27Wzxv/btal1JrH4RGfmbeOsvrntvE0wQvX+zbk2pvh/TfXygmzt\n8Woy8/pStQc0tZcRGqnoP2qq29Y5M9aOlWt7V5LRJ+40aw9oai8j9PsAjzTVbeuc+VJ6HedKMuHh\nOvbN7WaEbgc4nW6u41Z589X9/yrJROoOaGqojFB8/RwqN9Vvy5zVJ1RJpq/Qsli8HFNCtX8joXmv\n7isOC75/VUrr31w2/vjDj+YwOm3W9avlINVktrb3r2cTaspxXamarwgrsjANIh/uy2OMb6Zj4yTU\npUdJex4lSqhJMNYOcaE9+6uR0G8A9OXi28jNSbsAgaLMlErof+TuVms2oflWT9Uc/76icREgmYln\niD/fOETyRLCb8pcP4uWsnY0SCuQ6XmjntFOfy1eM4ttyssQITRZhMKc4k5MJI/3tbIxQfNIYa++1\ne8o5+ooJcoamGKF4HR2DLDq79THSfkbcysnE3pnyVFMayAjFZ+GPTWl4+wfhTQmvoUMVRuhgGWYn\ncnIUcjJJes+SLVqpMUIjZf3BVs7SRN+xIt7ZYR8wQuOFxE6/4l1OZqikdNdQT0l9T0taowojVF+y\nMdfoiM7aaT1nCsFpcwpGz6oyRqLNenTlo0pEcjJbU0q3S135ggUFZdNAjuHG/oxloOzu2vuZwg0K\nBoxQFe0ivSfvTsaQIB0vurTFsxIOJUtNkkPnbv5vAbyOP7lFzsp612kbKu6UAjK011JHZBget/TT\nCtEM1g8j7LduebeLoYPDQuxKQa96sPFrOVVO6FoZhjst3ft+HSfmhkXfcTF01BRiVwqJc+60jDUy\nZhFqlGQYYmUG/EHBmbqM9GoZptiE7vY4gMymO7Z+681T673meD+m9ORmE355/n1lKqxc89Uf5AH2\n0i0ETOynxRbL2J9hwEXgo1HnTaOO9RzTBaH+Nr9H8HDato/jexNpA/CbwjcBEjtgKcBOLvy5oONr\n17N0C/EC2tFiCzcuMeAsHw0BWoI5mkI8IC0XC0JH89jXzS1pnTEmbIVXAaITpJKOhDJhP8AkANtC\nqMKLLZYxuUCS6ksJLMBJVER6A+OEBtY7bIxNv3NoXSL2WXln4UM0I6N3YY4QClR4hhLKtpCs8GKL\nZRwcZ4CJL7dstIMU9gbGl2M4odLyVRzudwzoEnEUSWFtHdlpz2eHKKFMcBHKiy3UmBBKgAoOpADx\nwFuIOsaTntZif8xqsaAfzXIDgEg26dBs/KqWlpWs8LUJwNMpXoKh+7I7Ic8EidBQGeusrNjCjMlf\nXgIgQEswjxXRp48+wGcs78etPSzfxSWyf8updId8LMPy+FV4HB4CGETCvp7bCSYTnnH+5WMF7KfF\nFss4WlIA5optg5O49/MzUBCqvecw0n/vUFohrmyF09o+q3jaYUtciA1reYBQChY+kF4KJhMkQv0Z\nPINJsYUbuwBwttEyGJ/mgCAU6OOpBX+e883Nmrz/8gea7LC+O62apkb6gflzt6Ck7RsZ+BPcPS1N\nhXurM/92LsO2eJvahv2k2MKN4xUFkOYLzp7+OQHYhA6VBKjfPCDk1ggnWuO2hlevF6VLmq9Wevir\npwJ7qTahSXptpTaR6nkv2yZi7Sc07Lyk1cuEF0O4XS8X6u9PCROrfOffeGqmwGoJRt7Z+7RTseQa\nrhol1A4PfUYrHpM0CvkmG7VEO6V8p5cuY6wwtQid7ys6n/FFtyUEnzUt6V6pi9dgnWANV7UJvVSh\n9xandyHbIQmICEOmpEYmJLW2oqWkfh+7/EpYfcUitEJfZJ3mFacCy/lcL0qwqME6ULcr0akSaoge\nIlyq0BuXrJhSATskqft0RlIvb0XpRmnsw5LWqMIr9kn1cGQkDzGL0HBegkUNVncMd7kSQ1RCGyv0\nRk3hQAgZAB6SwKjA3wUt1HHPle1apnFC74ecNEc0I6k8+lBWgkUNNpG3cdWV3aMS2lihVx+2PVgS\niY6H5Op0AmOmU2uHzAgNji/AioqzvZlxaiL6tyUUsyozwCbU7coeohDaaKH3OduDJZHovAn9RE4y\nXliR1DYojFD9wF83iXMvOrIEoj3brwUiBPffMnIAo59JtgBL8OeqwSJmEyq5IkPstvhYv1DqFXoX\nbcLF4sUbP7U5DzBPjEKBfHpHo2MhBfvn5N5e95cHnzp/8thLgXOv9KTg1J5HgMBk1DGyaWvjf3nH\npCfSWAGMZACoED9Iyi2xI6zocgTtXDVYxGxCHY5qiPUKvcZqOAS6Gf1paBvA352OVtBP7zJ4jGlI\nJ8A4C9v/NalPkgBn4HmrFyECFMZhVr3e6aDFsgehoznjHUooFWLDkMwD2wJ8F08R+sGbowZLIrxc\nQusVevEr2dvAD+HxRA6PoJMD+ukdOdwspHUAP4HDWLCcTd7TTSTU2IUDKYyxtvlLMQyUEZqsWm2c\nxP7apglKKBViRUoo3QLggoGPfvDmqMGSIZxQydFNtNj1C9LP/dM9AeoUensITzrgdzfYhsjGauzT\nO0ooCSnx7p49HwSyijaWPj5uVMiVdcOsHINpXZ4PbNfe4wy9aUaQEUoFF6GuGixZaTn8naN0paVu\n2KeuyxGbeoXe90Anj+ShPDF2Eso+vROERi8SA0JoyDTX+/G8TcHA7jMMxoM/TLrb2mxC5+3NspmP\nQnDijkgmDFSQCcXXqT61BktG8TMU/LfN8Iyfey8FaY6svnvJQq82CYlxfKTsy5FP65x/efbpHYmO\nBmbQpTJCaGBX/jos7sRSwTSM/sNaQQtlPINpJSgIDWTxVkQaXt4TE29EMn4myIQeVEqupAZLmiD0\nZrKq6G7C+y6g1ZjB2oVe/SL4Sq9G01shjIQ+5fSH19ChCkbHCIVvA9xFz9DgmfTQ9wihGEogT2G0\nzDmHtkUWhEbSWPenbRX4J14JlPxABZlQfIJx1WDJIEHoDnJWuZvtnVQd6xd6j8CJjDlW2A83ojFO\najd8mtoHJDoW2OkKzKeEws8hUqKEroVYmsIL3Etrtp9WSYLQUJksUZP2yf6HFuT1vR+hwsM9Zx44\ntCZIt9j3Fl7+1BosGSMIXU+eXtzN9n5PmvTWK/QuGnnjQOXuTQO9BTR+iYzgjXx6BxidFZI2fW76\nn+euxd4tEM4Dol/qHbkeCAzHvqhWOLmTFu4FoUiKXRq95IQhSofdzWuwglC83Wa1fnbnsc1QQu83\n4Dq17n2JlUwVGvRhqbdxZbFHGI2PnqKlg9C4Wd9HVLHptYY4yqQvwPJ0X9blKm7qO7Sz8IU7FA8u\nQxAVF6vLn/ewuWKhGH3uoOHNaSTIFyUjjxqsPwXTYYVkZXn3ZYLbYHd1m7tPQeLy4bhH6b6y1bB4\nl1BPPu+4F0mwRw32cfL0v1GyIgp6T1bCKRfuBSiF3mu8bK5YTDvHQ3sNvsLFGnuyFms3dw3WMIP3\nnYWDt9s2TELvg9nYE2kV99TJrV20cE6IV4WwrMDCDD53soH7Rd2UVp58Obs2OPGEYki8h7JDX5P/\nzIpRd6h81SVUrY43IaMN1Sq8vmVzQXFFvBv9T35WgbtR1XdXujGtDuYkfznawUC6ZuqPd00mciL/\nA6gEk16N8pC2AAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$$\\int x \\operatorname{atanh}{\\left (a x \\right )}\\, dx = C + \\begin{cases} 0 & \\text{for}\\: a = 0 \\\\\\frac{x^{2}}{2} \\operatorname{atanh}{\\left (a x \\right )} + \\frac{x}{2 a} - \\frac{1}{2 a^{2}} \\operatorname{atanh}{\\left (a x \\right )} & \\text{otherwise} \\end{cases}$$"
+      ],
+      "text/plain": [
+       "                        ⎛⎧               0                  for a = 0⎞\n",
+       "                        ⎜⎪                                           ⎟\n",
+       "⌠                       ⎜⎪ 2                                         ⎟\n",
+       "⎮ x⋅atanh(a⋅x) dx = C + ⎜⎨x ⋅atanh(a⋅x)    x    atanh(a⋅x)           ⎟\n",
+       "⌡                       ⎜⎪───────────── + ─── - ──────────  otherwise⎟\n",
+       "                        ⎜⎪      2         2⋅a         2              ⎟\n",
+       "                        ⎝⎩                         2⋅a               ⎠"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "a, b, c, n = symbols('a b c n')\n",
+    "int_table([x*atanh(a), a*x**n + b*x + c, csc(a*x)*sec(a*x)**2, x*atanh(a*x)], x)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Limits"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Recall that the definition of the derivative of $f(x)$ at $x=x_0$ is $$f'(x_0) = \\lim_{x\\to x_0}\\frac{f(x) - f(x_0)}{x - x_0}.$$  Write a function that computes the derivative using the limit definition, using `limit`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def lim_deriv(expr, x, x0):\n",
+    "    \"\"\"\n",
+    "    Computes the derivative of expr with respect to x at x0 using the limit definition.\n",
+    "\n",
+    "    >>> lim_deriv(x**2, x, 0)\n",
+    "    0\n",
+    "    >>> lim_deriv(cos(x*y), x, pi)\n",
+    "    -y*sin(pi*y)\n",
+    "    \n",
+    "    Note that we must use this trick to take the derivative without evaluating at a point.\n",
+    "    >>> lim_deriv(exp(x**2), x, y).subs(y, x)\n",
+    "    2*x*exp(x**2)\n",
+    "    \"\"\"\n",
+    "    return limit((expr - expr.subs(x, x0))/(x - x0), x, x0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAAoAAAAOBAMAAADkjZCYAAAALVBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADAOrOgAAAADnRSTlMAEJl2Mt1EzasiVIlm7xEe\nOPwAAABJSURBVAgdY2AQMlZhYGAIYxB1YGAOYGAuYGBtYGB7ycCnwMDyimHeBgaWx2DyNRL5GCz7\nBqSS6yVIF3cAA0MUg6wDA4PQ5hYGAON0EpMbNABcAAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$$0$$"
+      ],
+      "text/plain": [
+       "0"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "lim_deriv(x**2, x, 0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAGAAAAAVBAMAAABLWfZ5AAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIs3dRBCJmXYyVLvv\nq2aiBbi/AAABmUlEQVQ4Ea2SO0jDUBiFT0vSpra06uRS6ODmUlCcA4I4CBYHFx0CDq4FQXSRdrEV\nRermg9LgVNBBFxUfoIPoGBEHt+IgTqJgfWGNf7zJvTcWN39IOOf/7rkvLvDfNSBPGNdlx3XkhUtE\nLKFJzficZ5RXTwHBjNCkgj7HjTSoyJs/Im74fbM787fUE79nLrDKu0qKSyYOuB+ZQqAOKEv3qWQD\n6+crCzliYYM+m8py+QQPGEPQHoFRII1joKumPhML1oDptfxDG1y+4QUi5iSi20BfBoYTOALeiMV0\nKKbWmofHB9He7VSPigskcjSiMQ8ncMgCCZ1SUVjweIU8q5Y6KiVAHbet34Ek7RIuF4FwCosUXUb8\nQwrETOrNgg7n8kE2Pf2DWWccqnRIKRCt0aJ1vHN+ywNhS/kis5XBjhQIZQEtDXpcLhfXqu4XnijQ\nX5zTy/Z12b7Z/KTBCu2ernaP1mG8k68AhAg21anoOFx6GlcYMwXk6s5TjIdynkcvdrmWBH/ejA8L\nVC3owggVsFzN+KUgf6kOGWglfAOzz3frF+JlMgAAAABJRU5ErkJggg==\n",
+      "text/latex": [
+       "$$- y \\sin{\\left (\\pi y \\right )}$$"
+      ],
+      "text/plain": [
+       "-y⋅sin(π⋅y)"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "lim_deriv(cos(x*y), x, pi)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The function you wrote above to compute limits using l'Hopital's rule is very fragile. And even if you try to make it sophisticated, it will still be unable to compute many limits.  Try it on the following limits, and see what happens. Then try computing the same limits with `limit`. \n",
+    "\n",
+    "1. $$\\lim_{x\\to 0}\\frac{\\log(x)}{x}$$\n",
+    "2. $$\\lim_{x\\to \\infty}\\frac{2^x}{3^x} \\textbf{Warning: Be sure to save the notebook before you test this one, and be prepared to kill the kernel!}$$\n",
+    "3. $$\\lim_{x\\to \\infty}x\\sin{\\left(\\frac{1}{x}\\right)}$$\n",
+    "4. $$\\lim_{x\\to 1}\\arctan\\left(\\frac{1}{1 - x}\\right)\\; \\text{Remember that $\\arctan$ is called }\\mathtt{atan}\\text{ in SymPy}$$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABMAAAAPBAMAAAD0aukfAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAMt1URBB2Iqvvu4mZ\nzWa4xGRRAAAAeUlEQVQIHWNgYGBgVDJwAVIgEMbemQBmYCdYA0DiBUDMuvLnBgbWU2c2MDBwCbD9\nDYh1YKhmYEhnYLC/epGBgbmAIYGBge3nA6DKBBCTYT2CufIjWPQpUMH2nwEMfAUMPAwMGQz+Uxhs\nGBjYe84+YGDvn3kAqAZuGwDaSx3BxThQpQAAAABJRU5ErkJggg==\n",
+      "text/latex": [
+       "$$\\tilde{\\infty}$$"
+      ],
+      "text/plain": [
+       "zoo"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "lhopital(log(x)/x, x, 0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAACMAAAALBAMAAAAHCCkxAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIs3dRBC774mZMnZU\nZqvpz9EoAAAAeElEQVQIHWNggAHWABBLAMYF0qzp3xsYWKfNbECIsS3g/hQQ5MAggRDayMBwXlWL\ngYFHgEHIGARMGDYwMHB/vwBUAmRAAYiVjymU/gsojlB1Faix8XsAA68ATB8DJwPDPgb/EoaTcBEG\nxpeTLjAwvi+fgBBigLseAP1wHBzUhNGNAAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$$-\\infty$$"
+      ],
+      "text/plain": [
+       "-∞"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "limit(log(x)/x, x, 0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "ename": "SyntaxError",
+     "evalue": "invalid syntax (<ipython-input-26-daf458c59400>, line 1)",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;36m  File \u001b[0;32m\"<ipython-input-26-daf458c59400>\"\u001b[0;36m, line \u001b[0;32m1\u001b[0m\n\u001b[0;31m    lhopital(2**x/3**x, x, oo) XXX: Don't run. This hangs the notebook\u001b[0m\n\u001b[0m                                 ^\u001b[0m\n\u001b[0;31mSyntaxError\u001b[0m\u001b[0;31m:\u001b[0m invalid syntax\n"
+     ]
+    }
+   ],
+   "source": [
+    "lhopital(2**x/3**x, x, oo) XXX: Don't run. This hangs the notebook"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAAoAAAAOBAMAAADkjZCYAAAALVBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADAOrOgAAAADnRSTlMAEJl2Mt1EzasiVIlm7xEe\nOPwAAABJSURBVAgdY2AQMlZhYGAIYxB1YGAOYGAuYGBtYGB7ycCnwMDyimHeBgaWx2DyNRL5GCz7\nBqSS6yVIF3cAA0MUg6wDA4PQ5hYGAON0EpMbNABcAAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$$0$$"
+      ],
+      "text/plain": [
+       "0"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "limit(2**x/3**x, x, oo)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAUBAMAAABhbjCNAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAEJl2Mt1EzasiVIlm\n77s6qyWGAAAAnElEQVQYGWNggILWhAMwJgMDm+A7AQQPD0tah4Fh9i6oAs62vCs8iiwGDAxCxioM\nzAwM/bsZGDIZGMIYRB14GBj4PjIw8DAwBzAwFwB5HOEMDNMYWBsY2H5yOTBozX3IqMDAr8DA8ovh\ntIYDo27dBIb5GxhYPsPtBvF+4+EhVIJM+QNXCbSB6yecB7SdOwDOY4hikHVA8IQ2t8A5ACXSIfGJ\ncN/4AAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$$0^{\\tilde{\\infty}}$$"
+      ],
+      "text/plain": [
+       " zoo\n",
+       "0   "
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "lhopital(x**(1/x**2), x, 0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAAoAAAAOBAMAAADkjZCYAAAALVBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADAOrOgAAAADnRSTlMAEJl2Mt1EzasiVIlm7xEe\nOPwAAABJSURBVAgdY2AQMlZhYGAIYxB1YGAOYGAuYGBtYGB7ycCnwMDyimHeBgaWx2DyNRL5GCz7\nBqSS6yVIF3cAA0MUg6wDA4PQ5hYGAON0EpMbNABcAAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$$0$$"
+      ],
+      "text/plain": [
+       "0"
+      ]
+     },
+     "execution_count": 29,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "limit(x**(1/x**.5), x, 0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAACkAAAAOBAMAAABA5yhLAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAMqu77xDdmc1mVEQi\niXYYNmHTAAAAuklEQVQYGWMQsndlYFD5VsAAAgiO8CcGBtYGsCADA5wjqb+AgQGilIEBzpEMARoB\nF4VxJLk/I4nCOJIM9RNAauc9vwA0AcoBMtj+AEW5chgqQKJgDojB+AMoyvmRYf8BGAckynD/AdAE\n7nv3BeAcEIPtTwEDT1OAPFgUxAGr5QF6jaOBQV40AKgExAGLMrw3YIh/wLBeWgAoCuIwMKwFYg4D\nBhYFhvtSB6AcBuH/VkBdCgw85u9i+2AcAItCOkbAdyQwAAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$$\\mathrm{NaN}$$"
+      ],
+      "text/plain": [
+       "nan"
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "lhopital(x*sin(1/x), x, oo)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAAgAAAAPBAMAAAArJJMAAAAAHlBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAACGjDitAAAACXRSTlMAuxCrdpnvzWYiHG0BAAAAI0lEQVQIHWNgYBBiYGBQ\nnMTAoGwMJBhYSCVYw6ZHAPUxMAAAQGkI1Fjz0FgAAAAASUVORK5CYII=\n",
+      "text/latex": [
+       "$$1$$"
+      ],
+      "text/plain": [
+       "1"
+      ]
+     },
+     "execution_count": 31,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "limit(x*sin(1/x), x, oo)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAE8AAAAVBAMAAAD1D64kAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAZnaZiVTdIs0yRKsQ\n77sQheylAAABgklEQVQoFaWRsS9DURTGv7aa1z5tI0gkLC9YLNqEoeNL/QHtZmNowvr2Dh4jjTQS\ni4qaRCw6WEQkLxgMFCmLSBrpZCAYBEnDOff28l4xuck553fO+XLuzbnAf49uuCb0urgVi1wIT2W2\nOAYK7PnoMrh8nvlA2zdEzRaeXECBin5DkYjdKutSoGLUUSTiaTPTq54yJZtcOGGnsYtlgM4BE30v\nexkBa9WlYYM7o2SV2iVwWGdsSyA4jSSQRRMWOyLvLJwlu0M8H5mHZlLThu8N2xYLJdwDzyy8BvwW\ngq/HtJhx2so5WSpdYKGEh6aQxvqpFr8gRxB+hLbglIRQQosw9vQlDNkorTpZGBKU8EpOjNXoappI\nV58ZmFwpZGFKUMJberQDDM7cAD3ENqJlpJetJEwJSjhGVybgL+uN9WBCrEer9x/NobJjCSh+7E40\nqIENstwILSnX4M8IrZP79UQtKn//jPrCn1qf6amlPJknybuziO3OvJxzp+38kD+OZrgaQ8Anzrdr\n49xeRX8AAAAASUVORK5CYII=\n",
+      "text/latex": [
+       "$$\\operatorname{atan}{\\left (\\tilde{\\infty} \\right )}$$"
+      ],
+      "text/plain": [
+       "atan(zoo)"
+      ]
+     },
+     "execution_count": 32,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "lhopital(atan(1/(1 - x)), x, 1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAB4AAAAlBAMAAACno0T/AAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIs3dRJmrdjJUZrsQ\nie92pBgeAAAApUlEQVQoFWNggAHW/0CQAOMxMIR3Fq4SRHBZJrALFCK4QBY3QwIKX4zBAIUfxfAB\nmc/zh+EHMp/dgOEvMp9pAcNWZP4AsYWMQcCEgR8UHP//09AVjKHaDsjGizGw/0Tm5zAw2CPz3x1g\nyEfWoH+AIR6ZD1RrfwBIIAAHSgAzMDBtQMiBWNGoXPYEVP5UBkYBJBGOAAYuZL7w3bvBSNIM9v//\nf2YAABDvJavRuLWzAAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$$- \\frac{\\pi}{2}$$"
+      ],
+      "text/plain": [
+       "-π \n",
+       "───\n",
+       " 2 "
+      ]
+     },
+     "execution_count": 33,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "limit(atan(1/(1 - x)), x, 1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Series"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The Fibonicci sequence is rexcursively defined by \n",
+    "\n",
+    "$$F_0 = 0,$$\n",
+    "$$F_1 = 1,$$\n",
+    "$$F_n = F_{n - 1} + F_{n - 2}.$$\n",
+    "\n",
+    "The first few vales are 0, 1, 1, 2, 3, 5, 8, 13, 21, …\n",
+    "\n",
+    "The Fibonicci sequence has a generating function given by $$s(x) = \\frac{x}{1 - x - x^2}$$ (see http://en.wikipedia.org/wiki/Fibonacci_number#Power_series for a derivation). What this means is that if we expand $s(x)$ as a power series, the coefficients are the Fibonicci numbers, $$s(x) = \\sum_{n=0}^\\infty F_nx^n$$"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Write a function that uses series to compute the nth Fibonicci number. \n",
+    "\n",
+    "Hint: `expr.coeff(x, n)` will give the coefficient of $x^n$ in an expression. For example"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAAgAAAAPBAMAAAArJJMAAAAAHlBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAACGjDitAAAACXRSTlMAuxCrdpnvzWYiHG0BAAAAI0lEQVQIHWNgYBBiYGBQ\nnMTAoGwMJBhYSCVYw6ZHAPUxMAAAQGkI1Fjz0FgAAAAASUVORK5CYII=\n",
+      "text/latex": [
+       "$$1$$"
+      ],
+      "text/plain": [
+       "1"
+      ]
+     },
+     "execution_count": 34,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "(1 + 2*x - x**2).coeff(x, 0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAAkAAAAOBAMAAAAPuiubAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIpnNu0SrdlQQ3e8y\niWbzIQYJAAAAT0lEQVQIHWNgVDIJYGAQY2D/wcCQycCwnoFh9wSG/AAG+wkM+kAJoMgEIMHzF8Rk\ndgCRKiCCPQFENjEwCjDwKDDwCTBI3b2rBVT8//8vBgBR7Q/Fm5CwxAAAAABJRU5ErkJggg==\n",
+      "text/latex": [
+       "$$2$$"
+      ],
+      "text/plain": [
+       "2"
+      ]
+     },
+     "execution_count": 35,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "(1 + 2*x - x**2).coeff(x, 1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABgAAAAPBAMAAAAMihLoAAAAJ1BMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAilU6eAAAADHRSTlMAIs3dRLsQq3aZ72YDTSHvAAAALklE\nQVQIHWNggIMwOIuBIfUYgpNejsRh4CCTI2QMAiYMZBsAcxDnrEOzYWwwDQBP9Q53CSxxJQAAAABJ\nRU5ErkJggg==\n",
+      "text/latex": [
+       "$$-1$$"
+      ],
+      "text/plain": [
+       "-1"
+      ]
+     },
+     "execution_count": 36,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "(1 + 2*x - x**2).coeff(x, 2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def fib(n):\n",
+    "    \"\"\"\n",
+    "    Uses series expansion and a generating function to compute the nth Fibonnicci number.\n",
+    "\n",
+    "    >>> fib(0)\n",
+    "    0\n",
+    "    >>> fib(4)\n",
+    "    3\n",
+    "    >>> fib(9)\n",
+    "    34\n",
+    "    \"\"\"\n",
+    "    s = x/(1 - x - x**2)\n",
+    "    return s.series(x, 0, n + 1).coeff(x, n)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAAoAAAAOBAMAAADkjZCYAAAALVBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADAOrOgAAAADnRSTlMAEJl2Mt1EzasiVIlm7xEe\nOPwAAABJSURBVAgdY2AQMlZhYGAIYxB1YGAOYGAuYGBtYGB7ycCnwMDyimHeBgaWx2DyNRL5GCz7\nBqSS6yVIF3cAA0MUg6wDA4PQ5hYGAON0EpMbNABcAAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$$0$$"
+      ],
+      "text/plain": [
+       "0"
+      ]
+     },
+     "execution_count": 38,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "fib(0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAAoAAAAOBAMAAADkjZCYAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAMom7VCKZRHbdzavv\nEGbh6M2uAAAATklEQVQIHWNgEFIyYWBgTWCob2Bg+sLAP4GBBUwyMIBEgGA1EDNqbQAxGXoKQCTP\nXwZWAQbmfwz3/4JI/gUMnF8ZOB4w1CswMLilLWEAAJ6qEfrOOFffAAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$$3$$"
+      ],
+      "text/plain": [
+       "3"
+      ]
+     },
+     "execution_count": 39,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "fib(4)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABQAAAAPBAMAAAAWtvJmAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAMom7VCKZRHbdzavv\nEGbh6M2uAAAAf0lEQVQIHWNgEFIyYQACaQYG1gSG+gYgczIDA9MXBv4JDAwchxkYWCDMuMUgVWAF\nChDmagYGvgAQk1FrAwPDDQaIaE8BgwKUyfOXRQDEZBVgYP53iQHEvP8XyPTevfvPDgb+BQycX4G6\nDwOtecBQrwBhMrilLQGytP/nAUkYAAD6ySE1M5863gAAAABJRU5ErkJggg==\n",
+      "text/latex": [
+       "$$34$$"
+      ],
+      "text/plain": [
+       "34"
+      ]
+     },
+     "execution_count": 40,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "fib(9)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note: if you really want to compute Fibonicci numbers, there is a function in SymPy called `fibonicci` that can do this far more efficiently."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYAAAAAZBAMAAADK9+SzAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAu90iEJl2MkTNq1SJ\nZu8+uZRyAAADV0lEQVRYCe1YPWhTURg9zXtJk7wmleIgODTWQSgFA1KEgvBcHKS0WVKotRoEBYva\nLA5KoQE3lyrooC4BwSGDZnFxaRRE1EAD6iz+gG4VjWK19Xnffa/p+77vDaEKkuIlP/eefOd857x7\n01eCvoEsOnbEB4aQ6Vj32vjIlghgTpws8n3osjmC7RwZntzBoO76wyqFEi+N5xTBaH2KIXC1JRde\nA2llrr7TVbionnoHIiVzD5M0+22G4GCTIUYZs8zuMOLfaFXacWoUQQ7RBoNcbcn1GkgrRg4LBaWw\nSz11gBPAaapoVu7ZFMHhCg+QtBH5RKuWqvhMkcSRJxRAqgEzQzGtLbm6QYiVnp/oVQqxN0pFBxgE\nFrJUErM2AxDjAdLvkfxOqxZFgCQtUKuesgigtSXXbyCsWF6AA1eVmg7wFZhnZ6GdAIkmoiwAxBGS\nAawfdk+BxfIuDj9+fgMRQJHdI1RbD2CsqgBcUrLEDiidCN8VJMoKDozkqZlSYOlO+9fOMMTfXc5V\nVW4DaQW4CaSyJECNaUpWWIB5TptTymR02Sbfpaizm5SohdYWXPWB20Ba6X5aBg7hLwRwJeiIfaRr\ntbrLkFcXHH5gvYsTwnUbyADAuRJqNECBdZGskB2IbmMstVy2ObZUJEgqh9f85PnagqsbSCtAumkV\nWwHgfokbpElY7JAAM4yE/eqEU6U+YKlEytI2jDWCeEdIcgHdQAQwiuhaG8VGgEFgMcskBUv+GYWV\nwz5CMx2bB3gLHKfaY4oyQWg6QAjXbyCsjDdVgAeVyq87GzeyRzCppstSj8Bwd4AWnQde0KIVYG+W\nFOWAG5SWVnluU5q+OJIL3UB/B4iV3iuIfFHOWjeySNX8gPFMwKw+Qia9qboBSJExVH+coUVnEV+l\nRcOw3lHEugarRmk6gOTqBiFWYg0s1IIBzKMzRYy5mVojv3y9YS4H9z56bGWaFkUcx8nQIis/WaVF\n3flKliK4nJ8CpWltydUNIK3gfv6WcvrMmfaPkGf7Usv9+iQeDPBHRW1p6w6yUsMhVjxD+l8Jb9rw\n3gKvqcDcn26yqC2abiErNRxixXO0hQLE/GsceCsE5t50k0Vt0XSHkEqNF7z+8jWwA/LDTkD+B/jX\nuzSCgc7+XWjwN9UKBtQPwW28AAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$$\\begin{bmatrix}0, & 1, & 1, & 2, & 3, & 5, & 8, & 13, & 21, & 34\\end{bmatrix}$$"
+      ],
+      "text/plain": [
+       "[0, 1, 1, 2, 3, 5, 8, 13, 21, 34]"
+      ]
+     },
+     "execution_count": 41,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "[fibonacci(i) for i in range(10)]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`series` is nice if you want a fixed power series, but what if you don't know ahead of time how many terms you want? For that, there is the `lseries` method, which returns a generator of series terms.  This is more efficient than recomputing the whole series again if you determine you need more terms. Here is an example usage (**Warning**: since series are in general infinite, `lseries` will return an infinite generator. Here we use `zip` to limit the number of terms)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAAgAAAAPBAMAAAArJJMAAAAAHlBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAACGjDitAAAACXRSTlMAuxCrdpnvzWYiHG0BAAAAI0lEQVQIHWNgYBBiYGBQ\nnMTAoGwMJBhYSCVYw6ZHAPUxMAAAQGkI1Fjz0FgAAAAASUVORK5CYII=\n",
+      "text/latex": [
+       "$$1$$"
+      ],
+      "text/plain": [
+       "1"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAACcAAAAvBAMAAACS3s5rAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIs3dRIl2q1SZEGbv\nMrsbSYq4AAAA5ElEQVQoFWNgQAWs86pQBUC8WQyTMAUNGeQvYIieYFjvgCHIwNC/AIugKhYx1gIs\ngluxiLEE8GLafq+jfQGSWsawwrZpDOf//0cSY1jKsHnDYWQBEDuAIZ+hF11wAUMduhCIfwyLIONf\nBi504Y1sHxiy0AQ5fvMdYExAE+R6FhWajSY26LlCxiBgwsD/Hw4+DIyjGWfqOWDYLM7A9gNDEJiy\n7TEEzyxgqMfQr7+AYT6GIFCr/QIggQZ4v6IJgLhMD7AIzsMixoYtwXcyMAqgq+WdwMCNISgcGjoZ\nXSGD/f//n0GCAFRmOfCpSmWyAAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$$- \\frac{x^{2}}{2}$$"
+      ],
+      "text/plain": [
+       "  2 \n",
+       "-x  \n",
+       "────\n",
+       " 2  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABYAAAAwBAMAAADnb5cjAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIol2q1SZEGbd7zK7\nzUTvhYErAAAA80lEQVQoFWNggAJeGANIxxfAOez6CDZzPYK9FYmtgGBzCCDYxQwIdlhafgbcTAZ5\nkDlCJqJmBgwc/q4MDOwKHDO4JkDkmRiYP7BugLDZGVgOQFggkssAwZbfwAAyAwg4BOwZmKHs+IZT\nDMIQYYYaoyLlBiib1tR/BKDMKrHccyADtgAxowODfQCQngPELAUMnB8YGJjXANlcyxlY/jEwSNwB\nsnm/M7AB2QogNhBwfgeGBpS9X4GhmAHKBlIKUDbbAQZg4ELETRgYihggbNYEBsEQF5dfzkBTtjEw\nNAIpkF2Mk5TUJkDZnEA/Atkq/5HiESgFAEGkQFKV6+ITAAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$$\\frac{x^{4}}{24}$$"
+      ],
+      "text/plain": [
+       " 4\n",
+       "x \n",
+       "──\n",
+       "24"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAADEAAAAvBAMAAAC4bj/EAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIs3dRIl2q1SZEGbv\nMrsbSYq4AAABXklEQVQ4EdWSvUrDUBTH//1Ky21Dg+LHFl/AD1BwEGneoAGJoCAERUonO7uYSXBK\nQSq62Dg4uNSuTr6AQsAHaB/AIaCVOsVzK8WkOe76H+495/87595zSYCE7ra7Ce/bWFQDnuSawuRJ\nyeF9QD+tazzrmeoKT3QDQ56UfXzwJO3gnSeFRjZ5z0xtvm7jYceb7BFmcaOUrKeyHJSg4E/Wy1wg\n36eNVclmbTJ1Hx7HitoRFJa43VfMci3oHN7++jnZhv9lTq1KraEcxhX8pWe8tCzLTF0tGRAX9dh/\n8khTN+agDJExxGZ05l0gj2OgggNgP0pMYA9PHk6MdaCqRRGyNpY9tI1PoOfESGeUVW4GROwYuZSZ\nOkhJQmf/SAQyTveTRFmQ5BojYst4rEyDIoUWOUF37Mr9vknLGVIaTe1qUVIlojZR1OilW1EAl8i0\nZZ0j44jnGJFnV8LwDaJV84EvR7hiRhgZDXAAAAAASUVORK5CYII=\n",
+      "text/latex": [
+       "$$- \\frac{x^{6}}{720}$$"
+      ],
+      "text/plain": [
+       "  6 \n",
+       "-x  \n",
+       "────\n",
+       "720 "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAADQAAAAwBAMAAACsx0TOAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIol2q1SZEGbd7zK7\nzUTvhYErAAABnklEQVQ4Ed2TvUvDQBiHf2ka2/TDKoiIizEVnYRKBcWlFbuIDoLi4lIRP0CEUqGg\nCLajWxCcFBUcRHAIIq4WRNykgm4F/Q/6ITVFofUubUqOprt4Q/g973N5cy9cAGY5g8sMm2AEeyZi\n4hO8DJtgWu0yERN7v9YZNgH/fmwiJq66z2JMoQGODLzJBjGBS4NvofACe3NDzj85v4KE3M+00SGO\ng+RVc5lWJISwZK1imLUWtHrRUnE/cFjLFJ/HmKUSyp5zLmCpHA9D8ril+X/Fasv1h2a9BRLBTeBG\nfgS6t57rSE94ApxiR+WiyAW4MEJzOlLDX4NXwGdsJfgUcnnFvI5U9WQhhtFeEKhyXcJe0ZEqKQtf\nFO4SibmAV0NbxUBnRxZ9EtyfRL3SraJm4DZqqgj3cJiqe4mqIklSQwETH6Rg7ISg1jNt6NKAtrTR\nP0630e+WORWeMjCKGgILkcj3FDmtUNjXqBKi6NSRNAH0kW2KLwOxgDsgRUa2KXWFI+yq5AfPSdyh\nPKjoSNVAdQMJ/wywuPYGkdwHpYb6a9aPX900isnj4kp0AAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$$\\frac{x^{8}}{40320}$$"
+      ],
+      "text/plain": [
+       "   8 \n",
+       "  x  \n",
+       "─────\n",
+       "40320"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAFoAAAAvBAMAAACRacBDAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIs3dRIl2q1SZEGbv\nMrsbSYq4AAACSElEQVRIDe2UMWgTURjHf9ckR3pJmqCIOIjiIojYiAUFCcnWTQOSDII2KKnUDqZ0\nE9SDgOAgCUpTI6gH0qHS4cTJKYLiosUgKLioILhqG1JrQznfvTb0BZKrXYqD3/C/7/v+v7z73ntH\noHd8hkC23NvvcD5NQp7hjp5HUYQEUcuDUK0ixgo+U2155EUigs55EKpVxL8lemtrGwuETfV1Hrk4\nk3miMQ9CtQSd55Ta6Zpr2YmbFXYNVtBH73cl1OYMz+yXasMzT3OF256EalpcV8tN89ebEgqgrWIo\npXf6VP/JZW9kww22Bl5ouY3aOzO+n82MeyP/3e05gR3H3Bgi6vxFbM9I/85bIpnzJsxMnUOrHkmJ\nLHNvXWZHH4BRGasrw+7Bv4SWYJLd6MtQpt9ekyEe1/GljIRCj5g08KU5wFVIErIx4lL0OPp+LsIF\nhS65dM0SnbcWN1KBgqCl+Ar4FzgOpzv+EsUkh92fD1o8SgV/WYGclGiZyDK/4Yvpuu3oK7D4ccx0\ny6TFj1YeKfvSRJa0pqBzrrUeHw5iNGxOijIivH7n6Jq4dFPS6TbqPvVXhgMjFvR9hefvHVNKD5p3\nTxpQM+EhhMrUVqR0nWSvmNJeFHQOvQBhC60lxd1lS+7SFgOsheGIjdnf5Nq30GJzol2RIk4wKE+w\npJygWDYZK7lzR8qEYmFhTUgRtxOIu7dzpr2yeI7jbzKQNt6wM5O5S/AQwbQUTjAnbt405hU6WL1j\nwvR0iqTjiN0OV8VXJWU2e018VVOX6vwBf37U8ArfDb0AAAAASUVORK5CYII=\n",
+      "text/latex": [
+       "$$- \\frac{x^{10}}{3628800}$$"
+      ],
+      "text/plain": [
+       "   10  \n",
+       " -x    \n",
+       "───────\n",
+       "3628800"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAF4AAAAwBAMAAABqAtB3AAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIol2q1SZEGbd7zK7\nzUTvhYErAAACYUlEQVRIDe2Wz2vTYBjHv0lM0jbdFhRBvDR0QxARgxsFD8OBBZFdclCvldrDUA9l\njoEyWP8De/DHYCK7CII7BObNgz0ooqeCF5EJRf8At86tm7LV53mSg/A20F6GB19IoJ/vJ2/e93nz\nvhTo3ZwGcOpttXeoUqdSh1W1mmqSQMw60q72OyFVMfmZwD5QgwRCPmB2ElIViz/kqUECEX8sIeyB\n2U95PYIExP43vE5IVUy+8+7aZTVQyNGJ4wVfO7vjZ7rdDSVVgO2lljJczD6bDmPDDPuUSbNxpNG/\nzWbGH8zPhaj2/0TKvQhjAL9U+4hj/XePhfOzo7UB/P/q4VagO1g73MH9G297BedxPp/HXHkamB+/\nTZv4ZoG3/Hu6ZstnYigJj/gpUlTUn9pznHTxDPdCpFv2MrBAx7O2jCuIoCSkG6vQaQNOZVfoaDDq\nMJq4AExirkh+2sNXCIwS8k+sQwf0cKQJvZOewvAmHgI/XBjkP+CtLDBK6Je3Tjd8x2IDxsHIDTjb\n2AHeBOJ/4UxglNCp7bJvN8D97+Y8OFtam3xf/P21QgCBciPzLti3AlgryG4xbYvvsW/v1bAkflsS\nMj3xF+kVn3Fd8bvAuaqosU9nK/c/SVdqfG2b6V/jsfdoyoFAudF6QHyqCDW9w7PalfnWovGT7wuM\nElwtFn9dgk0VoTbUpKqZUs9SVM8P3L/AKGFrFRgm39hErkWrotd5vU4ToPqXePwCoyT2Tfaf4BPw\nCPfpewjsl5Gf9ewXMZSE/LHuDI+Z/o/cCejTGp2mUpUnQli39meASqUVQ0m4/0HaH8rI7cFFVzeG\nAAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$$\\frac{x^{12}}{479001600}$$"
+      ],
+      "text/plain": [
+       "    12   \n",
+       "   x     \n",
+       "─────────\n",
+       "479001600"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAIUAAAAwBAMAAADN86TJAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIs3dRIl2q1SZEGbv\nMrsbSYq4AAACqklEQVRIDe2VTWgTQRTH/5t0t5vdrEbFLxAi3vRQI1ZUPDQnBU9B2IqnBqUWD9J4\nqgqaXHtqUFBDqxmUKoXSrhfBk3gVweBJT+bgQaTQD1v7BY3vzSRpQCOhU0/1wb7973/e/DIzL5sA\nrYRXpqpQK5VNa7yHCRobEk0LWhmwieH06DOsSX3Gp01gpPQZbkyf8Rz6jMFCcbiVFjat4d4ivtG+\n7O7bdy1tXFhOw83ebPoZfx1wUu6ZKC9CI0xYM3ZJA0BTHbSX6aYZ0bQmgKbHSxB6FDfWD0uTMRRM\nYY/eMjDRO9odaDL+T9/qJ7DzOEcnUNlozGz1I/zH+x/1H8E77fs+sE1UFXswCh1JOLcu8m/zd7r2\n3/sKjF19XE2Ny8ojErjU4EU40wJKsYe9sJZwIGe8BSZWCJlBfw6deFZSqYHhBnASpgAyzkBWQCrp\n4TbQhSngLl4MEKNdIDxjJWAdlAkNYWaYAZi05H5isJIe3gtkk3NAj4BFjOg7tM+HM2iblakBAXtR\nmGkyztJFDKmUd1SgeH6N3KRkhFYQmd+eh7ckE1fWY3q1l7RTpiQZrJRHexG8jkAyaDy8Ek/B+ykT\nPa5HpHKMHiI5SpLBSnnwFjBCwHSN8SXF0xdkovL1eP2xkgMm2ZAMVspDqIyngV2sMzrwZ4abxxs6\nsct1BqmqhydkvrpOHeUzpdWVJeP3vUQFjFXgZJ1BqupZGTZrfQH6AD7OVZnkUDWN0/0BnGV+5L2w\nUh4GYcTIPQS1DjuPHdRWm3trz3J9LaJUdgNtdQYr5Xl50P9uzJivMj4DL+nrZSZkqs3nu30Edgp2\nncFKebt8/z6uiFBaMYwT/qUETmG8pFIj5FyB3i+PjgSFD4cDpaTXVan8gFn4Roc5MjeMML1TCYx1\n36F3jtOmxC8/qCMkO/cynAAAAABJRU5ErkJggg==\n",
+      "text/latex": [
+       "$$- \\frac{x^{14}}{87178291200}$$"
+      ],
+      "text/plain": [
+       "     14    \n",
+       "   -x      \n",
+       "───────────\n",
+       "87178291200"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAJIAAAAvBAMAAAD6AY4WAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIol2q1SZEGbd7zK7\nzUTvhYErAAADFElEQVRIDe2XTWgTURSFv2Q6mfz0Z/wF3XRIpSIiBC0FF2Lc2EUXDgrdSUOrRbFi\nLCJUBCNCcWcURUGwdSEF3QQEwYU0axdacKFgoVm4b2utqZvG++4ku2IDE3ChD3oy99x7zrzcuWle\noImVKsP1nkITlVuUpM4V4WtqeYuyZtJ2kWjO8Zop3aJGnJL+FjXNpcWp+0y/21zxH6vEac5LSbNC\nL7OnCmuhfUCcukqstsapw2ejNU52tjNcn7b37erPRA79zDDVmw+zJ8eLP0mG20v99lGsZbsUZi8N\nrUNbuXEd9jWZCevQ0HeXCNXphk/cPY7VEqfhwnt2NGxDvd48PNGKf5Wh9vBf/I92oNaq9Y/276++\n7d2XP8g568gluDYyCBpGxhYqvB1Jpz0n3evXMxPp86CgpDPaX6oLVU0ky3GfZ0yWIi/Y6wbhTqw1\n7sl8ZGNwAc2QI1YIQMlExXmKCgOgLU9i2SpizbfPyDeJhgzANPuhjbswiWbiBZyiQkAehWOoUAGS\ns7RtJLJ0rnTNE61qyMs8pyoeHGSfcdJMNCtOCgH5EJZcFSpAR5XYRleO1NqtMtaGhizmuVKBzgzD\nA/SgGftHPppRCMifMOerUAGzEtVuj9SqufO6hoaclq+Um9Beu+Ppntb5uH6YAAwZ+S5OGRUqGI2c\n18z199gM7eaMNOcJpKQQeVZc+eUSZGK1+6BgSHUKhKqWUlhAr50vDBmnBcN1lMFZhvilxTWCzNS7\nmo+CITdzipXVaZX4kddyApRQ1rj8WfMwRbyW10w8x72qgpJXN3l3fWB6ZloUrYKEYpIVkGfCLHQX\n5Fqeap7IukJAmo4XVNhQ2zm2icZekfqOeUwIQ0RcbuVwZmSTGc3cEBxVCEiZgmEzBfZKQ/0Gbsts\nRYvWijnhmpBUjrjLUg6ey3i6mkm6cEIhIGUyD5jJFKEBiDxI9xZ5xI2S9ZhP9XBPOn1RbilOZ/Oc\nRjP2Z2xPISATvvMKFQZAQj5dRfmlNAi94349nK7Vfpk2yHCeHPODDN/GZCoUlHRG+krmJ5YIFX4D\n1xNlQbFLfTUAAAAASUVORK5CYII=\n",
+      "text/latex": [
+       "$$\\frac{x^{16}}{20922789888000}$$"
+      ],
+      "text/plain": [
+       "      16      \n",
+       "     x        \n",
+       "──────────────\n",
+       "20922789888000"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAALkAAAAwBAMAAAC/PMZ/AAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIs3dRIl2q1SZEGbv\nMrsbSYq4AAADeUlEQVRYCe2X34sbVRTHP/k1+TGb3dFStYo2b1qK6YAtCEU3/8GGwmxZQQ2CW0qF\nrlBbWpAGQaQgbKiUGkrtYKlQKE18KYgPruBTkW6gFOlT90FBRDDrtksaK/HccxMzT6WFnYfC3oeT\nc+73nM+dOXNvMoHHHsUVuHbQe+y6RyoonvVxvIIsEcvI+UyGlGJhg9CzbyQW4qMnlpthfHTeW+vE\nR8/Xb/bjo38NO+OjvwSH4qMnPU5sOH3rgecO1hL77tcKZ4INP6uFqrt3wt/wax4CMzjdXFw7kQLZ\nleFCsXxM1GLBDqHbO4Rx8V3vME5s9MX2nzwT16Vz9f1Ls+3Y6JvgzQ488R14+jUzdsNg40f3ie/O\n5g08vAOFucD8JP8Cl+fPw7bTv8Kt4He4eSYIqsXgnbr1rLwz3DqME81yhUIwVx8WarWa6HpbOllf\n4jdhNxc78gp9uJ5oMFPjB9mrC9tIr1tPZZYH97Dxszg98nDOFlrZIKJw9pAsgXMDR/5clLIhqW6m\nx5TPW5Dl3Tpr1lOZHR9JtSryVjbN93DRFqpscyJ4t6/BC2VSC6RXJ66TvZtTehXeZtHQ1VOZBZOt\n8c8hJyv7DV2VsYnASS5pVC0z1aDYS/bJ35UZ6Qyk1axbT2VLV2VXyIXK4glmbaHKNkfyR2Pq1fkv\nwfXKbK9SNKSUuZuXjX7VmKS5XPGsfHT+iJlUhelwcnCtahWVRwiToqO1l1Sbb7B0eWTckVX2aQdk\nWW7pOuKZynv8Qasis0YxIRfWPKuobHOMNhytLpm+dHJMLxvlgwoUusZzfrLeqDK7NFKSK7jnd/Ue\nSvdxe/IS+n9n8iuGOSHtcUrGYzlUz9BN4zL/jpSv4DvcQajK2GjR0EyVcNcvIXTzSP6BA5DoMCme\nbANehL/a6qk86ZORh24UHDHXpWNtVcYmSpd8t/fZsWMPjkpJbpVcg6dafaW3GhQGoaGLZ4i5VXmP\nz6+iMadIPL8E+ZoqYxOl57TvoKcp43MbvpX7SQljRph/y5nx1JOTkvHlbJqzZ5RiQ3baj3LiPFXG\nJkrnN660ZeIGvM6VTmJPMOc7bWaqsCiMQ6RlZxjPyg0+92y8JQi+4JOQT62isjVRfP642cH7B+e4\nPPsxKfly8TnVfEXm7rTl/3vzdN16KnP77IdDZXowWCN9vCmyKYwYSYhz/AcfkpFQNTd5DQAAAABJ\nRU5ErkJggg==\n",
+      "text/latex": [
+       "$$- \\frac{x^{18}}{6402373705728000}$$"
+      ],
+      "text/plain": [
+       "       18       \n",
+       "     -x         \n",
+       "────────────────\n",
+       "6402373705728000"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "for term, _ in zip(cos(x).lseries(x, 0), range(10)):\n",
+    "    display(term)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Write a function that computes the number of terms of a series expansion of a given function are needed to compute the given value near the given point within the given accuracy. For example, in the expansion of cos(x) near $\\pi$, suppode we wish to compute $\\pi + 1$. Let us see if terms up to $O(x^6)$ are sufficient (remember that due to a limitation in SymPy, when computing the series away from 0 with `series`, we have to use a shift)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAALoAAAAPBAMAAAChJ8gEAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIs3dRBCZdjKrVIlm\n77sGqe+vAAACHElEQVQ4Ea2UMWhTQRjHf8nz2qZJ06Lg4BScXISCDhU7ZHFuFgeRmk5KGsVgoaWD\nEHBwtFARMkjfUuiWgChihkbBOYqLgsMDcXIpqa2gw/O7u753Z3ijH+R39/5/7v8u310CJ6XurLf1\nNP8+90aGqS3Bd/ncbL4G9arf9mBF44zZznnU7Pd7st5WUFULejYTx1oMIrh1BLkFtuFMuzDvwYgO\nmc4wjmO9Q1tr8EDP8g3ZKzyMuNGR9KDHebhKvuLBiA6Zzkso6CBbV2BpTqZWyr2LYFLShzXRSjLx\nYEXjjNmeIw0w25SVUsfwJJTRphfzkU2/KBL5D/8AIzo423PgVEuvNZX7I+n6sbCxWYW3Sfro8XrI\n7IWNVQ8Y0cHZniPHZpM1Tbp8G8o19RPVOklXhwMWqS8SDByM6ODZngirGekiPadIkh7Dfq1+QPHI\nQWnxegrPdk4NdSBRpy/pupx2RqT99l6afigHG9bnKf12UFrcTeHZzgmZrEhUUvpUB/LwTdKv9ZJ0\nRhLUmq1Q+uVgReOM2Z5DsJVEyyg3sjsn4ye4f67T2fnSMjdSXjYMy3rvDnoHw9Ah06G+4qWvwQsU\niCY/H2YieyO7uu/Tuu8OGNEh02FJktIKQvUZ6e1Zpj+KmKSXe+or/GB54MGIDpkO3ZU0W/6omptt\nliOmbnekQcWd48HEvdFdaDSqMPHsqQ8rGmfM9hxzit4L/v/0L9iNQMEYAVEuAAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$$-0.541666666666667$$"
+      ],
+      "text/plain": [
+       "-0.541666666666667"
+      ]
+     },
+     "execution_count": 43,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "a = cos(x).series(x, pi, 5).removeO().subs(x, x - pi).evalf(subs={x: pi + 1})\n",
+    "a"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAK8AAAAPBAMAAABgoIKoAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIs3dRBCZdjKrVIlm\n77sGqe+vAAACyklEQVQ4Ea1Uz2vUYBB9SZr9kex2V8UiXiyCYD1IxB7UCu7Fg6cuCILIuksPW60W\nFwVL0WLw4KWHriDiHkpzEm8NFqq4YKOgVxUV9GRAvejBtnZbrAtxZr40f4FzSN7MvPfyZfJ9AeIw\nR6+7DPVX2jO6ZZqQSqb93APOTFwA+ka+AdPtH1AdRTzXHqN8se1CEPCdTUidhFEyj3CSjyKfbkYI\nqfShZwMYxGlXa+KWp9Uw3FAdRawhFWCHm3UgCOc7JGZ1EteAq5zoF5/ybSqEVJY8/EbaQbo/W4ax\nbG+i4KiOEHMBTAdD0PsVOtsSY1IncRQYLlKWlYr2MoRU5tnYaKJnJf8R2TVLjKUjRJsm5uTYTBCQ\nZszqJNaBGY8yZWzrIeIKjaJQQ2ZT7yC1RgQahXSEaP0p2w39LZUFxcas3grtLxk3KMtOTJaAF3q4\nVdGb2OMjQ5OGwcsZgOoo4q/uDRT2T4wBjGJjUhNUIWT+ar1lcw1mIzb2MT0AMaYHY4Ye8LipjH0h\nIhUdQvU4jECQMma1cqVrYkx4FjYSY6Q/JMYHmT5VSrizwOvbkVddht0RpIxZDWw/zDGoXo+FwJL7\naMuYh/OlHI8iFXI330m4S26uhjedqoPcpiBlzGpmquAPEhD8SsYnfW5JZRcNL+CP1wUm6cVc9HZV\nh4mlfBlat9CP3IYgMTZFHduCN9d8kbL3wJXdrdbc5wZXdkZlMqbtZq3AqmFbtcPGwmVisUKK0V5e\nsSAxtkSdGNNxWIAJOkDYS8W8HJAFrAIninRAbAd3aLPQ4owVPiALipintdy1eMaC1ChEnRgbnvkJ\nNK0+WO+UsVRuoof2wzFUXG2oveikAwz7kI4QrX2wfPxEJVBIHRBeVhLmpUkXlRCZeotWYc+tB1Kx\n6iMe/YSePIARRZGDh/UD9NNhriKeqtMWTt2/Byg0vnpZqRPj/w3+AWrzIIzvy1iMAAAAAElFTkSu\nQmCC\n",
+      "text/latex": [
+       "$$-0.54030230586814$$"
+      ],
+      "text/plain": [
+       "-0.540302305868140"
+      ]
+     },
+     "execution_count": 44,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "b = cos(pi + 1).evalf()\n",
+    "b"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "So the expansion is accurate up to two places after the decimal point, i.e., within `0.01`. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 45,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "abs(a - b) < 0.01"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note, with `lseries`, we do not need to worry about shifts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 46,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABgAAAAPBAMAAAAMihLoAAAAJ1BMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAilU6eAAAADHRSTlMAIs3dRLsQq3aZ72YDTSHvAAAALklE\nQVQIHWNggIMwOIuBIfUYgpNejsRh4CCTI2QMAiYMZBsAcxDnrEOzYWwwDQBP9Q53CSxxJQAAAABJ\nRU5ErkJggg==\n",
+      "text/latex": [
+       "$$-1$$"
+      ],
+      "text/plain": [
+       "-1"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAFoAAAAqBAMAAADBpFHwAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAuxCrdpnvzWYiRFTd\nMollB7CEAAABv0lEQVQ4Ed2TPUjDQBiG36ZNamy0gg5iB7O5+Tt1suiioNRBcfIHcVLBHxDEqZsU\nHAoi6uakgyIOgoMIziIiiKM0qF2l6CKCxO+S0MvFKpfVG+7e78lzafL1AiBiQn4orSFspac3hA1k\n/7ldamQvKPmWqqkuydtGQf+St7VT5VPeBhJvYey4BYwtruZoD1CbcZZqU80+o8/+S/f+IpAnqK6x\n/HDFXwRynOoTPHIay/D8I9F961IX3ZxrJs8/kjINzbbLnB/yWCWlAmySav0lfTYq8inbtt+Bkkix\nRnU7NnMLAleHz3bzBeBcoMAc1RayuBT4EQZjJOPApfRD7uOzQ2Ciy6E7N2xcO7khypaik/nEbGCW\nAzfpnQYLQXueQTqUClv5UHNJVnhPUuHNlPKxMvoqxAkdZvKOwoZIWY8SH5FpPSPyISQtIsEOHgNK\n09PrgChTYyMjhNY9vD3e4iSNNeq3Qf+8M/ROZE9ZEg+ke7Ey12fcGDVhlJ3414lt8/ZpM4i6rd7y\nSLUl7cH4G1TXDnbDtyt2xwuDfcvSo2hJqyQuh5HVhjB2fxg5MYI9ef+Bjp60rd++lq6kbYM+NGn7\nG0/gY7SgevO+AAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$$\\frac{1}{2} \\left(x - \\pi\\right)^{2}$$"
+      ],
+      "text/plain": [
+       "       2\n",
+       "(x - π) \n",
+       "────────\n",
+       "   2    "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAHcAAAArBAMAAACwWwo1AAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIs3dRLsQq3aZ72ZU\nMonLrI/bAAACDklEQVRIDe2VP0gbYRjGn8ufSy5eTNpJyXJLJ5dA7VoyOjg4lNIxS6l00DhIOiqC\nFkQMnWodjBRDx4QWupVMrUshW+nUmzQuIiIRWyS+X87c3ftqNLmsfYfkfX7v85Av33dfArB6ztRg\n4mVrML/f/ao4RBjx/2H/Zt7sLYEG2TBTbu4g4blhwqtDhJPfhwiP6iJsfDjddrdwyu1uNF+I1GTY\n70oW/Ir3RgP60l3hUJ4HmLJgbm1dVBnzi7d+IftvBDTxnf2eil/I/jWBr+d1ibs6YnW7296j9duo\nywybFtZc2H/vkk6z0263z4HREsdChWg35vC5+pFxY2M/U0sDpsWwFIkcYGMTP9lgGstxyiJSdvDD\nx6omAVrQdZ3QJJUD8ljseFwLqZmYQkll6V0qDHySBq0QVuiecKJOHu0SuvJ6ZVRTSnSX7Q1YF63S\n4xs/wSqjmM+nGkRGLI6FosMw/0XL2hLnK0jZRO45qkgW+ouD43WexQSiJUKhHL2wGn/3TOlfDtxl\nMyHU48lKK2CzTuSJQ9Wz37OachLLI0zHF99zBnddSd2S4UQFsTMg88gZ0EJ6ViwtR6EWDArb12GM\nSYOnN7zW68ItjKS7YQ/31/2xMYugYcrZQcPGDMxG0PCauv8Bw2YJD34Ui3/f9LdB3PWb7hGRPU77\nU9rT46Ns0HCYfoQofNj2/q76+9SArisQh4Bog/FyCAAAAABJRU5ErkJggg==\n",
+      "text/latex": [
+       "$$- \\frac{1}{24} \\left(x - \\pi\\right)^{4}$$"
+      ],
+      "text/plain": [
+       "        4 \n",
+       "-(x - π)  \n",
+       "──────────\n",
+       "    24    "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAG8AAAAqBAMAAABPfhiMAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAuxCrdpnvzWYy3YlE\nVCLumKMEAAACRUlEQVRIDe2UP4jTUBzHv0mbpknzp4OjYJa7QYeLOLnooQU9B1tEETnQ43AS/DcI\nLkLmU44sLi4XEBc9IUhvytLhJkEIeIvbDYpOWu4U7rie9ffy2qYpSa/p7I+S93vf3++Tvvf7vReA\nm2D1nJyDeGI6UDxzfjoQqP8Hk00SFy8PhFzFkd216cANnJoOvD/A8vXROKzdHqB59qgc4FUfvPHw\nidP3adwc8kfcF4DRgRmOyHyq2KlyJEousA9zPjVDtlJlLj4CnsFspWbUUtWe+Bz4jI/pGcvpMldn\ngfLitdQMjVaTbUKYGZN8qlzz3Nb1ZMadbre7C1QaSXloJjugM7Xi3BvSAGlh68fqNqBnr6fUAnzU\n8SUBfsLVInHQlrhM/58wUlmtLZyO4t/fMluP/GqBDUo7mqQ9eJPujoYMW2XSGLAUUtzYh5hEJcdk\nQn+pyWA0ExxgtdjGhWRszjJdUsrZxaGC63vCkjGfBK/A9EkZ0w7Ng3jsQxB/V/gLnkJokCe3+FR5\nEwQBvt08DszUbnHtAR/Sn3TkIitTM3YNG/UQ6zjJNgHQOc62Zi9UsQC7YEFtFz0U+cbHXSuRp9Be\n6eeWllHoqDa0v9HraAGZVtiOQ5uQdyB1zAaUQ65+jYOj3kIsiFXmqzu/fCi/Y/loTwpZzprPwIOj\n0+OMuch9jNzgJQZK1QjMtdTXDLxIt4mKs8f8CU38Q4l6Az+pHTpvx2SkxsCX7D54qHiTMVGWTqDx\nLtjw8B6zbg6Q7UulA+thpnl2cu4fXiCRCxxGVLkAAAAASUVORK5CYII=\n",
+      "text/latex": [
+       "$$\\frac{1}{720} \\left(x - \\pi\\right)^{6}$$"
+      ],
+      "text/plain": [
+       "       6\n",
+       "(x - π) \n",
+       "────────\n",
+       "  720   "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAJUAAAArBAMAAACDTNd5AAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIs3dRLsQq3aZ72Yy\niVR4peFTAAACwUlEQVRIDe2UPWgTYRjH//eRyyVN0tTBWhGMiIiTBxZcqs3o5g0iOvVAHFoQIiJZ\nhCYKNlohsYOk+EFFqQ5CU3UTIauDJiJKHII3OhRatZSUttbnvZiU95I7cjGjz3C8z//5P7+7e7+A\nduEz2qldacpYz1hKcrJnLCD7n+VpQb3PV1/mrsMbvLPSuNgz1lmIPWNdKQ72jLV3/V7PWOrRkfas\n2YUjBXvllF3YyV/T8FFo1NhR3EehhHM9UIQSg9jyeqcO0XCqkB6DoEPtmJVxQeEtcAB+t7dx3fNc\nZksmgPHqR5vomMoxxxIVfKZb1V4LlAGhcvl7ni8EtikSCOd42T1ji3QJrwpPeFv+Q/rNABCJ8bJ7\nFowDZWSxxNlkU42mSZHn6vKuYyyG0c8+t22skLE/Dhi4arUIB60WUmimkKBniFk6DsYCnrf4B6GR\n5o0VNKlF2IRio90H+6TGP9qKDqmvACyqK7jJ15U1bJLSF+Nl94xWPbLhmxNSvE3VsEWKtz0ha1DO\nfalO8yh2ns+TJMbpwQfdBUr+VhGh6mcTGJo5Q0cj86Duecxb+YzOkD0kHVJcGcEQ5BqEBLImhnGh\naNno+DpHpbV0W8cN4Dq+mfjFjr20QvOhxiyjaLT6GwpdXvYQXuo4DpyOLjNWcB7+VSkB+Yflo890\nDH+0pRQWdawDJZM2TA3iGgKr/TmEfteNe1r8TeFOc9QcLIq6QCtcStHCWF8hre0vI1RrGjofKKm/\nrDLeH7baSmXGYhvIa4TRZEF9yroPoVvWUoOVIsyCAQR0i9XFPyplYllzX9gHjNH5m6KrhuZ+g9Ae\nI5JMTj5L0Z5Y3r1tMFYkhwHaE5H6nvBIQ9Daq5/wExiN4h27GTSENa8Yy08syVReYBryFoQT1a8a\nTmKi2A0rPLleUB5OFRGZnTEh0X2tYbxyrRvUv/f8AbPRzoUQwhp7AAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$$- \\frac{1}{40320} \\left(x - \\pi\\right)^{8}$$"
+      ],
+      "text/plain": [
+       "        8 \n",
+       "-(x - π)  \n",
+       "──────────\n",
+       "  40320   "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAKAAAAAqBAMAAADGyk2gAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAuxCrdpnvzWYyiVQi\nRN3cr+EFAAADD0lEQVRIDe1VS2gTURQ9mfymmemkiAtRxBGhgptExF2Fwbb+KG3A1k9dWKQbEaXW\nTUWE2YibogERwU0HsRSCSBYVcdWAiC5ECoIuBDOgC60fQmox2pZ434vYeZPfJOnSCzl597xzz7x5\n784MUBYbypjWiO351urd1Tv2rLMhAv8N3ZvccN7sHrZ1AKneCpdr0rDtqI2A1R4vd2zSEIoNLYkK\nLdKCYUzHl3Vd4ZSOj+tqmK1kGDz280T5VYhpNyrSjJTnCWgPK6+wWtmtahPEnywZxjI4V0Plmhp3\n5c40TAmtMJTEipOuOQ4YNaZlixtSH1J3e4yQXkMojUCdWTLQ01tLJRq8FVNXtsWVe0iHSaPe75od\nFLWni8XiIjAtsl6yCRLtwg3zgiAOHp59MZkBHgusp+Q8qSwM4Imgfoe+QIaYN2ssLblu5Ei+Sj8d\nu3nh8+8svvFxh5/9TfFxQ8AMgVF3jRrXGNWEIX8E1F+QRMugGWWE45bF+erZJpqaDOSwX5TE9GiS\nmOsi6yWjxlAKvhHVEMX9iFrENNE27wFp473UIdEPE/AliLrqoO+mqM2l6VQSz45vpV5LnfoL0mBv\nEhyYOpQhqBb06P0LNYGsgVdJv63GMZBGAkGzBNq89BkcmJg9/1UjYqxNRZYRtbGA8Jhfh5aTTUg2\nB/QDB0vA1bVeXzvX/KAwQ5l9rEJn4F+NxMmQAz4A2QwHLn/qKHIPu0Qia4RHiAnnEVxVFvWIwQFL\n1K9pDlzuPl+HR4B1jiMuIXq5h44C0PLYVjgCDupvMuxjYDi0HoZtM3HEPkEzSTtlIVj8Cg7c8AEz\ntDy4CJID87EcImwbLwLX7hTTHFowDOVjNuRlWlgH5ARu5jlww77Gb1lNwleIjkH+AXTTUetQCxz4\noZjsUEzhfuolsTwZ+vgKlQRedpJ+kANrmznWNnOZeh7CPC1OW1H4Ht6m90mIqrs4sJ5+WAKhoF4S\nMJG1sBmdprqQmraVcSgWB2hp6WwJ6nmI84+GrtBx7N0HjT4FNl4PUUdykIa76eXAoJH4A6F8EmVH\ndtj7AAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$$\\frac{1}{3628800} \\left(x - \\pi\\right)^{10}$$"
+      ],
+      "text/plain": [
+       "       10\n",
+       "(x - π)  \n",
+       "─────────\n",
+       " 3628800 "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAMcAAAArBAMAAAA+rYEMAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIs3dRLsQq3aZ72Yy\niVR4peFTAAADZUlEQVRYCe1VXUgUURg96+6Mu+4vPUUSLoFQSbSRFZHEPvpUC0H01kSEJchuSG0P\nQqZQSoISmJZJG2EEha7UazQvkj01EJRBSxM9aBD5U2hlun337pTddpxtfwqCPpiPPee795y597tz\nF8gRB3PUS1E+Nl8KFWuNhvhfMIHzv4l1G8TqP7BdY4C397T42iaoqJU8bgYu45KJrEgVZYI3wDZU\nqaJkNiraZBjRcLasyBRtAkwromQ2KoHJlmxVkXFdnRsQGQHVC0gA9xminsAbE/i8gcdivkslOWby\nIG9ZcUKZImIBBQmRiUPzqAKfL+iwmsBWQCZj7ycVq2E5a7esRjQC67f2YySdthqVs+YIWg2RdKvq\nb9dcGmCbODnVL864nk6nF+hU9Yh0gagsCTThXvKmMN/VNVU5GgB8QYEuFFSEAQ3deCcI7MM5J3nA\nkVih12xnUQvQIvMJUvCHAQWnuNYPGUKRckZ5Znih2MRMgNu/ythidkaVyKRCJy3bV8hMcyVcST8D\nP2/XSjHvXxI1ftQ5g/PizKjiV4lxB0W6QESH1LcoJWyt4vx2+DViSnSEHSHIh56lLooeqIHUQ1RZ\nmJJJPIJndyqVQsNgC3Ci45qRICk0uGnwJeT+TvU7SdQNelYNulZMYwfcdIoXbMNYF0AtjqqZJB9W\nqMF1aIY9LNchQzIBy1t8wtQCziF4SS4mJVAecYbgDPIkx88Sa9ewAe1AGzjJFayuejnIh2Slymp4\nqWGqPwjvvD0GxyxPQLcCPKQHu4D9AYMkaItRWiXKA+YFrZrx9YhG4Pzo74FnmaeMyWZW+ww80Q2S\n4bUsmUeXOe0OMBM5AraSxSoNnk88ZUzmxjt12xKZtBqkuUgu9jiYiUuHKwGJ6y8xPRKm7ZI/JLGH\nm2gGmUvOvK5xkygtpgZvs0zo/+3VEbaSokx8Kjdpozdwd4wv800xdoavhHr/uujtagI3oQNE4Z1n\n7V3kyegJmbSyxicNko/LN03G41/OQCYdirIgHVQfO8K+2YzJATLR6Q2m2RFmZKExRBc0mThnURWm\nT84b4iljMk09UehjfMo+Rm+oUAuATHzMZCc2AnvRqGYS/xglTb4Duy7fNSqFujxPD1AfaPaLXp2u\nwYkWI10Z2ZQE+vrCkAcvqAZZqMkfm/cNx+U5CyYfG4QAAAAASUVORK5CYII=\n",
+      "text/latex": [
+       "$$- \\frac{1}{479001600} \\left(x - \\pi\\right)^{12}$$"
+      ],
+      "text/plain": [
+       "        12 \n",
+       "-(x - π)   \n",
+       "───────────\n",
+       " 479001600 "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAMoAAAArBAMAAADLUwq8AAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAuxCrdpnvzWaJVN0i\nMkS9ILV6AAADrUlEQVRYCe1WTWgTWxT+OvnpJJm0WYm4sPfBQxEXjYobETpQRKRKIxp/kYiLtxB/\nUBBd6SwUXQgGtEhQMAtFXKUgD3y8nw74+56CBRHBjeEpCrqwtoh/0Pidm7bTVDuMSQkKnsWZ757v\n3PPNnXvuZQAfa1E+5ExRRkcTVIwlXU1QAXp/qnxjX/woXyyZ4sJa/RfX8FqS6/qpUFK+Mg2rIE4V\n40IzVMKdzVB53BSVvL9Kdu8Bx3ffgDZ72gSzTIr7Yrr+KtMW8IgHHvwCbWOEKr+iYZX9X9T2AnJM\nqHIpm9vkBetBYdtnlpnXKsB95ZMVgIr6zTe2wzr71obZtSxAKZ+UFz4cMMeXDU5uZuq/3f+tsGun\n5CqVygjQVxute3SI90fevBaV28qzyJqLd066wGUv1BDaA8QQHooP1lR5idVhiuC5F+Xi6rMh1hjl\nWhBK6Wq3/xT7R+NUSB5PNG7cUQWI2lMLWemEhGZKZacUuz8IJU/PIk67DCZ9MY+rA80Gr6lehFXt\n3E7VLjt1vDZa94i9WnJm4caUAj1ozzM0U538Cvhl1YIzzhSVQ2jJMHR4UnhBYQuSvxcKBaBFjSGj\n0FeEld1XhrH09CCTyeDmxrlsqfUrBquOUURduumMN4xnGUQck808AvkvrqIIsAnXEf6IW0VrF2uT\nsdLoLSJRNv6uOqkgF+K0FrM9ynRg9McUkNb/xRrhBLAQi4EBzAIWQTMhhcQQeoCVVadL+N388z0R\nxNKiwjPMD9OreJQFnRaV3xS6yu+AC3wFMtEdCI3iKvDa1U7XuD6p0lS4fFIgPqL00p4xxlo0otJi\nnMERhdz/bxgta6Z1GJFRvOVhK2onqbBs/fiaC8t+TljH+1XERopOqwhqqRzNS8KAkrU44/qJYesD\nVVaLs4UPbpHKX0yOFOm0ika5Ty7HyQ/YAHTY4ypP8lrlvKjot2BOQDv2qFIEOiVbqwgytx35yEdr\nCvOdeM4eV9mHelXMDE4NS+PQtIqgY+xoBawlPLqG/Tu2ylRVpY4vFuVJeA/pnbFagnbwDnQQTktw\nvMeAbg5k4x3tNBfUzWPiehicWFURJKc2YuMSLJfRg2NMPIN78jYl6eSSMMEt6gLL0TahohGPe8hN\nZuTCda1RFpNv+RA4KQfyXNUxGtzi+xHPIz6hotFlhSu4WyhsRY9qtVmMKtYfhb5+JIrG7qoLLiGZ\nT7Nb2LPcGuj/Yo3almaLGKhUPiGWlf8dYRK86/phbO7mbSnu+7PPCp1DTSYOx48AAAAASUVORK5C\nYII=\n",
+      "text/latex": [
+       "$$\\frac{1}{87178291200} \\left(x - \\pi\\right)^{14}$$"
+      ],
+      "text/plain": [
+       "        14 \n",
+       " (x - π)   \n",
+       "───────────\n",
+       "87178291200"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAPsAAAAqBAMAAACHPjAfAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIs3dRLsQq3aZ72ZU\nMonLrI/bAAAEFUlEQVRYCe1YTWgUZxh+Zn9mZ/Z32pM/0AwFS8GCWyrtpcpCD3oQ3EMRKYUOFRE9\nmJWixUNhYqCmlHRXoSXxZ7NSkB4URuxBKdShHmoPbZaKoKeMFDQ5dE1sukYSs32/d0wna3YXJzsh\nIL6HZ/P+PO+T+eZ7v28TwI/t8lMceO3eeuAtfTTc9/mqykN5Ke/jbQVc+uIs/i1ALn/tb3mCe/o7\nnwGh6thqyeM6MIGDqyl/wZ84gpz765DmBk74+wWCe/e0+Kl53PQlr556ePp5CdvbF/4oUvT008jY\n7au6yqQK7elqlXK09Z4gY7av6ioTMjrQdcqR/FvI5DpUdZMa6ET+mZIk/ys+6FTVTe58J/IB4LVN\nQ0iUv+tU1UUuonciR+1O2QByqgNI44duDDX3Gmk0Go+AdKk5HLgXskAn6mXr+6bO6uCN9Zc0IKk3\nhYN34jnAQRG/N7XegT6F1BGpeOFX3xG2GaCFCcaot5goA4dZ5X8B8vIxEUpNcmLlwB3oH54VkAph\nEVpx+bhNKtITyELNM9XKCGfx4nvJAH+K0ta7pEziy+aevUamSpGE3hwO3KPRSs5GK5LZ3LkfGYci\nKz54kSzk3fdqz36X24hoieRDOYIltvbkh8D+gbPAvvIXALsMN8u1miPXJmzIR+/T6h2snVkM8tBX\nVTC4bNH43JLuiwJ06C41qYCijc3YU5UuYJ3Grhu7RgNZUIHTWGdL1LgE1VoE4Zy8BQzM5s7iVmlr\n460yMQPhSSULRY9WEMuzy4B7QAw/AXvwEWiYExbkrAfoB465wGzuHTL4oyXIeqtw/Dxi0+ECIlMZ\nHek6uwx0fuFv3BfyD4EHRrpA8h7gPWCnxsBs7k3L1tZiWqtUqA51OlNCaq43D2WaXQYqjpgYPYJx\n+V+gmEs+MtKmB3gMjNkMzHZ7r3E/WuFgq6CIhes9DlIz4uln2V2AvUC0ccXhp7fwyew38ECaJ/k+\nASazRaPl2ZgjGsyrFURnqMOYswC00zHyj4ZTJGtCbbwND1j+rpB32VS6TNsAlpc34jchv0G0ESBP\n0lF1dtMcPrWSIyau/tmwPQhMXs2z/AwSA7fn6PnypMyg6MBVJBoGrgwW7UQJ1+oesHxfAIt/nG5K\n2nritafp/xjkPgXa0aBvbz0WBR4YcQPSrAe89Syx9awFtiD6tmQJr5BQcoqYIR3CdQG9JcgVWgmT\nMq9DHFpDHojBGxWDN6otsKnAv90Rt1QW6awyhZ4chOsCdpb4GI1pRY3+NolrwCEPxInzlwvM9i/M\nDGlrbSKL93GgqryLN8GuG8Moyf9i4A/0GyETyTeQdDxA2JYvusDsZcqH6WTPYv843TYT39pg143R\nW6WT5+iwjfTwx9R92zANogdy+ThdOQJcth/9/wDcHM89tyP61wAAAABJRU5ErkJggg==\n",
+      "text/latex": [
+       "$$- \\frac{1}{20922789888000} \\left(x - \\pi\\right)^{16}$$"
+      ],
+      "text/plain": [
+       "         16   \n",
+       " -(x - π)     \n",
+       "──────────────\n",
+       "20922789888000"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAP4AAAArBAMAAACqSyj+AAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAuxCrdpnvzWaJMiLd\nVET4aMmqAAAEhElEQVRYCe1XXWgcVRT+dnZ2Z/ZnNnlRFNRMwaYEhCxGfbBgF5JQS4WsNEsbUdr6\n4IN/yVZE8UEHURR86KoNMkXpgIgIlYzE4k8rHRGhrdoMiPiYBUVfhC7bVhObdD3n3l13V5Jh0t0l\nKJ6HO+ee75zzzZx777m7QFiJmGE9e+KnDGwqvzKyY1P5gYn/+XuyscIm/Y/VP9kPvDTuhv36bu+/\n5B4PqqvQS4SVLtff8BAxMROWvdvfD+KPnktlN5M/NV0wN5MfO1ec0PyF6aet0M7kmMmt662XCaL6\nx/zj1XWdOgXeDUjwgOTfBjwb4NUZdCggXJP8HwH3Bnh1BKm5gHC9JOqvubg9wKsjKG4GhCsHkHrr\nck6Zst0Ar46gXwOjbw5EuwFOUZLPRr8Yz7Uli9VIqOfMtll7MaGNrZT0M3GvLfnkh7tfPUmWH9us\nvZg8CSSgVgynNXnGV93dbPilaeWKdFkqlP0qfT+i/YLnk29ZzrMeAVUfmOOhp0L8QDz3T455eGzq\nPf8TTHPagcnPpuwDF6e1/k2sq9oNgO5OQDXbsipV/MmGV9qsvZjQCVu0rsfH7blVD8ts6f35+w3Y\nsmvoiNXOr1m4ji3Pt5iVWduhKd1XW8foYjqx9xYgab/u4/iUbZeElvzatm0Jay+m3pFIqlAsA0P2\nQ/VAEa1MjnMy2nqueKw9UP9tyikn6tHsS+A8bnPoF9GEjxPIXMJhOpZZoemkXRQw4rVaSSLzUFeB\nPGKWRDga6bJyTqTmK2ZdSeRaoLPQZgD1IGhx1JmoiXQFx3ys4A0gKrWECWQFDG3PUUiErq4F6BYU\nTyASvg/YKXMH3b/bWuj1qph8WkQ6i8yV+MOIXsUi89MXHJVagpqZI2B6IxKBPGJiRzmRJX6BSPgr\n4IIrEs6Lce1he4tZOyAmpSL68kiualXEuHdQ/eu/oYSGnyUs+QXygon9ZeOimciJQDHgMvUWXyRM\n5cRjrUF1Wqx9z43RDtLdIk6XkGTWNFdEy9Kwhf2ERn8UJBwdGy03ECyYGFjaJREBp+h0zeUIDy/D\nZ5C2cCskP5/OOSrvB09xBnqxuhbzBcsyIqbC5WEESfKO1b6RCPMvC34K34AMV5Co0oo2+YscrdIF\nplQaGoapmTIBG+5qIFo/8PL7NV8g18zvQV+la/Lv+scoK8m0SaehofGmZgJeHhxz6sj9tG55HK4K\nRAzXUP++GeiXhkD8vIOWgFGi+BwYsJDONjTQvpbwTcRfFghUguMmUksCkTDvP4tfMrRE+Pu/Hxn5\n/Q6iM67AyOOkUqONZWE4j7qmUF4JPw7sdxkBfkDKHaTnpEAkTO+56IbmZkdDrD8g+k/Cw3vAa/iD\neouLC8QitQzxU4MhmEzP0BmnRzIP3eU2u10gEqb+8/aG6IEbMWhRyEHgOww6qbP2rEd/CzK01RaJ\nRWoG8QuYOrPxmERO2faDMA7BKEmEo5H2lUc3yB+78x6KeLO2D1uP3I00tXoPRmGvL1dSarwvBIxk\nYYQ+mdd4oVZbAX4q0FHkQDkoU6MOuf575C9+Ztihp/kcUAAAAABJRU5ErkJggg==\n",
+      "text/latex": [
+       "$$\\frac{1}{6402373705728000} \\left(x - \\pi\\right)^{18}$$"
+      ],
+      "text/plain": [
+       "          18    \n",
+       "   (x - π)      \n",
+       "────────────────\n",
+       "6402373705728000"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "for term, _ in zip(cos(x).lseries(x, pi), range(10)):\n",
+    "    display(term)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Hint: to get the exponent from a term like `3*(x - 1)**5`, use `as_coeff_exponent`. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 47,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAADwAAAAaBAMAAAAZJyJqAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMARDKrEM1mIu+Zdrvd\niVTWGHL+AAABSklEQVQoFXWSPUsDQRCGn1wuuXwn/oIErEVBFMHmGusExMJGUtgJco2F2NjZCB5o\nk8pAmiAWgq1IsBG7IFiqtZ0Jh2kkcW5zMZsLN8V8vM/M7g4ssECEdX3dWImgLPpgy47CmaaQdVh6\nfwy1JPatD3gG6xTLpew3apYajeTmFqRd8kOKHY1Jmrh8FV+1SZUozOO46s7VWVZJ+PAxTt/RVnhb\n+amL37RKkPxmTTTjLbx71jZ7EPO4VyNt6Q3Zhoz12VVqygtB+Kxg9XiR1Stkf2bxg+AS5tDHVW8O\nn8O140/Lm4s1cgNsfd6FHTm2zyZk6pS75q+OjymcycsH3Ir61djDvHA0bjRWpZS9yxMxpuOxmK9R\nrAQ8OembxkSTeDcaVx2MToCbQdTCgeThj6LhJ8mPtHo2TbpSFyaXzzKpTpRyOKcHwlUU+Nf/AKUL\nQ2ycOKYsAAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$$\\begin{pmatrix}3, & 5\\end{pmatrix}$$"
+      ],
+      "text/plain": [
+       "(3, 5)"
+      ]
+     },
+     "execution_count": 47,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "(3*(x - 1)**5).as_coeff_exponent(x - 1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 48,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def series_accuracy(func, expansion_point, evaluation_point, accuracy, x):\n",
+    "    \"\"\"\n",
+    "    Returns n such that series terms up to and including (x - expansion_point)**n \n",
+    "    (i.e., O((x - expansion_point)**(n + 1)) are needed to compute func at \n",
+    "    evaluation_point within the given accuracy.\n",
+    "\n",
+    "    >>> series_accuracy(cos(x), pi, pi + 1, 0.01, x)\n",
+    "    4\n",
+    "    >>> series_accuracy(exp(x), 1, 10, 1, x)\n",
+    "    23\n",
+    "    \"\"\"\n",
+    "    # Make sure to compute as many digits as needed. evalf defaults to 15, so this\n",
+    "    # is not actually needed for any of the doctest examples.\n",
+    "    digits = max(15, round(1/accuracy) + 1)\n",
+    "    real_value = func.evalf(digits, subs={x: evaluation_point})\n",
+    "    expansion = 0\n",
+    "    for term in func.lseries(x, expansion_point):\n",
+    "        expansion += term\n",
+    "        series_value = expansion.evalf(digits, subs={x: evaluation_point})\n",
+    "        if abs(real_value - series_value) < accuracy:\n",
+    "            return term.as_coeff_exponent(x - expansion_point)[1]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 49,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAAoAAAAPBAMAAAAv0UM9AAAALVBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADAOrOgAAAADnRSTlMAMqvdu3bvImbNiRBUmeNE\nfywAAABBSURBVAgdY2BgYBACYgYGExDBmgIiK6aAyAUgkqMARG5lAJELQCSPAIjcxQAiDykpPVMF\nSjCAdUHIRe9ugEQYGAAZ5A24Epj20wAAAABJRU5ErkJggg==\n",
+      "text/latex": [
+       "$$4$$"
+      ],
+      "text/plain": [
+       "4"
+      ]
+     },
+     "execution_count": 49,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "series_accuracy(cos(x), pi, pi + 1, 0.01, x)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABMAAAAOBAMAAAA/Njq6AAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIpnNu0SrdlQQ3e8y\niWbzIQYJAAAAjUlEQVQIHR3MMQrCMBiG4beUEocgpYOgOEh1cnEprnoDc4SuTt5AghcwN+nk5OAJ\n3FyD3qFDpSDxT5ePZ3j5SMrKoP3LwgT1pSDr4AgNb0sPd8fJXAfuHBvDECCBg7QWoH/w3EaR7mXU\nLXIVh4dUqoY5HD5wIZkGF6kXjPNWbnJm3q85k8lNE0LPqFxa/n51I/Ad/d+pAAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$$23$$"
+      ],
+      "text/plain": [
+       "23"
+      ]
+     },
+     "execution_count": 50,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "series_accuracy(exp(x), 1, 10, 1, x)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": []
   }
- ]
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 0
 }

--- a/tutorial_exercises/Advanced-Calculus.ipynb
+++ b/tutorial_exercises/Advanced-Calculus.ipynb
@@ -1,1298 +1,1355 @@
 {
- "metadata": {
-  "name": "",
-  "signature": "sha256:c1084350b7f222e7e4f184f84198ae92334c8ebd0fdd2ad2cbca02f80695cc3b"
- },
- "nbformat": 3,
- "nbformat_minor": 0,
- "worksheets": [
+ "cells": [
   {
-   "cells": [
-    {
-     "cell_type": "heading",
-     "level": 1,
-     "metadata": {},
-     "source": [
-      "Calculus"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "from sympy import *\n",
-      "from IPython.display import display # This, with init_printing(), will let us \"print\" to MathJax\n",
-      "init_printing()"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 1
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "For each exercise, fill in the function according to its docstring. "
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "x, y, z = symbols('x y z')"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 2
-    },
-    {
-     "cell_type": "heading",
-     "level": 2,
-     "metadata": {},
-     "source": [
-      "Derivatives"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Compute the following\n",
-      "\n",
-      "$$ \\frac{d}{dx}\\sin(x)e^x$$\n",
-      "$$ \\frac{\\partial}{\\partial x}\\sin(xy)e^x $$\n",
-      "$$ \\frac{\\partial^2}{\\partial x\\partial y}\\sin(xy)e^x $$\n"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 2
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 2
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 2
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Recall l'Hopital's rule, which states that if $$\\lim_{x\\to x_0}\\frac{f(x)}{g(x)}$$ is $\\frac{0}{0}$, $\\frac{\\infty}{\\infty}$, or $-\\frac{\\infty}{\\infty}$, then it is equal to $$\\lim_{x\\to x_0} \\frac{f'(x)}{g'(x)}$$ (we will not consider other indeterminate forms here).  \n",
-      "\n",
-      "Write a function that computes $\\lim_{x\\to x_0}\\frac{f(x)}{g(x)}$. Use the `fraction` function to get the numerator and denominator of an expression, for example"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "fraction(x/y)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\begin{pmatrix}x, & y\\end{pmatrix}$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAD4AAAAaBAMAAAAd0vJXAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMARDKrEM1mIu+Zdrvd\niVTWGHL+AAABRUlEQVQoFX2RPUvDUBSGn7YxbdMP9Re04K4uurjcxalIBadu2QXp4qJo+wu0os4G\numhRWnARBAkOiltWxf/QWgRBRDxpSUksNwduzjnv857LvTfAPLrwfJBc1mEWfLKutNxyBK1qMTxD\nuhnD25BtxfCqIjMXw/M2SzGYbI9L4Qftwysn4jNePRoKc8AKGJ75lHEjvJAY0IXEJ7dQwBoUyxG+\nmHW5l7cbUpN5Ur0IBZVx+JbLf/DiE+n+RV/JLMbvmDfKqKjhHKs5mt8Cs97FUlFHjZz8t/SQNejb\nd+xh/IR3OKVky/m/uIbKzcabjXFcDxkqnQtp5f6liZgIc3gXUNhkthwYzKCQnHKNI0kzDilP8ijC\nPO/lfL1aJ+mOKThBIbnYOfG7bVkPfqGJR9F3NUxksyWf4uQAU8b9kbIzpQfCWVDo8x9x5EPeMJ02\nngAAAABJRU5ErkJggg==\n",
-       "prompt_number": 3,
-       "text": [
-        "(x, y)"
-       ]
-      }
-     ],
-     "prompt_number": 3
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "You may assume that the only indeterminate forms are the ones mentioned above, and that l'Hopital's rule will terminate after a finite number of steps. Do not use `limit` (use `subs`). Remember that after taking the derivatives, you will need to put the expression into the form $\\frac{f(x)}{g(x)}$ before applying l'Hopital's rule again (what function did we learn that does this?)."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def lhopital(expr, x, x0):\n",
-      "    \"\"\"\n",
-      "    Computes limit(expr, x, x0) using l'Hopital's rule.\n",
-      "\n",
-      "    >>> lhopital(sin(x)/x, x, 0)\n",
-      "    1\n",
-      "    >>> lhopital(exp(x)/x**2, x, oo)\n",
-      "    oo\n",
-      "    >>> lhopital((x**2 - 4*x + 4)/(2 - x), x, 2)\n",
-      "    0\n",
-      "    >>> lhopital(cos(x), x, 0)\n",
-      "    1\n",
-      "    >>> lhopital((x + sin(x))/x, x, 0)\n",
-      "    2\n",
-      "    \"\"\"\n"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 4
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "lhopital(sin(x)/x, x, 0)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 5
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "lhopital(exp(x)/x**2, x, oo)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 6
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "lhopital((x**2 - 4*x + 4)/(2 - x), x, 2)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 7
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "lhopital(cos(x), x, 0)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 8
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "lhopital((x + sin(x))/x, x, 0)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 9
-    },
-    {
-     "cell_type": "heading",
-     "level": 2,
-     "metadata": {},
-     "source": [
-      "Integrals"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Recall that the mean value of a function on an interval $[a, b]$ can be computed by the formula\n",
-      "\n",
-      "$$\\frac{1}{b - a}\\int_{a}^{b} f{\\left (x \\right )} dx. % Why doesn't \\, work? $$\n",
-      "\n",
-      "Write a function that computes the mean value of an expression on a given interval."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def average_value(expr, x, a, b):\n",
-      "    \"\"\"\n",
-      "    Computes the average value of expr with respect to x on [a, b].\n",
-      "\n",
-      "    >>> average_value(sin(x), x, 0, pi)\n",
-      "    2/pi\n",
-      "    >>> average_value(x, x, 2, 4)\n",
-      "    3\n",
-      "    >>> average_value(x*y, x, 2, 4)\n",
-      "    3*y\n",
-      "    \"\"\"\n"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 10
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "average_value(sin(x), x, 0, pi)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 11
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "average_value(x, x, 2, 4)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 12
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "average_value(x*y, x, 2, 4)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 13
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Write a function that takes a list of expressions and produces an \"integral table\", like\n",
-      "\n",
-      "1. $$\\int \\sin(x)dx = -\\cos(x) + C$$\n",
-      "2. $$\\int \\cos(x)dx = \\sin(x) + C$$\n",
-      "3. $$\\int e^xdx = e^x + C$$\n",
-      "4. $$\\int \\log(x)dx = x(\\log(x) - 1) + C$$"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def int_table(exprs, x):\n",
-      "    \"\"\"\n",
-      "    Produces a nice integral table of the integrals of exprs\n",
-      "\n",
-      "    >>> int_table([sin(x), cos(x), exp(x), log(x)], x)\n",
-      "    \u2320\n",
-      "    \u23ae sin(x) dx = C - cos(x)\n",
-      "    \u2321\n",
-      "    \u2320\n",
-      "    \u23ae cos(x) dx = C + sin(x)\n",
-      "    \u2321\n",
-      "    \u2320\n",
-      "    \u23ae  x           x\n",
-      "    \u23ae \u212f  dx = C + \u212f\n",
-      "    \u2321\n",
-      "    \u2320\n",
-      "    \u23ae log(x) dx = C + x\u22c5log(x) - x\n",
-      "    \u2321\n",
-      "    \"\"\"\n"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 14
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "int_table([sin(x), cos(x), exp(x), log(x)], x)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 15
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Now use your function to compute the integrals in this Mathematica ad.  Remember that the inverse trig functions are spelled like `asin` in SymPy. \n",
-      "\n",
-      "The ad below probably has a typo, because one of the integrals is trivial to compute. Include what you think the integral should be, and see if SymPy can compute that as well."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "from IPython.core.display import Image \n",
-      "Image(filename='../imgs/Mathematica-ring-a.png') "
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAANAAAAEECAYAAABZfLr5AAAACXBIWXMAAAsTAAALEwEAmpwYAAAK\nT2lDQ1BQaG90b3Nob3AgSUNDIHByb2ZpbGUAAHjanVNnVFPpFj333vRCS4iAlEtvUhUIIFJCi4AU\nkSYqIQkQSoghodkVUcERRUUEG8igiAOOjoCMFVEsDIoK2AfkIaKOg6OIisr74Xuja9a89+bN/rXX\nPues852zzwfACAyWSDNRNYAMqUIeEeCDx8TG4eQuQIEKJHAAEAizZCFz/SMBAPh+PDwrIsAHvgAB\neNMLCADATZvAMByH/w/qQplcAYCEAcB0kThLCIAUAEB6jkKmAEBGAYCdmCZTAKAEAGDLY2LjAFAt\nAGAnf+bTAICd+Jl7AQBblCEVAaCRACATZYhEAGg7AKzPVopFAFgwABRmS8Q5ANgtADBJV2ZIALC3\nAMDOEAuyAAgMADBRiIUpAAR7AGDIIyN4AISZABRG8lc88SuuEOcqAAB4mbI8uSQ5RYFbCC1xB1dX\nLh4ozkkXKxQ2YQJhmkAuwnmZGTKBNA/g88wAAKCRFRHgg/P9eM4Ors7ONo62Dl8t6r8G/yJiYuP+\n5c+rcEAAAOF0ftH+LC+zGoA7BoBt/qIl7gRoXgugdfeLZrIPQLUAoOnaV/Nw+H48PEWhkLnZ2eXk\n5NhKxEJbYcpXff5nwl/AV/1s+X48/Pf14L7iJIEyXYFHBPjgwsz0TKUcz5IJhGLc5o9H/LcL//wd\n0yLESWK5WCoU41EScY5EmozzMqUiiUKSKcUl0v9k4t8s+wM+3zUAsGo+AXuRLahdYwP2SycQWHTA\n4vcAAPK7b8HUKAgDgGiD4c93/+8//UegJQCAZkmScQAAXkQkLlTKsz/HCAAARKCBKrBBG/TBGCzA\nBhzBBdzBC/xgNoRCJMTCQhBCCmSAHHJgKayCQiiGzbAdKmAv1EAdNMBRaIaTcA4uwlW4Dj1wD/ph\nCJ7BKLyBCQRByAgTYSHaiAFiilgjjggXmYX4IcFIBBKLJCDJiBRRIkuRNUgxUopUIFVIHfI9cgI5\nh1xGupE7yAAygvyGvEcxlIGyUT3UDLVDuag3GoRGogvQZHQxmo8WoJvQcrQaPYw2oefQq2gP2o8+\nQ8cwwOgYBzPEbDAuxsNCsTgsCZNjy7EirAyrxhqwVqwDu4n1Y8+xdwQSgUXACTYEd0IgYR5BSFhM\nWE7YSKggHCQ0EdoJNwkDhFHCJyKTqEu0JroR+cQYYjIxh1hILCPWEo8TLxB7iEPENyQSiUMyJ7mQ\nAkmxpFTSEtJG0m5SI+ksqZs0SBojk8naZGuyBzmULCAryIXkneTD5DPkG+Qh8lsKnWJAcaT4U+Io\nUspqShnlEOU05QZlmDJBVaOaUt2ooVQRNY9aQq2htlKvUYeoEzR1mjnNgxZJS6WtopXTGmgXaPdp\nr+h0uhHdlR5Ol9BX0svpR+iX6AP0dwwNhhWDx4hnKBmbGAcYZxl3GK+YTKYZ04sZx1QwNzHrmOeZ\nD5lvVVgqtip8FZHKCpVKlSaVGyovVKmqpqreqgtV81XLVI+pXlN9rkZVM1PjqQnUlqtVqp1Q61Mb\nU2epO6iHqmeob1Q/pH5Z/YkGWcNMw09DpFGgsV/jvMYgC2MZs3gsIWsNq4Z1gTXEJrHN2Xx2KruY\n/R27iz2qqaE5QzNKM1ezUvOUZj8H45hx+Jx0TgnnKKeX836K3hTvKeIpG6Y0TLkxZVxrqpaXllir\nSKtRq0frvTau7aedpr1Fu1n7gQ5Bx0onXCdHZ4/OBZ3nU9lT3acKpxZNPTr1ri6qa6UbobtEd79u\np+6Ynr5egJ5Mb6feeb3n+hx9L/1U/W36p/VHDFgGswwkBtsMzhg8xTVxbzwdL8fb8VFDXcNAQ6Vh\nlWGX4YSRudE8o9VGjUYPjGnGXOMk423GbcajJgYmISZLTepN7ppSTbmmKaY7TDtMx83MzaLN1pk1\nmz0x1zLnm+eb15vft2BaeFostqi2uGVJsuRaplnutrxuhVo5WaVYVVpds0atna0l1rutu6cRp7lO\nk06rntZnw7Dxtsm2qbcZsOXYBtuutm22fWFnYhdnt8Wuw+6TvZN9un2N/T0HDYfZDqsdWh1+c7Ry\nFDpWOt6azpzuP33F9JbpL2dYzxDP2DPjthPLKcRpnVOb00dnF2e5c4PziIuJS4LLLpc+Lpsbxt3I\nveRKdPVxXeF60vWdm7Obwu2o26/uNu5p7ofcn8w0nymeWTNz0MPIQ+BR5dE/C5+VMGvfrH5PQ0+B\nZ7XnIy9jL5FXrdewt6V3qvdh7xc+9j5yn+M+4zw33jLeWV/MN8C3yLfLT8Nvnl+F30N/I/9k/3r/\n0QCngCUBZwOJgUGBWwL7+Hp8Ib+OPzrbZfay2e1BjKC5QRVBj4KtguXBrSFoyOyQrSH355jOkc5p\nDoVQfujW0Adh5mGLw34MJ4WHhVeGP45wiFga0TGXNXfR3ENz30T6RJZE3ptnMU85ry1KNSo+qi5q\nPNo3ujS6P8YuZlnM1VidWElsSxw5LiquNm5svt/87fOH4p3iC+N7F5gvyF1weaHOwvSFpxapLhIs\nOpZATIhOOJTwQRAqqBaMJfITdyWOCnnCHcJnIi/RNtGI2ENcKh5O8kgqTXqS7JG8NXkkxTOlLOW5\nhCepkLxMDUzdmzqeFpp2IG0yPTq9MYOSkZBxQqohTZO2Z+pn5mZ2y6xlhbL+xW6Lty8elQfJa7OQ\nrAVZLQq2QqboVFoo1yoHsmdlV2a/zYnKOZarnivN7cyzytuQN5zvn//tEsIS4ZK2pYZLVy0dWOa9\nrGo5sjxxedsK4xUFK4ZWBqw8uIq2Km3VT6vtV5eufr0mek1rgV7ByoLBtQFr6wtVCuWFfevc1+1d\nT1gvWd+1YfqGnRs+FYmKrhTbF5cVf9go3HjlG4dvyr+Z3JS0qavEuWTPZtJm6ebeLZ5bDpaql+aX\nDm4N2dq0Dd9WtO319kXbL5fNKNu7g7ZDuaO/PLi8ZafJzs07P1SkVPRU+lQ27tLdtWHX+G7R7ht7\nvPY07NXbW7z3/T7JvttVAVVN1WbVZftJ+7P3P66Jqun4lvttXa1ObXHtxwPSA/0HIw6217nU1R3S\nPVRSj9Yr60cOxx++/p3vdy0NNg1VjZzG4iNwRHnk6fcJ3/ceDTradox7rOEH0x92HWcdL2pCmvKa\nRptTmvtbYlu6T8w+0dbq3nr8R9sfD5w0PFl5SvNUyWna6YLTk2fyz4ydlZ19fi753GDborZ752PO\n32oPb++6EHTh0kX/i+c7vDvOXPK4dPKy2+UTV7hXmq86X23qdOo8/pPTT8e7nLuarrlca7nuer21\ne2b36RueN87d9L158Rb/1tWeOT3dvfN6b/fF9/XfFt1+cif9zsu72Xcn7q28T7xf9EDtQdlD3YfV\nP1v+3Njv3H9qwHeg89HcR/cGhYPP/pH1jw9DBY+Zj8uGDYbrnjg+OTniP3L96fynQ89kzyaeF/6i\n/suuFxYvfvjV69fO0ZjRoZfyl5O/bXyl/erA6xmv28bCxh6+yXgzMV70VvvtwXfcdx3vo98PT+R8\nIH8o/2j5sfVT0Kf7kxmTk/8EA5jz/GMzLdsAAAAgY0hSTQAAeiUAAICDAAD5/wAAgOkAAHUwAADq\nYAAAOpgAABdvkl/FRgAAv9BJREFUeNrU/XmU3dd134l+zjm/4Y41YAY4AKRAQuIgkwJlDaZE+knR\n4FB2EktO6HbiKN2hYrcT97O0Vi9bK89Wr5bc3ZH8nuN+K4nciSy3bTqW7I4tilLLUgyKjGiJhEjJ\nJEQCEEVwQGEq1HCn33TOeX+c87tD1a1CjVDeXeuiClW37v0NZ5+993d/93eLNF20bPihgICr+zBA\nG2sLQKzyuo2eVgMhom0/C2tbQL6GF679jISIEaJ2heuyFceeg+1gMVv6WUKUXycBeZXXlcbazrrX\nTWCt3cRCtv5ExVU8UeGfFqxd5+naofewY97X+kUdXgUD0oAevXZ2I6Zvx9yT7T72wh//+o5WrPif\n8n3xG7K4Kucx+tkpUKzbcIONHaj1T+09wdX2QmroGJYfmt2UB0qB6lW4YcYveMFG7MWO/cXVMqDc\nG9DQZjZyHnasldghT2PNwOOMWJAIrrrxuHWcDF3DdRnQpi6l30XVVfZCEdAbPVk7fNk3cwOKMQti\nezYBa3PAugVlBwtqY0GBuUrRQHnP7ZJrbdccRpfnN+485VUIn5cfTzK0ma07hDMbvIjl1wJr5VX2\nQuXOZ65wYdYSuo1778wb6XbeNPxCdLuxRbD2cHql89j+0MdFHIU/Vrsld3LwnxBrr3b4VnqfjW28\nweYP1iJEjrVX2wvFfqHbZZm23RSwYLG2uApAgl2yA9t1/e3WgSYbWXB6aPMS6zB2Me4q9DdDQXyV\n1xBY213HuWxpCGeHnoXfTa+mF4pGjWfLQjhYEzq2ZeHQuJ9tZBGZq2RE2l8ftcZrbddg5HZrMooN\nhevppq5bsHnjKRPD9Cp7IQmEYNOVIu1NLOrshwuEbBjYuRrXPt8Gj2eBGCHUD8H7LAVDrkoIZ5fk\nQaUXyrc9dxh9VLD0tsErmCFwZDvzOMvqCJZlOcq10vfmKuzg2iNwFiHMKhnNeo3ZIETM1az9uFpW\nAsIuOWZxtQxoqSeyCJFgbXgVvVA8BCZsRfJphxZKhhDbCWfbMZvRSr+HUfzaLskhylx0uwEEQ4lS\nuvxNjD1mhyoO0MXyZ+Pf0yLE1QahADpYCrDSXbv+6dirYUDLjWfghTK/sK9WGBcD3a0JKfp5lEGI\nYpuPfTUPJEaMxV6RcXG1kCvjoXexiuHTR9KGjWxlgNH48C28aqZjbTaEvLnN1yI2VD8Its54Si/U\nxdroqnkhIaqegiE2nkcsQ+7MVciDVH9hCWGXFEjtOs/F+lLCdl/zHGvNGnIVu/Zjt1z18M1tuMOs\nA/vDCOGGq7bDRqSBhKtRzXeP0F8Is8qOw0g4sbZdqvBx/nbdWNGvpYwe1xJvZAc5kF0GBw+DOME2\nG5DF2qwfdo072hVTolXvi4KrWDy1NvXgwdJ8c2PAyCYMyIz1Ru7i9oDKVfJCyhtra3SxL/Eqg5su\n1njh9FWrB42GbGVIMewNV9vdr074Zq3xfLGlOdgqlmNXD15L8EBcNQOyWNv191UuyS83tlY3aEDL\njWdQmS4JmT2gdjWCOG+si6xenBwXt9tVESfn5rfn5vbDIDsMBKx2XHbV7zfGKNlI/rPSdRVjDHo1\nTpwdiiCuTrjvjr+zyia6oUKq2bA1l387ajzl4uv6hb39sa0QIdaG/gJJtqa2on0etF2bgBxC0Ta7\ngEokazsfZbFcrnBd18+JA+XbL65W+Fa2waghe1kPzWuLQQRrxwEK5SPzXqh+FS5N4MO4dMt2sxKy\nFVeXWbIBgy9vfLitRmRt5vIxsXXnJ0TgAYSrhbwNvE+5dEV5QmJj4fCGc6BRrzNsPGaJF6peBS8k\nfKglV1mIq+U7Sy6cLdGYctdV23RT7YaT15UBne3KHdI+lLH5e+W+Xi3jGXgf7QxGjNmm7Jpwj+UG\nJGUda8cbhENJzOjPrfX2a1fxPiXKlCDE1fJCkX9mG9jRl/LpbN+AXMK5PQYkRIS1vY3ZzFIoYVs9\npR0CENaGZo5DPYVgaF1JhKhfJePJMKY9MH9/YGLEpkvPtL4LKZfvZN5I+sbDCFBgx9J4lj6H/669\nzbvjYDG6YpxZ92K05XPpr0zpgbbrIdfmXIaP0a60bW0fD3G4A3WtpYBxryuPvwx+rhb6Zu3i2HXh\nVzXWbuoOLrkVyzo6bf8Gjg/VVtseha/4JlfJUa8DtFjBaEZfUjKPr1KeY5cb9Jq6bqz1XnK7DGjr\nr4GU1atkPCnG9K4YhYz2jq39GbgFVww7awa8qqUh2zjkZdx+aJftAEJcDUSugoNF05U/y66vi9/a\n3F+LrV+cAomxW26G27IIr7RLr7egKkTjqhiQMYtLooiV7uWGmQjRkAGVZEA7lOTadVjm4D0GHkt4\nD7T9uZCDswOsTcf0269joQ291qE32lf6t/qAw62zHru9BrQpI15Sm5My3p7rOdbwk1WMZfT/1l4Z\nJJGq6gEQiRAS6WLncEzItlrBcSUmsR2Kc4cNS2DtAlejYi5EdbRIuYZQbeWwTnr6iuaH/lglH3In\nHmzTIjQYk2/piUhZ52poNxizCDZf4eaPr1etxUWMnIv7ZsAnGzCuVvM+jAnprpSM5R6H324DqvuF\nb9dnNCsambn6BnQF4GD8Y7t6l7K1ZmJrDlyvRvHU2p6j7Xif0t/Y7WoXXazzJsnSgCQulBNj2MB2\n/Da45JYup9CM81qLV8ELqf65bBZEGHjV7QISgvGehc1ow231Qsy28P0tUlbY3kZFt+lp3fYo6nIa\nkd1s2a2/EVSGM+1wKJRbyWhWWoj2CsZTZpI51ravkhda0UuvPaTrAwnZtixSIdTakbYf0sOYbOUL\nOTYqWSXwsQYp69tOO7I2cYzrVT7H2tVSk7VsVSFCVByVR/Qz7ooHFAqWw9ErUWtLMoQdC7sshQeF\naCNEc1tjYEENgwQxRrhwRTbKSso+glJ4YutvvPDX3m5isVgcp0wO3cetBxDEsqsmxvxXrHqcQiqk\nrGzLcQ7fPK3L2qNaHRhcVoEWVzw2IVwRuMzjlqyIssOTJeHZGqr44ySLxuiyOVRrm72QUD5UWE/C\nsZJ3Ej6EM9ti6lvlybZjV3fFU7uqb7FDYdG452AZWd8iv73om6v7dLhSyWSjXt+1oNf6KOKYT4lG\nULnlrs6ugszZkTBp/OuMN6DtZSdcuc5gGS4Sr3ZB3WLIt+EYNwhjj4uO7PYsRjbZJjG0DSNldZuV\ndyxaL2zuaK+wUzgPWhlxOWMeNbByldxmZeO5cn4hgeQqIHJl4XaFfG4duZBz9+l2mPm6jGUlRG6r\nVEKX5z+pn8CwFbDi9lN3Bt5nHR2mdhQY6P/XxWoglCsRiBAhKz6/FlcyIAl9qHEt4dtSr3OlpMx6\nL7R98LAQEilqjKUqbaAuZGzKtqf6S4zli198hH/8wf+Rd7/nn/Af/+ThFf/ItQVsRwiXew+0+X4l\nt3NvL/u6KOaX3CKxhiOzA2RuaAGPqg6V+XttWQF4lYA0RohsCVt4dbHwtT8k2B7W9jZM6Th+/DjH\njh2j3W7TarU4e/YsBw4c4OjRo9x///0uIZR1bLHoEsN1GM3yMxVYk27TbZdjZx3963/9Wfbt282/\n+Bc/z8MPP8Kjjz7Jz/zMT6zi1eUWG49xJNJNm4/tC4dsJ/pmjFtPo6DA+o7eLoNKBn8vRIyUy+tX\nwerhRc0jUHrF9Guj84VcatXyieX64uJPf/rTPPTQQ3zyk5/k5ptvHjGqj33sYxw7dowPf/jD3HTT\njQgRDI3iuHL4u/KvjefFbW0Y4o5vVELr0Uef4KmnTvCZz/yvANx55y0AtNsdGo06K9zjrd7P13bd\nrmiIjimv1GDxtVotms3mlh6t1vMuwe83yI3b9MW6wug+tUcEK7InrrAlBEMewq6Cvq2/hVoI6avF\n62Nqf+pTn+LBBx9cZjwAR48e5ZOf/CQnT57kIx/5CO1218esdk1h2pqS6i2Pk5bflK9//Un27du9\n7Of/4T98nqeeOrGOq7zJ8A09BKJc+Tm+BGQRIkSImFarxcc+9jFOnjy5xd6ni/ERwjAquBwZGvfD\npVQ0uyQzEUhZWzH8XINPjX1CfiVh8PXd1jLGdBy5tSWqx48f56GHHuK+++5bZjzl4+abb+b++++n\n1Wrx6U//rkNMtqSgyhZzwgY3aOnj0UefWPazP/mTh3n44UdWiBXUlodwxmRDU+jWDw6WvTYg+yWF\nhx56iGPHjm0D8lb2+4jxx7OuavUonVSIECkbq7iYNcToQjR8NT5jfJF0HcazpEhZVo3Xkgs99NBD\nANx7772rvu5973sfDz74IA899BD/9J9+kFotwpicTqfLt4+f4G1vfyMADz/8CO12h7e97Y3s3798\nx2+3O3z960/SbnfYt28399xz96qf22q1eOSRR/ohytGjR9m/f//Ia06ePMnx48f7HvPGG3egh9Zp\n6WHa7e6Itzk3cxGAU6dexFpoNGq0212sNShVJwgmOXDgwLLPK49reNcfft3x48c5efIkN998M0eP\nHh26t24G0GOPHeemmw7RaNT40pce4fDhQ/2QsjT2c+cu0mjUedvb7hoNMS0IqVCqzszMDGfPnu1f\nA4BmszmyES69NittkktzH2OSNRl3/5iWRW8rxcESpSZXDfPUv/yX//I31pT0Y1nbKAixrjzDGWGO\nlFdmJ3zsYx8D4Fd/9VdXfV2z2eTP/uzPyLKMI0dex8GD1/A//8//H/63/+3f8/VHn+TNb/4R/tW/\n+j949tnTfPWr3+CrX32ct7/9jTSbg5t/6tSLfPzj/5Y777yFRqPOb//2Z5mZOc9b3/r2sdXqmZkZ\nPvjBD3L06FF27tzJn/7pn9JqtfqLstVq8dGPfpSTJ0/ylre8hSzL+M3f/E1mZs5z6603EkURjz76\nBP/pP32Vc+cukmU5585d5NlnT/Hss6c4deoM7XaXdrvL6dMvIgRkWc7v/M7v8/DDXyOKIm6//fZ+\nbvGzP/uzvPWtb6XZbJJlGY8//ji/+Zu/SZZlHD16lJMnT/Kxj32MZrPJsWPHePDBB9m1axc333wz\n1moefPAP+Y3f+G2+9rXHufXWm/id3/l9vva1b/C1r32Dn/u5n6Ld7vAbv/GvaTbrHD58iM997kt8\n7WuP87a33UUURf1lKWVEEEzx4IMPcubMGWZmZti/fz9Z5lrvDx06tOK1OXv2LLfffjtxHK+4oIpi\nDmPSDQAUYvDvMhaFS0uCYGIZcFDe+/LrGg2oVL7MgWJDQ6xWZgKJfr/NajDn8ePH+cpXvgLAP/7H\n/3hN4d7MzAxHjhzhtttu4e67b+Gb3/wuly/Ps3//bn75l3+en/iJe4jjkG9+8ztEUcQb3nCLN4aL\n/Mqv/C/8D//Dz/PmN9/BwYPX0GjU+IM/+HNuu+11HDhw7VhgI45jfumXfolDhw5x11138dBDD/Gu\nd70LgI9+9KOcPXuWT3ziExw6dKi/u/7xH38OLNx5560cvP4a3vGOt/KHf/jn3HrrTXziEx/hHe94\nK+94x1vJ85ynnjrBRz7y3/FzP/dT3HrrTdx00yHa7Q4nTpzmfe+7r2+sx44d46GHHiKKIo4ePUoc\nxxw6dKgPvLz44ot85CMf4Zd+6Zd43/vex7333stDDz3E888/z0//9E9jbcZrX3uAVqvNiROnabe7\n/NRPvpObbjrE4ZsOcucdt/CRj/wmb3rTHXzgAz/B/n27ufPOW/gPn/k8zWadW2+9yec+AqUmkbLC\n0aNHmZ2d5fjx4zzwwAO8613v4tChQ6temwcffLDvjVbyPloveOBNbMiAypLPsNgJuIKplFPLNsul\nBrQOs5UIMeEKrOvp4rJXgLlteTG2r19IiBgpIhoNt5sMw8Hl96dOvTiSb7TbnX5I9dRTJ2i3nRzs\n889/b+xnzMzMcPLkyX54sn//fj784Q/3F/Tx48c5evToCPrk4Hb4k899iZlzFzd09m9721G/YXx7\nZPMYDnnLn91zzz00m80+3F+GwmUoNTMz4zc7jTFFPxy7445buPttd/H+D7yXD37w/XzpS49w6vQZ\nf32e5amnnmVm5sIgBPXJpUCg1OpNlFe6Ng8++GD/uJbC7EXRwhjtgJgtXToCpabW5NXW6fciEM1l\nrm4l73PFJH2k87PwyinjHwcOHBiJldf62L9/v4Oe11HEe+qpEzQadf7jf3yYr3/9CU6edMb1T/7J\n+3m7z5+WPu69915arRYf+tCH+NSnPtUPVYaPd/gcyscb3nDHisDBlbN1y+HD17N//96+0bRaLWZm\nZrjvvvtotVp9Izp+/Djve9/7+tfkk5/85EhuOXxNlzYRHj58cOTj+8bz9Am+9GVnTKdOn+GDH3w/\n73//ewdtlDK6Yufpatdm2KMuN6AEYzougoHlPT927WmGHSlgG5SaWHO5Ilj/bt7AUXF6q8LYV/I6\ndtkJGaxtAY2x7nj//v3s37+/v9NfKcEsb8yRI0e8S167Ac3MXOTOO2/hN3/zI8sxsxUMsVywJXjx\n0EMP8eEPf5j77rtvc7CtXbbTsFT25e1v/zH+43/8s35h+d5772X//v089NBDHD9+nPvuu4+ZmZmR\nazYzM8Mf/dEf0W63+wm7M0KLMcWqe+u5cw7Q+PjHP7zqoSt15VrPRq6NtZaiaA/NFloPYDAeNBjw\n9Wqrom6b9EDlkUwyOhpifSHbSoLkTr+rtSq6ttKOtPSmlAl86QUcDWNtTXaNRt2HbeP4emZFYun9\n99/PH/7hH3Lffff1a1bDnqhEocY9+nUfO25rHN9xM4DuX9P3MseOHeOee+7pn/uxY8c4duzYMuP5\n0Ic+BMCv//qv94+3DN/KKQwrPcpQ+NFHn1x1naxFeWct12YpsmhtgtbtNbVFLIOyVysoCIe6rYfw\nuqHigdNgm1xev7lSNX/V3wt/81YelnXfffexf//+fj1opceDDz5Is9nkgQceWAKCXJniDoPK/5/8\nyZfGQsLjDKhECJvNZt/zlAujzDXKMGvU252n0ahx5x23LLvLaytfKO655+00m00eeeQR9u/f388l\nyg3nt37rt0ag/2PHjtFqtcaWA1z+k62alB8+7JL/z33u4THQf9d7n7Uxr1e7NmfPnu2XA0aRtwVG\nmNPrcearIMVSTqwrUtmwAQ1CuRoDgfnV283XpmZZ1oV6K8LTv/Ebv8H+/fv59Kc/PdYTPfjggxw/\nfpxf+ZVfGRPmyX4IsNpx/czPvLcPJvzrf/1ZnnrqBI8++gQf//i/YWbmvF9gy1G/4UXQbDb7N79M\n2GdmZvrI0jBS+MEPvp96o7am9fDlLz8yEkYJJALBPffcQ6vV6htNueE4j9EYuRalgT300EO0Wi2O\nHz/e9wDHjh3j3Llzqx7De997D/v27eb06TN89KOf4tFHn+Spp07wO7/z+z6XsyjVWHGhlpvfzMzM\nFa/NAw88MAIuGJOidZcR+YEROsT6TKlcvELEKDWxbjtYM4w9PpQLgJ4XYhfrDNlW8lLG7wa1se+5\nc+dO3vWudxHHMb/7u7/L8ePHmZ2d5ZlnnuGzn/0sAL/2a7/G7bffPhKyfPrTn+aRRx4F4MyZsxw+\nfIhWu8snPvFvOHfuIufOXeTy5Xne9KY72LlzioMHD/DUU9/j2WdP8bWvfYPTp8/wz/7Zz3L48PUI\nES5Dl1qtFr/7u7/bX5DHjh3jE5/4BDt37hxJiD/72c8yOzvLmTNn+L3f+z0eeOC/493vfiMgeOqp\nE/zv//vvDx3PAgcPHqDRqLNz51T/OP78z79Ko+HgYoFAqjp5bjl58uSI143jmNnZWY4cOTKyi998\n880888wzPP744zz00EMcOHCAe++9l0ceeYSZmRkOH76eL3/56/z5n3+VLMs5ceI0WZZ7eBqiKOTW\nW2/i1KkXOXHiNI899iTf+tZ3eMc73sp733sPIAnDHcs8UAmlnzx5kq985SvEccztt9++4rX50Ic+\nNBJeAuT5xWXcwZX9yvj2Y7H0d8Idr5TRmjb5ka9pmtrhXXm95FBj5rB2ntU7UtdkOSPRfhDsW5N6\nS5nvrFYvGL0B5zCmu+a6QQlv33T4UH8olJRVwnD/shi8rLYvrbAvNbQycT569CjWatL05TXN92m3\nu5w69eIIEwAkUbS7X+1fmi/MzMzQaDTGkjdPnjw5EvKdPfsqu3YF6KK9ZrHtc+cu9kGXcsdUqkEY\n7hmbo5TnP+5eLb024+o+aXpuTXHb2ozJUU9VMEEQ7Fhj5LXFBgQGYy5gTG9wwdbldeyYaXIGKRsE\nwW62nuPVIs8vsSYa89jWBkeOjKK9W8LMttaQZWfHhoVruXZSRoThnnXH7uOPpSBLZzCb6b61hija\niwq2lm0NkKUzaNPb0N+KZcYkhu7lgTUzGTZRSF05jRJicoD3r9l4BiL2S7TyPVO7sy3sZ+fV1ibq\nvuIAeqtXDCOu+sPCVs5E0maTw5VFiJBb3zhnTBe9iZ6swb0UfUMHQRju3FSfktyaRVlFiPraxQwB\nrFhiOKOzQq3Fs2ztFhvQKoIja9RlGyBV/7U87BYZULapMSmuCFndhpH1lqIYP2Fho4Zk+1y3yqbe\nb8viI8cbqqzxQi/1OqWo93A4JzCms+5+oTUhJ6qxouGsba3aLfVAbsHZjf7xFslE2S3ZFLZDtkrr\nLlpvxToQ/bRDysoVmdZX1YBc38f0WqK2FXZNO+SVhi/e/DaEcV5wZCSEXIvVD8tz5evul1n5pm7s\nNrjDkWyFVJS1XkTRig2/gRTRluRio2/rdd625FqX2gZqLEr4QzYgtzClnBy/m65aJ7JYK8ZMqxYY\nMzzfZauO0wnj2TVd74HhjCrh5P+V5EFyy3IgY5INv5XFIlW8Jih4fcfUc3WfLfNqFqWamw7dtsWA\n3OKcRBCzstLnEnc6kjeNm89iMGarvVDJErarG84Stf5Rwy5gCwyoVLq0P2RtXzcKxGzwb8sIpMJW\nCjRYa9C6tUWe3t1YKSsEwdSWHec2GJBEqunBvmTHj4Uo3bNdpuFlx+xCmdf72srjLJnCdlXDWfle\naMyWeCCx6Vk5W5FzuKa0zSzMcMt29YEBJWjdWS6guwkAKQynt1TccVt0hspQbsWakhVDult2FEQY\ns8Cs1WjdYisROYfG1QciEms1nCHX4ThxP0zXYbdsMbj8h409KbUD4i00HktRtNz92SKnJmVjrDTV\nZh7bJFQsEKKJED1fy5ErhHN2FcNZvhsZ0/XyQltzjG7HnO8bztLH6dNneOqpE5w+/SKHDx/iAx94\n75IwLsNas+FFPDMzw7Fjx3juuWd5zWv28YEP/MQPzRSdCunGHo89dpwLF9o8/fQJ7r//fo4ePcqx\nY8eYmZnh+PHj/Z+t1/sURXvLED1XcJ7elgx0e0xIhCg5TTm4a3XjWX02peh7ofaW7vhSOtRoterV\n6dMvrkDb9x5ok/H52bNn+frX/8t6gaRBn9AW5RqbA0Qkjz7618sY1WW36UY8a54vbOVq3DLU7aoZ\nEIAYak4aX2RdaVQkYzyW8PpfvS01cueFxifPhw8f5D3vuWfl22wKP8l77Y+Stweuz+VKCkOrzxhU\nW7IoNsv4uOeeu7n33h8f+dm999575XNbxRtq3XVMtU3vESXqtj1T8bZ7bDZSTnvOmB2DwomVvc+y\n4qbrWnWojNmynckZ0AbrMP3uzbU9jh07xm/91m+tYikrG8z41ENsiQFpnWzimorlhelNPvJ8bh2b\nyOqbjxTxtoRuV82AXLJeus81ijOu0rW61ewEKWOf/NoNnJvAmGTNBNyPfexjIx5o6a2wdr1rZmtC\nuM0wEFwX59bt7q7uk6x+DdZgTNZnBsE2hW5DIMK2iSsPLdIaxtS95sEVFsAVu1adFxKickUS4HBr\nd9nEVfaXHD9+vN+V6TxkQrvd67cvjLYMjH+cO3eJxx77CkpNcNddb1xVp2FY9KP8fvT17h6cOn2G\np58+QaNRWzF8PHfuIo895vKyN77xLbzudW9Y8bxLoGJpuFgKKh49epTrrlubATz99AlOnz7D4cMH\nueOOW/y9rW6haLwlz+dXtIxxMcz4H7pfBMH0lhr3WAOytr3hCQnreSi1w2th50OOT4yELmua1SME\nRnewasIL049frKUewQMPPNDXSSsff/RHfzTSDSllhT/+48/xuc89TLvd5YMffP8VDehLX3qExx57\nkve//728+OI8H/rQh0ZauZeGbqU003DPy7ABnTt3kY9+9FP978+du8iXvvQIv/3b/6+R9/ryl92k\nhg984L2cPv0Sv/iLH+5/bimu32q1eOCBB/pGcvbs2b4Yy7333suDDz44Ysi/+qv/PXfffeeKG+nT\nT5/gM5/5PG972xt59NEn+MxnPs8//+f/iPe85+1bukCLor0uzpsdbzdYLEpWCIKJbV/XcjBycXvr\nGc7VT4/3wevpH/J8uX5f/JjH0aNH+52Zx44d48CBA3z4wx/m3nvv5Z577uGP/uiPlhh3jb//93+S\nf/7P/9GaDuHRR5/kM5/5PL/6q7/AnXe8jn/wD/4e9913H5/+9KfHhmj33ntvX+fswIED3H///dx/\n//0jTW7nzl3kV3/1F/j4xz/Mv//3/wt3330Xp703Kh+PPTb43DvuuIUPfOBvc9997+1/7tGjR/mV\nX/mV/nm/733v45Of/CT/7t/9O/bv38+DDz7IF77wBX7lV36l/3OAz33ui6saz0c/+ik+8IGf4P3v\nfy8f//hHaDRqfO5zXwLUlhlQqfO2Ucb18IoSCFQwuekC9Vo+VZYojBPz2G5AoY6UzdGEdQPDrgaI\n3Mq7Vbk4m80m999/P/fddx+//uu/PrYz06mihn21mSs9PvOZz7Nv325OnXqRp57+Hk8++eQy77Le\nx5133k6jMfCob3ub05877TXYhj/39OkXefrpEzz11LPLPrc8v1LaqvxZqZVw77339l9z8803c+ed\nr+f06RdXPK59+3Y7YcW77wKcIs/hw4c4d+4igapvWZ1G646/n5sf5qWCJkFQ3/b1rHWHwAl5GC/w\nrtbckrBRxCYIdniD9cov4zptxxmVGI15LQKtF1bcAcsbe/To0VVvcl/jWNX7yabjpy1p3fU724wP\nr/bt283nP/8lDh8+xMTEFAcOHOCBBx7gyJEja5j0LJZ97/KIQWvCsEi7EKIf1vU/9zUHaTab7N+/\nf+Rzx7330s8Wy4ZQseLC3bdvDx//+EdGQsjSqFWwfGS9GNNeIa7QcuHyWhcFbS6fsggREUXT2zbM\nqzwPZ/C9kongIGJjFv3i2T4jEiIgCKbI84sre5rVvNAS+NWxEzYfRjhyqRgfFwx9O+OnJLz3vff0\nmQNCKKrV67cVjBn53Pf/hGM/y4hKZf+GQxUXCVzZ/587d7GfH9555y0cPnyQp58+gVLxlu3kRveW\n133WfTlLMZOQ7XwY0+uzJOTgiN0EBmMWriist/lQruFVK+2GjcefikdttgpuD8cazmhouFxU0LV4\nb5YxLFaO/y00h8QMR2tjG99p18LlO3fuIr/8y/+TBxt+YQkyuBVFXO00rq3BLpnNs976j1I1gqCx\n7caT54NOaTkYYz+g1jilne00IuEVIKNRjbZVssOV60IZWm+Mqb004R9W0lzpnh0+fIhGo+4pPk8M\nXdhslRrPGg1ohcVigdcMfe5jjz0x8tuNfq4jkK6+Mh977In+DKWlYd9G8p+leaLWPbTujdRqNlL/\nEUIRRTu32XhSZzxDm6UUY/ThXc//whb2YYw74aivgG9XMZ4rbz4bY2rffPPNnDx5so/InTx5kocf\n/ktgIJ6+0qMklf7O7/w+n/vcwzz11Am+8IUv8KlPfWrVxdxsNvvQcqvVWvG1dg2f+/nPf4mnnnqG\nhx764hU/d+UFkXMlFYsyF/vSl9wwsqeeepZz52b7SN9qkrzjHh/60Id44IEH+MIXvuCQt3xxXQjb\neCuzhOGubUXdrC0oigXntYf2DfXRj374N+zQbPVB72UBZH5X3p7YXsrYd3Zm68uFxsTyrh/FdUN+\n4Qtf6EO7J0+epN1uj+ifgROdP3bsGI8//jh/+qd/ShzHHD16F8eOHSPLci5fXuDcuYt85jOf90Ot\nzvRzgFtvvYkoCvnWt77D00+f4D//52+Qpikf/ei/vOLw3OPHj/OFL3yBmZkZZmdn+exnP0ur1eLU\nqRcAuOXWm/nylx8Z+Vwh4JZbbuKWW24ijgef+7WvPUaWZfzar/0azWZz2Xk3m02OHDnCpz/9af70\nT/+ULMt45pln+nN5Pv3pT/Poo98C4MSJU9x6603LhhgfPnyIEydO8a1vfYcvf/nr7Nu3i3vueTuP\nPvo4Z8+e5ciRIzz00EMj7x9FEY888siynx05cqQ/eOzd7343112329F2NpPwW00QThJFk9u2Tq01\n5PksWrtBXs7zOmBE9HpnrbUGrPHGbHwsbrynqHnBELlNB5eTZTOjbOB1qpliDSooxfzWd5zlbJoy\nvHjllRc4eLCx5pvx1FMn2L9/N/v376dave6Kf3fy5EkajcaycR5FsUiSnF8z7eSpp57hmmuu54Yb\n7tjwjpokFzxp88rX7PTpF9m3bzf1Ro1KZQ8XLrTGjiRZSwg3MzPDTTfdRJK86hflRhe+8UDKgW3z\nPs54LrvrJOSQAclRAyoRmQEyY3GTCNy8FCmnts3CtW6TZef7I8rXX9J1+VsU7dt0Yc/agqT3Cnbd\nBT1JpbJ/w01lRdEmSc6ueSG4+1KjWj2wsaVnEpLkPMYUg9HwV7zKFiUj4sreTWsfuPM9vwnjcask\njvduK3CQZZd9iuA0yIUc9kByta1n0Kej9eKqY0e2AkJWqr5usu1wAj7on98cU1uIsrpu131Dr65W\nnEDKje+6xhSeSS7W0XhqvHDIZmFix3kTm9roDEEwccUJeFtjPGMGcg2wa8tqU+bc4sQPc21v22LY\nbMOTQKKLrWBqC1RQ34DEscWYdFOf62DhK085L8cnbuZ6GZOzPtqM9ZvL5nPiomhjdLYceVzjDmqt\nRakKUTS15Rp0g2NcQBet5ZfejtY35JUOdBiuLIrLXph9e1C5IJhmw+qTAiyGPN+8F3KdquF61hbW\nWoxON3H+EinVeFR5I70wV9i9N+ItBw2Im/U+C9jV9CdWPV83vDgMp7atYFoULfJ8ftVZwHa4DjTY\nbe0VT74oLm1bjUipssBqNrwItW5vgaZ2gFK1KxvisqY3s0njXV9T3cY9gcGanPUVYUvlnXCTi7O9\nzHhXdUJLfmEtBEGdYBvE610+3iXP51Yf2dNXlVrxCtpVojpDnl/YFiMSQhIE05uTugXfT283cRzl\neEJ7RcMZFVs0GzbeMjFd62bsjnFji3n92t4Wx7zeXL7hEK1Fv2GLNe1NdsmuL2W4bQVTY1KybNYj\nwmJZvjNOTVeO/aUdHdS6fCBwTpFf2hZlTikjL3y30UhOoPXqTO21h3HxaC60guEMby7rafFeiuIJ\nT41Zeyeq2OBCKbymnVjH9ZAEQXVT19T1+6TrPu7haxFFO7YFsra2IE0v+o1Frh6RLQcRlrimEeMZ\nAzJYgbGJD+e23oiUaq6uHLqGcGpZX/26DSj0CbNZg+F4sMWYDedBQsjNFRTXCXasN/mWMt7UwnX9\nPu2N57hYwnBiWyBrZzwX/HWRS+OKZVYznBvJK0fky0MLnz5hTMeLv2/1CBLpJ4YFa4Rlli9urctZ\nmpvA9YYER9aSw1vMhodTWbtelEBsqLhtrXUI3LpE5MWm+2u07qB1b4Ne0yJlQBRNb8uGkmWXPB9P\nLIm0GArj7LL8Z5kHGj85YbUbK9F6kaKY23IjckJ4U2xsipwLp4pifpPH4MTS1z71SG54+JYzBrWO\n67hRSWCPwK3LA8lN5T/WFuR5qz/UaiOPKNq5DaGbJU0voIvuUDF5BUDNjsHh7JphGDHyR8t3l3nf\nELW1jyCYdL0+1q7TeNwxG71xpvYgD4rWhay5BD3fkAFJIdc5WFZsYDGbdechQbA54RCtE3TRgw3V\nrTRhOLkNBVNLls1TFJ2RlOUKguhjtpYx0Nx4L7R6IlsUl7bFiKJoB4gl9RF7JeMpf6d9n73dhBFV\nkFKteTlbs/Hxj1tY6lkFQMjWaXh2U+FbH3nb2NEiZYUwnNjygmmWzY/kySM9VuO8zQp3S1prPfxq\nVzCklexoNF50YuCXtmGWT0QY7lhmMWtdbFonFMXGvVAQ1BGEq3uG/sEILBsf/7ieRSJgQyGNMesd\n47g54RCtexRFdwMG4KDuMJza8plDRdGmyBeWsU0srBquW2uX5EPDHsiWL7BjKllX3u1LbYU8v7Bp\nCHn5InaoXBlK2XUsM2sLX1zdaHE2QMpw9Yr5kutjTLEBKtA6c5o+K3h9AILW6Xr6RAiDjQuHWGvJ\nsrk1k1WXXttA1bdcHETrHml6CWOLFaWD7VqS7tKArDVYYzFDKJAZw0xYviDGJ1nGaPJ8q9kKot/r\nbtcZDAix+bqQVDW/iOzY07dL9qSNT69bX2i10XxkrS7IYlBBbcOJv9M6SDcwXc4iZEAU79jSNhpj\nMtL0AtbmrpFzc5fS3W1jJMZqSkNa271aWctAULa+zm5pjcgVWCc2tChLzbGNeqEgaCDKPGwNNSFj\nNmpAdh0v2wiAkC1pV1n5aa0TLdm4cIhL0u2GN8ytDd2MyX37Rg4Mcurx93DNLhpZTte21nkhY8yK\nxjF2pxzLWhCeU3R5C4XgHSrn4vH1vWfJkduoFyr1n4f7lVaVHzbFBg1IsSZgVAikWP/ics1ra0Ax\nrEvgA1Vjo8Ihed4eyrfWQbe2FqVqRNHWqYpaa8awDEYuJ+MDrNUcSp9MKoAmUOnnQANQwa6uUrzM\neEaBBa0XyfPLW4YtCSGHWLh2nRfRUhSLGzZopWqsddqGBbRefwgrpVoeKm5FtFfuwmX+s8qkuZFz\nDqobzH8849raNVjqaJogREAc72SrmjettSTJ+VWLuNauYiPL4rySRy5QqoZ0Hsep5PRHHl7xLi3p\nHLXLSED9fEDrBV/Q3BojkrJKoJrruZe+f0ZSFJ0N9+woVVtzPO6mNuQb9752DSe0kZxklXNfEsB5\n+H5j4VuetwZI5Jr6fQa/iOLpLWjYG3ieLJtdMwPC2rXcDOujoQmiaIczIGOMq6rKCZRqjqGVjHmT\nAQV5iU7ZcmPL88sUxSJb9QjC6dXZ0isk+u7mbsyYhSjn4KxJAt8DCRtRNRJr2q3XC2G7HqBiTc6n\nbFjbCEzukNgr5JtjDsB1mDa2tE0hz+bXzMwXq1z54bUOiiiaIgwnyhDODuBrnBG5xjax+pDgde2M\ngjyf27JCqxDCU9rVFY1nybJD6+66JgCM5mD1NRuB24HXm6spjw6tIhBn3fVf7+J27AO7js2isqHw\nbSnjek0Gi0WIkDie3rKCaZ63yPqim2vwPqt5f+HFdoQkjneOgFkjBjQwogZBsMJQrCUM7bXv5Zos\n27pCq5QxYTi5SgC78rHl2dyGP9PpENg17cTrpfSU+tgrJ/abg3DXmsEpGaPU+jtPnfdpwxrGXi49\nrSia3jLUrSi6pOnFNfUdrWhEQ+vKmFL9Z++yovJYA3KLpU4QlGJ140ADMXSAawtrBka0NYXWIJhC\nqurynp0roGTaJBtiarudee1eaD27/loc+sgIj3XWR9xE8TUJDiBVZUOCJUVRMq7Xc2yGIGj2Q6LN\nPrTukSYX/PR0saHLPuIsrEWpiDjeOzYnlEsNZ9QTVbzWWtUhc2NZCesjPxqTeXg73/TFcqGcL7YN\nMSiu2HZg7QY1tUtav1nTsa150Q6BLksNY5wDEoJ1J9rlHNTy/pa579KnRSJljDHLX7PSZuuuabEB\nPQpXa4rjrREHMSan1zuPtXpTBdjh+CpQNS9XNv56B+NGYow+Y6JoN3l+yYvwObhaiHWOhrSDu+8E\numeJoj2bnl+pVJUo2kGaXhwZRbKaRyoXt9addTdoKRWhVNWpyojVjFRgTT4yKuXKIWLg86DBWYgV\nDLm8P+VCHmeo5c+0zimKHGPMyN8sRZ7cbquwNkRrPXK9lh+rHHmfPO+S5+2xxNuVz18QRVMbCheX\nn6trigPTZz6IVfGZKxXE3GYZx7vHjnApvwYOe7/SPJuAMNwDzHqdLNYRuo1bxK6wmeeKKNrNZjH/\nIGh60mJ79GRX8UjWaoq85ecCrefznbST1sl4RU87uDrGI3Hr2yTsWCMY/t5a0NoAesQbjPvq6l9d\nsmwUFVwmJONzW2urFIUBslWNZ3gxuVrLPFprhLDeuJcvtuH3stYSRU2iaGpL4Ope74IPmcfs2WN/\nsIIDsBYEhOHEmupRaw50hZBE0S7yXK46XnFty8ItRAdtS4+obdyInDL/FMYkGKNHyIur5UKF7hGs\n0wu5PKgGzK96ggNGRrLm5Nh61ZmSDbLUEFyYUr6vRetsmdGUfzvMKEnTNlmWYH25YiVjQwjiGIRI\nxp73sBEMfzUmpdeb91p1om9gQvgBaqL8+eBvXIfp1DLptI0YT5Jc9LnXFYKfFX8weC+3zqfX3P26\nzkxREIY7EUJ5hsGGLGck5i+KeYRQhOHm2nWlrBIEU2TZ5TVnZ242TXtdRdJBGFdxXkiIlTimQ+gX\nq3qV4f9rbSkKs4pBuMJ3lhUjhrb0Ofx3abJIlrf7bdwlLX/kOPohJGRZe1m4stTrDIxC0uudx5gU\nKdzrBr+X/v/0vwrh5HErlWmMUd5DjzfOtTyy7HJ/I15zFjEaqY0YTxzvJgzXXovaUI+sU81R5Pms\nhyzFGkO38UaU53MIJEE4uSkjCsNJX+dZW+VZCMdOCILeumjzTqGzgi66DNei7NjkPR3RGBv2DMOL\nvFz4eW7Isxx8e0hZ5DZmOPm3QLef6C99j6UG1O0uUBS9Ie9jxuZNStUxprNq/rI0R7Y2J0kuI6Xo\nC69L6QxLSomSwz9TCCmIwgZQIc9zlFJ9Ax02yivnT46smmULbETlp1+lssLXoQIqlT0Ewfp6nzbc\nZB4ETYSQZNlFN3BIiA0Yz9DFyC8jZLCp1l3hC11Jcg5j1sYCKNVilFpP27LoV+rH9iqOJNc94tj0\nd/yli3vp91nWI0nSIaMw3lC88WiLRWFtp280A+Px/9emb3zGZPS68xR5D1MUCNyxCOuSbZN2sEWK\nCGvE9T1kYYbNewhjQAXgQQEZNxxC53McqQKElKTpQJlJKTlkCN6AVGlMCqUkSgWEYZU0zVBK+ZBY\n+deqfk51pXmvRd4hTS/7nGUzcLUTLKlU9ngVJq6OAZU7VhwH5NkFtMkGJ7ku43EL0vGWLhFFYlMd\nkFJWCIIJsjUWS50XahMEzXXtPkpWkCry8DDLvMrAG0CStFGqsgwSLr/XWve/7/VS0rTX9zrGFBhd\nGpDGGIuQIVq3B3+nC4zRLscpMihSTJGCUEhy8vYrhKZDIDSRtMhAosiphAmKi1iREQmBKqqIQmGS\nDqGZQwqwVqFtjAl2o4NJtIkwYRMT1NAWlJAYVaEnanQThTYWpYRnsEtvHAKlXHhYr++m18uRUhME\nAUEQoJQaMaLSe8m+9xr1SEXRoZdc2LDxjK7hmEpl74b5d5uWOZEyJoz2YrMLI3pj6+7HFAJjCrJs\nljgONlWVDsNpH8qla/RCljxf9F5Frun1CIUQIcZ0HGTdz1lsP9wqx8ZY2yEIWGYww19dt6gmTRN6\nvZ6f3qYx1qIL7bQWTAFZAkVBLs8RmIyQLlXTQtoeoegQ2nlCfQlVdFC2i9IL7GpexprLLhdRIIIB\nhiokkAMdYM6Db2XEqYYi1LKNaOnXUh8+jLkcvp5cTFBUdmGCmF50gHZ8PXlQp0cEqoaU7loHQUAY\nhiil+oa01KBKYyo9kpTSAxYX3YeLzaK3dSqVzU22ExcvXrTDFt+PXZVaVzLnPMgFr4Kz8ROzxiBV\nhUpl36ZOzF3os2sv7Fmo1g6s6MbHJf553qLbveB2/z56NvAUxhiKQqNUnTCcpiiKESMaNqDy2evN\nkfYuokwOukDkPao2IzYdItOizllq9lUi5phuXIJ8DptmiAKEXnLlAyAceiq/sRXOaEQGpP7/Zqgy\nUSpsBf45rDVo/OuHjcj/vS1AFIPXlpfeBrBQfz3diTvIG4foNG+jF++hEDFKKcIwXPYcNqQgCHxI\np+n1ziGE2QRyZ/spSKWye0MF1xFofqsMqDSiPJ8dYl6L9Z+bcG3hYdj0hdaNV5SzbI4sm13bcVhQ\nQY1qdd8gxVzChyp/VoZgWme022cxpofW9BP8gXFYiqLAGkWlupeiKNBa9w1Ja43JU0zeRnQvELRO\nEuVzRLKgGlmq5gKxniHkAvXaJYRHuoT12E2J38ih7/3/bSAgiiAMQQSIIoReAmkChXEWIhRIgxUW\nIS1Wag89CxDGU4aCwRtnKWjrPssugbXK4xguD1rv3bT/Wrh02Raw2LiF7p63sLjr7bQqN6IJiKKI\nKIrGGpMQliK/jLXZANWTYp1r1LdMRNPE8Y4Nb/TbZkCDhXvJ14rWYURL8iZrtS9m7d1UgS1JzlEU\nnfHE2DF1mGp1f98LlYYy/P3SMKzbPUeWtSgKjdZmxHi0LigK930Y7sYWGbZzAZucRxRtAptTVSk1\nfZFq7wdUzMuo4iL1uIMKU1dDCQZyataCMH3wEqslaRIhIklYBWljUBIbWAgFiDrkMaKroKcgy0Bq\niAWEAQQKG1oItA/VvCvRGnKD0AqbG0ThaVJFCnkKOnNWobwVSTMwngJMBjZ3RmML98S/xHpvZrR7\nOxNAZ/dddA+8k870XXTCa1BBQBzHxHHsjSigKOaxNiGKQgRiBLBgLWyPfp1rx6YVTrfdgNwYlAVf\nk1kD5Wcs6OCqimE0vSk1fmMSet1z2FUYwsMVfqUqVCr7RzzNSnmLy1kW6XTO9/9fFNobk6YockTn\nEjJvE8uQsPsKTfMqNbFIVS4SZWeoB5dRIkFKEPEgZLIKkAKhhYNaTYQwTj87N4rjp6sc2BVRdGP+\n03dC3nir5G13hSAlBBaKENpAS7swDQWRhIrEVgNEJNzrJC7ukv4CFAabaURmIbWQ9SDtDaSAhXcj\n5N6AANuFJMF2CpI29HqQZyAFBAqUhFCBUsN1F3eLtYaicPYoFbSvfSeXb/onLFQPEUURcRwDHaRM\nCILIeySH6gVqFGQQUqxiPJJqZQ9BuHlt7atgQB5qLFpk2aWhAHsdxjMCCkxtyoiybI40nV12Pksr\n/e4piKLdSFlZ0WiKouiHY3me02q9Qp6n6DzFtmcRJifsXCaa/x5NNU+1qqiJDpX8NM3ovIt2Ym8w\nXgbBShwwgcISAVUQMcKGYBWWEJSLlf7ikZCujfjJvxUQVRUzswG1qZBdO0MoJCQa2y4QnQK0cqs4\nCrCVECoCEVgIrUua/IBpjIDCQqEhLbCZhaRApBkUPg4LLHjDs2gwBqEtJD1YbKMXE9qdHlk2uN9C\n2n6EZ4X7GGH7sgsI6aO/ofxKa2gdfCftW/8pC9E00KMSV4jiiDiOPAChUCrwtabl7IfRBR9Qqeza\nMomsES4c2/gIgiZSBk5KyBQroib2CtSFPF9AipBgg5R3V2DteYFFMZLXlFDzoMZiKfJLhNHuvuEU\nRUGe5/3cpTSgLMsoki69+YvYxVdQrz7BRDHH1FSTqpontGeZMK+g2gVhA+QkEAORMxgrJIjQ/6CK\nkCHWhghqIGOsCEAEWAIQAlEPaF8O+O55w99+S0D9UAXCgOtfI6BQ0HbGQ5aBiKARQBA5AwoEIpI+\nVNNYaRwh2O/ObgSQAZGDTRHKJzqRhsS5ChtpiC0i0g6uKzLoFZAH2LyGtYJqJaAe5yAs1qQUhSXT\nkBWQ5aCNsxPpUy1jPT2ptLIyGjz1VWrPfBVx83to3fGP6GiLNg6trFSs59LRd9kWgyoRu/IeC2c8\ntdq+DbenX3GNr18AcP0UmzjeQ5rOLh+rcSW5rCFPkWWzIMSGWn5LMRJdpL6t2Y4YjtbGjSYxhkJr\ntE4IMgFUyLLMf35GUeTkWU6RZ2QLF8gv/oDs2S+za1Kxo55TCy8Qc4F6e5aoArICqumcCSHYEFAS\noWKEiEG4ijwidMmAUAgityhUjJAhiBARBs771AJalyQiKmjsjWEicgmSkJD7WCiTQAURK4hClxMJ\n6fIoT5RE+XBHWe8B/T0pLIQFeZbw8qWCCQrOtzTXTMDUFIggg7CAUDsjTy026SKsRMgIEcUoU6AC\nDTIj7/TIiy6GAqlcWhbiPIwpbdc/tXb4hPXonS1h9L/5MuHZk6i3/zKdiWv76GalEnlAYGBEfSIr\njhgbyCqV6u4tVzYdMaCimEP2t8btM6JKZR9pen4Zf2wtfUWO2azJsjk/ZnDt9Pfh3iYp6+T5HMYO\nAQJ6kPznRRme5VibodSU8z5Jj3ThPLpzGd2Zo/Ps11CtS+zb22Bq6lUaxXmavbYDvaZA1JxToeIN\nR7lkQKiqj90aIF2Ihghc3kLgvAYheMNBRqBCh6SFChpgpgwiLugEMUzWIFXQ05B5j1ETICJsECBU\n4Nq/jQ/TBBAICIwzGuWfwlFaEM4Dyarg/PmUlpFkheFiIJk6HLiQT+YumigKhNGIWEI1AJWhbA9D\nwee/Lbk0X3D/kRaVyNLJUsd5UxphXS5UgnjaQpKALhywYBgYkcDhIGrhBXp//j9R/fFfoHvNHSzt\nkCqNqETnDIYwdDD1ZiaZr9EDJeR5gbUThGGD9XUTrscLBMTxXrJsliJvOcrGspESq8V3roiWJOd9\ng1N0RaNZCjtLNYE2LYqi66YU+IQ/zwvyIYg5ywqKbBFJG9NtU8x8j+TE/02tEtMIDDvFWWrxi0z2\nNPU61CdA1YHaIEQjEtggQqgYZIgQVWc0QQSiCipy2bUKnKHIyHsilwMJobBSIeIA4tA9JyT7hGLn\nnoTkcgjdyIVXPeXeb6paKty7ekxiXXIhwEpH4iS0fsP2eLPwLgHrELpAoHbAjXslc4nh5glDGgvs\nTomQBkyEyHLophRpApUqaneMyFNsoZBCc8thwde+mVNUDHFDErQKjC7QpusL3AajB0ZSDSGQkBeQ\nZC7c66PjBlQM9WyWzmP/hsrNP0565z9Yds+dESkf4k1Tqexa81CAjSG8BXneISgDTzcoK0OISa94\nsz1G5Pp/pK8VXQGhG/FSThHF6Iw0vUilsndZoXVp3WaYe1YCAFI2yLIFitzlMXmRk+cOMcvSlDxJ\nyHsdigtnUBdOo84cZ2J6mslgDnnpBZoB1JtQ2wnVClQq3uNUgEqAjRWEMYQ1hKphRex07GTovE8Q\nue+VR8xUACrCyhBhJdYIIMCGASKOoBE79CwKIQpQdcENB0I6HYudkYi6hFB6L+XeU7cL9CsFUR1o\nuM8QgYJIOQMPpasF5b7yKrWvhHpgwYTYMOD6/ZbLPU1gLGLat/YnGRgFVUXr1RDTMuy8EcgjRKqg\nSNgznbGrKckqNZJ6RKVaoDopYRqAiUAsYnoFRQFp4dK2SEKlCrFyP8v8U1tn63EMoZ2l99TnkaYg\nuevn+vHJMLk1jncQe0ngtfS6bQwc65LnCy7UH4F8dZc8z4EmSm280HSlfCSKdvmWiFUGc62EzgmF\n1l3viQ4s67AcNpxh9GxQxLQURUynu4AuNEmakyUdsoV5Oi9/DxbOo85/j+k4oBJoZDRHPPcCU9PQ\nuB4qNYhcCQUReSStGmCrMcQNRFx1W6bw+YsMPFAgfYhW8eGaK3A6IEG5cAu/0MPIeZxKCHEAgQ/p\nCrdN72wYXpqx2CxC7PSFTolLLLAksyFpTzF9wEWIyBBiidWSZBYKJI0aiJp2BpNLkouahTnLnkMh\n53+Qc6En2XFTQDOx5LMZNgJRFKB9+B0HTO8LSRZT99k7BPQspJLKtKJZEzz3suXsCcEdBwW37jcQ\n5pw9F/OdVyZ54+4WnQQqoWGqVpBk0MugXnEpIxbSHBJvYNJHbdFO6D37nwgjycLtP4ubJOjg7Fpt\nF0Ew0c9thzl0W+N1NFk6R6E7WOvePxgsbCc+aExBni8gREEYTm8LeuG0DKaRMiDLLjlNbnEl4xn+\npfQq+xeIY9fROs5wSqMp4eYsy9BakySQJIb23AWS+VnaLzyDmTnFhJmjUY2IwzZx8iLTE9A4BPVp\nt6YD4aIu4QuZRApbiaBSR1RjUFUIXMgGoUvwjQQT4lZg7Mlo5e8DkN5oKjFUIlfgLL1JEA7yoqSA\nTgZdy45ayKshFLJKVIkcjFUYn40HJAuCYEIidoT98My0JL0FCZWAF58vuOGwoLHHVzRjQyCg/UqG\neEZTf03I4ddZwp0QYeCaEEwBufLom+ClZ1POvKg5PaPY/4pm976AG6+rMj0ZEExHzFjJDVHAG2/O\n+Kvvaq7ZI5iaEFTzhMsvxPyfz1Q4OJVycLrD3r0FWRtOnA95+6EcqyGzbpOqWzi7AGdbMF1xKVvU\nhOzUI+zYdZC5A3ejVEC1uhuo+ihDjmysW+GFiqJDls15eWTZR/qCURrNwOVp3cWajCCcIAgmt8Eb\nCa+vJb1Sj14XN9BavIiFJQx3LTOcEnLOsqxvOGmakqUpnbnzzL96mrnnv0H+gyfYv2cXVdmiYl9l\nMuwyuQ/qUxDWfdTl17LyG411GD2iugMRVb3HiH0e4wlkVrkajA7AVhw8LeSAWiDc60UcQi1y3iYK\nfJLv8yIi0BLahYOLtYQ4YPeegGBGk6QBUcn4FPhKpWSumxPXYyYbFZdodCzd8wVqd0R1f8z+Toaq\nSWes5b2owv47u8w9u8DOAzX3e4oBWU7kEBXu2NDoHa54dW2gsHlKqjQ6Vw6GtrCvXmHPPsXNtyge\nO1Uw07FM7YHpWPL+ewv+338Rcd2ejNtuTCm6UKQSZSQvXAi5eUfO7CLkuYsY8xwuzMFlXEQrBNSC\nWcQjv0/tp27G1vZgTECWZX0CarmOncaD3VTHa5rOuhGVPuUYbsgLxlDR+qC8RXtBxB5huGNbvFEQ\nNJAyIEkuODFyVmdzDxc/nbEsUhRusrfWA+MZ9jhpmpJ023RmzzL7wrPMPf9NWs89xqHDr2Fyd07N\nfptde53RRJFLS4LQpSuq5gxJxeXFUYig4rbBaNItqKDikngReXqydLB0HoGNwUhEIZxBWV81lYHz\nOjUBkXU1GIXnrsXOxWU5tApIA8fIjCKoBsSTFisz5tuSiczD0UL5PEvRmFAY43lAQY1UF7SDDjv2\n7oRqTPPAHGG9DtQ9Sc1VMGu7JS+LHguzkh21ijegwDNPe277zxWEBTfcZLjhJkHyfYW5LKkdLiA1\nkOUYC1FsaFYFaEE9lkyHnvotQuI9KUf2G76/2OCN+xdJF1Ie/k6Dr59U7FCav33IsKdq6PYs/+VV\nQWws1VAwX1h01Tnj5+Zgd2WW1/7FJ9j1j36PXq/XJwCUXmeYyb0xNk3Pl1+yEVracOauPvzhX/gN\nwWjvuoMDB0Q9a3O07vjfRVuemAkR+H6ZFGOLsd5uqeEMs52zrE2eW4yRzliShDRN6fV6dNuLtF4+\nwaVnH+Glr3+exZNPsLeec+3ujF2V73Pt3jZ79jokKMSFDWEEQdPF29GO4QJojK1MIao7IJ7wZM2K\nC9uUD7+EcuBASTUQkQvhjHDeCIkNQ0QlcI7Kagc11/zfy8gZS0fDnIYsgqDqwzvl6D1WcHFGkquA\n/QdjqDYgrLnXNZpEVUWrZ6nu3OkEUHpuRk91zzTWwJmXetR21AmjuI+6ZonGmIKwIlAXclQkcG1Z\nTs8PW3imgnWZfeGMQ6QCOwcq9EIiRqKN4NWzlkC43xc5HL7BooSlKATzc4LuvOWlWcm1kWJqUnPN\nNT2uPVjwg/mAC5HizbfkLASC4y8rDu40CAQ93yy7tw7PXoD5DJrJIr3Lr9B43T0Ib0DDPUXLNBrW\nRP8qPHvlkhdiGRX+HWUilMU1xo/47v/fN7wp1fOzWypbakRSxlQqB7ySfmcETl9K6NTa9MmaZZim\n9XnclImQNE1Jkx75wlnmnnucV5/8S3R7kT37JpnYNcN02KLR8EajQXUhqIFqQDDhjEbtAFX3u3sB\n5AHYSYRt+N6AMhyTPjD3bADpmQUmcAmTlSAFVgaIyPcIKD9PQxnSuYDzZwMOvL1KqCIXji1qmNfO\nY1UrUI+doRoHScndEZPXdJlvG5ja4YolQ5FDuEMgZnJMT0MkCISiQYHNnMxWI4jIFjTVuovirTG0\nXu2gapbpayaZ7Qnal1Omd4Z99NPlcAEob0wmh0ygqmCv897FSDAFsYAfOWI49bLmlQW47XUQVQLQ\nlqST8VdPGN58WDKfK/7kW01+8R2KnZOXeWvcZcddOTccTIknLQtnQvadU/yd9xZkieW5Z+BvvueA\nxQMTzoCCCM799X9mx+1fQdz23pFWiDIfWo8XKooOaXIZbZIrdgLYMgeyy4bwrQQvCz9nJyUIJgmC\niS2dICaEolLZQ5bNkuftZV7HyTmNAgRZ5sK1NE0o8nmwdYr5c/Re/Q6vfPvrtM6/yjUHJmhOzDId\nvUg9djUHUbicO2hCOA1q0n0Nm+5JRTjUa1FBGoFtgKw7KDhSrrovJEhJ0hVceElwYKckmHTAQGk4\njlEZuMp/gSt2aOHylUqA2BWTfl9i2gJiS3EmQ+gAVa/DdAzVpgcTYveewhlJY7pgbi5FJwGqhK0c\nSQahqkztyMjaGZXJBmpyisvtFpdPF9xweII9NzTIM+HdaoEQMLl/CpQrwEzeMAnWM67xEldSeIi7\n8NJBnjYQWoKmT5Uy018+O3db6g2BLQKqymIzCVZQrcPdd2p2VAVva2pu2m+QoYReE20h0IaFS5I9\noWFfrUCIgAuJ4MB1ljv3walCokLD2e8LmoF1m+AkXH7yz6m99h0kSbKsMa9sG7+y15knzxacwEgf\nwVt9QkkwvidHrMJXk76INIsxXZ8bVbY0nIuiPVgr3YQzO9ADKBkDha/d5Hnez3WSXg+9cI5s5ntc\n+u63mDt3jl17dnFg/yWmojNUfJ6d5+7ca3WIpiHYCbLpvI+quUiMXGDbEtGLsHkMso4IfT3GBmAU\nwrh+mvkLIX/8RUgWLP/sHymCHcLXVyzahohcIQX84PmcuXOGN9wWIqZCaFTRYUw3DeiiOfblFKYM\nE3nAHW+uUd3XHHizvscbaGfvmoo5nSYstlOmq9GSxhxFbd8ktt2BJIfKBJPXVmnkEhkFvl4iBt5F\nWIJa0xtMRqACz6PxTTylcRoPlYvQIQXSuJBTu4qnlaHj1wkLRUQlcO9vc4Gwheu5Uoa9O0NINJPV\nnMlrUseisAIlYq7Zm7jTzKDRtFyz2/CVx0Punss4fCNMThp2HxQceFUiLmt0Dpc7wHe+zfTrvwh3\n/FS/pygIghEvtFIYl+dt0nTOS06LIeNZzZl48cV16ouOWJ/WPYw5RxBMEoZTW4LUlScahjuwVtLt\nXvQ5zwCOTlNH7EzTzCFr7TmKV4+zeOKbzJ69THNqkhv2LTAVvkoUuDphljvHUKt7hG3KhW2y7tHn\nwG3AMnPsfNFzzAARhdho6EKaAIrAEdtsTF0p9lcsRilEy7cASIUtFM89ZTjzXI87DgnaLUFYC2Ay\nhIk6RTfkO9+2nD5bEIaSOFTceVeTiekKlb5BlF5l6TYmUFMhKIVI7FAnW9lKqpBBBSYqjlhKjpIV\nVDzcedcn0zDaWlo+9dC9LttTS/q0cnC88hQgo32eh6MJ+QkSWAfJiSBwncHWIIx2by+FK8gaX8PS\n7tirkXHhgXEds+85mvIXT4S8cEFx+DrNoSnozMHtN1mkgqkWVH4Af/I4qC8/yBtufSdZFveNaDUv\n5PrFZimKNsYUK0RTqyuYBitHd2JNhmStR+qKDlG8c1MshuFcxxXCGgRBQa93gTzPyHNNljmjSdOc\npNuiOP886QuPM/v8SaLJneyZmGdK/IA4dOsgT51XqVahNum8jqoNqGYy8Euu642nB0JLBydXnSqN\nsAJrBCIL3I0WvrmlKghrLoGOrCCqKRcWWQmFZecUfLdr+PKTkp//uxHqhtiBC1WBlIYdRxQ//qMx\nu7Sk87KgudfnTctunhkyDhcFBHHMtTtiHEAkh4KJsgdbukVeqTB+1pMZ+r8e9BI4N+Of2v8sc0TV\nYqiRh9KQfKFWSYS1WKM99075Wpc3ssC3p1rtEEcrHVWJ0P0ssCUHCkzPnXriIub3v9nrqGvodmF6\nwnLDLssfHBP8vR+zvOMOeEVD5wcv0v7eI9R+5G/32fNBEPSLqsNeqCi6JMklJ9GMWCUVWd0WAoYi\nNofGDVEj+rzW1fWNsRZjM9L0HEEw5ccwyg0bzwCiLhyzWEyT9F4lzXrkeU7S69F79RT5979O+srf\nkKsdTE4V1LKniPzGWPQcIhw3IJ5yX5UnAeALolKCzEG0wXZceB9IoKLpphZtIppTEnSIMJHLe6TF\nBhahLFlLM3vGcuaspBJbRNMTMlOD0IJ9Nynu1iGPfE2wmIZMV3xPjwC5Q3LDHle30fOK2QWNXCio\n7wiHFq9cYkRF31hCBfUpSdI1S/qt5NBz2BCHPc24x7DHsUM/04P3Ff5zxND3/YHHjgokhMRKiZCe\nn2ctKO1aj1BYoRAycOGe8SFgULgWVoEzOhP68NF//II/nRhqyqFwWQjX7oGvPy245X2WN7wBLu6C\n5MRfULnt3SO1wLId361hTZLMk+eLXhxGruoqRuW0xdCXMTmQHQsnrF0D2wltXEbrLlG0c006W8sR\ntoHAhmshKEhTg7F1er1FurNnSb7/BNnpv6JSCYknJwjmn6UmjKs/CudVohpEDUdLCyIf4Bi3fmXg\nmRcdMF3XcKmEK8sQOuZ03gv5mxciDAFvuCmgMel3X49UL1yE587A7p2SyZpkqirJL2aEoXHoGQoK\nwe6m4sCU4OTzhjdcbwmVgZ3GQcEYUBrZgB23CcKa77PpexvNQBpHDn0NEVISNy3FZe0SflHmP8WQ\nEYgluZEc+n6coRhG5HYIBscRaLfrFL5HuxRmKHWmbZ/OMhgsbI0L77TBFqbfv4cxCOtCXXIXCrv+\nBf/Zoga0HeI3zDdO4eZ97s9qMfy377G8cME1zZ56CeIq7LFPk559jvDQjxDH8YhkmCt3zPnBAHJs\nXWfpD0Z+N8YZydXjvbVNdrLLkLoeSTJDll1edczhSsbj8pyUNE3pdDquntNJaJ95gfnH/5Ti+a9Q\n21klzU4h2t+jVjWoBogmqJ0Q7nZwtAhcdCAzl/8LH8rLDMxlSM5Bd9axXVzhVLhai1FMVhW3HTCc\neCXk//prQb5oEYWEQmBzwXdPCNqp4NARQb1q2BFqQm2gZ7C5wUpN2rWEHcNb7oBT53P+88Mp5N5w\nMl94TN1imthniSIfQ9rEPRl+ZkO5iUvua7Eh6+XorIvTpWoPfW0DPf93mf+bce+ZDtgG5P5nwwal\nB3Ugo93TakaUQ4Rv1BPDK8p6xK5wXXRlGKzVoB0V48K5klpS1pdy6Z7FkkjTgCwPM3XEiNdeA40G\nvPUmqOXQ2An62T/wQFPuPVFGt3uRdnuGokjG1xmH1/ESnzHScmOXhXC2rwu8/E2v3G4wriGvZMKW\nA16jaHqZWOLSfMcY0z/h0oCSJCFJErpzl7jw1MPMPvF59lyzG6YWSTtniDz9rOxBk57+LrM+aQAR\nuXtx5pLk2l2GaQ29eVfGSArnoaY9QdR5+Ig8j8mLClM1eNMNmj98Mua2l+DOIy72W2xJvvOi4e43\n5kitmV8IyEOLsQLbMagJQeus4LHjOXfcHLL/TsFblSQMBDQMdAqHYikx6GWWajQK6y9Iz1IQeogZ\n4DyDUQW91GDy3AMES3KgvncRSzyLHOQxrvoxBCIM50P5gGdXFIOmHV2Azl1R1RgvtePRN+xQ5Clc\nbQgQtmS3CN+7E/jOOTno9bb498PlUKYY8m5LUje83WsXUbzmBjjkBqkTn/0rZnvz5HGFJFkkz3OC\nwBBFMdZK1/q0pphtfCbk9Ek8CheGO4Ee1qZjfNeVPdCArbDED3nGpdZd0jT3U8im+8blULyBoGAJ\nSed5PsIkWHj5e1x66i859+QXOXjL9STZU0SRQ9CEHqwV4TfZ/s88AhxW4eV5wZeeUPzDuwwt4TZ/\noeDFVsidUwWBcjep1ZU8OxNz/JUq104p7rvNcvOOnEas+JuXJXfeaiE0tOYt7W7AdENhWpbLLcuC\nEDz+hOVH32q9qoHmpusFU9dYbKK58bBwMWQv9yBE2R1qB4m5Ko3Fb7VlohZ41EtI32ynQQRUAsuO\nwNFnBrdXDxmGXBLCjfuZHELePGzdNxLtO131wIByH4fp1L2uP8/FuFAtc3/j7ofFFtZ53cI6dR/t\ni5pWYa1AWOmdkTckG7t8yNZd8da0Rnd+y6gWXc3zEwWoCefAD98IaedJ5sM3obWgXouRsuo1AuUV\nOZZCjDckOxz8GmcfgevUrCJE4Wf/ZH6nWBsO19cxRizXibYDhneWzQ9x6ioj8lClvkCWZX3j6Swu\ncOnE13nxr/5PlBDsf02dXvdpKk23jnTer/u5ml6ZgwaeIOBbqrFAx5J1LC+fkxzea6jW4AezAedb\nEc04J8vhYivkmy/V2FkreOplSUVZhE2pNwJu3hnywoKkV+RUlcIEiksJvPyqQXYEU7GhXQjCHYaw\nqqEL8YTk8G7fYtmx0DOefW37Omx9dqrwoUxRohthP58oEa5+56oy7sRDCLVkwhpEUnj0asgohkGf\ncoX1d7alT+1csi58oVcPWsSLIQMyvhZkXShnbeF1FfyKKgpE5t8j09g8R+TufW2RQ547GNs6gxXW\neGPJ3Gfb/socCh+jgRLQUhwkcXuRjcD6znjrI4kdnb/gYu0WNwTAREPglO23fq8pN1km+e7ONwgb\nRNFkicJJpKz4pD/FmEWE0Gx6si2DOTmOJtGjKM6iVBOlJjHG9guhwxy29uIcM9/6Aqe/8gfsuPYA\nsX2ePOsRNr2XT0H4DVB6JLXkVYgYbNVdVJlDMu94kEGgONOCO25wYMNL84peLtDG1RoffrbGVFXz\nhmt6fPVUk13NAtlsQVDjNXsqvDAfsdCGasOwZ1pzcIflC0/AP7jb8oG/Zcgt7JguiZ9+p+v6+KJs\nn5YOyRAydItDaawqfB9QmX0HzlMhfSjnk22pXX5GAbkALen1BDOLcLCwrq278NtzaXxllCaXGJAQ\no8G+Mc5Icu0Wf2EGelNOMdKrgfhwU3vEDTFQSvTvYfPceaC0QOQFpM44RGmM1mBNmZNphHUiJs6r\nSp9jAXTdTRZyELZJRr+XQ1FX4FutcF5onzrOjFokMTFFYQgC17ovpR3Z+NdQ7hwRkAyCKnG8oz/F\nPFgajklZIwwbWNvDmBZGZ15TTawcwvUnd6+ILPQHErtwbRZrWwgxMUIA7fV6LF6aYebbX+X5r/wB\nBw7twXafdry0ykDbTyUuwinXpvB6z8RuJwoD95qZS4K5jmBX07B/ytBOJYEEYwUvzkbsqGuyDF6d\nl7w0J/nxm9sEAVhtUCrDCo2goFLNaYQx0kc4lcDwT348p4tgx3SOCvwC7Sksxvf7KM8VkghZOKMo\n60fCLxIRIgJfoJS2j6tbESCUJ6UqXwEOFIvnJQuzgmuvV4hJQedlizYgyRzUa8wSA5GDMFzYQRG0\nfI0t8w7vZbR2xmOs/1p49Mz/TpdeyLrvMd64cqwxCG2c0Rjr2AVZDlmB1Zo8014ov0AXmZveR0Fg\nC5RwG1wQCIRKvRqj5xiWDIhhFVQ5pDlR8WIt3ltI5aITWRjq9lVa+Q4/qcP6sTBXNp7RbMQghUKq\nmDieJghqI38brNZmIESTomhRFC2McUNqBWIkPFhN1ccuec1AsROKou2pOjWKQtHrpczPnOHZL/4+\nl049xf5DDaR+lsoeZxzGushF9NwiVt5ojKeblTmPNHDpvODpFwXPnpfccZ3lxj0wVdF893zESwuS\nayctuRa0eoJmBeYSSZZn3DCtudALuNQRnF+ImZ3N2bXXrS8lLLWqcYiE0dRrOXVhIHF31ElQhQgp\nsGVYJgIPV3tPROHzGA9NS+t3ghLFkq4gKQOsclA1UrnqvlG89D3Dn39T8/bbFLccDpg7Z7n2Jokq\neo4BUYZkYtjbeDjZTb9y1X9KpoBvqDM+v9EuV7G5L4Yaj6CVYZz24iRaO/lR7RG5IkMUPlwtCmxR\noIuCQhdordDakBc52hjyQmNMTqFdCK9sSmAzAhUSR4K40iMKc5Twa60kO5sh9maIa1utDlhOfXCy\nlD7uwMTCE5xt3tIXuhwI/q8lOTFIqZCyThSVeiErFFJX79dpEgRNimIRrTtoL8jR70VfIfcZj7ZZ\n37OTk2WOktPrzZNllu7leZ77yh9z6QfPs3tvD+xFgimfEntwwJaIrGfSGNdZjHL0NGQB52YFf/U9\nicVy72HNzXstUsLeJvxYraCuDNrAdLXgfEsSKTcrZ7YjOb+geGVRUpiCM5cVCu2Inzm8/toeVdmF\nrkeIyoKiDLEidGtWuuRfCOsKhkaDcMVDh3CU7dve4KQnnKJcCKeUFxkpcyQ1BCtaXnvQEih4eQ56\nC5IbbxSEoYVF64q8S4N2n+1a6wZbubqM39G1NxyjnXCi9vUaoxHah2lFgShy9/vCexZtfL6isdpg\nTY7ROaYQGK3IjG+dt4a8kORaoE2KtplDKbVBW4PVvmPUpkhrECiUNEShoVKBalwQR5aw3CR9u1TZ\nr0js8AakB47KLuYyGskgnD2LmmCkFlTKma2867uZtkHYIAwbV5xWt2bNnyCYQKkGWnUpijZat72I\nnRxrRHaE6TpqPCWfzSFtGe2LL/HMFz9HZ3aBieZZZKVNWHV5rSjrjSWqiotCtHXaGPOpE5qZtNBL\nodOx3LbPcN20ZaLqXqMsvHaXoVYxWNfVzC17U545W+HsLFw34UrIH/5Cg394V87/8+0L1OowXc+Y\nvRDS7Xb50UMdVJL7loWKo+TIyDM3fFgk6UPBQgQ+Xrfek4gBBC2VC+sC3w4hLDZXCCWwSntD1N7Q\nLMJvv4EUvPag5LXXea9SGOyC9Uwfj26WMJLPUdwGVkp+miFvUwwhbVkfKBDaGZQ1BSYr0HlKkRfY\nQlOYAl24HixtIC8suYHUWLJCoq1CW+s09qzAGIU2BiNyLyXmQkbflYHE9plLQkiUMCgBcQT1qtdH\nqLh9JPKNun3Wkhpavdlgxpv1YKWQsHP+e4TkGBO7fcMbkVLLwzhXyhGE3tuEYX1NMNq6RLOEkARB\nA6VqaN1wXqno+rH3473PaA+P9swCZzzdbkLn4lme/8s/JW23qckTVJoFQei8jRUDyNL6TVDFbn2F\nCl6dgy8+K3nXLZaduy3tDlSk40pFgaPlxMrrqIce5PLvd2TasLNa8NdnFPfdpvkXb2uzmEiOHtRM\nNvxJ9KCa59y2e54qxnkfGXr4WfswzdP8hWcAWM8VsulA4KxU4aHwaJpX5JGFVyfRCOlaJPo6bVL1\njccOY6uWAZJl7WBMjvWUK+wg7NGFY0GbFPIeFAloi80LTG4pcicUmeWaIjfkWeGkvnJNWhiKHHIz\nUMcxZf3Xpze5dp3maQG5cTFUWQ/Vw8m+z00C6QxGDlGpRClPJ43T0PYyc40eNGNoNqBec02OVAY1\nvz47yb+/8CSOUmTV4RtdItOlq6v9EM6YpWmHu15uYviEn1S4dlL0hlTnhg3JhAlZdtmLLQxB9UO9\nPIM2BGc8SZLQ7SYsnn+Fl//LQyzOzhMV36G+0/egeeUkz3Rx4bYviwRefcko16QZSJhdgG+2BS9d\ngh+7wVKrOImCwIu1G+FuqvB1wUxCI7a86fqCb74ccGSv4fUHXGXcaMjaDi2WOKk3lMGm5c3KHAvE\nhP7OJc6QrN8abTp0B8VAsFAWQ3WcwhuVb1CTmfdKJYO5vLdOKMRNZPDJu8FX+J0BizKPwSJM5g1L\nYwuNzlJMUZDlBUWuyfKMXmpJcuillm4POokrTWUZpOkAiEvK+qkv45QSvAUBWii0lRgVkA9AOfop\niwDjicZFnpMmmStzCXe/qhWIY4EUllA5owmkb5GSUI2gFkI9hGYH9pQMk/oA0QePbg8TrHN/C8pw\nvzDExWXaaro//rL0NiWkFwZ1onhqzcPVtsSAhg1JqRqVSgWte45nZLI+jDEcumk9aD9I05SF86/w\n8uNf5OLMWar6u9R3ulpaUXjE11+Ewq+JoGQKGE/yDeH6aTgwDU/8QBIKw+lZyY17NAf3eYBBesPx\nUrLa3+SSYfb2w5pqDE+9Kgml5tqGL8mUoNWgvcbnOGCldTYhMw+1+m3WeoMyws8wjTBGYKxBYN0I\nQRm5XVcZH6b5XnvpjaysgfQTZyc5jLW+n8aHQibDGNcVqo1L6q11ox7TQtPLXTjb6zkhn8WeGw3U\nS6HVcwbTTb2Hj0O0it2M1F0HiWo1wuYOJib3ENQaBJUGQilUWCGsTRLGDVBuNmy3M0uvM481hqjS\nJIir6CIlS3q05y8gZYAKYnqLs6TdRWyRo3WB6nV4+utfodDaSUpId38jH15XA7c51gKYTlyUKWJo\nVZzaVyOAWA8iYOnBROkDAVH4iQ85yKyHjfxcWuuvJwqlqlSrO5ahalfVgEY9Up0gqHt0bY6iSLBW\no7Vrvc6yEjhIaS/M88Ijf8biubME6Q/4/rylmgtu2udgWeu9TuFj2zgayElZPzeqq0GmUI8NSSb5\nqTssDz9neKUtEJF1+XI2xACxA/DLdxsQCHjrIU2764wmT3wJxn9OwVDtUpU6zsKT6ZwemkUirPJj\nHSW5gUJLCu0n1VmNFYpQCZSySJk7JV/pK/pGYsVA2FD4rdwaJ2esPVxsrcHYglwXZIUlzayreZae\nQkMnhW4PFtowu+iFfAKXthnRoLrvCFOvv4U9e64lmphEVZvIqI5QEiElhdGEYZ1abeeyadxlyUII\ngTWabm+WRmUHjZ27loyBqRDUGoTNKYpCY22Mal5H0OtirCtZqOf+EjKDUdDquOusvPEEofNIldAJ\nrWoJsge9BcfErhfQ6Dp1nnrsDCoqSe4enSX35S1AmNRPEHQhrlQR9fo+KpWJEfWeH6oBLYW/laqT\npnMkyQLGtCmKzBtPRq+bMPvCCS6/+H2iYA5DwsVE8Jpp64rSPTe/qewcjn3KUfjSQBzC2Xn4/NOK\n1+03vGa3pVGx7NwB1++DCy1BnlnXcuJLIKYkksp+Xu9oWKlbt00fOeU99/+0BMR8MhoypAlnLbI/\nnkNgrKQoDHlRuPBHW/Lcok0Xi8Ra6eHQwhmO15+2aEdjwWk5Y1wtzehyajduPqrvAs8LJzTYKyBJ\n3ffdnvta8lITDbK5h/p1R5i4/g6u338T1em9BNUJRBAjpXIpZdEhSeZQKuyLbggBSgXU63tQKhor\nxFFqrfV6l6hVFZZGP68YkRTLc5RyUJnWiiRJMFYQk3Pqq5/l1HeeRFY9z7RkMfnkPzNwqS0ojGWq\nDgsa5gQ0JUzkMNWBiRo0I2hWoFmFWgWqsVdKTiHKPPik8EVbgZQVKpXd1Os7CYKt66DecgMqdyIp\nG0RRhTwPMeYyWdYh6fVoX77Iy098nSgusN0FFgW86bAlFi73EL53C+uaqQrPWwy9XsdfnYJLPTiy\n1/DyZcnr92ky63Q4Du6Av3lJMDML1zUHuZIeHp1hXfuJHGKLFLafbjij8+WX0MsblOFfUDZkethU\nG0tWFG4BZ9ol23qAFAscNOTe0/Y15dwsK4EVRX+nLGuVeVmbtC5Rb6dOsbObuDCsa9z/USETB49Q\n23MzE/sOUt93kHByD1Y4UmutNkWlMrls5hNYer2ESmWiL41cepZ6fRdR1BjxOsPqntZa0vSyK/+E\nNW/oJYu+8B7H0W+iuEaeg9YJUgoqs6f56wf/v8zOt1BVZ+yJp1+VSq9SOECim1l6OSymcGER9rVh\nYsoBCjtqMFVzhtOMYUcDphuuYbJed1IWJnUbno0c0hfHO6jV9qxrCvsPzYCGjUhrjRAVhJgECtJk\ngXPPPgm6h+28Qk8JRGEJc2ckNnc7rbXOYJKiXKhwoSPY2bBc7AhyC3ccsMzMGXIB0xOCF87BgYZl\noQenZgQ3NC25H+cprAfJKBNc9zNjBgx947su+qpUPrVR2su8+eMoScaFH8OT5a7onucu2dZmkGs5\nHGAU4C8HTGGcd9Ha/V2JbvUS6PRcONbzxqMDQXXvQSauv5nrbj7K9PW3UpnYhQyrICx5toDWKSoI\nHPc0iGk09hEE4bKR8UXRwVo3Bb00DikhihrU63uXhWvDj15vDkipVCpDsmKFR80dvKlUSBg2vMxY\nQlXknHn43/LcXz+KiRwQkOSe/2pd3qPKGi/ufK0P6YQAUwjStqWrIUkE8xWYjC07Gi7E6/bc30xM\nQiJhSjuwsRK6jhCZO/rNdmhkb7kBjRuL6NoTCnQhWXjlVWZPfY/u5b8hjmBh3rKj6nYMUy5C3xW6\nkEI7c239L807adddXcGtuy3PzgiM11GeS6EeW554Ad53i+BfvMWwfwK6uW/bN6MMF1M2TxZDRXgz\ngENLpE964y2BMu0J0WU+leb+eHO38HPjK0C+UF+2vJR9ZsYOxnnkvqhfWLeY2j2X6Le7zmhkNWDi\n+tuYPniYm29+A5Wp3USNaeLqTsIw7nsT51E0SZIAoddDE4RhlWZz1PuUm0e7PUe9XnXytH0NwIBm\n8xqkDMYaDkCSzGNthzAIMdYihHZsaiH8VPIcIUKiqE6WaXSRUJw5zqP/4RN0kpyg6RZ6mg007eMy\nTPbhWzdz11WbQVlN+ZlhNQtCWzIDF7vOM7fr7j53gV2h680zCUwWvsi6CLmaXBaG/lfvgYZHIfaJ\not0OJ//Lw+S9F4lFwXwXvn9esPM6i9EOQsWzWXILpy/D6Ytw8y7BfAq37LY8dwkqO6CdWopYUKtZ\nnnxB8IbrLDfWJYcnDXHome6eT1nG2CXLxfohbNrXMawv6okhMEx7TqO2HmWWg24CYwfeJ/HeJ/Nj\nSI0ZGI0dKDw54zLeU3nyai91yX6r5+7C5PW3cO1b7uLa2+6msfsaZBTR680hpEApQRTVaDQmCcNo\nZASntRlSxiOqnPX6bqrVxognkVKSZYtEkfKjYcpCoqVe30sc11fs9UqSRbJ03oEcUmCL4SHKOUWR\no3WAUg3SNMfOn+HFL36GU48/ivaMgV7mIgqtB9xaMSBikPlrUphBmOvuiQt9tR7049rQcWdnuq5l\nMHXNv5hkABLpEMIU0uqekWswrhXnvzoPVHqfvuxUmjL78ilIL5MsnKXZcAhapt1FDRxkT6h8gV3D\nxQ5kRrBvwrLPwnwPilwgK5bJKcH3zlt21wVVAT+yFxrSkOQuhg6U06gQ/mbpobb/4V6w0q6UL7Aa\nMVrTENYRn8VQGaYonPH0vOfJSmaMHZAQjfFyHJ7gnPhiYy9xAEC3gGhqJ9e97R0cue4mdh96HY0d\nB/vKmk7TTKKC3HsQiKIa9Xp9xICklOR5G4iQcgAINJs7kDIYQZmEgCTpEYZh3/O4WTqT1GqjGhbl\nfRRCkGVdet2LaF2g+7rjpVh/QZ5naB0gZR3TXeDcV36Xk3/1JZI8RzbcufdK5Srj6sl9oriPCvxY\nVnJ/7eXQfYkCB1fboU4MIQXCgEksc6knc3fBeDKx9IrLImyQVw4QbAHatqIBad1GiJqbYbOJ4VrD\ng3qX9vmkSZeX/+YxOrOnXKXYlzn2Na3ruPehUlHAbMfVAfbX3YXdW4PFxHUJXDNtOTEvUAouLwp+\n7AZLQznUbhGH5AQ+UddDBHLhjce3sTjWPwPPMzw5uigno5Xj2IVHBX3fWlIMPElhh2qbZUeycYaV\nFs6rdjxiplHse+1dHLztx9h1+HaCRg2DJQiUM45Goy8IWC58IapIqRDCUqlM0Gg0PaJXStYKoIu1\nFYRQCAFhWCOOq8tQtCSZQ0rr0TF3v5RU1Go7UCroC28Mb4JFkbCwcJY8T72QpemXI5xKUoG1EZEM\nWfzuwzz3Z/+W7sICODlwOpm7FgYfTqtRQS3BoHCr+2Uwr7WGL7L6dhU7VKQtB4NJATpxdK4gh3DC\nUX4qqatvM1nFBLURid+l0PzmHIYmyPMFjGmhVIUwrBMEfn4nG5vuNbj4fjBvnrM4e5504SxJa4H6\npNvZL7Whlwknvuenky324IVZwY3Tlj11eGnB7V4vzrnCvwrgzAV4961waJdFFi40kL6SXcZMeomU\nWjlbxuIZDnbAwhnWpBEjd3YwtLq8wakP1zxp2c2oMgPB0V4O7aHKPkqx/5ajvP5N72XfzXcRNaaR\nSiGEJsvmXY1JScIwplaLiaLqyHQBa6veMxhq1QqVSqU/dc0ZiCHPIQi8V8FSq00ThuEyXrzWXRcu\n+bDNWqhUdyBEOEK0HEQPKYuLM6Rpm6IYmtxXuHJEluUEqop89bt87//6V8ydn3M1p4rLZXpeShvP\nYbN2tCXa+FwwK5wXz3yxWw71AJZAgpKD9qSoDI/toG+wKGCu44qvSnqt/grUpUIGwYjxrFcne/n6\nLrC28L1tHQLh/aK1KVmWUBSKMKxhbRWlKki5NorD0vCtT93JUubPv0zr4ov9Xb0kFJ5rCfJ9lhhH\nKXl6Bq5p2v4cmFDAuS4UgeA75+Hth+H+w5aJiiuySl/gRAxynqI0GDEIqYQP40rZgbJ3awjd7rfo\nlNTLfm9Z2Zxph/KY8uZrV39Z6LiCoJYQ1ifZd9udHLzzrey4/ibC5k4ajT19kb/ya5pajMmdAQUh\ncayoVmsjAoBFHvXpF2FYIYriEZTM2hwhNEFZsALieHllPU1baJ33uymN0YShq9cNM5UHxpPRas3Q\n7S54rzNsOCnCSioLM5z/2u9x6bnvkgdgKj7P8d5ZCN+XZQfqV2aIDF5y7EoqkNb0RdSkGHis0ogy\nDWkbJn2bvi08Q0pCIQVJbrncdqjepGfqFwd+FIHse/WlRrQeo9E6ReuUouhiTNrXEQmWMgocCNAF\n26OQgR/OG6JU1XesijUZUX/ESJqSzJ9n9uwLTNQH+cFkCGlhaSWe1Ow9Ryd16IwEdtbg0VcF977W\n8oF9Tg8sFg7mDTwbV5Rwpw+cjafi9OXKys6DAbXMFTSHpkQPMWcGO6M3nDLPyb2uRmpcGNdNYbEL\n7Q409u/l9nf9FDccvZeg0aAwPQ8hK8JAUq/HRFFtRK85DDV5vuhvrCCOFXEcj+QtcVxHmxQQRHHc\nBw4GYI1wiprSxcVh1Bgz9tKQpoue0UC/FSWKJvscxfJ+OWGXjHb7Aq3WrMt1spw8dzSsWOTEr3yH\n1rf/klef/xs3zSR2CX2Se0EtOTRHyZcRyutq8ZC9Jwanvs3IDmmQKDEwvtAbUDmNMtVgLgt273Fx\nsxN8EgTCOl17j25qfFPd/rsQUvXzyvUYj7WGouhSFAlaJ2idulYPIRBSOQb+OBBBDDI13OzUTr8B\nzo0hiVGqPqL5tjT/KYXfjTEknRYzz32TIjFuyrRfmM0KTFahlThPI4EDdbjQdqHcRANuPmipTQuu\nb8B06Hasns+XjG+2XJrDyJLHKUvumg8NSgq9z2v6f2YGzIQSWs79Dct8db/Me3oZtLrOgEU15uBb\n3sXNd/8U09feiAwr3rtAns9hrXb/l4owzGk0GiMFzUolpNvN+sm8y1/Ckbk2YRi6BrUyZ1ty87X2\nVApcJ2xZBB2+J2m6SJZ1XIjm2Q1xPOUlDtIRKbGiKGi3L9FuX3R5TlaQ5TlVcqLTf0X7yYfpXrhI\nTzvIOLduUWsGk7cphXZKKW1/LXPjpRKKfuuRQ9xKVSw16EYP5MB4rO23JmGta1cJ510B1RWtHW3L\nljmsdlB5EYDceQTlN61h5HLl8M2S512KoovWietz8uN2SsNZJwrnP8xarC1cS65JnDGhkKpKGDYR\nIhrxPn0PlGXkvTYXX37O9fCYQUIYSLcgzy8KpgKLso6ecaonOJdYJvfChIIfiSw6gbnEUdojNcpv\nG467jAcRGKK0Gw8WGAaTSgSDRs3ywpe1G2vceMEEx0ju5E5OttMBE1fZe8ebueOOu9lz0xuI67uJ\nopggCAjDkDB0hUtjKuT5nL9hkiAQKKWJ4+GEtoLWtT6LvezgHpks7dEyt3Etz2uMp6k4SNoVR8tc\nxhlYQa+3QJ5nWCPQRqOk64NOkmTEcPI8p9udZ3HRySjrvKCRXkJ972G6z32DdKHtDCZwVKfMs7SF\nLzobMTCaYkgJK9NDA4PNIIwr/P0RPkIIPMtJeeBAlSCBN4qSDa6BuQUXpcTSGYsbhCHIretPSnoQ\nvu4t6Ma1xENefxSVHBiRGxrcoSh6PscxlDNLSk+zCowtlrypGBm0NdArHUCf1hosGlPkFEULkAhR\nxZhwaJKCi6UXZr7PpYsXmag67yO8elG5o3Qzl9BmXh55V8PJtkoBRcflOrke9I+YYAAElOBASTKV\nwtdwGArNRH/Su4OazaiyS4miac8ELwoPvRbQWXTepnHNazh89xu59kffiaw3USpABYJKRVOvNwiC\nsG9EzmgmyLKQPG/1QzQhUqJo50hCW6lMkKZzQ5mX9jWa4YYv4UVf1JIGMIv2us7GGILA5arDYECS\nLNLtLgzlN5ZarU6SJOR5PqL+miQtLl8+i8RS7c2Qf/MPaX//2+7eCMj89Oy0VI7znRol+lgCAnmZ\nJ3qjKfVJdOHLCXYg1dDXSRUDuQglfIuUGEjSOeBGYLyqnNZwYRZ2Tnol5cIRdSPlPic1MPGGD6CC\ngCiKiKJoyAu5+6F1Qp63KfKuMxrsQGGqL2s9otE27Fb6u/i660Cin5yLoZ0wR+vE1wUMaUp/DMmr\nJ79NlrkpCOWwr9xrBDYDf9Fzh1yd78KPHLJMNRwvzvhuYoOnvCsPQ7uGTac5IYYgaTuoYosh2ows\nazRDhuN70Rw4UAwYBUkCbT+fc/eRu3j923+aHTe/gVz3EALiOPICGAqlNEplNBpTvrVjsNNVKnvp\n9YQPs9yUP2OSkTCrWp0gyxZ827UT3Ri+zlIGq5QLNHmeeP6ZIQxj8lwPhdE57dYsSa+HsYKiyAnD\nJr1e1vc4gzpdB909R+MHx+g+9RCt2QuuCTF2IWyW++mNPofpF4bLp994CgPtfMDrK1niSTHIa4cl\n3oQYdI/2dSR90boEcNJBt3kf9VG+XrfQEUzXLYFHFQVumMDULbdTuf6ukTEnSgmMyUiSlp8qko+I\n4pQTGgdQhlhdfNEOPOdyUbkNwXvWJ14pvV6HbrdLr9Nhfva8Y8kKd1GER2CUgaqynFt0tIw4gP27\nHbPWJgOemdEDBkHq+9FC31pgGOrTMYNwrQwr+gqUQ2FeWSjtMwoK5+WSFNrzIMKII++8n4Nv+kkq\nOw4QBKHPTTRaO7kv52nKek0K9KhUdozUaNxzJ93uBa+dZsjzFnHcHPL4EYGKKHyC6jzK4C5JqbyQ\ni+orGpUGVBQJSdL1CKoDFNI07XubJGmzsDjrBTUKrA2wVnmRGFefQ2dUFp5BnvhzOs89ztzllKgK\ndU/E7XnDSa3PBz3VKtEDCD8tBp7n5UWX0E/EHokDZnvu0te9znypn1iOTJVygNL1NRP9RpiZgSGV\n3kf6cE0IS6wsUSzodSzCy+zpHrz2Pb/gowKFEIYsW/CKPLn3QApZwrCU9YvlExr7Px0nkrjUAwmx\ngvHYlQ1wuTLP8CQ5Q7d1mSRJHdOgGOwcWe74ZhXl2ccWpqagUnWFsU7mdznPbGZYmNaHdypyN0LL\nQeu3tB488L0/ZUd1Hzr3O6f2OU+WQ9KBtAvVqV3c9d/8Intf+yaC+s7+7lW6f2dE07i6WY9AhajA\nTalzqkUVomh6pM6g1ATGpM7LCIEuEvK8QxQNFF6iqEneTTyCmHsCbqmj5xe/VBS59nmoM5A07Xmw\npkDJGnlusDbp/6zVukC320ZrS1FoomiaNF0AnRN2z1L5wdcIzn4DOX+ahTnn7XftdL01qfb3oNQq\nLb1MPqjZZMUAHBAWLnXhxKzllh2un8caeP6yC8tunHAL39qBnlufPqUGEHdu3GfkJYPDt5QjBuCQ\nG/rnWsOrFYGxlk4CjQgWL8KRe3+MxrWHgdSL17i5vlJGLvT2fL816fluC5XHrqylNYzEWWMweUHW\nnnN9HoVjyObaabsl2gu+CydPFEVuIWephzbtQG98OOQSyWDDCBnAz1J6OeVyRxsCBfDvY4YQnV7P\nTWWY2n+E23/6Z5k6dDtxdYJabQdRFPdBgTKvkVJ6KHSCNJ1F6y5CKLeDIsizBcIwRqnmSJJaq+1C\nFz20yTC2IMvahGGtn6+ooOp2ZmPIsoQwzBFC9cOwotBIoSmiwm8ozoA6nXl6PbdI4qiCNr0h9keX\n+fnzfYAgCptEvXPo7z2MOPklVHKRHdPu2l/quR2/WnMATZK5ZsXc12JC6wZzB8ohW/1pjz6PUd7r\nT8SCZuR2cyGdx6lGjkVSDb2R+PcsDaEEBUr6VupZ2tp6ao8XAiojKykESti+2nEUWnqZe3+Zw/Te\nnfzoz/4ihW4T49DiIKj4/iYXMaw2bWFY1kOIK6uULjegK+r52itSeYyHxoyxSCFJWvN9KFJb33ef\nOY8yUYXJqmvSynzbca596GUHs5n63sMPgGOoUKqMg7XL15UyBFYOzWBzwwEcQpM4I52+5iZ+5J6f\nYeqGNyCVJAwDwrBAyg6VSp1qtTHCeh6e/BzHB0jTObJsYUjay5Akl1AqGOk7EUISV3bSbr/qi5qL\nBEGt/xqtQYiYokgpigSluigVOwPKLWmSogKJTHKfRzkR/nZrnl7Sxhjp4/l232BarXMUaZsob1M7\n+wz6+a/SOXuKWgzTEzB1wHX5XrzsSgZ+Egudnlvwie97CgPHXavIgdGEHkyQvkcr91LeAkvhuYex\nBwGumxR8q2O5mMLu+pAhDUnNlXqOZe2tKJE8j7wNCLEW6Y2n30MkXTG9JiGuxPzkL/+PiDigUgmJ\nogpB4LyOY54PddSuYETD2teMj+rW6YHs2n48LCBSfs3zlPbCLElvEeNh6yT3EGMAjSrsnICprqVI\n3VCORA8AgX49Z8iQcm+EthTWNO5ClpP7ykjSygE7oZw7kObOeHZed4ij7/x5pg7ejlABURR643Fw\nZ6AExixgrSCKdi2rYg88y26kDNxsTS84WRQ57fZ537xV7fPLlKoQBE16vTm/0cxRqymfv1isDcmy\nFGN6fiqfR9HSnG4vQSmB1p3+kOU8z1lYuEyepyAitM4crcRkmMVXCX/wTdSznydYvEyAu9bxbjes\nbnICGnXH/Ohkbvh3HDkjyLRDOAvjclCTuXAsUl6zIIBLCdQV7AyglbnXzvZgIYN6JKhGlqqX6d6p\nnBGdnoddTafKk+UDelQ+FGkMU3eMFejQJfL9qXI4DySxBAIaFchzgc4tSge867//Rap7r6NSqRJF\nFeI4IopCzy+UQ2jogCy8Re0Mcgh5KGXlV7Aeu7ZhW9ZarLEIqTBGOm0EA0nX7U4TTaeak/lpf6dn\nobHHk0qHEI6+uA0DCogpZa7897kP3/qjacTQiE5vRFkXart386M/+2F2HX4zhhQpc0fkDAOCMPQG\nFCCFRCqJLlokSeGbzCpjVVjjeMo3ms1SaFdhKooeeTZDrb6770ncLlr3XqJNns2CDZGq4j2KJk0L\n8izFmHnC0HiIuUOn00EpS1FU+lPXiiJjYbEFOqNhCvTstyheeYr0le9Qab9CbKDmlWysn1ZZCaHZ\nhKlpd+ytyz6sjhyAk3mFmyj0Sje5q7GUIZ0K3O/me4Jvzkredr1hom6ZT+DsrGBXA853BUpaarFj\nnJ+atVwzAQcm3X1P0gFaZxnkRX0miP8a+DAwUk4jQ5tSDNHlPvWKO+bZnpv+/a6f/Rn23XYX1WqF\nSiWiUokH6JuUzvCGoGlxpZF0dpWIbARpEwRxvAshSiX8DDBD8lRm+diSNSZJUiniWoMsMy5+zt0N\nmGr6RNWHck0Fp1KXhO6seQlfNQRDewChP2HQJ7XGkz1D7duB5SjlXfr6Q1CJ+ZG/+wscuOt9BGFM\nFMdE0TRB4IdwkiHlYMKE9BfcIsjzhIWFl6lUpojjyWVFNVc3qBGGliy75AubYE1CoTVxvGuA6FiL\nMRWSZA6tc7L8PHG8yyNqBWkKSa9Hls0TRu71SdJicbFDGFqSRGF0QWS6cPklKt//Ovn3v03ROoMy\nOc0Y4gqEOx1SqX3OqISgGlom6g6oCZoxrYs5nY5xRhE4I0tSZ0TGc9JC6ShWuYeU08yFbrtjy7cz\nwxNn4R2vgU4h6OSCW3cbTlyCyym0Cl/QxgmF1ALn7bSPMJQcsBb6lQVfTC43R+UBByWdF8p9qBf5\n6KXIwLQF7/qZn+LGt72barXiDajSz12FkAg5qLuttHjHuQXLoKnLUdx8FIJEqQgVxCgVE7gqt1oS\nphQIYXzMnWGtQ4DcV73ko8cjGkIIdJaRJJqJhot/Yz/UN8l8LpK5JHR3BVo57BaDwprxoZseMng5\nBFdr69oMcj8RUfrRi4H/eVSNOfzmd3LTO/9biBtIFY5w0RzMWUdKx/1zYvqFZyqLwVxYC618hiRp\n+Wnk1ZFNxXkYiZRN0vQSedZziFunSxj2qFR29kECBwxE9HottO5Sq4k+GzpJclqtNlLmTkTQFBTJ\nPEEyS2X+Rcyrz6BfeYbuhZOIbpdq1ekDRDsdAKNC13jnJjm4rjIlJRVlqMU9apMhYsrJGS22LVa6\nieWBcnoLhkHBuaTUSB96W+XY8I+/pLhh0nDbDsvfXBDMLkCSWS614HLX5Zrn24LXTFmiGG7c4e51\nOx3kLWYony0XqjGjG3uZs1oDBbZfd6yElumaM8rLs4If/6n3cOO9f5tqvUG1WqVacdO548iH44Hn\nvvkeonFuQPj3tz5jttb9jfKzXB34EHogIkKpaHVxeVcpHyUuOsPJPZUn89/nWKOdyr4t+iBC2eko\nlUQoh1LFyiEyhXauvfDhQeGRuIYnJPYl1kqGgB2a0MGAoiftAOIuC6TWt2fbFG54w53c8XcegPoe\nClUhWsIhG6YbOaNqYG2FwnbJ8i7GJJ5dISkn+HW7swgx54XGmwihlo2otLZJmnUpih7WWjqdHkHQ\nIwwnhuo3ll6vIE07dDo5cTztfpd3kXlCoOepXfou4sIpzJlv0nv5lJPCC12NLJ5ShHsUUey4cqFS\nhDJAqgClIjc0t98ObQlDi6w10fUKl5OAeP48hXFcwyjwUL73Cipy9yO0rp1eCcfI+MoLiiiAayYM\n105C3IN0RnJ2UbO75rzL116Q3LHXUgsttcCRbQtf7A7DARJatiWU4bgxwyguLJld4MYCWXcu1dB5\nM5sK7vnpv8O1b30P9YlpqtUqlUqFKI6d8QQRgRL9utwoh3CwTj3329f0nKEMvobeWOTmYWzXrFVC\ntuUJF756nqNUghAdtJZIUY4JtARRSGOiAbZNryyMmoH0ayncsaMK359zN61ZcbWGsgO07Aw15WwY\nTw61JY/KG1rSgdrkBHd+4L9h6qY3kQYRMYyh6uf9qXhKKfI8H6LXOLVyYxRZ1sKYFIErlbsQTGPt\nIspzAIOgOqID4YypSpr2SJKWT/oXCcMFgsCLlJsMmywSJ5eIdYtq3kX2LpH/4Ankue9RDZL+sLCw\nCuEhiQhCVBAThBWCULmO20ASKGc4UjpdNzEci5SCdjWDjgTfOBXyrecMRyo13rK/QxTA5W7IK/MB\nU0FCHLj6yoIRXOoIqtJgcQqh105avvGK4o0HNKFyLQU765aOERwILG88YMmN5YYJd+96uZdVjj0D\ne6jY2t/0GIhXGgZMem0HYV15KgpXM6xKCIXg9p/8Wfa94R3UJyap1ZzxVCoxlUpEEERDoIEcGm9f\nbu7Ko3MltF1+DcYyP7atpVuIwBMYY4SoAnXfHdlAmzppegkhLlGf3M3CubbTOiiGNMBESZ50cOhk\nxVF5qpHnyYkB21r7REh4wqFlyHgKyBK48abreMPf/Rk6yQJi/klE7RqM2YE1jrSZMdn3OkuZucM7\n1KA/qkpRBGTZIkWRDjYOA8Z2EVwmjGoEQcOFfKUHtjk2aWG7FzHpAjVRULU9YpMSF23E5ZOwcJ6g\nPYPN5px6ZuB2aTXlYGMVVRCygpAu1pZRAyndaHulBLKc4lBi+NLP95Al1uP0u0QsoGbodQuu3Z0R\n5z3O/KBKoxYjhOI7ZxpUTJd9dRdSn18MOT0X8MwFwfte03PJvIGjBwyPv6x49oLklp2GQMBkxbrJ\nGApumHJ5aSdzh9CI3SHlnsGeDXUBDxfsS0yqvKcl6loCRvgQUgqINExM1Lj9J/4hu2+5i+bkZN/z\nVKoxcRwSBKFjGgiXxzpEVxFElaHwq2SQqA1J+W6TMqlPvmXoEqugRqUyRVSZJq5P0uq6UfPaj6mJ\nGciyGhzjuemLbt180Epdthv0L3pJDPVi4oV2gMR73wk/8d55Cr5KK91FJmrk9gJpUUMv5hgbYyv7\nIWwgigQZNbCVHU56N08QRYKt7YKwhpChm+9jMoROkHmboMjJS06bcR2gqIBwsU0cBoRSEekOQTKL\n7J5DLT6P6LQITYsoW4Rex2GdckiOtglBpNyALREiZANkgBAhVlSxouLCMRUighiEQSqBCNTQLCF/\nQcvx9sK6EYehwYbatW+GblTIDRiiSxHXvCYjbk5wdi7k1JzkngMLVCLLhbmYM62IvY2M5y8HhKED\nYiyuK/iOfYbvnpeE0nLbLheq7aw4sCDzpYfp6oDH1htS2PGBhiOg2kGOO8wps3Y0rZZezNJ4ldr9\nr7uRO+67n903HqEx0aRSialVq8RxTBQHhKFjxUdRzRe0I8KwVB+SW2Is2yoqMjCikq6vaEzuZNeB\n63j2+NNUwsEFKncXKZ0RfONVwXRsuX7CEwftANK0ffqG35H87pVpODAFf++d8GPvANloQfYd9mZ+\nLEoOxsQw0SBJm2gbY3VEEdbQucBmMcJWXVOaFtisihAhwliEdnmdAci76CTHFAWKHFn0kEWXiu5C\nMY/IeyjtJGlVMMjhUfQHQclp6cdKRIgwcKPDpR/iKsPB9AYR+RUUDKRUpe+JLscaSIkVxrPa3dQ7\nJwessWQOvqoJRMU4BUmboxKLnoN2L6ZXKNS8ZCEtaKeSaigIJDx3ucJUtaAeGrLC9rXZLifw3CXB\n7bs1e2uCeujqdVUfykXSoX94j1NKU/Ub5cQgt/U6k47gK4YAoiE+o/XMe4XLZwOpuPO9/w8O3/1e\npvcdoFavebStSqVSpVptEMd1KnGNMKp41vqStpBtfGy5rNWwEakwYu+hm90uZEtp3EEXqfYX+IYJ\nS+Jli5Ji0GIwjAaVUkhlH8nRa+FnfhRuPAScATsJYsqvPeMHIJCCTqnL2XIkJzYZEEuFHoiNkA+U\nSvFD5UREX9LHeJ5WySCWMYjq0MAnibMiGQ2mMEjhjaThMnQZuj9Uke8vV35OpRttImQ5+Kac/aH6\nRWGQbkPxhTIrdD8/tLZwSvwSRGRd225NgCrQ86CKHjPz8H+/qIgjy0/thlAL5lJJbl3N5Qdzkp94\nTUGSW15eVLzakhyZdry86aqgHluO1Cxp5gqoBydhMnYonsYhbWWn6YBN7pscS1rVMB/Oo6x9r+M5\nb2Hov09gz3V7ue0dP8m+172BHXuvoVqt0WhMUKs1qdUaxHG1T7UqkeRxjYf/f2FAI4ajBm201cnd\nrsvQx7PGDi6sLtyus6fu/p8Ug52r/74+Hw69t4oi+Ilb4P23Qi2C3ktuB5QdIPWGFPhpzYEfCK39\n4CU/nqdvKGYJqFnCfQaI4OJCQGgM7TSgEWmm6toZGnj3Eg7iMhmCakLQwKoAEURY5T2JDJ3RqNDX\nrv0MVCGwUnrkzFmhFao/x7SE0YWlv+JEScEg9wlZ4QTvhYSKhqrXIA5yLp81fONxWHg14HW74J1v\nKjhYNdRjyaw3wAu9mJt2pggpeOTlCq/bkXJ4h2W66oxjf9Oyp+Fa7/PCIXd7vAB8KQyZeEZCn0VS\nehBf0ymR01IrrwzRtCxpQJ6JYJ0+eajgyN1v5fq73sG+w7exc8811OtNDxZUiON4pP/qh2U8W5oD\njQvlVBBQm9zpksBw0N9ufQMWXqij1FAr23wZ6g0pvVaeuwLa378D3nerm6RwzrN969rN8VF+BhBV\nv+gi70UYFGFtOJh614d6FEMNKUAMM5fr/B9fn+bnfzzn6bMRp1+S/NO/ldJsCIdq2Mi5oDByOtHK\nFe6sDBBBCFHgpnELH54pL7Qt3HAtK33LgwVE4EZCClcXGlZfESVz1rgEzOKH/lrlh+AIV6QJLMli\nwvmXM/a9TpAtKBZeFBx5jeB7rYA9u+DaXcZzpiw7mpo3HxQ8MdPg7usXec/hLg8/X2GqYvhnb+xS\nFMahph5ubkQuCi0lw5JsMNAbr+FWKsGWPVll8Xu418fgWxrMAKIuvCqtTmHfwT3cfu/f5cAtb2HX\nNQepNwaGM1wkDYJx9UvB1X5sqQENQ4flCTand1GtSoQ1fXGPchB02aZQdjCWzNtQuZ2u7Isv1Xfe\n/Rp41w2Ov9VNnKCHVY5+jxwYEX42DDkwAbbuvUyp2u8jJeujJeGLhUIorKogmjF//WQTS8yBQ4Yd\n14TccpMkaE5BoLA+wREqwqoIEUS+munmnzqELPbhmlcGLD2LH8smUP2hwgjptR3kkBKKw3k7l3KC\n0BJPurZdoR1EabAUi9CbM0zuMXQvZMxnir/+riE4Y3nNfkHPBrzldsFNOzT2XIJd7CL86Auh4N23\npnxqJuLRF5u87YYWd+5LSfwArsS6a1lRQ306ZqBrXZhBHqt8ZBFIL4HsQ8s+2moHTh8/YrVsiUhd\nWxK1ZsSt997DwaPvZPehW5jcsXvE48RxPNI2P6qf98Mxni0P4Ya9T3mSlVqT1x59K6eeeIxKfdCI\nVepRW9+UJSzUYj8XMxoyIOV2vx+/HhoFfP8VOBzD5H4neXVhFg4IuFTAZA4T1iv2hFC0gQUIpoCm\nP1vtGTwCRAVPNZagA6ysIqiDrSJEhcIorFY06iGHmwpbRFjt+0kCF5YJFQ+YlmHshBuUjx/LsK2c\n3VGuKCEHjU2lPKfRg0piyUsKLDIPmP9+RjUxTFwTgAkwWc4Lz1r27xLU4gw68PwLMHFQcv3tMYeu\nNcz/IONbJwquvx5EFlEsVNg/mREmqXMh3YTpMOOf/SicOq843w7YXcv7OgVhMOgEzXyrQe49hTEe\nLBHO1I0/XC0cE8SIgVEVdlADsnrQDl4UkPWg1qhy81vfxDWvv5udB1/Ljr3XUas3+kYTx3G/N6tM\nCzYjUbXlBjRsxcOLfyPDh8oTLBvRwjAkqsQcuvUOTj7xWB8QEENkPaNdftSoQbPmx//52lCl6l5/\nbQN+5Fr4vf8Ciy34uQhUy+3Vr3Tghl2uQj3XgvkuLFyEGw868mT3PMTzLman6cIzCqCNE1aeiNwH\niYrzGiqGXoW7ro05/p2A1nzMjmYINkJUfA6j/DyOMvcJY8dTCiouCw5Cj5z5sXrSE860clt6X03D\nDNivwn1vtcDgevy7sxnhbsVEEPD9x7tcv0MxsV/CnKZzEZ46b9h1CG4MLKdmDO+4DV5zVJBeKJjc\nnfOk1Pz6b+e89gZ4/90R4Z4mzFl3kUyK7Xa5tmHYX3XFTyscSVOkkHqwJffG002HNA7MYGZqyRYp\nu4Oj0OcyZtAQNyxEmWROoEUquOH1r+fQ7W9l35Gj7L7uMLVGc5nhBF7XYGlLyQ8j3xkXeW0pCrd0\nFo0zpog9B29y7Qh+VGNJFi0MFEoQVyyV+iBkK6vYKoTXNeCamhso/HdvgS+egGdm4JWX3M2akPCN\nM/D3bneTnS+14PPfkry5bXnfj1lkFVotmAg8BN705XUjsZ0c0Y5ATCLi2v+PvW8Pkus66/ydc+6j\nu6e756GRRpqRZMWWPSMbx3aikaGAylr2LkuxseIUW0vFik1sdlkHp8I/2LHX7B8QEmSoWoyNxKOy\nhRPB7h+sbQmW5SHLsMBCNDIbkk00k+A4cTJjx7Ze/e77OGf/OOfce+7t2z3dMz16QVe1ejRz+z6/\n3/m+7/e9AJKDIBZISLGt7KBNCN5pOpiwXAg4II6rwJGTvg5VBTOWJTWPqzUQk0Aimp5zgHeFRHki\nIVU5XySmTcIgwLeWmthaJGABQ2gz5LbaYOMhqisBytsp6KiNGz8gcOYrAn/7fzy8PRli9zbgf7zU\nxu6dAcK6j+9/P8G/+zEb26c4prf42DXThmg3gTyR55VzQap58EoTvC0nV7d0Dwo/Lm+otyR42n7c\nmdUP4847EZh0eEF1aG2pgjhPWRjtAGjWpXLdedMcdt3+w5jcfRu27ppDwfBzdBMQEzhZJSWXy2Tr\n0EBB0FSdMC2VbSwZISHM8iLS0XwxC42mJosbCNqY3H4jJna+B8vffF0OQXJkfpwlCDgVsHNxmMOi\nqsaHACUBzE0Bu0alBrEDYP/1wBtvy+zh23bK6XJ/ukjwtbLArinJyOVc4NtvAagA+QnZL5m3lPZh\nkN1MNjkgbh44lweattQorgNi5yAYAxu3ML2V4Bvfy2H2jqIEgm3LohrmgFBlqulPpjQNU2kFRI+U\ndlC/SNE872PTeF6mBgFATfYza1QFChMWSJ4CCMBsioIb4PXXmtjzAwVYRQDwsXWbhcp3fPA2AXUs\nFFyO993sYKoQ4Fv/GGD2doaGRXHxHDC3nWDE4qDtAHfdphoLvNVWQ4jbEMIDmA/kczIeU22ifZ6j\nXlXJuUxlEbTlfW55cb9vz9A+vo7rhTKXsaEmMGhiyAvi2UmUANfN7sKWG+exbc8PYnr3LcgXinBT\nwMkiCS4XyxanAJFUclHcNckKgovgnMieBToNgun2TEilPFAjpZ+oYBVNNmJQ7WYZheqHRpAbKeKW\n778HX/3S70AoNk72LxAycTiUsQLbkiaEReQQ2S1loFCUcjjiAM2alN+pceD0eWB+p4xS//lrAn//\nFsG7TYHFCuBzgvE8gIbAuQbFl5ct3DbugzUJSi4H9VuoBi7erk3ghpKvetLaQA4QjII4OaBg487r\nBf7ydQv/BhaI7UhTzXKBvItWYEFYNvJ5V/ozloUgZKCWA8IttC4QeC2K0CHIUSZnENO8zLWreRDN\nEGzMAX+jirotUMyraXHUxuTOAqrvhGg2gVJRBqWsPMHFkGIbZ3BEAL8lcOG7HI5FcOv7GEbKAj80\nz8DrDLQZyI6VXlupgZacOiUCSZpAALwJhG2Z00hEFJ5qKBPL0/0oWNzrTRcy6l4GVHXcaaqpGKFK\nemWQvyMUcC2Krddtx5bZf4HyzPdh2+6bUR6fjEw008fR5r+pcdandVSFm+CpZFKeBIkuBI3+pv7P\nwygYLGvcVOwNBFwEEkCUaKDQON0ZYZRCLssXRCqTlRj/jzWQEETV5cuZoWHYghANAA3ceMc8fP47\nqNWUP6IWfUsNrCZUOqBMyM+iA2yZkNaNFwC+JX9381bgewXghvPAa+8Ac5NAwaFoBAJv1QlePwvc\nOMElMB2gxAXeqlr4+zdcbBvx8eN7PTglB61mDq+9mccNP5QDznKgSST1ZCsVaNkojRO439X8rOLE\nHRd+w8G3XyN46wLBnvfaKDoOfG7DGnXAQhv+BQJmS23UrhHY4zZ8wQHkZLebc204RRvMtiGojYJr\nJfgchwbYMkZxbrGNHBOwJzgsQTCVBywhh6XaJY7Ns0J1geQyzb0O0CaHaPggLdVW1fOUXUYAYUH4\nHgK/At9rIPC57PCqBnNYIwALZCym5cVAybvy+QRhPIFCA4Q6UuPr8u56U/a2IHYOU9fNYXTnHZi8\n/g5M7rgepbFNCW1jmmta43SrAJbCzlPCH8YpQKnaNSFCI02IJ8CU3I6nqoG6Fd3FCXxCJaUCBJbZ\nG5cQqkwMEdWR67Lj+EJER584o1AgJgoIB2MCjAlYDChNjuOWfe/HPyy8ikKOgAkBlicgekitkIE1\ncEmMjZdl2a7KVon7KvgygPq+aeBLy8D1k8C2EofwgO/VKQIBnGsINATQrgO5SYEf/D4Pv/03o/jI\nrQ3YPkHlu2N49cIIzjZC/O+v5XHzDMPkhMo+kAQxCFxsmnZR+CpBvZ7HyGQe4BYC4uIfFwl23VbA\n5iZD2LLRdGwsfjXAzI0Odu6y8U7Fx/g2F6OjIxiFDb/JIdACgQU/EDjrWZh0R2AHAk3PQklpJiBA\n61wDpOGjfIODi0scXsBhq+lsYzsBavM4XT0MJTiCQNVy+BCBmpXJPUk30raKanKIdhPN+ruotxsI\nfCKHVrF4/o7HJA8yMgaQmkwwBZG/c3NS42gKm+RiEtH3gcoFmRHPaR5ju96Hka2z2PSeWzCz+xaM\nlMfgOLZhplmwLKY+KSjlICRUg7QChKHR4JAIAwgiVeDJI9mMza2M5m1AnKlu9oJWTSu79T9MVqSS\n5F7VfiwdPdRNF0DiCjx9Qt1H5MUN7QRINLOGUzkr07I4HMeFmwvgegF+9Cd+AotfelWWE6iBL76n\nGFxbAsgiQNkFxkbkg4Xqz8FDSZO2PFl/TwTw/dtkFrdlE/ihwO5Jjm9WCP72LYatZWDprRC3WALj\nToi2YGhMOyCFNsTrTQhRwDtNCv5NYNqyMH6TC0YYBKcgIQE8ii1bHBRLwHcrFLMTtgxYtih8TiGo\ni4mdBQA2uLBxQxjitcUQ3AfG8nnwC1Q2/waBnRfwbI6gJmCNOBgrOGifC5DbxOCWHFR9jrLMO5ec\nwpgFlqe47nYq0ytCAXecgJRtGakkej6L0bKIypwZQkOgFUK40sMnnpAZus0WSNCAnQPy1AF3fdkP\nXMT9CTyVKkXz0hQLWxIwvlBNFTnQcmN/qNECKueBRgWwR3Zg263vAxvbiokdN2Hbjd8H27ZUhyMC\nx1EEpcXBGFcugi7SpKqYkRodcQmEQM/2U5HlJER/yaIk2VV0dZYt67Bxw0XFwpEEWaBPhBipJKJH\nS5GoSWCEaDkuPQwFbNuB74dwbBeuG2Dmht245Y734rX/92UUC3KMRautakS4nLDsWrImqFAC7KKU\n2bApxwSGRNncDeBCVdLeFxvAZFGgWJb1Inc0gB1jHJ4gON8E/uY1iq9XLFznNPHyq2PY8a/bGL0p\nxI+SEDe9aWFskmBsOwG1CcAsEJ4DAqltBAhalKDZIJKCdlxYdh6TWwS+9ZUQe37IQdhiYDbD1HYH\nExMO6m9zjIyN4O03PHznyzVMbbIwOT0Cd6KIxrkWyiUbpc1lVC42IRyG8q6iHHMPOd06N8p0NzZl\nDci4EBm34sQ8JgCXx5WEhEvbiwWAE0IEBMQnshNlI4SwWyD5NtAmsJsUdttH4HPZIFEpq1DF53w1\nlc9zAd+R7lOjpUATyqG+tbrsqdBoEpS37sZ7fvgDyG3ZgdGtO1HaNAXbduC6uq+erRg1TQzEs1xj\nxrabn0P6aRWV2eQg211KdhsVEF38KtJnmypi9sY2QaTNORF39zQaiwhj57KlU8xU6OG1jHHV2cZB\nGIbIqWHDH3zwP+C/PPY4eFAHbOWYGrN6cqrU2C6rhE01wk+4cRZ2U5UJN3xg82Zg33Vy3uj3zgOz\nmwRu4ALMAsYLwLstghIT2LelgS9fABrnCJxtRcADRnMemi0Xm0ZsORbPVXXnLA9QF4Q6KIxyXGyr\niC6XXU8mZwv41l/4+Os/rOGmW0uYfE8B588KjJYsjO+Q/tK2m3OYaAdwLAcgOVgFghELQNgGsW2M\nTuYiZodGdziMM12je6qb57E4WY8ovt9RKRfCkzlMFgccARJwyTsjkOCzXYgWB8EFCL8OXwi0lenl\nQ/W+1l1HuXQFdQyn7ct7ffEiUL0gFy9hjWN013tx/U3vhzOxHcXJbRgpT0Rmmm07cBwZwpBtkGUn\nV8ayY429CQJD6FchEbQs6oEI/Wy/qsrq+V1DA0nApGhrQrvsQqTqyk2bUtbhMmbJER+WA98K4boh\nfD/E1M5d+MCP3Y0v/tFxuI4kCFyV7WKrzi9WMZ4ZJGTfD9lhR/nE9ZYqDRfy580TMvxi2bJpoxdK\nIIYArp/kuHmrdJZ/fGsd7vmyZCk22xjb7sCr+BBvMpBRGxiHnLUyQoARBkZc7L0N+OZ3lIeNHAAb\nTt7Bnf+yiAvnGMoTLhijmNzsKCJAxn4YKAoFVZCj7ilzcoizUZkBFhhJeULx7aqBeGLsl05V5vKm\nWIqyzAmpbTzpxYtWHaRZA9oVoM0hvBCkVQX8BgJjskJbqPEtftwJtNWMYz/VBnD+vGoIYo2guHU3\nNu/aC3diB/JjWzE+tRN2BBjdHsxRbJqlQCOBw1RuJNEdcig1yKvB+0wRsgooVm2905fFl/Efkg6k\n0hg0xFwRaDZwovZAIru3iZC1GAIElApQxpQW4sjlZFn1j3zkp9A6+zqW/uErEJSAMgHblsmihRFV\nqcqV+V8DwoLKnVRZKDqYJ4hcIQUkU1QakavoRaMtMKHSCQ4pcDEkcC/4KIODEhvW5CiszXmINldN\nzhyINgEJVM79CEG+TOGEKhefuDJTFQ6YZWPTFl304yihdxTIDG0R3V9z8RFGF6TAuJeqFkjOGTfS\nxj2VNtFQn00AdUlF83ZcjxHKG0QEV+1faxCNGkhTphT4XHZDarbiz5ZqXdVsA426nLZ3vipN45ag\nKG69Bduufy8KW3bDGZ1BcWwL8iOlCDAy1mdFoJGMmqPGutDEWJFE1otucEgwAHiGETzt9KNEas7U\nQIFUDZaYOED00NNqNcmAkG5emmpqQVTrKKLKdPXYE/n+0Ycfx9mnfxZe9V1YKoGUC2kqjDuyHEGo\nfDmMyAREv6mmYou4PVJUJUqlJsu5KuCnOvb4HmCVgEJBZYF7FIFXgHNeIXKTDVJ0ZYYqs0FslXcf\nKBMgJHBcpsCjwVJUQLEygOIrgSep+2nWTOhM19AAlG9onZYCSUsCxQQOb8gkMq8tYztBCARN2fyu\n1ZBOTVgDgioQNkG8AEFLMmTNpmTWWmEcIK17QK0BVOrA2QpQ5wTO+C5M3nInclt2wylNYWzqOuSL\nY4kyAhM8shurbn/MUrlqhmVi+Myajk4TBYT0AgxZE1zEalqLrBWEBFYU/zGJg4wMhPjiBbI7acWE\nENGUuCIUdN9sCSL5Dsc2Y/99D+P4bx9Crii1TrUtZS/PgTEHKGyStWiwJCVdr0qzwtf0K4sL7nSu\nptnBxw+k09tqASMFAlZwkCvmALggwgXaNlAhknkr2UDRVjEgAEwKd2ECGHFVUphNEjcvTtQXkeMf\nm2TM2IYhOZs6gDkTKAaUZ4CnHgOINyVIWipA025BtJsggQJRvQ40qxC+BxJWAP8CEIQIAgFPlR40\nfBUkbckxmtU6UKkBlYtApQ2E+XFsvvVfYWr6FvjCxeT2GzEyNqn66DmJIKf51rEbM0/NzFczgZMO\naJoLc7w4c6PDLYz7idT3Sd9mHukqr/2SBd23sWLgpIFEI3tSQGSir3PnIu7hFrFzBILJWI/rEkAw\nCDV/ce7OH8E3v/IPOPVnf4LrtgNjZZkuZit3grtS1LwKULsoH3rNkyM3bCbbPBVyKreOSQ6g4EqB\nCVVv5VZbrq65nEDZ9UFyoap54HF/YM+HqLVAQjXByyeqC4YHh9oo2Q44D0AjgATqTdUtJEo70RSw\nOOKiDaOaTMV8JGi0ltEmWiPWOH5DXkDbN8DjAUETxG8BgQfRqoG0LwJeHcSvAe02eFvNcVUapq78\nmYs14OxFOdvVFy7C/HaUZm/HtsndIIUpbNpxIwrFMhw3l5hKkQaP2WxfN2fRg5F7EQP9DqtGV9Y3\nCSw9GlMu0NlA6wyUrtU0JN3KGTLYtygrgXRhK0QqVkQNzYUo3Ueo+l0WhrCsUHXE8UBoDoy1QGkd\nP/ZTT+DdszV85W/+Gu/ZAWwpAmOq2Z9zQZUMt2WEu6Hm1YACIxaweRSYKEvyQED2cM45siRC8Lj3\nXK2msh5sioKlGDdbdWG0BGCrgUVQoXaVdA0u4LcA4TBQlxlMmX63I/rZjJvF2ihMGxEKXKHhy1RV\nanhDfdakadkOVDJaS16I7ym7tCUT+4KmBI13AfAuAi0PQRNoVoBaUy42588D756VI+CrHtB2x+BO\n3YCx2+fBRncgIHlsvu5G5PJFBZpkpadZQtBL06RHJ64n0bOf0SNyE9YVaEJ01yLdwGUGYhM9DiOW\nOfuMLAkYFo0QlP2xmNH2icWUdWIF6e8m6dSfBDATN4rgJ5/4Zfzur/xnvHriJBpT0v/1PWDrRWCq\nLJnlkMp75hDZ5XSiAGzdJPtsw1LjTBTmtXnnW8pnCoCwKvXHZOCjPOqDli3AEhC2BeLmZJ6bKoo7\n/zZQ2iJgTRD4LY6L3FMCrtgv+Ao8TsoP0tdkaipibKPB1DJAU09qnrAp1UfLh2i3QdpSC4lWE8Rr\nyIRAvyadmkYbQd1HswY0asDFKvDOeeDd81LTNAUQjF2PketvxfjOPWgLB4XxrRjduh2O46rJ39r5\nt9Wno9g0V9HPehpf9/y0KyM7mvTh05A1dOcRiaRSIWJrghACi7F8ogQhvklsKDcl3XstmYcU//yx\nx34RxWIJX/yfx+AwqTkqLdnYfMuYzINzXemmjOVlk/SSorsFMZSCkluCuDI6UClAfoWg0W5hokZR\nrhLkSznYJS5rwt0AGGkDAfBnf+ajavk4cE+Id95g2LnbBmoB4BTkG54iEdyU5tEP0swfZEajBX2S\nhpmGlupRXJPkQMuDaPogrRZIvSZVSvMiSK0BNGrgDR/tdohWU46iPHcBOF8DztaACzWgXZqBGN2F\n0m23Y8SdQG5sCyZ37IabK8B2HOXkkygmY9tMLZimlpGTDGTWAJU0NNOLEzXGhdArpqxgI4GZzMRJ\n9hAk586dE1kAMlv7DuOlu3fqIVB6zGC73Uar1UKz2US73cLXTv01/vj5Z3HhO9/CphFgelwWzO2Y\nACZHZYpPcURmKjgO4KgeGkJFzGsN+dn0VdBV9WBglMngKCvAsi3kHIaCm0OpkEc+78DNOXByLsiI\nha+fdbF4LofrNrvYOuVg6gZX2oajthoNoBuE5DJiOcRg22zDF9JkQVNqH78hgy3NhvLs1YCkRk0i\no1EHmh6a1ZYalylwsSr9mGpTmWSCoO5sBSZ2wxrbheL0HPKbr4OTK4DYFlw3h1y+qGIzdpekTaHG\nfkhqmbJkdgBAEiaazCCwIvCYlgVZKxd8tUJr2AV1/di22tk0bWazBPzWH/gXuOmOffir4/8dr/7p\nMbzxzndhUxnjGZHZNgiYDATmfdmExvakn9RUrZV8nZaiXBqhR9VRgEKoIccUARPwmyHyQRs5T6DQ\nFsi3bdxUAm6aAoTFQVwP4p0WSNGRB27JcgY4alirniOpe9a6kMVOEamgzT1PJpf5TUkM1FtAvQHU\nL0r6udoAak3weh3NC23ULgIXKtIkO1+XCrAWFtHOb4E9thOl627H2MwctoxtBScEtuMily9FIKFq\noi9jRAFIBjxt20kslnFvgZjxEoLHuZEKNImsaB6CI0ysyrEZpxk48k9CQ10yDWQ6Z1oTZWkj/dlu\nt1E//zZe//Jf4bW//WMEb34ZU+PAtilgQvUkKzAZhLdVMnLgxUNv22Fcgqx9I2pTEOrCYjYs2wZz\nRuA4OdgWQc6iyNsMedeGqztdOpZ0uPSMjrwlOwq6jkrehCr8V86oA6DMgFFLAok3VHymKVViU1HR\nzTZQbyCoN+BXW2g1fVQrkuy4UAXO1YGGz9B2d8LecitYeRfyk+8BcUfBiQ0nV4aTd5HLF2HZjhLw\nAIw5ajKbbvckZzPJ4VUUlm0rTeRmdrTRP2vnWgiu+oFzw69IkyIioXzjDBqaCItIlyA7vng1a6BL\nCqAsEOmm73r0uud50acGVOi38c63vopvf+kvsfJ3/w15CJQdac6Vi6oviB4kHBidTZX1pCdBMwZQ\nNQaEUAKbOWC2C8sicC1p1uUYg+3mQJkF27GRL9hwcgTMsWQcyFIsnVA1zYGQDhZpAWXIKPCIJf9f\nuwBRaSOoc3iVAM1KC82qkGBpyqh/pQV4YAhzU2iN3Ah7bAdGpm9EftMuOCNjoFYOlm3BdnIghCuW\nLAcgVOMmC0rwBYQIYVkWXLcAy7Kj7HhJ9Uq/TPo/lsqWdxK+bhYZoGtwOA/BeZiIy/Q217IyVYiR\nbR3P2yGUXpWm32UBkEkemH6Rnv1pgkm/Pc9TwGrDa1RReWcZ777xGr73jf+L1/7uj0HVoFlXWVX6\nHfX+UEHWnOo2Y6tOuZbZG0SZM7alUppAYFsWCnlgxBZwbQLHpmBUTqFqBwRNjyHwQjC04eZCsBEg\nzMtcs6YO/FbUuESWRzO3B6IwA3t8O+zRbRDuKKhbArFdOIUSqJ0Ds2xQwmE7haiFE8Bh244yqwRc\nVw4pFiJQQU432g4IQIilKGknQeBwHkCIwDDPqMoicPt41mqOjggNMIm1PP0EoKKfqDb/2Ib2sr4m\nAJQFIvnJEQTarPMRBB6CwIPn+fD9NoIgjAbpysIrDr/dQqteQ/XsO1j+xlfx1uv/iGb1HVz49tfA\nPR9BO5QTnS055tBlavoaldWWjuplHbVzU40c9RQJV3WsiuZ3qjShpi+zmC2Loli0kC8WEJR3wCpO\nAHYB9vj1yI/vQq48BermQZgLoVZc280rwbWUj0TgOAUl6KFix3JxKAECtiPBwHkAV31fahUOx8kr\nmpkgDOVANEplYqceCGXOeuLcN+IhKtFVzcgx43mrWxKhmhnFU3l+65Gb+LtSs9Irlqi4rACKVzR5\n88PQhxASPJwH4GGIkGtfKUAYhAjCEL4vwcNDCbaQx76UEBw8lLZ74HvwWw00azX4rSZa1QtoNSvw\n6lX4rQZ8rwERtOHVKwjbTbTOfTcCT2FqF9yRMizbBoFAvjgKN1+GUxyHnS/Dcgpgbh7MscGsHIhl\ng1iOnKRghAGYmo4m+0QQFXPJRYOfZDQ9TAg654Gc3erkI+deCB+WlQdjFGHoRX6MrOBsg1JmAFCo\neymbVFuW1ESm0Emt70UT+cy6G0qleTeIBojBFBol07x3zmRCE/VnBpqsX1JLXR6/6pICKDEVTAWj\n9M3WzRoAYkx7i5NPtZ8kTQf5cxjIvwXq9/Lvwvh+iDBMarc47kSVs8sSZSNCO05CxCMe0dkJJh1A\nTAcW9T2UJlOoqF892MmOgBEEHhijsO28Yic5OPeV9om3078jhMqhX4TAtiVgpMYJYFm5aEAUIQRh\n2FJmlgRFGkTapNMLVzovLB46xQZ+ztlgIkPSHAJmN/pOUJGEv3VJaOysqPL6ossiunHxJ49ApHOY\novQhFqf+aJqbc66ArADALXDBwblAEIQQjqSPw9QEOs7jqXSaTZI/EzWtjCj/AUbSougrtSQ9iCsN\nMDNtX3AfIbeiURuOk1MCqQPKPoSw1EQ1V2kfH4IzOO6I4dwLBAFU1rOtph9wWBZTJQN5+H5LAdU2\nKorzCIJWNN9W9j9IjiyUILXAuY8wDBLmlwQ/hxBMaUyrb6GSvpVtgEnGweSnWDOY5NqWThfToA1S\nz4Umcjy7l+is72UNR7vEGkVrGD2WPEuVxxciVhVWIYQSSAGhwGDbFrjSLmFC6yQ1Tpy4qTUOTbCA\nJniyQJTuBWGyVWlAxdnHCggiXoTikYI0yqcLAplP6DiFaLswlH2kJHnAEpMY4s6cDoJAzmLRQi1L\n6D1l3rmRwFiWC99vqUUkAIQAs9yOaLoedxiG7UhrafBy7oPzEJQGA49BlNdlqWkcApTyhHbqmuuW\n1jcEXdN0SEahm1DzkrgezoZ4QlukHECj+rdLCqDeYMlyIuma1WPiZzUSRWskRuWQX2aAIZ5VSg3z\njCZAkvVzVmpROtibPqc0aHTAMQg8CCErU6UGtRPgEUqLUqrjMXrqswSPZAPt6EELQUC5mbApeyZw\nHoKx2NzSzBjnASi1o4XKtnNKEwFccIigHWme5LVSMJYDIT7C0E8xZSIyn9cCpBhMTF2jlhsNJtGV\nS1gXHUEieyju/SaSeZhpM3BQ089a3W/hHT5Ltk2KNajmbs6kSGkrkVDhjJEoascNQEgWyUqo9nT8\nKZ1eNAiQs7RRcn9tWFbcfFIyYbkEAMOwrR6SrQgFTTFLX4lRyabFjSrDDu2tG/1JgZamHKVM+oSB\nD9tmhilHwZiDIPCi+xAEnqLurY7r0tooCNqGFo/9oySQ7DVNgkuDSWvIBDXeF5nXKT/EGBe5Og5E\ngp435ZhSbQb2BpUV7ySOPEfMRpeQWHeFuz7asvvvTAESkXkEQmGpsgr5IEmmNskCTzdavZ/VJyvY\nGIbtyMyS4GFgzE2ATfsVWsuYZqoGc2dQkWSYujRawXVav9ZCmmGzrJyhKS1YFiIQAVAgEpG2Su/f\ntvPgodRGIuM5SD+zrQgSW3WwJWu0NCRwGRMQnIOL0GiamF0FTZL/dDHr1ip/sujTdD/M5qMmpW5x\n7kdN7WRZA1EFb+wKiw6LBGUpV16rZ6/ubqbZsBiYCDyB30EwSPDQxDlw7id8g+QD68ZUiS5amSsh\nE5EJIrVQoITbT4BD0tNckQUaRL5qfmlnPmvKbBDKEIa+sbCmta4A555iHq01Ayl6tpSBgUVaWV4j\nR6ILLtamndYKKqJuv4hyBcOYhZMrGUlw6nGTEW1EissMHDNKzYz+3IP7U8MNBoeSRk79Pg0eKQy+\nWtUQZTOb+4lbgtEMNrNTQ5iUsQYjpbahhfyOUe6MOSrmFoMoDAPFfjpdzFUKy3Ijpi5mUNFhDg8P\nSIi0OMAiVyL2l0TGeZA+tUv/f1/t9IUQej4QrsBXTAZoQbiS0jtkDMXrAKpJJZsA4TwwcsDS2sdk\nvkjGA+4sjc4qZZaaz0YYeLIVcuhFZqQJItnkJYieuzy+1zOAqs00rY3SGQHxWssRhp5RpLl+IGny\nhDHWERZZvWR7PSBZ/byt+AaR/lZwgY4S1+GbRzQyz67EnCipTfwOp1U61VbHKhWzWjCykk3/jGcW\nqMW+G8n0G6Q/yBO9yyll4FSO/tPOPiF2SkPaEXB1cqd24NOxok5t5KjAtd/F0zdM21D2vB4WkEww\nSZZVGEywGbpYBRIDpAOtdspWOr7RXw3HsFWWpmOZMkeu3JR3zj1FBpj0tgClTia1K4y8M10y3xkW\n6GVqioh1S/gKEZGQNOM0rS1NOGmipU05zbYBXsQ+6QbtYeitwq6RyESTgd+wU+Ki9A5teslA6jCB\nlFxIaAaYRGaMaFWJJhhI9i0TNGZj717fJ334+qLvm2CaaVdySnscVDT7nMlryI6LcB6CizAeV58S\nZL2NFN7B7HiZxmOOGjfPh4GQMJFnmPZxInMvVAV0HWSH6Bnr0SDkJDRy6tLLNkndvyACUpo1HSaY\nTFZZTjYfXLP026nHMjuRxrEDGIG8Ac21rACYSDe3owZwrvy0dSlUXqovWSys0iTK+k6QeGJZ5p3Z\noCL7XvAOwEYgQQCh8gcJEakqX6ZMKBJR3knmT8eIbMMci5+bPvfVAqbaJE1mePcWQB30HbZGSmpo\nYpAtPOUriYGB0tWESw8yMjvnqFPpOZ1hdeHT6RQ0CqANyqJdXvDwDOGIxEdRxSTjewHiJEqR6c/F\nwbve+WGmn5U0BXSsjnf4I1oLQTVbl6RB5zlkgQgJEGlNRFbXRjxMLhqrmsMhCOEGSbQxFoh53VIr\nCcOPXyvVHZlwZllvRndSggSEdDLf6j6NtpepoXEorqZXEjykgyHsRv3GAWmS8BuytkuumL1NuOSg\nMyTAJ4kImmIEmRJoElHWkmkjPUDUKeTaTF1NwLU20ik65iLcazGX0+RC2R1zg/soEDUKhERxJdFl\ncewTQP2OmOhpO0YmmjC0GLsqQdMJniymiWYKYtLWN7bO1D4mwya67qtbG2XdRYcLGGaKSPk5DISY\n6Vci05TTz0wCLux49tJE9BWVvRotTCIGVYhQlYj0t+QKEYJAN0Tf6IYkxKgIIIl8zn7cFn1uVlZX\nyRhMYgBkI6IXr/bGESZ4NAFg6tVe8ZI42GcIcqb2CVMLFOnjYad/TdVkhvREaVOYWZTqL1lBDkF4\n5vlrLZnUnrEpLrMbrL4WxcgVoGG279jVqxdRYFkH+DdelkzyLG3aidVNOLMBeLaJsMrB1bTua6Hb\nii6CS9DKxkcv4iNy1k1Dj9Luo2IAYxXM3ob0sH2IGgityZ60GRdrFhprAiNxMut5aRB1M2vie0P7\nWqUJsRJxmv5CJCSlDcgllK8kE52cvdrZKMWKc7jEqjZ458O7ek207uDhPQW2OyslYlIgApzIJEy0\n+da5WHVuB0IM/yebbdLCak6jNoVYCAqQMDqMrpfJMuU0iJL3In3uQd+aKHbiCTgn6L9vQmd9T7oH\n+6V4mcfrHGSsTDjJSqT9nOwhWuke1/8MnqQP0o39QQ8msx8CoftsG9KReZ5Vt8R5Z2P1LI1lEgKy\nVyTvQpT0r4liIoV1jKof1LTWNV6XGkjZYNKpPCRrWqRIqflrS9sknX7Z3YZkMkSxg939wYqogWHy\ne6yrICTpadL13HptowvuTOshGxQkUVcVnzPvIYjEOH/RRUPyDsHqVxvFeWz9m1bJ45p9Dy5PQxHl\nA3VOodM15ZfzBC8NWSCi1lC9HvhqUfNOQkB01T5x3VFsb/demEjPqLkubchm75LbmSaeJomyNFZS\nSFjq+rK0Aona+fbvZ2i5MjU36UFQmV1PTcLBdD8uvZxa2SsVueZ7GifB041CphGr2EuA0gJ76vTf\nY3HpG1hcWkKlWsXhZ55JE7bolmndffXt5TsQ9I4XpUEUfy/WInTNINL1TIMyZvFCHVeG9h5N0vt5\nXg4gdQzYutq1TaVaxaeeeirxu6QAm+ARePmVv8SLx45Hf9s3vxcP3P8RxKUUZBUQpv0mgVMLr+Kl\n48dRqVbxiY9/vIv/Q1YlavoDWIbAiOzYSyeAYJh93QVvcWkJzx89irvv+gDuvuuuHiQKXwNbFqeM\nEbL+xoyXGki0s5/W1f0ql0o4/MwzKJdKOLWwEL2TJodcTavVGp478ls4dfpVLK+8ic/+4i/ggfvv\nR/+TBXi0n1OnT0cC8YmPP4K5uTkAwMz0dAf7ll2egMGBguwp1yIjwTRp8qGraVmpVhP3CwCeP3oU\nJ06exIvH/yh1LhnzdDP7ZvSnjYZJTvVTxj8UAF2r/o0puGeWlhLMk369qLQEANx9110olUqrsGed\nrNup06fxwMP/HovqGFoQtBDuUUDKYt/6B08//kQ2IDKd+C6U+RdPncJHP/ax6H7FWnke++bn8YlH\nHkmmC2VDCP1G83uRDMMiiMQaAT0AgK7N14mTJyPzaXl5uQM8yysrOHHyL7BndlZqrnJxAPDEpttz\nR34LyysrmFP7AQjOLC5G2tAE8iAmWvZDH5IgZJXvA3juyBEsr6xE90S/PnzgAA4/8wz2zM3FpS9a\n/WW91wki0xe/0oFkXYvgWV5ZwZ65uUijnFlc7LD9P/v0r+LRR34an336VwEAc7OzmeBZXlnBmcVF\nLK+sSI0yO4v5ve/H8soKlldWIs0DAAunX8WePXuibecM7VOpVvDnL59AuVRK+REkOsdTp0+jVCrh\nnv37USoWoy1efuUVAMA9+++OzKwTJ0+irLbVIDh1+jQWl5aUD9fJxpnXIoTA3OxNuHPv3uhaTM1z\namEBc3NzKJdKarE5iQcPHox9KWW+SpPvNJZXVrBvfm8KfBJEC6dfjfY9Mz2NPXNzfSwsZuMWMUQg\niaH6+9ckgE6cPIk9c3PYrh7SmaUlVKvVCFAvHj+OUqmEfUp4pAYqJ8BzZnERzx45gjvn57FndhYn\nFhflfmdn8fznfgcvv/IKzix+PRIKCSSKO/fdGe3zzvn56Hw+c+gQKuocTAAtLi1FxwGAzxw6hBeP\nHcPnP/c56Zc9/Ss4dfo09u3di3v2340zi4v41FNPYXllJQJQpVrFEz//FE4tnI4Wgzvn96pcst7X\ncud//RxOvPIXWFxajK7la4uLIIRg3/w8nj96FM8ePhwtHvvUeRJC8btf+AIWlxZRKpUkEXMEePlP\n/hfK6j4/f/T3cOr0Au679wBKpRKeO3wYlWoVv/zpT/cFoDTJMDQNbHb4WSeQrkkT7osLC9i3dy/m\n974/4QcRAlRrVXz+6O/j0Ud+GguR4w/cPHdzAjw/88lPYs/sLB48eBD75ucjX2bf/F4AwAP33x8J\nwX0HPogHDx7ET370o9HxtTA+f/QoTi0s4AG1epuCsbj0dfzMJz+JO+fn8eDBg9EKv7y8jEq1is8+\n/SsR6OdmZ3FGsWEf/tCHEqzjEz//87jv3gMxkVIuRYKy+rUIPHjQvJYDePDg/Xjw4EE8e/hwZI5q\nX0i/nj18GC8eO4YnHnsMT6r3fQfujcDzmaefxuePHsWTjz2Ge/bfhfvu/WDkb5r7GYxkGDbRJRIj\n7f8ZQEqglpeXMTd7I4TgkWBoU+vzR38f9x34ILbPTEcPVD/0NA3+oAKECYq52ZsS2iMmLOIHu6iE\nbnllBaVSCU8+/jjKpWK0ihPlxj/3m7+JSrWK+w5I4X/h2DEAwKMf/zjKpRI+++lfiMBQLpfw4rFj\nidV7bm4On3rqKXzikUciYMtjzPV5LXOxCZm4FkmSPPjRj0bCbgr9qYWFCMij5bIC3r148rHHIs3z\n4rHjeODgwWh/WjvumZtN3O+1ESbD78mxViBdcwA68fLL0cpKiHxgUti/jjNLSzhx8hXcd+BeJeBv\ndvgqLx47huWVFdyzf3/iQWtQSEdaPkhNXWvnWmsvDczl5WV8+MABCCEis27f/F6AAKdOn8aphdPY\nNz+ParWK548exfNf+AJ++dOfxocVoCQVL4/x8slX8Ogjj0TH0Of0kwcPYs/cXLRdDCSCF48d73kt\nN+/ZY4AiFnD9KhWL0bZ3GgDSQJf+TpIFrFSr+PzRo8pnu6uDCZVky/pMsY3RRmsD0jUFICEEziwt\nYo+hJbTGOLO4hOeO/BYePPiRSJgWl77eoYFeeOmlDlC9cOylyH+ZMfyqmGnb3iEoM9PTePLxx2NT\nSv1eO9n6/8vLy3j28GGUSiUc+4M/UKSA/M7yypsR8J54/Oei89TfNTVEBNC984nFoPNajqFSrRoM\nIUldy3RCoLS2is9L+nRJrRSD6OWTr6BSrWJmejqxL30uM9MzQ/JnNjLNrH8gWdcOeGQD/JdPvoIH\nD34k+r1+iMsrK5iZmY60D0AjTaF9gkq1GgniduN7z3/haMfqvLioVtS52cQKvLy83CFwMjvhdLQ9\ngEh7ffhDH4p8n/TrzGIMOm2WaRMqfQy9P3293a/lCwlQEUIS15JmIJdXVhJgSAdZ02zi8oq8/pmZ\nGDzPHTmCqr7XagEZpBd5f0zdEGn+TLKBXLsaSIPnxMlXEloCIJiZmYm2e/D++6PLNoOdadPGNEd+\n6dChyBTZt3dvZBaZK35FmWCmdtCgFCIGjzZ5tOloAs7UEPq8NDN2twkU9be0ttDnvm9+L84sLUWg\n0OcQX8v+yCR7QZmrndfye0rTvBIB1TRNzftjEi8Lp0/jjNLqseY5jlKpHG07Nzcb7b9SreBrqXt+\n5WmjdBxJXFsA0uCR9PQfKjMnvpl6xbvvwL3YN//+TPBopssE2wvHjuFTTz2FRx/5j5GAvXjsOM4s\nLWFmejoCysuvnMRHP/Yx7Nu7NyHgsXDH5tvyygoeeOhhVKrV6LxOnDyJF44dw4mTJ/Gpp57C4uJi\nZBppATZjK3pfplO/vLISCegDDz2MxcWlhAZ48fjxiGzQ1/LCSy9hcXExeS0nT+KBhx6O/CitTU4t\nLODZI0c6zMHnDh/GqYUFfObQITx75AjmjNDB4uISnjtyBGeWFhMEx6Of/NmYyXzoYTzw0EOR2bxu\nGJFLAaSkaUevBfC8eOwP8aF/+xM4tXAaZ5aW8MBDP5UICu6b34tHH/npCDyfOXQokXD63OHD+NRT\nT0VBPr26PvnYz2HP7E2RcN6z/y48+djPJfymUqmMw7/+68qRX4iEO5nCQ6LV9zee+TXsmZ3FfQc+\nhJlpyQR+5tAhPHv4MO7Zvz/ym7Rm2DM7mzCtvriwgJnp6QSAKpVKBNrPfvoXcd+Be+W1KOBVqhX8\np8cfx565OeNa4mNF11IuReeX8Kvm9+I3fu3XUC6VUC6VIpPzhWPH8EuHDmFmZibKPzTPq1Qq48nH\nHkO1Uo3O74nHH+vIdCiVSkMMll6KEpwYSITrkQFXrebpt81WfwmzMQ0+G2k2LUgz0zPR/irVGlZW\n3kwARTvnpukkt61mpMgoJm9hATMzMx2BRSF4x/4AoFqrZ9LApxYWML93b8LESB5XHi++luku1ywS\nmi25bUwWLK+sYHl5OTOmc2ZxETMzMyqbQkb+Ty0sKM1DUue3bNyXYZfRiA3yjYyneLUBKFafHIMU\ncA36cLLqfJKAJH0lnPZ2fsnA3137Mfu5/tXy1wYX8KxuQfE97HYMDFWDDDeLIcXCXU2Fc8nGGnRD\nwaNbEK/PTOjVzZOu6burC1efUza6frebsMU9MgYtmkuCsp9OoMMFUVx9O3xtRK8m8MQtbNdiEw9y\nHGC9w5k2LoV+7efVX8PAzsUnKfiDr+aEZA0LJX0668O7bxvhG9GrCzyDX97gGlYMIBAbBQKxrvNb\n/7mRDG0Rv9ci17FGMfu+rVbWPvyiuGEzdfTKBw9fI3jWYq/zAQUMl1zQV5OnYVjk/Uy3HlywtVkm\nOnzJSw2iYWojeuWDR6zxBtEBjyX6FC6y7n1trNuZJZBZWmU9iwRZkymXrX1EH/sSGzYoer1AotcO\neMiawTOYYG28H9NLVvoDH8kQ2P402CBkxdpMOYLBOhJtLIjWq42uQAD1OziWZNrUawHPMLXP6mAk\n61xYNsLnWvt31tpApH8T7lKAaO1NTeiVB54sdZ7dumK9Pk8sAMPUPpeLfRvMhxk+ybNWTSR6XCdZ\n4wK7PiANcq+tKxM8ZMMvfFBh6hecw10gyRpB1GuqhohKvfu55o3saJOcy5N13mJV0G5EHHMQWboi\nNFCS81+rubFW7bNRJlA3LXm57zYZUJg2Tgt1aqJB93Fper9d0QBaf5rFWvOn+j/uYL6PGJIAbzTS\nhr94rB1E67neywsi+k8TPBujfbrv8spLlxq+zK33OQ7D/P8nBKD1O4KXAjzrsbFXIz022FAjw9xX\nPzEkgvU2U1zfvbo8IKKXDzy4LOAZzNYma9hvr3k7V5qvI4YASJFBXqzXH1oPiDaOobsiALR+8KyP\neel/kRpM4HsPyroyX4Mt2N1oZ3PxEOs2D4eRYrOR5QuXEUBiSOChl/DGDhsQV3cj/3hB6VXysF5T\nbnggukTTGS4VeMQQHuD61PsgpttgxxJXKSTWsqCQjOsmGWbs+rTAcJI9Nx5E9OoCz0aabmvfv7hC\n8dPPGjDouWfvU2QCa73PfThBUnH1jjcZlholWC94BLKLubKYMrJB0e1harPhNeBY23ey8tdEj3t/\neUz2SwEiupHgGcaDJomZM8MQGLIO4VmPMA8TlMMOxooNvHZxxWui9O/1wm++ze3M7enqIOh+kN7b\niiEL/HqA3L8wDV6Ed7l8l+HtY3Azbi3P5fLE/LJBJFb5veh467+nP2k/GiR90F7/HyZ41nvTLiWd\nOTzNvRGgFRusEfsR3Mu/mPY+l9XOUXR8CtFFA5nBqHRgqtf/hxfEGqYfMujY9UutCS47ZNfkqwyu\nhYZlypEBnjnp8jfRxS8WA+yTZGugXhe5mhk3LIEfBnguRQxgsOrOy0FIZCVqiqt6IegEUT9dikim\n/xuXUpAe5BLp8nf5SZMrxGoaRGwwG3T5wLOx/fHIZQFu9rF7xXGGoRG6Cfj6A6y9QUTWRBKt93Ss\nYanX9QmRwEbRx1e2I3+pzzddSk06Fp5BnwEh3dKYuoNoGItKXIx3eV//fwC0VWZuzsA9mQAAAABJ\nRU5ErkJggg==\n",
-       "prompt_number": 16,
-       "text": [
-        "<IPython.core.display.Image at 0x10853c7b8>"
-       ]
-      }
-     ],
-     "prompt_number": 16
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 17
-    },
-    {
-     "cell_type": "heading",
-     "level": 2,
-     "metadata": {},
-     "source": [
-      "Limits"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Recall that the definition of the derivative of $f(x)$ at $x=x_0$ is $$f'(x_0) = \\lim_{x\\to x_0}\\frac{f(x) - f(x_0)}{x - x_0}.$$  Write a function that computes the derivative using the limit definition, using `limit`."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def lim_deriv(expr, x, x0):\n",
-      "    \"\"\"\n",
-      "    Computes the derivative of expr with respect to x at x0 using the limit definition.\n",
-      "\n",
-      "    >>> lim_deriv(x**2, x, 0)\n",
-      "    0\n",
-      "    >>> lim_deriv(cos(x*y), x, pi)\n",
-      "    -y*sin(pi*y)\n",
-      "    \n",
-      "    Note that we must use this trick to take the derivative without evaluating at a point.\n",
-      "    >>> lim_deriv(exp(x**2), x, y).subs(y, x)\n",
-      "    2*x*exp(x**2)\n",
-      "    \"\"\"\n"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 18
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "lim_deriv(x**2, x, 0)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 19
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "lim_deriv(cos(x*y), x, pi)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 20
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "The function you wrote above to compute limits using l'Hopital's rule is very fragile. And even if you try to make it sophisticated, it will still be unable to compute many limits.  Try it on the following limits, and see what happens. Then try computing the same limits with `limit`. \n",
-      "\n",
-      "1. $$\\lim_{x\\to 0}\\frac{\\log(x)}{x}$$\n",
-      "2. $$\\lim_{x\\to \\infty}\\frac{2^x}{3^x} \\textbf{Warning: Be sure to save the notebook before you test this one, and be prepared to kill the kernel!}$$\n",
-      "3. $$\\lim_{x\\to \\infty}x\\sin{\\left(\\frac{1}{x}\\right)}$$\n",
-      "4. $$\\lim_{x\\to 1}\\arctan\\left(\\frac{1}{1 - x}\\right)\\; \\text{Remember that $\\arctan$ is called }\\mathtt{atan}\\text{ in SymPy}$$"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "lhopital(log(x)/x, x, 0)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 21
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "limit(log(x)/x, x, 0)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$-\\infty$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAACMAAAALBAMAAAAHCCkxAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIs3dRBC774mZMnZU\nZqvpz9EoAAAAeElEQVQIHWNggAHWABBLAMYF0qzp3xsYWKfNbECIsS3g/hQQ5MAggRDayMBwXlWL\ngYFHgEHIGARMGDYwMHB/vwBUAmRAAYiVjymU/gsojlB1Faix8XsAA68ATB8DJwPDPgb/EoaTcBEG\nxpeTLjAwvi+fgBBigLseAP1wHBzUhNGNAAAAAElFTkSuQmCC\n",
-       "prompt_number": 22,
-       "text": [
-        "-\u221e"
-       ]
-      }
-     ],
-     "prompt_number": 22
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "lhopital(2**x/3**x, x, oo) XXX: Don't run. This hangs the notebook"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "ename": "SyntaxError",
-       "evalue": "invalid syntax (<ipython-input-23-daf458c59400>, line 1)",
-       "output_type": "pyerr",
-       "traceback": [
-        "\u001b[0;36m  File \u001b[0;32m\"<ipython-input-23-daf458c59400>\"\u001b[0;36m, line \u001b[0;32m1\u001b[0m\n\u001b[0;31m    lhopital(2**x/3**x, x, oo) XXX: Don't run. This hangs the notebook\u001b[0m\n\u001b[0m                                 ^\u001b[0m\n\u001b[0;31mSyntaxError\u001b[0m\u001b[0;31m:\u001b[0m invalid syntax\n"
-       ]
-      }
-     ],
-     "prompt_number": 23
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "limit(2**x/3**x, x, oo)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "lhopital(x**(1/x**2), x, 0)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 24
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "limit(x**(1/x**.5), x, 0)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$0$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAAoAAAAOBAMAAADkjZCYAAAALVBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADAOrOgAAAADnRSTlMAEJl2Mt1EzasiVIlm7xEe\nOPwAAABJSURBVAgdY2AQMlZhYGAIYxB1YGAOYGAuYGBtYGB7ycCnwMDyimHeBgaWx2DyNRL5GCz7\nBqSS6yVIF3cAA0MUg6wDA4PQ5hYGAON0EpMbNABcAAAAAElFTkSuQmCC\n",
-       "prompt_number": 25,
-       "text": [
-        "0"
-       ]
-      }
-     ],
-     "prompt_number": 25
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "lhopital(x*sin(1/x), x, oo)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 26
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "limit(x*sin(1/x), x, oo)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$1$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAAgAAAAPBAMAAAArJJMAAAAAHlBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAACGjDitAAAACXRSTlMAuxCrdpnvzWYiHG0BAAAAI0lEQVQIHWNgYBBiYGBQ\nnMTAoGwMJBhYSCVYw6ZHAPUxMAAAQGkI1Fjz0FgAAAAASUVORK5CYII=\n",
-       "prompt_number": 27,
-       "text": [
-        "1"
-       ]
-      }
-     ],
-     "prompt_number": 27
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "lhopital(atan(1/(1 - x)), x, 1)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 28
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "limit(atan(1/(1 - x)), x, 1)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$- \\frac{\\pi}{2}$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAB4AAAAlBAMAAACno0T/AAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIs3dRJmrdjJUZrsQ\nie92pBgeAAAApUlEQVQoFWNggAHW/0CQAOMxMIR3Fq4SRHBZJrALFCK4QBY3QwIKX4zBAIUfxfAB\nmc/zh+EHMp/dgOEvMp9pAcNWZP4AsYWMQcCEgR8UHP//09AVjKHaDsjGizGw/0Tm5zAw2CPz3x1g\nyEfWoH+AIR6ZD1RrfwBIIAAHSgAzMDBtQMiBWNGoXPYEVP5UBkYBJBGOAAYuZL7w3bvBSNIM9v//\nf2YAABDvJavRuLWzAAAAAElFTkSuQmCC\n",
-       "prompt_number": 29,
-       "text": [
-        "-\u03c0 \n",
-        "\u2500\u2500\u2500\n",
-        " 2 "
-       ]
-      }
-     ],
-     "prompt_number": 29
-    },
-    {
-     "cell_type": "heading",
-     "level": 2,
-     "metadata": {},
-     "source": [
-      "Series"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "The Fibonicci sequence is rexcursively defined by \n",
-      "\n",
-      "$$F_0 = 0,$$\n",
-      "$$F_1 = 1,$$\n",
-      "$$F_n = F_{n - 1} + F_{n - 2}.$$\n",
-      "\n",
-      "The first few vales are 0, 1, 1, 2, 3, 5, 8, 13, 21, \u2026\n",
-      "\n",
-      "The Fibonicci sequence has a generating function given by $$s(x) = \\frac{x}{1 - x - x^2}$$ (see http://en.wikipedia.org/wiki/Fibonacci_number#Power_series for a derivation). What this means is that if we expand $s(x)$ as a power series, the coefficients are the Fibonicci numbers, $$s(x) = \\sum_{n=0}^\\infty F_nx^n$$"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Write a function that uses series to compute the nth Fibonicci number. \n",
-      "\n",
-      "Hint: `expr.coeff(x, n)` will give the coefficient of $x^n$ in an expression. For example"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "(1 + 2*x - x**2).coeff(x, 0)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$1$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAAgAAAAPBAMAAAArJJMAAAAAHlBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAACGjDitAAAACXRSTlMAuxCrdpnvzWYiHG0BAAAAI0lEQVQIHWNgYBBiYGBQ\nnMTAoGwMJBhYSCVYw6ZHAPUxMAAAQGkI1Fjz0FgAAAAASUVORK5CYII=\n",
-       "prompt_number": 30,
-       "text": [
-        "1"
-       ]
-      }
-     ],
-     "prompt_number": 30
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "(1 + 2*x - x**2).coeff(x, 1)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$2$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAAkAAAAOBAMAAAAPuiubAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIpnNu0SrdlQQ3e8y\niWbzIQYJAAAAT0lEQVQIHWNgVDIJYGAQY2D/wcCQycCwnoFh9wSG/AAG+wkM+kAJoMgEIMHzF8Rk\ndgCRKiCCPQFENjEwCjDwKDDwCTBI3b2rBVT8//8vBgBR7Q/Fm5CwxAAAAABJRU5ErkJggg==\n",
-       "prompt_number": 31,
-       "text": [
-        "2"
-       ]
-      }
-     ],
-     "prompt_number": 31
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "(1 + 2*x - x**2).coeff(x, 2)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$-1$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAABgAAAAPBAMAAAAMihLoAAAAJ1BMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAilU6eAAAADHRSTlMAIs3dRLsQq3aZ72YDTSHvAAAALklE\nQVQIHWNggIMwOIuBIfUYgpNejsRh4CCTI2QMAiYMZBsAcxDnrEOzYWwwDQBP9Q53CSxxJQAAAABJ\nRU5ErkJggg==\n",
-       "prompt_number": 32,
-       "text": [
-        "-1"
-       ]
-      }
-     ],
-     "prompt_number": 32
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def fib(n):\n",
-      "    \"\"\"\n",
-      "    Uses series expansion and a generating function to compute the nth Fibonnicci number.\n",
-      "\n",
-      "    >>> fib(0)\n",
-      "    0\n",
-      "    >>> fib(4)\n",
-      "    3\n",
-      "    >>> fib(9)\n",
-      "    34\n",
-      "    \"\"\"\n"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 33
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "fib(0)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 34
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "fib(4)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 35
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "fib(9)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 36
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Note: if you really want to compute Fibonicci numbers, there is a function in SymPy called `fibonicci` that can do this far more efficiently."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "[fibonacci(i) for i in range(10)]"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\begin{bmatrix}0, & 1, & 1, & 2, & 3, & 5, & 8, & 13, & 21, & 34\\end{bmatrix}$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAYAAAAAZBAMAAADK9+SzAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAu90iEJl2MkTNq1SJ\nZu8+uZRyAAADV0lEQVRYCe1YPWhTURg9zXtJk7wmleIgODTWQSgFA1KEgvBcHKS0WVKotRoEBYva\nLA5KoQE3lyrooC4BwSGDZnFxaRRE1EAD6iz+gG4VjWK19Xnffa/p+77vDaEKkuIlP/eefOd857x7\n01eCvoEsOnbEB4aQ6Vj32vjIlghgTpws8n3osjmC7RwZntzBoO76wyqFEi+N5xTBaH2KIXC1JRde\nA2llrr7TVbionnoHIiVzD5M0+22G4GCTIUYZs8zuMOLfaFXacWoUQQ7RBoNcbcn1GkgrRg4LBaWw\nSz11gBPAaapoVu7ZFMHhCg+QtBH5RKuWqvhMkcSRJxRAqgEzQzGtLbm6QYiVnp/oVQqxN0pFBxgE\nFrJUErM2AxDjAdLvkfxOqxZFgCQtUKuesgigtSXXbyCsWF6AA1eVmg7wFZhnZ6GdAIkmoiwAxBGS\nAawfdk+BxfIuDj9+fgMRQJHdI1RbD2CsqgBcUrLEDiidCN8VJMoKDozkqZlSYOlO+9fOMMTfXc5V\nVW4DaQW4CaSyJECNaUpWWIB5TptTymR02Sbfpaizm5SohdYWXPWB20Ba6X5aBg7hLwRwJeiIfaRr\ntbrLkFcXHH5gvYsTwnUbyADAuRJqNECBdZGskB2IbmMstVy2ObZUJEgqh9f85PnagqsbSCtAumkV\nWwHgfokbpElY7JAAM4yE/eqEU6U+YKlEytI2jDWCeEdIcgHdQAQwiuhaG8VGgEFgMcskBUv+GYWV\nwz5CMx2bB3gLHKfaY4oyQWg6QAjXbyCsjDdVgAeVyq87GzeyRzCppstSj8Bwd4AWnQde0KIVYG+W\nFOWAG5SWVnluU5q+OJIL3UB/B4iV3iuIfFHOWjeySNX8gPFMwKw+Qia9qboBSJExVH+coUVnEV+l\nRcOw3lHEugarRmk6gOTqBiFWYg0s1IIBzKMzRYy5mVojv3y9YS4H9z56bGWaFkUcx8nQIis/WaVF\n3flKliK4nJ8CpWltydUNIK3gfv6WcvrMmfaPkGf7Usv9+iQeDPBHRW1p6w6yUsMhVjxD+l8Jb9rw\n3gKvqcDcn26yqC2abiErNRxixXO0hQLE/GsceCsE5t50k0Vt0XSHkEqNF7z+8jWwA/LDTkD+B/jX\nuzSCgc7+XWjwN9UKBtQPwW28AAAAAElFTkSuQmCC\n",
-       "prompt_number": 37,
-       "text": [
-        "[0, 1, 1, 2, 3, 5, 8, 13, 21, 34]"
-       ]
-      }
-     ],
-     "prompt_number": 37
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "`series` is nice if you want a fixed power series, but what if you don't know ahead of time how many terms you want? For that, there is the `lseries` method, which returns a generator of series terms.  This is more efficient than recomputing the whole series again if you determine you need more terms. Here is an example usage (**Warning**: since series are in general infinite, `lseries` will return an infinite generator. Here we use `zip` to limit the number of terms)."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "for term, _ in zip(cos(x).lseries(x, 0), range(10)):\n",
-      "    display(term)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$1$$"
-       ],
-       "metadata": {},
-       "output_type": "display_data",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAAgAAAAPBAMAAAArJJMAAAAAHlBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAACGjDitAAAACXRSTlMAuxCrdpnvzWYiHG0BAAAAI0lEQVQIHWNgYBBiYGBQ\nnMTAoGwMJBhYSCVYw6ZHAPUxMAAAQGkI1Fjz0FgAAAAASUVORK5CYII=\n",
-       "text": [
-        "1"
-       ]
-      },
-      {
-       "latex": [
-        "$$- \\frac{x^{2}}{2}$$"
-       ],
-       "metadata": {},
-       "output_type": "display_data",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAACcAAAAvBAMAAACS3s5rAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIs3dRIl2q1SZEGbv\nMrsbSYq4AAAA5ElEQVQoFWNgQAWs86pQBUC8WQyTMAUNGeQvYIieYFjvgCHIwNC/AIugKhYx1gIs\ngluxiLEE8GLafq+jfQGSWsawwrZpDOf//0cSY1jKsHnDYWQBEDuAIZ+hF11wAUMduhCIfwyLIONf\nBi504Y1sHxiy0AQ5fvMdYExAE+R6FhWajSY26LlCxiBgwsD/Hw4+DIyjGWfqOWDYLM7A9gNDEJiy\n7TEEzyxgqMfQr7+AYT6GIFCr/QIggQZ4v6IJgLhMD7AIzsMixoYtwXcyMAqgq+WdwMCNISgcGjoZ\nXSGD/f//n0GCAFRmOfCpSmWyAAAAAElFTkSuQmCC\n",
-       "text": [
-        "  2 \n",
-        "-x  \n",
-        "\u2500\u2500\u2500\u2500\n",
-        " 2  "
-       ]
-      },
-      {
-       "latex": [
-        "$$\\frac{x^{4}}{24}$$"
-       ],
-       "metadata": {},
-       "output_type": "display_data",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAABYAAAAwBAMAAADnb5cjAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIol2q1SZEGbd7zK7\nzUTvhYErAAAA80lEQVQoFWNggAJeGANIxxfAOez6CDZzPYK9FYmtgGBzCCDYxQwIdlhafgbcTAZ5\nkDlCJqJmBgwc/q4MDOwKHDO4JkDkmRiYP7BugLDZGVgOQFggkssAwZbfwAAyAwg4BOwZmKHs+IZT\nDMIQYYYaoyLlBiib1tR/BKDMKrHccyADtgAxowODfQCQngPELAUMnB8YGJjXANlcyxlY/jEwSNwB\nsnm/M7AB2QogNhBwfgeGBpS9X4GhmAHKBlIKUDbbAQZg4ELETRgYihggbNYEBsEQF5dfzkBTtjEw\nNAIpkF2Mk5TUJkDZnEA/Atkq/5HiESgFAEGkQFKV6+ITAAAAAElFTkSuQmCC\n",
-       "text": [
-        " 4\n",
-        "x \n",
-        "\u2500\u2500\n",
-        "24"
-       ]
-      },
-      {
-       "latex": [
-        "$$- \\frac{x^{6}}{720}$$"
-       ],
-       "metadata": {},
-       "output_type": "display_data",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAADEAAAAvBAMAAAC4bj/EAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIs3dRIl2q1SZEGbv\nMrsbSYq4AAABXklEQVQ4EdWSvUrDUBTH//1Ky21Dg+LHFl/AD1BwEGneoAGJoCAERUonO7uYSXBK\nQSq62Dg4uNSuTr6AQsAHaB/AIaCVOsVzK8WkOe76H+495/87595zSYCE7ra7Ce/bWFQDnuSawuRJ\nyeF9QD+tazzrmeoKT3QDQ56UfXzwJO3gnSeFRjZ5z0xtvm7jYceb7BFmcaOUrKeyHJSg4E/Wy1wg\n36eNVclmbTJ1Hx7HitoRFJa43VfMci3oHN7++jnZhv9lTq1KraEcxhX8pWe8tCzLTF0tGRAX9dh/\n8khTN+agDJExxGZ05l0gj2OgggNgP0pMYA9PHk6MdaCqRRGyNpY9tI1PoOfESGeUVW4GROwYuZSZ\nOkhJQmf/SAQyTveTRFmQ5BojYst4rEyDIoUWOUF37Mr9vknLGVIaTe1qUVIlojZR1OilW1EAl8i0\nZZ0j44jnGJFnV8LwDaJV84EvR7hiRhgZDXAAAAAASUVORK5CYII=\n",
-       "text": [
-        "  6 \n",
-        "-x  \n",
-        "\u2500\u2500\u2500\u2500\n",
-        "720 "
-       ]
-      },
-      {
-       "latex": [
-        "$$\\frac{x^{8}}{40320}$$"
-       ],
-       "metadata": {},
-       "output_type": "display_data",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAADQAAAAwBAMAAACsx0TOAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIol2q1SZEGbd7zK7\nzUTvhYErAAABnklEQVQ4Ed2TvUvDQBiHf2ka2/TDKoiIizEVnYRKBcWlFbuIDoLi4lIRP0CEUqGg\nCLajWxCcFBUcRHAIIq4WRNykgm4F/Q/6ITVFofUubUqOprt4Q/g973N5cy9cAGY5g8sMm2AEeyZi\n4hO8DJtgWu0yERN7v9YZNgH/fmwiJq66z2JMoQGODLzJBjGBS4NvofACe3NDzj85v4KE3M+00SGO\ng+RVc5lWJISwZK1imLUWtHrRUnE/cFjLFJ/HmKUSyp5zLmCpHA9D8ril+X/Fasv1h2a9BRLBTeBG\nfgS6t57rSE94ApxiR+WiyAW4MEJzOlLDX4NXwGdsJfgUcnnFvI5U9WQhhtFeEKhyXcJe0ZEqKQtf\nFO4SibmAV0NbxUBnRxZ9EtyfRL3SraJm4DZqqgj3cJiqe4mqIklSQwETH6Rg7ISg1jNt6NKAtrTR\nP0630e+WORWeMjCKGgILkcj3FDmtUNjXqBKi6NSRNAH0kW2KLwOxgDsgRUa2KXWFI+yq5AfPSdyh\nPKjoSNVAdQMJ/wywuPYGkdwHpYb6a9aPX900isnj4kp0AAAAAElFTkSuQmCC\n",
-       "text": [
-        "   8 \n",
-        "  x  \n",
-        "\u2500\u2500\u2500\u2500\u2500\n",
-        "40320"
-       ]
-      },
-      {
-       "latex": [
-        "$$- \\frac{x^{10}}{3628800}$$"
-       ],
-       "metadata": {},
-       "output_type": "display_data",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAFoAAAAvBAMAAACRacBDAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIs3dRIl2q1SZEGbv\nMrsbSYq4AAACSElEQVRIDe2UMWgTURjHf9ckR3pJmqCIOIjiIojYiAUFCcnWTQOSDII2KKnUDqZ0\nE9SDgOAgCUpTI6gH0qHS4cTJKYLiosUgKLioILhqG1JrQznfvTb0BZKrXYqD3/C/7/v+v7z73ntH\noHd8hkC23NvvcD5NQp7hjp5HUYQEUcuDUK0ixgo+U2155EUigs55EKpVxL8lemtrGwuETfV1Hrk4\nk3miMQ9CtQSd55Ta6Zpr2YmbFXYNVtBH73cl1OYMz+yXasMzT3OF256EalpcV8tN89ebEgqgrWIo\npXf6VP/JZW9kww22Bl5ouY3aOzO+n82MeyP/3e05gR3H3Bgi6vxFbM9I/85bIpnzJsxMnUOrHkmJ\nLHNvXWZHH4BRGasrw+7Bv4SWYJLd6MtQpt9ekyEe1/GljIRCj5g08KU5wFVIErIx4lL0OPp+LsIF\nhS65dM0SnbcWN1KBgqCl+Ar4FzgOpzv+EsUkh92fD1o8SgV/WYGclGiZyDK/4Yvpuu3oK7D4ccx0\ny6TFj1YeKfvSRJa0pqBzrrUeHw5iNGxOijIivH7n6Jq4dFPS6TbqPvVXhgMjFvR9hefvHVNKD5p3\nTxpQM+EhhMrUVqR0nWSvmNJeFHQOvQBhC60lxd1lS+7SFgOsheGIjdnf5Nq30GJzol2RIk4wKE+w\npJygWDYZK7lzR8qEYmFhTUgRtxOIu7dzpr2yeI7jbzKQNt6wM5O5S/AQwbQUTjAnbt405hU6WL1j\nwvR0iqTjiN0OV8VXJWU2e018VVOX6vwBf37U8ArfDb0AAAAASUVORK5CYII=\n",
-       "text": [
-        "   10  \n",
-        " -x    \n",
-        "\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n",
-        "3628800"
-       ]
-      },
-      {
-       "latex": [
-        "$$\\frac{x^{12}}{479001600}$$"
-       ],
-       "metadata": {},
-       "output_type": "display_data",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAF4AAAAwBAMAAABqAtB3AAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIol2q1SZEGbd7zK7\nzUTvhYErAAACYUlEQVRIDe2Wz2vTYBjHv0lM0jbdFhRBvDR0QxARgxsFD8OBBZFdclCvldrDUA9l\njoEyWP8De/DHYCK7CII7BObNgz0ooqeCF5EJRf8At86tm7LV53mSg/A20F6GB19IoJ/vJ2/e93nz\nvhTo3ZwGcOpttXeoUqdSh1W1mmqSQMw60q72OyFVMfmZwD5QgwRCPmB2ElIViz/kqUECEX8sIeyB\n2U95PYIExP43vE5IVUy+8+7aZTVQyNGJ4wVfO7vjZ7rdDSVVgO2lljJczD6bDmPDDPuUSbNxpNG/\nzWbGH8zPhaj2/0TKvQhjAL9U+4hj/XePhfOzo7UB/P/q4VagO1g73MH9G297BedxPp/HXHkamB+/\nTZv4ZoG3/Hu6ZstnYigJj/gpUlTUn9pznHTxDPdCpFv2MrBAx7O2jCuIoCSkG6vQaQNOZVfoaDDq\nMJq4AExirkh+2sNXCIwS8k+sQwf0cKQJvZOewvAmHgI/XBjkP+CtLDBK6Je3Tjd8x2IDxsHIDTjb\n2AHeBOJ/4UxglNCp7bJvN8D97+Y8OFtam3xf/P21QgCBciPzLti3AlgryG4xbYvvsW/v1bAkflsS\nMj3xF+kVn3Fd8bvAuaqosU9nK/c/SVdqfG2b6V/jsfdoyoFAudF6QHyqCDW9w7PalfnWovGT7wuM\nElwtFn9dgk0VoTbUpKqZUs9SVM8P3L/AKGFrFRgm39hErkWrotd5vU4ToPqXePwCoyT2Tfaf4BPw\nCPfpewjsl5Gf9ewXMZSE/LHuDI+Z/o/cCejTGp2mUpUnQli39meASqUVQ0m4/0HaH8rI7cFFVzeG\nAAAAAElFTkSuQmCC\n",
-       "text": [
-        "    12   \n",
-        "   x     \n",
-        "\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n",
-        "479001600"
-       ]
-      },
-      {
-       "latex": [
-        "$$- \\frac{x^{14}}{87178291200}$$"
-       ],
-       "metadata": {},
-       "output_type": "display_data",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAIUAAAAwBAMAAADN86TJAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIs3dRIl2q1SZEGbv\nMrsbSYq4AAACqklEQVRIDe2VTWgTQRTH/5t0t5vdrEbFLxAi3vRQI1ZUPDQnBU9B2IqnBqUWD9J4\nqgqaXHtqUFBDqxmUKoXSrhfBk3gVweBJT+bgQaTQD1v7BY3vzSRpQCOhU0/1wb7973/e/DIzL5sA\nrYRXpqpQK5VNa7yHCRobEk0LWhmwieH06DOsSX3Gp01gpPQZbkyf8Rz6jMFCcbiVFjat4d4ivtG+\n7O7bdy1tXFhOw83ebPoZfx1wUu6ZKC9CI0xYM3ZJA0BTHbSX6aYZ0bQmgKbHSxB6FDfWD0uTMRRM\nYY/eMjDRO9odaDL+T9/qJ7DzOEcnUNlozGz1I/zH+x/1H8E77fs+sE1UFXswCh1JOLcu8m/zd7r2\n3/sKjF19XE2Ny8ojErjU4EU40wJKsYe9sJZwIGe8BSZWCJlBfw6deFZSqYHhBnASpgAyzkBWQCrp\n4TbQhSngLl4MEKNdIDxjJWAdlAkNYWaYAZi05H5isJIe3gtkk3NAj4BFjOg7tM+HM2iblakBAXtR\nmGkyztJFDKmUd1SgeH6N3KRkhFYQmd+eh7ckE1fWY3q1l7RTpiQZrJRHexG8jkAyaDy8Ek/B+ykT\nPa5HpHKMHiI5SpLBSnnwFjBCwHSN8SXF0xdkovL1eP2xkgMm2ZAMVspDqIyngV2sMzrwZ4abxxs6\nsct1BqmqhydkvrpOHeUzpdWVJeP3vUQFjFXgZJ1BqupZGTZrfQH6AD7OVZnkUDWN0/0BnGV+5L2w\nUh4GYcTIPQS1DjuPHdRWm3trz3J9LaJUdgNtdQYr5Xl50P9uzJivMj4DL+nrZSZkqs3nu30Edgp2\nncFKebt8/z6uiFBaMYwT/qUETmG8pFIj5FyB3i+PjgSFD4cDpaTXVan8gFn4Roc5MjeMML1TCYx1\n36F3jtOmxC8/qCMkO/cynAAAAABJRU5ErkJggg==\n",
-       "text": [
-        "     14    \n",
-        "   -x      \n",
-        "\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n",
-        "87178291200"
-       ]
-      },
-      {
-       "latex": [
-        "$$\\frac{x^{16}}{20922789888000}$$"
-       ],
-       "metadata": {},
-       "output_type": "display_data",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAJIAAAAvBAMAAAD6AY4WAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIol2q1SZEGbd7zK7\nzUTvhYErAAADFElEQVRIDe2XTWgTURSFv2Q6mfz0Z/wF3XRIpSIiBC0FF2Lc2EUXDgrdSUOrRbFi\nLCJUBCNCcWcURUGwdSEF3QQEwYU0axdacKFgoVm4b2utqZvG++4ku2IDE3ChD3oy99x7zrzcuWle\noImVKsP1nkITlVuUpM4V4WtqeYuyZtJ2kWjO8Zop3aJGnJL+FjXNpcWp+0y/21zxH6vEac5LSbNC\nL7OnCmuhfUCcukqstsapw2ejNU52tjNcn7b37erPRA79zDDVmw+zJ8eLP0mG20v99lGsZbsUZi8N\nrUNbuXEd9jWZCevQ0HeXCNXphk/cPY7VEqfhwnt2NGxDvd48PNGKf5Wh9vBf/I92oNaq9Y/276++\n7d2XP8g568gluDYyCBpGxhYqvB1Jpz0n3evXMxPp86CgpDPaX6oLVU0ky3GfZ0yWIi/Y6wbhTqw1\n7sl8ZGNwAc2QI1YIQMlExXmKCgOgLU9i2SpizbfPyDeJhgzANPuhjbswiWbiBZyiQkAehWOoUAGS\ns7RtJLJ0rnTNE61qyMs8pyoeHGSfcdJMNCtOCgH5EJZcFSpAR5XYRleO1NqtMtaGhizmuVKBzgzD\nA/SgGftHPppRCMifMOerUAGzEtVuj9SqufO6hoaclq+Um9Beu+Ppntb5uH6YAAwZ+S5OGRUqGI2c\n18z199gM7eaMNOcJpKQQeVZc+eUSZGK1+6BgSHUKhKqWUlhAr50vDBmnBcN1lMFZhvilxTWCzNS7\nmo+CITdzipXVaZX4kddyApRQ1rj8WfMwRbyW10w8x72qgpJXN3l3fWB6ZloUrYKEYpIVkGfCLHQX\n5Fqeap7IukJAmo4XVNhQ2zm2icZekfqOeUwIQ0RcbuVwZmSTGc3cEBxVCEiZgmEzBfZKQ/0Gbsts\nRYvWijnhmpBUjrjLUg6ey3i6mkm6cEIhIGUyD5jJFKEBiDxI9xZ5xI2S9ZhP9XBPOn1RbilOZ/Oc\nRjP2Z2xPISATvvMKFQZAQj5dRfmlNAi94349nK7Vfpk2yHCeHPODDN/GZCoUlHRG+krmJ5YIFX4D\n1xNlQbFLfTUAAAAASUVORK5CYII=\n",
-       "text": [
-        "      16      \n",
-        "     x        \n",
-        "\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n",
-        "20922789888000"
-       ]
-      },
-      {
-       "latex": [
-        "$$- \\frac{x^{18}}{6402373705728000}$$"
-       ],
-       "metadata": {},
-       "output_type": "display_data",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAALkAAAAwBAMAAAC/PMZ/AAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIs3dRIl2q1SZEGbv\nMrsbSYq4AAADeUlEQVRYCe2X34sbVRTHP/k1+TGb3dFStYo2b1qK6YAtCEU3/8GGwmxZQQ2CW0qF\nrlBbWpAGQaQgbKiUGkrtYKlQKE18KYgPruBTkW6gFOlT90FBRDDrtksaK/HccxMzT6WFnYfC3oeT\nc+73nM+dOXNvMoHHHsUVuHbQe+y6RyoonvVxvIIsEcvI+UyGlGJhg9CzbyQW4qMnlpthfHTeW+vE\nR8/Xb/bjo38NO+OjvwSH4qMnPU5sOH3rgecO1hL77tcKZ4INP6uFqrt3wt/wax4CMzjdXFw7kQLZ\nleFCsXxM1GLBDqHbO4Rx8V3vME5s9MX2nzwT16Vz9f1Ls+3Y6JvgzQ488R14+jUzdsNg40f3ie/O\n5g08vAOFucD8JP8Cl+fPw7bTv8Kt4He4eSYIqsXgnbr1rLwz3DqME81yhUIwVx8WarWa6HpbOllf\n4jdhNxc78gp9uJ5oMFPjB9mrC9tIr1tPZZYH97Dxszg98nDOFlrZIKJw9pAsgXMDR/5clLIhqW6m\nx5TPW5Dl3Tpr1lOZHR9JtSryVjbN93DRFqpscyJ4t6/BC2VSC6RXJ66TvZtTehXeZtHQ1VOZBZOt\n8c8hJyv7DV2VsYnASS5pVC0z1aDYS/bJ35UZ6Qyk1axbT2VLV2VXyIXK4glmbaHKNkfyR2Pq1fkv\nwfXKbK9SNKSUuZuXjX7VmKS5XPGsfHT+iJlUhelwcnCtahWVRwiToqO1l1Sbb7B0eWTckVX2aQdk\nWW7pOuKZynv8Qasis0YxIRfWPKuobHOMNhytLpm+dHJMLxvlgwoUusZzfrLeqDK7NFKSK7jnd/Ue\nSvdxe/IS+n9n8iuGOSHtcUrGYzlUz9BN4zL/jpSv4DvcQajK2GjR0EyVcNcvIXTzSP6BA5DoMCme\nbANehL/a6qk86ZORh24UHDHXpWNtVcYmSpd8t/fZsWMPjkpJbpVcg6dafaW3GhQGoaGLZ4i5VXmP\nz6+iMadIPL8E+ZoqYxOl57TvoKcp43MbvpX7SQljRph/y5nx1JOTkvHlbJqzZ5RiQ3baj3LiPFXG\nJkrnN660ZeIGvM6VTmJPMOc7bWaqsCiMQ6RlZxjPyg0+92y8JQi+4JOQT62isjVRfP642cH7B+e4\nPPsxKfly8TnVfEXm7rTl/3vzdN16KnP77IdDZXowWCN9vCmyKYwYSYhz/AcfkpFQNTd5DQAAAABJ\nRU5ErkJggg==\n",
-       "text": [
-        "       18       \n",
-        "     -x         \n",
-        "\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n",
-        "6402373705728000"
-       ]
-      }
-     ],
-     "prompt_number": 38
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Write a function that computes the number of terms of a series expansion of a given function are needed to compute the given value near the given point within the given accuracy. For example, in the expansion of cos(x) near $\\pi$, suppode we wish to compute $\\pi + 1$. Let us see if terms up to $O(x^6)$ are sufficient (remember that due to a limitation in SymPy, when computing the series away from 0 with `series`, we have to use a shift)"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "a = cos(x).series(x, pi, 5).removeO().subs(x, x - pi).evalf(subs={x: pi + 1})\n",
-      "a"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$-0.541666666666667$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAALoAAAAPBAMAAAChJ8gEAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIs3dRBCZdjKrVIlm\n77sGqe+vAAACHElEQVQ4Ea2UMWhTQRjHf8nz2qZJ06Lg4BScXISCDhU7ZHFuFgeRmk5KGsVgoaWD\nEHBwtFARMkjfUuiWgChihkbBOYqLgsMDcXIpqa2gw/O7u753Z3ijH+R39/5/7v8u310CJ6XurLf1\nNP8+90aGqS3Bd/ncbL4G9arf9mBF44zZznnU7Pd7st5WUFULejYTx1oMIrh1BLkFtuFMuzDvwYgO\nmc4wjmO9Q1tr8EDP8g3ZKzyMuNGR9KDHebhKvuLBiA6Zzkso6CBbV2BpTqZWyr2LYFLShzXRSjLx\nYEXjjNmeIw0w25SVUsfwJJTRphfzkU2/KBL5D/8AIzo423PgVEuvNZX7I+n6sbCxWYW3Sfro8XrI\n7IWNVQ8Y0cHZniPHZpM1Tbp8G8o19RPVOklXhwMWqS8SDByM6ODZngirGekiPadIkh7Dfq1+QPHI\nQWnxegrPdk4NdSBRpy/pupx2RqT99l6afigHG9bnKf12UFrcTeHZzgmZrEhUUvpUB/LwTdKv9ZJ0\nRhLUmq1Q+uVgReOM2Z5DsJVEyyg3sjsn4ye4f67T2fnSMjdSXjYMy3rvDnoHw9Ah06G+4qWvwQsU\niCY/H2YieyO7uu/Tuu8OGNEh02FJktIKQvUZ6e1Zpj+KmKSXe+or/GB54MGIDpkO3ZU0W/6omptt\nliOmbnekQcWd48HEvdFdaDSqMPHsqQ8rGmfM9hxzit4L/v/0L9iNQMEYAVEuAAAAAElFTkSuQmCC\n",
-       "prompt_number": 39,
-       "text": [
-        "-0.541666666666667"
-       ]
-      }
-     ],
-     "prompt_number": 39
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "b = cos(pi + 1).evalf()\n",
-      "b"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$-0.54030230586814$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAK8AAAAPBAMAAABgoIKoAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIs3dRBCZdjKrVIlm\n77sGqe+vAAACyklEQVQ4Ea1Uz2vUYBB9SZr9kex2V8UiXiyCYD1IxB7UCu7Fg6cuCILIuksPW60W\nFwVL0WLw4KWHriDiHkpzEm8NFqq4YKOgVxUV9GRAvejBtnZbrAtxZr40f4FzSN7MvPfyZfJ9AeIw\nR6+7DPVX2jO6ZZqQSqb93APOTFwA+ka+AdPtH1AdRTzXHqN8se1CEPCdTUidhFEyj3CSjyKfbkYI\nqfShZwMYxGlXa+KWp9Uw3FAdRawhFWCHm3UgCOc7JGZ1EteAq5zoF5/ybSqEVJY8/EbaQbo/W4ax\nbG+i4KiOEHMBTAdD0PsVOtsSY1IncRQYLlKWlYr2MoRU5tnYaKJnJf8R2TVLjKUjRJsm5uTYTBCQ\nZszqJNaBGY8yZWzrIeIKjaJQQ2ZT7yC1RgQahXSEaP0p2w39LZUFxcas3grtLxk3KMtOTJaAF3q4\nVdGb2OMjQ5OGwcsZgOoo4q/uDRT2T4wBjGJjUhNUIWT+ar1lcw1mIzb2MT0AMaYHY4Ye8LipjH0h\nIhUdQvU4jECQMma1cqVrYkx4FjYSY6Q/JMYHmT5VSrizwOvbkVddht0RpIxZDWw/zDGoXo+FwJL7\naMuYh/OlHI8iFXI330m4S26uhjedqoPcpiBlzGpmquAPEhD8SsYnfW5JZRcNL+CP1wUm6cVc9HZV\nh4mlfBlat9CP3IYgMTZFHduCN9d8kbL3wJXdrdbc5wZXdkZlMqbtZq3AqmFbtcPGwmVisUKK0V5e\nsSAxtkSdGNNxWIAJOkDYS8W8HJAFrAIninRAbAd3aLPQ4owVPiALipintdy1eMaC1ChEnRgbnvkJ\nNK0+WO+UsVRuoof2wzFUXG2oveikAwz7kI4QrX2wfPxEJVBIHRBeVhLmpUkXlRCZeotWYc+tB1Kx\n6iMe/YSePIARRZGDh/UD9NNhriKeqtMWTt2/Byg0vnpZqRPj/w3+AWrzIIzvy1iMAAAAAElFTkSu\nQmCC\n",
-       "prompt_number": 40,
-       "text": [
-        "-0.540302305868140"
-       ]
-      }
-     ],
-     "prompt_number": 40
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "So the expansion is accurate up to two places after the decimal point, i.e., within `0.01`. "
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "abs(a - b) < 0.01"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 41,
-       "text": [
-        "True"
-       ]
-      }
-     ],
-     "prompt_number": 41
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Note, with `lseries`, we do not need to worry about shifts"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "for term, _ in zip(cos(x).lseries(x, pi), range(10)):\n",
-      "    display(term)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$-1$$"
-       ],
-       "metadata": {},
-       "output_type": "display_data",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAABgAAAAPBAMAAAAMihLoAAAAJ1BMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAilU6eAAAADHRSTlMAIs3dRLsQq3aZ72YDTSHvAAAALklE\nQVQIHWNggIMwOIuBIfUYgpNejsRh4CCTI2QMAiYMZBsAcxDnrEOzYWwwDQBP9Q53CSxxJQAAAABJ\nRU5ErkJggg==\n",
-       "text": [
-        "-1"
-       ]
-      },
-      {
-       "latex": [
-        "$$\\frac{1}{2} \\left(x - \\pi\\right)^{2}$$"
-       ],
-       "metadata": {},
-       "output_type": "display_data",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAFoAAAAqBAMAAADBpFHwAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAuxCrdpnvzWYiRFTd\nMollB7CEAAABv0lEQVQ4Ed2TPUjDQBiG36ZNamy0gg5iB7O5+Tt1suiioNRBcfIHcVLBHxDEqZsU\nHAoi6uakgyIOgoMIziIiiKM0qF2l6CKCxO+S0MvFKpfVG+7e78lzafL1AiBiQn4orSFspac3hA1k\n/7ldamQvKPmWqqkuydtGQf+St7VT5VPeBhJvYey4BYwtruZoD1CbcZZqU80+o8/+S/f+IpAnqK6x\n/HDFXwRynOoTPHIay/D8I9F961IX3ZxrJs8/kjINzbbLnB/yWCWlAmySav0lfTYq8inbtt+Bkkix\nRnU7NnMLAleHz3bzBeBcoMAc1RayuBT4EQZjJOPApfRD7uOzQ2Ciy6E7N2xcO7khypaik/nEbGCW\nAzfpnQYLQXueQTqUClv5UHNJVnhPUuHNlPKxMvoqxAkdZvKOwoZIWY8SH5FpPSPyISQtIsEOHgNK\n09PrgChTYyMjhNY9vD3e4iSNNeq3Qf+8M/ROZE9ZEg+ke7Ey12fcGDVhlJ3414lt8/ZpM4i6rd7y\nSLUl7cH4G1TXDnbDtyt2xwuDfcvSo2hJqyQuh5HVhjB2fxg5MYI9ef+Bjp60rd++lq6kbYM+NGn7\nG0/gY7SgevO+AAAAAElFTkSuQmCC\n",
-       "text": [
-        "       2\n",
-        "(x - \u03c0) \n",
-        "\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n",
-        "   2    "
-       ]
-      },
-      {
-       "latex": [
-        "$$- \\frac{1}{24} \\left(x - \\pi\\right)^{4}$$"
-       ],
-       "metadata": {},
-       "output_type": "display_data",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAHcAAAArBAMAAACwWwo1AAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIs3dRLsQq3aZ72ZU\nMonLrI/bAAACDklEQVRIDe2VP0gbYRjGn8ufSy5eTNpJyXJLJ5dA7VoyOjg4lNIxS6l00DhIOiqC\nFkQMnWodjBRDx4QWupVMrUshW+nUmzQuIiIRWyS+X87c3ftqNLmsfYfkfX7v85Av33dfArB6ztRg\n4mVrML/f/ao4RBjx/2H/Zt7sLYEG2TBTbu4g4blhwqtDhJPfhwiP6iJsfDjddrdwyu1uNF+I1GTY\n70oW/Ir3RgP60l3hUJ4HmLJgbm1dVBnzi7d+IftvBDTxnf2eil/I/jWBr+d1ibs6YnW7296j9duo\nywybFtZc2H/vkk6z0263z4HREsdChWg35vC5+pFxY2M/U0sDpsWwFIkcYGMTP9lgGstxyiJSdvDD\nx6omAVrQdZ3QJJUD8ljseFwLqZmYQkll6V0qDHySBq0QVuiecKJOHu0SuvJ6ZVRTSnSX7Q1YF63S\n4xs/wSqjmM+nGkRGLI6FosMw/0XL2hLnK0jZRO45qkgW+ouD43WexQSiJUKhHL2wGn/3TOlfDtxl\nMyHU48lKK2CzTuSJQ9Wz37OachLLI0zHF99zBnddSd2S4UQFsTMg88gZ0EJ6ViwtR6EWDArb12GM\nSYOnN7zW68ItjKS7YQ/31/2xMYugYcrZQcPGDMxG0PCauv8Bw2YJD34Ui3/f9LdB3PWb7hGRPU77\nU9rT46Ns0HCYfoQofNj2/q76+9SArisQh4Bog/FyCAAAAABJRU5ErkJggg==\n",
-       "text": [
-        "        4 \n",
-        "-(x - \u03c0)  \n",
-        "\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n",
-        "    24    "
-       ]
-      },
-      {
-       "latex": [
-        "$$\\frac{1}{720} \\left(x - \\pi\\right)^{6}$$"
-       ],
-       "metadata": {},
-       "output_type": "display_data",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAG8AAAAqBAMAAABPfhiMAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAuxCrdpnvzWYy3YlE\nVCLumKMEAAACRUlEQVRIDe2UP4jTUBzHv0mbpknzp4OjYJa7QYeLOLnooQU9B1tEETnQ43AS/DcI\nLkLmU44sLi4XEBc9IUhvytLhJkEIeIvbDYpOWu4U7rie9ffy2qYpSa/p7I+S93vf3++Tvvf7vReA\nm2D1nJyDeGI6UDxzfjoQqP8Hk00SFy8PhFzFkd216cANnJoOvD/A8vXROKzdHqB59qgc4FUfvPHw\nidP3adwc8kfcF4DRgRmOyHyq2KlyJEousA9zPjVDtlJlLj4CnsFspWbUUtWe+Bz4jI/pGcvpMldn\ngfLitdQMjVaTbUKYGZN8qlzz3Nb1ZMadbre7C1QaSXloJjugM7Xi3BvSAGlh68fqNqBnr6fUAnzU\n8SUBfsLVInHQlrhM/58wUlmtLZyO4t/fMluP/GqBDUo7mqQ9eJPujoYMW2XSGLAUUtzYh5hEJcdk\nQn+pyWA0ExxgtdjGhWRszjJdUsrZxaGC63vCkjGfBK/A9EkZ0w7Ng3jsQxB/V/gLnkJokCe3+FR5\nEwQBvt08DszUbnHtAR/Sn3TkIitTM3YNG/UQ6zjJNgHQOc62Zi9UsQC7YEFtFz0U+cbHXSuRp9Be\n6eeWllHoqDa0v9HraAGZVtiOQ5uQdyB1zAaUQ65+jYOj3kIsiFXmqzu/fCi/Y/loTwpZzprPwIOj\n0+OMuch9jNzgJQZK1QjMtdTXDLxIt4mKs8f8CU38Q4l6Az+pHTpvx2SkxsCX7D54qHiTMVGWTqDx\nLtjw8B6zbg6Q7UulA+thpnl2cu4fXiCRCxxGVLkAAAAASUVORK5CYII=\n",
-       "text": [
-        "       6\n",
-        "(x - \u03c0) \n",
-        "\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n",
-        "  720   "
-       ]
-      },
-      {
-       "latex": [
-        "$$- \\frac{1}{40320} \\left(x - \\pi\\right)^{8}$$"
-       ],
-       "metadata": {},
-       "output_type": "display_data",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAJUAAAArBAMAAACDTNd5AAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIs3dRLsQq3aZ72Yy\niVR4peFTAAACwUlEQVRIDe2UPWgTYRjH//eRyyVN0tTBWhGMiIiTBxZcqs3o5g0iOvVAHFoQIiJZ\nhCYKNlohsYOk+EFFqQ5CU3UTIauDJiJKHII3OhRatZSUttbnvZiU95I7cjGjz3C8z//5P7+7e7+A\nduEz2qldacpYz1hKcrJnLCD7n+VpQb3PV1/mrsMbvLPSuNgz1lmIPWNdKQ72jLV3/V7PWOrRkfas\n2YUjBXvllF3YyV/T8FFo1NhR3EehhHM9UIQSg9jyeqcO0XCqkB6DoEPtmJVxQeEtcAB+t7dx3fNc\nZksmgPHqR5vomMoxxxIVfKZb1V4LlAGhcvl7ni8EtikSCOd42T1ji3QJrwpPeFv+Q/rNABCJ8bJ7\nFowDZWSxxNlkU42mSZHn6vKuYyyG0c8+t22skLE/Dhi4arUIB60WUmimkKBniFk6DsYCnrf4B6GR\n5o0VNKlF2IRio90H+6TGP9qKDqmvACyqK7jJ15U1bJLSF+Nl94xWPbLhmxNSvE3VsEWKtz0ha1DO\nfalO8yh2ns+TJMbpwQfdBUr+VhGh6mcTGJo5Q0cj86Duecxb+YzOkD0kHVJcGcEQ5BqEBLImhnGh\naNno+DpHpbV0W8cN4Dq+mfjFjr20QvOhxiyjaLT6GwpdXvYQXuo4DpyOLjNWcB7+VSkB+Yflo890\nDH+0pRQWdawDJZM2TA3iGgKr/TmEfteNe1r8TeFOc9QcLIq6QCtcStHCWF8hre0vI1RrGjofKKm/\nrDLeH7baSmXGYhvIa4TRZEF9yroPoVvWUoOVIsyCAQR0i9XFPyplYllzX9gHjNH5m6KrhuZ+g9Ae\nI5JMTj5L0Z5Y3r1tMFYkhwHaE5H6nvBIQ9Daq5/wExiN4h27GTSENa8Yy08syVReYBryFoQT1a8a\nTmKi2A0rPLleUB5OFRGZnTEh0X2tYbxyrRvUv/f8AbPRzoUQwhp7AAAAAElFTkSuQmCC\n",
-       "text": [
-        "        8 \n",
-        "-(x - \u03c0)  \n",
-        "\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n",
-        "  40320   "
-       ]
-      },
-      {
-       "latex": [
-        "$$\\frac{1}{3628800} \\left(x - \\pi\\right)^{10}$$"
-       ],
-       "metadata": {},
-       "output_type": "display_data",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAKAAAAAqBAMAAADGyk2gAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAuxCrdpnvzWYyiVQi\nRN3cr+EFAAADD0lEQVRIDe1VS2gTURQ9mfymmemkiAtRxBGhgptExF2Fwbb+KG3A1k9dWKQbEaXW\nTUWE2YibogERwU0HsRSCSBYVcdWAiC5ECoIuBDOgC60fQmox2pZ434vYeZPfJOnSCzl597xzz7x5\n784MUBYbypjWiO351urd1Tv2rLMhAv8N3ZvccN7sHrZ1AKneCpdr0rDtqI2A1R4vd2zSEIoNLYkK\nLdKCYUzHl3Vd4ZSOj+tqmK1kGDz280T5VYhpNyrSjJTnCWgPK6+wWtmtahPEnywZxjI4V0Plmhp3\n5c40TAmtMJTEipOuOQ4YNaZlixtSH1J3e4yQXkMojUCdWTLQ01tLJRq8FVNXtsWVe0iHSaPe75od\nFLWni8XiIjAtsl6yCRLtwg3zgiAOHp59MZkBHgusp+Q8qSwM4Imgfoe+QIaYN2ssLblu5Ei+Sj8d\nu3nh8+8svvFxh5/9TfFxQ8AMgVF3jRrXGNWEIX8E1F+QRMugGWWE45bF+erZJpqaDOSwX5TE9GiS\nmOsi6yWjxlAKvhHVEMX9iFrENNE27wFp473UIdEPE/AliLrqoO+mqM2l6VQSz45vpV5LnfoL0mBv\nEhyYOpQhqBb06P0LNYGsgVdJv63GMZBGAkGzBNq89BkcmJg9/1UjYqxNRZYRtbGA8Jhfh5aTTUg2\nB/QDB0vA1bVeXzvX/KAwQ5l9rEJn4F+NxMmQAz4A2QwHLn/qKHIPu0Qia4RHiAnnEVxVFvWIwQFL\n1K9pDlzuPl+HR4B1jiMuIXq5h44C0PLYVjgCDupvMuxjYDi0HoZtM3HEPkEzSTtlIVj8Cg7c8AEz\ntDy4CJID87EcImwbLwLX7hTTHFowDOVjNuRlWlgH5ARu5jlww77Gb1lNwleIjkH+AXTTUetQCxz4\noZjsUEzhfuolsTwZ+vgKlQRedpJ+kANrmznWNnOZeh7CPC1OW1H4Ht6m90mIqrs4sJ5+WAKhoF4S\nMJG1sBmdprqQmraVcSgWB2hp6WwJ6nmI84+GrtBx7N0HjT4FNl4PUUdykIa76eXAoJH4A6F8EmVH\ndtj7AAAAAElFTkSuQmCC\n",
-       "text": [
-        "       10\n",
-        "(x - \u03c0)  \n",
-        "\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n",
-        " 3628800 "
-       ]
-      },
-      {
-       "latex": [
-        "$$- \\frac{1}{479001600} \\left(x - \\pi\\right)^{12}$$"
-       ],
-       "metadata": {},
-       "output_type": "display_data",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAMcAAAArBAMAAAA+rYEMAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIs3dRLsQq3aZ72Yy\niVR4peFTAAADZUlEQVRYCe1VXUgUURg96+6Mu+4vPUUSLoFQSbSRFZHEPvpUC0H01kSEJchuSG0P\nQqZQSoISmJZJG2EEha7UazQvkj01EJRBSxM9aBD5U2hlun337pTddpxtfwqCPpiPPee795y597tz\nF8gRB3PUS1E+Nl8KFWuNhvhfMIHzv4l1G8TqP7BdY4C397T42iaoqJU8bgYu45KJrEgVZYI3wDZU\nqaJkNiraZBjRcLasyBRtAkwromQ2KoHJlmxVkXFdnRsQGQHVC0gA9xminsAbE/i8gcdivkslOWby\nIG9ZcUKZImIBBQmRiUPzqAKfL+iwmsBWQCZj7ycVq2E5a7esRjQC67f2YySdthqVs+YIWg2RdKvq\nb9dcGmCbODnVL864nk6nF+hU9Yh0gagsCTThXvKmMN/VNVU5GgB8QYEuFFSEAQ3deCcI7MM5J3nA\nkVih12xnUQvQIvMJUvCHAQWnuNYPGUKRckZ5Znih2MRMgNu/ythidkaVyKRCJy3bV8hMcyVcST8D\nP2/XSjHvXxI1ftQ5g/PizKjiV4lxB0W6QESH1LcoJWyt4vx2+DViSnSEHSHIh56lLooeqIHUQ1RZ\nmJJJPIJndyqVQsNgC3Ci45qRICk0uGnwJeT+TvU7SdQNelYNulZMYwfcdIoXbMNYF0AtjqqZJB9W\nqMF1aIY9LNchQzIBy1t8wtQCziF4SS4mJVAecYbgDPIkx88Sa9ewAe1AGzjJFayuejnIh2Slymp4\nqWGqPwjvvD0GxyxPQLcCPKQHu4D9AYMkaItRWiXKA+YFrZrx9YhG4Pzo74FnmaeMyWZW+ww80Q2S\n4bUsmUeXOe0OMBM5AraSxSoNnk88ZUzmxjt12xKZtBqkuUgu9jiYiUuHKwGJ6y8xPRKm7ZI/JLGH\nm2gGmUvOvK5xkygtpgZvs0zo/+3VEbaSokx8Kjdpozdwd4wv800xdoavhHr/uujtagI3oQNE4Z1n\n7V3kyegJmbSyxicNko/LN03G41/OQCYdirIgHVQfO8K+2YzJATLR6Q2m2RFmZKExRBc0mThnURWm\nT84b4iljMk09UehjfMo+Rm+oUAuATHzMZCc2AnvRqGYS/xglTb4Duy7fNSqFujxPD1AfaPaLXp2u\nwYkWI10Z2ZQE+vrCkAcvqAZZqMkfm/cNx+U5CyYfG4QAAAAASUVORK5CYII=\n",
-       "text": [
-        "        12 \n",
-        "-(x - \u03c0)   \n",
-        "\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n",
-        " 479001600 "
-       ]
-      },
-      {
-       "latex": [
-        "$$\\frac{1}{87178291200} \\left(x - \\pi\\right)^{14}$$"
-       ],
-       "metadata": {},
-       "output_type": "display_data",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAMoAAAArBAMAAADLUwq8AAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAuxCrdpnvzWaJVN0i\nMkS9ILV6AAADrUlEQVRYCe1WTWgTWxT+OvnpJJm0WYm4sPfBQxEXjYobETpQRKRKIxp/kYiLtxB/\nUBBd6SwUXQgGtEhQMAtFXKUgD3y8nw74+56CBRHBjeEpCrqwtoh/0Pidm7bTVDuMSQkKnsWZ757v\n3PPNnXvuZQAfa1E+5ExRRkcTVIwlXU1QAXp/qnxjX/woXyyZ4sJa/RfX8FqS6/qpUFK+Mg2rIE4V\n40IzVMKdzVB53BSVvL9Kdu8Bx3ffgDZ72gSzTIr7Yrr+KtMW8IgHHvwCbWOEKr+iYZX9X9T2AnJM\nqHIpm9vkBetBYdtnlpnXKsB95ZMVgIr6zTe2wzr71obZtSxAKZ+UFz4cMMeXDU5uZuq/3f+tsGun\n5CqVygjQVxute3SI90fevBaV28qzyJqLd066wGUv1BDaA8QQHooP1lR5idVhiuC5F+Xi6rMh1hjl\nWhBK6Wq3/xT7R+NUSB5PNG7cUQWI2lMLWemEhGZKZacUuz8IJU/PIk67DCZ9MY+rA80Gr6lehFXt\n3E7VLjt1vDZa94i9WnJm4caUAj1ozzM0U538Cvhl1YIzzhSVQ2jJMHR4UnhBYQuSvxcKBaBFjSGj\n0FeEld1XhrH09CCTyeDmxrlsqfUrBquOUURduumMN4xnGUQck808AvkvrqIIsAnXEf6IW0VrF2uT\nsdLoLSJRNv6uOqkgF+K0FrM9ynRg9McUkNb/xRrhBLAQi4EBzAIWQTMhhcQQeoCVVadL+N388z0R\nxNKiwjPMD9OreJQFnRaV3xS6yu+AC3wFMtEdCI3iKvDa1U7XuD6p0lS4fFIgPqL00p4xxlo0otJi\nnMERhdz/bxgta6Z1GJFRvOVhK2onqbBs/fiaC8t+TljH+1XERopOqwhqqRzNS8KAkrU44/qJYesD\nVVaLs4UPbpHKX0yOFOm0ika5Ty7HyQ/YAHTY4ypP8lrlvKjot2BOQDv2qFIEOiVbqwgytx35yEdr\nCvOdeM4eV9mHelXMDE4NS+PQtIqgY+xoBawlPLqG/Tu2ylRVpY4vFuVJeA/pnbFagnbwDnQQTktw\nvMeAbg5k4x3tNBfUzWPiehicWFURJKc2YuMSLJfRg2NMPIN78jYl6eSSMMEt6gLL0TahohGPe8hN\nZuTCda1RFpNv+RA4KQfyXNUxGtzi+xHPIz6hotFlhSu4WyhsRY9qtVmMKtYfhb5+JIrG7qoLLiGZ\nT7Nb2LPcGuj/Yo3almaLGKhUPiGWlf8dYRK86/phbO7mbSnu+7PPCp1DTSYOx48AAAAASUVORK5C\nYII=\n",
-       "text": [
-        "        14 \n",
-        " (x - \u03c0)   \n",
-        "\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n",
-        "87178291200"
-       ]
-      },
-      {
-       "latex": [
-        "$$- \\frac{1}{20922789888000} \\left(x - \\pi\\right)^{16}$$"
-       ],
-       "metadata": {},
-       "output_type": "display_data",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAPsAAAAqBAMAAACHPjAfAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIs3dRLsQq3aZ72ZU\nMonLrI/bAAAEFUlEQVRYCe1YTWgUZxh+Zn9mZ/Z32pM/0AwFS8GCWyrtpcpCD3oQ3EMRKYUOFRE9\nmJWixUNhYqCmlHRXoSXxZ7NSkB4URuxBKdShHmoPbZaKoKeMFDQ5dE1sukYSs32/d0wna3YXJzsh\nIL6HZ/P+PO+T+eZ7v28TwI/t8lMceO3eeuAtfTTc9/mqykN5Ke/jbQVc+uIs/i1ALn/tb3mCe/o7\nnwGh6thqyeM6MIGDqyl/wZ84gpz765DmBk74+wWCe/e0+Kl53PQlr556ePp5CdvbF/4oUvT008jY\n7au6yqQK7elqlXK09Z4gY7av6ioTMjrQdcqR/FvI5DpUdZMa6ET+mZIk/ys+6FTVTe58J/IB4LVN\nQ0iUv+tU1UUuonciR+1O2QByqgNI44duDDX3Gmk0Go+AdKk5HLgXskAn6mXr+6bO6uCN9Zc0IKk3\nhYN34jnAQRG/N7XegT6F1BGpeOFX3xG2GaCFCcaot5goA4dZ5X8B8vIxEUpNcmLlwB3oH54VkAph\nEVpx+bhNKtITyELNM9XKCGfx4nvJAH+K0ta7pEziy+aevUamSpGE3hwO3KPRSs5GK5LZ3LkfGYci\nKz54kSzk3fdqz36X24hoieRDOYIltvbkh8D+gbPAvvIXALsMN8u1miPXJmzIR+/T6h2snVkM8tBX\nVTC4bNH43JLuiwJ06C41qYCijc3YU5UuYJ3Grhu7RgNZUIHTWGdL1LgE1VoE4Zy8BQzM5s7iVmlr\n460yMQPhSSULRY9WEMuzy4B7QAw/AXvwEWiYExbkrAfoB465wGzuHTL4oyXIeqtw/Dxi0+ECIlMZ\nHek6uwx0fuFv3BfyD4EHRrpA8h7gPWCnxsBs7k3L1tZiWqtUqA51OlNCaq43D2WaXQYqjpgYPYJx\n+V+gmEs+MtKmB3gMjNkMzHZ7r3E/WuFgq6CIhes9DlIz4uln2V2AvUC0ccXhp7fwyew38ECaJ/k+\nASazRaPl2ZgjGsyrFURnqMOYswC00zHyj4ZTJGtCbbwND1j+rpB32VS6TNsAlpc34jchv0G0ESBP\n0lF1dtMcPrWSIyau/tmwPQhMXs2z/AwSA7fn6PnypMyg6MBVJBoGrgwW7UQJ1+oesHxfAIt/nG5K\n2nritafp/xjkPgXa0aBvbz0WBR4YcQPSrAe89Syx9awFtiD6tmQJr5BQcoqYIR3CdQG9JcgVWgmT\nMq9DHFpDHojBGxWDN6otsKnAv90Rt1QW6awyhZ4chOsCdpb4GI1pRY3+NolrwCEPxInzlwvM9i/M\nDGlrbSKL93GgqryLN8GuG8Moyf9i4A/0GyETyTeQdDxA2JYvusDsZcqH6WTPYv843TYT39pg143R\nW6WT5+iwjfTwx9R92zANogdy+ThdOQJcth/9/wDcHM89tyP61wAAAABJRU5ErkJggg==\n",
-       "text": [
-        "         16   \n",
-        " -(x - \u03c0)     \n",
-        "\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n",
-        "20922789888000"
-       ]
-      },
-      {
-       "latex": [
-        "$$\\frac{1}{6402373705728000} \\left(x - \\pi\\right)^{18}$$"
-       ],
-       "metadata": {},
-       "output_type": "display_data",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAP4AAAArBAMAAACqSyj+AAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAuxCrdpnvzWaJMiLd\nVET4aMmqAAAEhElEQVRYCe1XXWgcVRT+dnZ2Z/ZnNnlRFNRMwaYEhCxGfbBgF5JQS4WsNEsbUdr6\n4IN/yVZE8UEHURR86KoNMkXpgIgIlYzE4k8rHRGhrdoMiPiYBUVfhC7bVhObdD3n3l13V5Jh0t0l\nKJ6HO+ee75zzzZx777m7QFiJmGE9e+KnDGwqvzKyY1P5gYn/+XuyscIm/Y/VP9kPvDTuhv36bu+/\n5B4PqqvQS4SVLtff8BAxMROWvdvfD+KPnktlN5M/NV0wN5MfO1ec0PyF6aet0M7kmMmt662XCaL6\nx/zj1XWdOgXeDUjwgOTfBjwb4NUZdCggXJP8HwH3Bnh1BKm5gHC9JOqvubg9wKsjKG4GhCsHkHrr\nck6Zst0Ar46gXwOjbw5EuwFOUZLPRr8Yz7Uli9VIqOfMtll7MaGNrZT0M3GvLfnkh7tfPUmWH9us\nvZg8CSSgVgynNXnGV93dbPilaeWKdFkqlP0qfT+i/YLnk29ZzrMeAVUfmOOhp0L8QDz3T455eGzq\nPf8TTHPagcnPpuwDF6e1/k2sq9oNgO5OQDXbsipV/MmGV9qsvZjQCVu0rsfH7blVD8ts6f35+w3Y\nsmvoiNXOr1m4ji3Pt5iVWduhKd1XW8foYjqx9xYgab/u4/iUbZeElvzatm0Jay+m3pFIqlAsA0P2\nQ/VAEa1MjnMy2nqueKw9UP9tyikn6tHsS+A8bnPoF9GEjxPIXMJhOpZZoemkXRQw4rVaSSLzUFeB\nPGKWRDga6bJyTqTmK2ZdSeRaoLPQZgD1IGhx1JmoiXQFx3ys4A0gKrWECWQFDG3PUUiErq4F6BYU\nTyASvg/YKXMH3b/bWuj1qph8WkQ6i8yV+MOIXsUi89MXHJVagpqZI2B6IxKBPGJiRzmRJX6BSPgr\n4IIrEs6Lce1he4tZOyAmpSL68kiualXEuHdQ/eu/oYSGnyUs+QXygon9ZeOimciJQDHgMvUWXyRM\n5cRjrUF1Wqx9z43RDtLdIk6XkGTWNFdEy9Kwhf2ERn8UJBwdGy03ECyYGFjaJREBp+h0zeUIDy/D\nZ5C2cCskP5/OOSrvB09xBnqxuhbzBcsyIqbC5WEESfKO1b6RCPMvC34K34AMV5Co0oo2+YscrdIF\nplQaGoapmTIBG+5qIFo/8PL7NV8g18zvQV+la/Lv+scoK8m0SaehofGmZgJeHhxz6sj9tG55HK4K\nRAzXUP++GeiXhkD8vIOWgFGi+BwYsJDONjTQvpbwTcRfFghUguMmUksCkTDvP4tfMrRE+Pu/Hxn5\n/Q6iM67AyOOkUqONZWE4j7qmUF4JPw7sdxkBfkDKHaTnpEAkTO+56IbmZkdDrD8g+k/Cw3vAa/iD\neouLC8QitQzxU4MhmEzP0BmnRzIP3eU2u10gEqb+8/aG6IEbMWhRyEHgOww6qbP2rEd/CzK01RaJ\nRWoG8QuYOrPxmERO2faDMA7BKEmEo5H2lUc3yB+78x6KeLO2D1uP3I00tXoPRmGvL1dSarwvBIxk\nYYQ+mdd4oVZbAX4q0FHkQDkoU6MOuf575C9+Ztihp/kcUAAAAABJRU5ErkJggg==\n",
-       "text": [
-        "          18    \n",
-        "   (x - \u03c0)      \n",
-        "\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n",
-        "6402373705728000"
-       ]
-      }
-     ],
-     "prompt_number": 42
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Hint: to get the exponent from a term like `3*(x - 1)**5`, use `as_coeff_exponent`. "
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "(3*(x - 1)**5).as_coeff_exponent(x - 1)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\begin{pmatrix}3, & 5\\end{pmatrix}$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAADwAAAAaBAMAAAAZJyJqAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMARDKrEM1mIu+Zdrvd\niVTWGHL+AAABSklEQVQoFXWSPUsDQRCGn1wuuXwn/oIErEVBFMHmGusExMJGUtgJco2F2NjZCB5o\nk8pAmiAWgq1IsBG7IFiqtZ0Jh2kkcW5zMZsLN8V8vM/M7g4ssECEdX3dWImgLPpgy47CmaaQdVh6\nfwy1JPatD3gG6xTLpew3apYajeTmFqRd8kOKHY1Jmrh8FV+1SZUozOO46s7VWVZJ+PAxTt/RVnhb\n+amL37RKkPxmTTTjLbx71jZ7EPO4VyNt6Q3Zhoz12VVqygtB+Kxg9XiR1Stkf2bxg+AS5tDHVW8O\nn8O140/Lm4s1cgNsfd6FHTm2zyZk6pS75q+OjymcycsH3Ir61djDvHA0bjRWpZS9yxMxpuOxmK9R\nrAQ8OembxkSTeDcaVx2MToCbQdTCgeThj6LhJ8mPtHo2TbpSFyaXzzKpTpRyOKcHwlUU+Nf/AKUL\nQ2ycOKYsAAAAAElFTkSuQmCC\n",
-       "prompt_number": 43,
-       "text": [
-        "(3, 5)"
-       ]
-      }
-     ],
-     "prompt_number": 43
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def series_accuracy(func, expansion_point, evaluation_point, accuracy, x):\n",
-      "    \"\"\"\n",
-      "    Returns n such that series terms up to and including (x - expansion_point)**n \n",
-      "    (i.e., O((x - expansion_point)**(n + 1)) are needed to compute func at \n",
-      "    evaluation_point within the given accuracy.\n",
-      "\n",
-      "    >>> series_accuracy(cos(x), pi, pi + 1, 0.01, x)\n",
-      "    4\n",
-      "    >>> series_accuracy(exp(x), 1, 10, 1, x)\n",
-      "    23\n",
-      "    \"\"\"\n"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 44
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "series_accuracy(cos(x), pi, pi + 1, 0.01, x)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 45
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "series_accuracy(exp(x), 1, 10, 1, x)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 46
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Calculus"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from sympy import *\n",
+    "from IPython.display import display # This, with init_printing(), will let us \"print\" to MathJax\n",
+    "init_printing()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For each exercise, fill in the function according to its docstring. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "x, y, z = symbols('x y z')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Derivatives"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Compute the following\n",
+    "\n",
+    "$$ \\frac{d}{dx}\\sin(x)e^x$$\n",
+    "$$ \\frac{\\partial}{\\partial x}\\sin(xy)e^x $$\n",
+    "$$ \\frac{\\partial^2}{\\partial x\\partial y}\\sin(xy)e^x $$\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Recall l'Hopital's rule, which states that if $$\\lim_{x\\to x_0}\\frac{f(x)}{g(x)}$$ is $\\frac{0}{0}$, $\\frac{\\infty}{\\infty}$, or $-\\frac{\\infty}{\\infty}$, then it is equal to $$\\lim_{x\\to x_0} \\frac{f'(x)}{g'(x)}$$ (we will not consider other indeterminate forms here).  \n",
+    "\n",
+    "Write a function that computes $\\lim_{x\\to x_0}\\frac{f(x)}{g(x)}$. Use the `fraction` function to get the numerator and denominator of an expression, for example"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAD4AAAAaBAMAAAAd0vJXAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMARDKrEM1mIu+Zdrvd\niVTWGHL+AAABRUlEQVQoFX2RPUvDUBSGn7YxbdMP9Re04K4uurjcxalIBadu2QXp4qJo+wu0os4G\numhRWnARBAkOiltWxf/QWgRBRDxpSUksNwduzjnv857LvTfAPLrwfJBc1mEWfLKutNxyBK1qMTxD\nuhnD25BtxfCqIjMXw/M2SzGYbI9L4Qftwysn4jNePRoKc8AKGJ75lHEjvJAY0IXEJ7dQwBoUyxG+\nmHW5l7cbUpN5Ur0IBZVx+JbLf/DiE+n+RV/JLMbvmDfKqKjhHKs5mt8Cs97FUlFHjZz8t/SQNejb\nd+xh/IR3OKVky/m/uIbKzcabjXFcDxkqnQtp5f6liZgIc3gXUNhkthwYzKCQnHKNI0kzDilP8ijC\nPO/lfL1aJ+mOKThBIbnYOfG7bVkPfqGJR9F3NUxksyWf4uQAU8b9kbIzpQfCWVDo8x9x5EPeMJ02\nngAAAABJRU5ErkJggg==\n",
+      "text/latex": [
+       "$$\\begin{pmatrix}x, & y\\end{pmatrix}$$"
+      ],
+      "text/plain": [
+       "(x, y)"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
-   "metadata": {}
+   "source": [
+    "fraction(x/y)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You may assume that the only indeterminate forms are the ones mentioned above, and that l'Hopital's rule will terminate after a finite number of steps. Do not use `limit` (use `subs`). Remember that after taking the derivatives, you will need to put the expression into the form $\\frac{f(x)}{g(x)}$ before applying l'Hopital's rule again (what function did we learn that does this?)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def lhopital(expr, x, x0):\n",
+    "    \"\"\"\n",
+    "    Computes limit(expr, x, x0) using l'Hopital's rule.\n",
+    "\n",
+    "    >>> lhopital(sin(x)/x, x, 0)\n",
+    "    1\n",
+    "    >>> lhopital(exp(x)/x**2, x, oo)\n",
+    "    oo\n",
+    "    >>> lhopital((x**2 - 4*x + 4)/(2 - x), x, 2)\n",
+    "    0\n",
+    "    >>> lhopital(cos(x), x, 0)\n",
+    "    1\n",
+    "    >>> lhopital((x + sin(x))/x, x, 0)\n",
+    "    2\n",
+    "    \"\"\"\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "lhopital(sin(x)/x, x, 0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "lhopital(exp(x)/x**2, x, oo)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "lhopital((x**2 - 4*x + 4)/(2 - x), x, 2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "lhopital(cos(x), x, 0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "lhopital((x + sin(x))/x, x, 0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Integrals"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Recall that the mean value of a function on an interval $[a, b]$ can be computed by the formula\n",
+    "\n",
+    "$$\\frac{1}{b - a}\\int_{a}^{b} f{\\left (x \\right )} dx. % Why doesn't \\, work? $$\n",
+    "\n",
+    "Write a function that computes the mean value of an expression on a given interval."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def average_value(expr, x, a, b):\n",
+    "    \"\"\"\n",
+    "    Computes the average value of expr with respect to x on [a, b].\n",
+    "\n",
+    "    >>> average_value(sin(x), x, 0, pi)\n",
+    "    2/pi\n",
+    "    >>> average_value(x, x, 2, 4)\n",
+    "    3\n",
+    "    >>> average_value(x*y, x, 2, 4)\n",
+    "    3*y\n",
+    "    \"\"\"\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "average_value(sin(x), x, 0, pi)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "average_value(x, x, 2, 4)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "average_value(x*y, x, 2, 4)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Write a function that takes a list of expressions and produces an \"integral table\", like\n",
+    "\n",
+    "1. $$\\int \\sin(x)dx = -\\cos(x) + C$$\n",
+    "2. $$\\int \\cos(x)dx = \\sin(x) + C$$\n",
+    "3. $$\\int e^xdx = e^x + C$$\n",
+    "4. $$\\int \\log(x)dx = x(\\log(x) - 1) + C$$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def int_table(exprs, x):\n",
+    "    \"\"\"\n",
+    "    Produces a nice integral table of the integrals of exprs\n",
+    "\n",
+    "    >>> int_table([sin(x), cos(x), exp(x), log(x)], x)\n",
+    "    ⌠\n",
+    "    ⎮ sin(x) dx = C - cos(x)\n",
+    "    ⌡\n",
+    "    ⌠\n",
+    "    ⎮ cos(x) dx = C + sin(x)\n",
+    "    ⌡\n",
+    "    ⌠\n",
+    "    ⎮  x           x\n",
+    "    ⎮ ℯ  dx = C + ℯ\n",
+    "    ⌡\n",
+    "    ⌠\n",
+    "    ⎮ log(x) dx = C + x⋅log(x) - x\n",
+    "    ⌡\n",
+    "    \"\"\"\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "int_table([sin(x), cos(x), exp(x), log(x)], x)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now use your function to compute the integrals in this Mathematica ad.  Remember that the inverse trig functions are spelled like `asin` in SymPy. \n",
+    "\n",
+    "The ad below probably has a typo, because one of the integrals is trivial to compute. Include what you think the integral should be, and see if SymPy can compute that as well."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAANAAAAEECAYAAABZfLr5AAAACXBIWXMAAAsTAAALEwEAmpwYAAAK\nT2lDQ1BQaG90b3Nob3AgSUNDIHByb2ZpbGUAAHjanVNnVFPpFj333vRCS4iAlEtvUhUIIFJCi4AU\nkSYqIQkQSoghodkVUcERRUUEG8igiAOOjoCMFVEsDIoK2AfkIaKOg6OIisr74Xuja9a89+bN/rXX\nPues852zzwfACAyWSDNRNYAMqUIeEeCDx8TG4eQuQIEKJHAAEAizZCFz/SMBAPh+PDwrIsAHvgAB\neNMLCADATZvAMByH/w/qQplcAYCEAcB0kThLCIAUAEB6jkKmAEBGAYCdmCZTAKAEAGDLY2LjAFAt\nAGAnf+bTAICd+Jl7AQBblCEVAaCRACATZYhEAGg7AKzPVopFAFgwABRmS8Q5ANgtADBJV2ZIALC3\nAMDOEAuyAAgMADBRiIUpAAR7AGDIIyN4AISZABRG8lc88SuuEOcqAAB4mbI8uSQ5RYFbCC1xB1dX\nLh4ozkkXKxQ2YQJhmkAuwnmZGTKBNA/g88wAAKCRFRHgg/P9eM4Ors7ONo62Dl8t6r8G/yJiYuP+\n5c+rcEAAAOF0ftH+LC+zGoA7BoBt/qIl7gRoXgugdfeLZrIPQLUAoOnaV/Nw+H48PEWhkLnZ2eXk\n5NhKxEJbYcpXff5nwl/AV/1s+X48/Pf14L7iJIEyXYFHBPjgwsz0TKUcz5IJhGLc5o9H/LcL//wd\n0yLESWK5WCoU41EScY5EmozzMqUiiUKSKcUl0v9k4t8s+wM+3zUAsGo+AXuRLahdYwP2SycQWHTA\n4vcAAPK7b8HUKAgDgGiD4c93/+8//UegJQCAZkmScQAAXkQkLlTKsz/HCAAARKCBKrBBG/TBGCzA\nBhzBBdzBC/xgNoRCJMTCQhBCCmSAHHJgKayCQiiGzbAdKmAv1EAdNMBRaIaTcA4uwlW4Dj1wD/ph\nCJ7BKLyBCQRByAgTYSHaiAFiilgjjggXmYX4IcFIBBKLJCDJiBRRIkuRNUgxUopUIFVIHfI9cgI5\nh1xGupE7yAAygvyGvEcxlIGyUT3UDLVDuag3GoRGogvQZHQxmo8WoJvQcrQaPYw2oefQq2gP2o8+\nQ8cwwOgYBzPEbDAuxsNCsTgsCZNjy7EirAyrxhqwVqwDu4n1Y8+xdwQSgUXACTYEd0IgYR5BSFhM\nWE7YSKggHCQ0EdoJNwkDhFHCJyKTqEu0JroR+cQYYjIxh1hILCPWEo8TLxB7iEPENyQSiUMyJ7mQ\nAkmxpFTSEtJG0m5SI+ksqZs0SBojk8naZGuyBzmULCAryIXkneTD5DPkG+Qh8lsKnWJAcaT4U+Io\nUspqShnlEOU05QZlmDJBVaOaUt2ooVQRNY9aQq2htlKvUYeoEzR1mjnNgxZJS6WtopXTGmgXaPdp\nr+h0uhHdlR5Ol9BX0svpR+iX6AP0dwwNhhWDx4hnKBmbGAcYZxl3GK+YTKYZ04sZx1QwNzHrmOeZ\nD5lvVVgqtip8FZHKCpVKlSaVGyovVKmqpqreqgtV81XLVI+pXlN9rkZVM1PjqQnUlqtVqp1Q61Mb\nU2epO6iHqmeob1Q/pH5Z/YkGWcNMw09DpFGgsV/jvMYgC2MZs3gsIWsNq4Z1gTXEJrHN2Xx2KruY\n/R27iz2qqaE5QzNKM1ezUvOUZj8H45hx+Jx0TgnnKKeX836K3hTvKeIpG6Y0TLkxZVxrqpaXllir\nSKtRq0frvTau7aedpr1Fu1n7gQ5Bx0onXCdHZ4/OBZ3nU9lT3acKpxZNPTr1ri6qa6UbobtEd79u\np+6Ynr5egJ5Mb6feeb3n+hx9L/1U/W36p/VHDFgGswwkBtsMzhg8xTVxbzwdL8fb8VFDXcNAQ6Vh\nlWGX4YSRudE8o9VGjUYPjGnGXOMk423GbcajJgYmISZLTepN7ppSTbmmKaY7TDtMx83MzaLN1pk1\nmz0x1zLnm+eb15vft2BaeFostqi2uGVJsuRaplnutrxuhVo5WaVYVVpds0atna0l1rutu6cRp7lO\nk06rntZnw7Dxtsm2qbcZsOXYBtuutm22fWFnYhdnt8Wuw+6TvZN9un2N/T0HDYfZDqsdWh1+c7Ry\nFDpWOt6azpzuP33F9JbpL2dYzxDP2DPjthPLKcRpnVOb00dnF2e5c4PziIuJS4LLLpc+Lpsbxt3I\nveRKdPVxXeF60vWdm7Obwu2o26/uNu5p7ofcn8w0nymeWTNz0MPIQ+BR5dE/C5+VMGvfrH5PQ0+B\nZ7XnIy9jL5FXrdewt6V3qvdh7xc+9j5yn+M+4zw33jLeWV/MN8C3yLfLT8Nvnl+F30N/I/9k/3r/\n0QCngCUBZwOJgUGBWwL7+Hp8Ib+OPzrbZfay2e1BjKC5QRVBj4KtguXBrSFoyOyQrSH355jOkc5p\nDoVQfujW0Adh5mGLw34MJ4WHhVeGP45wiFga0TGXNXfR3ENz30T6RJZE3ptnMU85ry1KNSo+qi5q\nPNo3ujS6P8YuZlnM1VidWElsSxw5LiquNm5svt/87fOH4p3iC+N7F5gvyF1weaHOwvSFpxapLhIs\nOpZATIhOOJTwQRAqqBaMJfITdyWOCnnCHcJnIi/RNtGI2ENcKh5O8kgqTXqS7JG8NXkkxTOlLOW5\nhCepkLxMDUzdmzqeFpp2IG0yPTq9MYOSkZBxQqohTZO2Z+pn5mZ2y6xlhbL+xW6Lty8elQfJa7OQ\nrAVZLQq2QqboVFoo1yoHsmdlV2a/zYnKOZarnivN7cyzytuQN5zvn//tEsIS4ZK2pYZLVy0dWOa9\nrGo5sjxxedsK4xUFK4ZWBqw8uIq2Km3VT6vtV5eufr0mek1rgV7ByoLBtQFr6wtVCuWFfevc1+1d\nT1gvWd+1YfqGnRs+FYmKrhTbF5cVf9go3HjlG4dvyr+Z3JS0qavEuWTPZtJm6ebeLZ5bDpaql+aX\nDm4N2dq0Dd9WtO319kXbL5fNKNu7g7ZDuaO/PLi8ZafJzs07P1SkVPRU+lQ27tLdtWHX+G7R7ht7\nvPY07NXbW7z3/T7JvttVAVVN1WbVZftJ+7P3P66Jqun4lvttXa1ObXHtxwPSA/0HIw6217nU1R3S\nPVRSj9Yr60cOxx++/p3vdy0NNg1VjZzG4iNwRHnk6fcJ3/ceDTradox7rOEH0x92HWcdL2pCmvKa\nRptTmvtbYlu6T8w+0dbq3nr8R9sfD5w0PFl5SvNUyWna6YLTk2fyz4ydlZ19fi753GDborZ752PO\n32oPb++6EHTh0kX/i+c7vDvOXPK4dPKy2+UTV7hXmq86X23qdOo8/pPTT8e7nLuarrlca7nuer21\ne2b36RueN87d9L158Rb/1tWeOT3dvfN6b/fF9/XfFt1+cif9zsu72Xcn7q28T7xf9EDtQdlD3YfV\nP1v+3Njv3H9qwHeg89HcR/cGhYPP/pH1jw9DBY+Zj8uGDYbrnjg+OTniP3L96fynQ89kzyaeF/6i\n/suuFxYvfvjV69fO0ZjRoZfyl5O/bXyl/erA6xmv28bCxh6+yXgzMV70VvvtwXfcdx3vo98PT+R8\nIH8o/2j5sfVT0Kf7kxmTk/8EA5jz/GMzLdsAAAAgY0hSTQAAeiUAAICDAAD5/wAAgOkAAHUwAADq\nYAAAOpgAABdvkl/FRgAAv9BJREFUeNrU/XmU3dd134l+zjm/4Y41YAY4AKRAQuIgkwJlDaZE+knR\n4FB2EktO6HbiKN2hYrcT97O0Vi9bK89Wr5bc3ZH8nuN+K4nciSy3bTqW7I4tilLLUgyKjGiJhEjJ\nJEQCEEVwQGEq1HCn33TOeX+c87tD1a1CjVDeXeuiClW37v0NZ5+993d/93eLNF20bPihgICr+zBA\nG2sLQKzyuo2eVgMhom0/C2tbQL6GF679jISIEaJ2heuyFceeg+1gMVv6WUKUXycBeZXXlcbazrrX\nTWCt3cRCtv5ExVU8UeGfFqxd5+naofewY97X+kUdXgUD0oAevXZ2I6Zvx9yT7T72wh//+o5WrPif\n8n3xG7K4Kucx+tkpUKzbcIONHaj1T+09wdX2QmroGJYfmt2UB0qB6lW4YcYveMFG7MWO/cXVMqDc\nG9DQZjZyHnasldghT2PNwOOMWJAIrrrxuHWcDF3DdRnQpi6l30XVVfZCEdAbPVk7fNk3cwOKMQti\nezYBa3PAugVlBwtqY0GBuUrRQHnP7ZJrbdccRpfnN+485VUIn5cfTzK0ma07hDMbvIjl1wJr5VX2\nQuXOZ65wYdYSuo1778wb6XbeNPxCdLuxRbD2cHql89j+0MdFHIU/Vrsld3LwnxBrr3b4VnqfjW28\nweYP1iJEjrVX2wvFfqHbZZm23RSwYLG2uApAgl2yA9t1/e3WgSYbWXB6aPMS6zB2Me4q9DdDQXyV\n1xBY213HuWxpCGeHnoXfTa+mF4pGjWfLQjhYEzq2ZeHQuJ9tZBGZq2RE2l8ftcZrbddg5HZrMooN\nhevppq5bsHnjKRPD9Cp7IQmEYNOVIu1NLOrshwuEbBjYuRrXPt8Gj2eBGCHUD8H7LAVDrkoIZ5fk\nQaUXyrc9dxh9VLD0tsErmCFwZDvzOMvqCJZlOcq10vfmKuzg2iNwFiHMKhnNeo3ZIETM1az9uFpW\nAsIuOWZxtQxoqSeyCJFgbXgVvVA8BCZsRfJphxZKhhDbCWfbMZvRSr+HUfzaLskhylx0uwEEQ4lS\nuvxNjD1mhyoO0MXyZ+Pf0yLE1QahADpYCrDSXbv+6dirYUDLjWfghTK/sK9WGBcD3a0JKfp5lEGI\nYpuPfTUPJEaMxV6RcXG1kCvjoXexiuHTR9KGjWxlgNH48C28aqZjbTaEvLnN1yI2VD8Its54Si/U\nxdroqnkhIaqegiE2nkcsQ+7MVciDVH9hCWGXFEjtOs/F+lLCdl/zHGvNGnIVu/Zjt1z18M1tuMOs\nA/vDCOGGq7bDRqSBhKtRzXeP0F8Is8qOw0g4sbZdqvBx/nbdWNGvpYwe1xJvZAc5kF0GBw+DOME2\nG5DF2qwfdo072hVTolXvi4KrWDy1NvXgwdJ8c2PAyCYMyIz1Ru7i9oDKVfJCyhtra3SxL/Eqg5su\n1njh9FWrB42GbGVIMewNV9vdr074Zq3xfLGlOdgqlmNXD15L8EBcNQOyWNv191UuyS83tlY3aEDL\njWdQmS4JmT2gdjWCOG+si6xenBwXt9tVESfn5rfn5vbDIDsMBKx2XHbV7zfGKNlI/rPSdRVjDHo1\nTpwdiiCuTrjvjr+zyia6oUKq2bA1l387ajzl4uv6hb39sa0QIdaG/gJJtqa2on0etF2bgBxC0Ta7\ngEokazsfZbFcrnBd18+JA+XbL65W+Fa2waghe1kPzWuLQQRrxwEK5SPzXqh+FS5N4MO4dMt2sxKy\nFVeXWbIBgy9vfLitRmRt5vIxsXXnJ0TgAYSrhbwNvE+5dEV5QmJj4fCGc6BRrzNsPGaJF6peBS8k\nfKglV1mIq+U7Sy6cLdGYctdV23RT7YaT15UBne3KHdI+lLH5e+W+Xi3jGXgf7QxGjNmm7Jpwj+UG\nJGUda8cbhENJzOjPrfX2a1fxPiXKlCDE1fJCkX9mG9jRl/LpbN+AXMK5PQYkRIS1vY3ZzFIoYVs9\npR0CENaGZo5DPYVgaF1JhKhfJePJMKY9MH9/YGLEpkvPtL4LKZfvZN5I+sbDCFBgx9J4lj6H/669\nzbvjYDG6YpxZ92K05XPpr0zpgbbrIdfmXIaP0a60bW0fD3G4A3WtpYBxryuPvwx+rhb6Zu3i2HXh\nVzXWbuoOLrkVyzo6bf8Gjg/VVtseha/4JlfJUa8DtFjBaEZfUjKPr1KeY5cb9Jq6bqz1XnK7DGjr\nr4GU1atkPCnG9K4YhYz2jq39GbgFVww7awa8qqUh2zjkZdx+aJftAEJcDUSugoNF05U/y66vi9/a\n3F+LrV+cAomxW26G27IIr7RLr7egKkTjqhiQMYtLooiV7uWGmQjRkAGVZEA7lOTadVjm4D0GHkt4\nD7T9uZCDswOsTcf0269joQ291qE32lf6t/qAw62zHru9BrQpI15Sm5My3p7rOdbwk1WMZfT/1l4Z\nJJGq6gEQiRAS6WLncEzItlrBcSUmsR2Kc4cNS2DtAlejYi5EdbRIuYZQbeWwTnr6iuaH/lglH3In\nHmzTIjQYk2/piUhZ52poNxizCDZf4eaPr1etxUWMnIv7ZsAnGzCuVvM+jAnprpSM5R6H324DqvuF\nb9dnNCsambn6BnQF4GD8Y7t6l7K1ZmJrDlyvRvHU2p6j7Xif0t/Y7WoXXazzJsnSgCQulBNj2MB2\n/Da45JYup9CM81qLV8ELqf65bBZEGHjV7QISgvGehc1ow231Qsy28P0tUlbY3kZFt+lp3fYo6nIa\nkd1s2a2/EVSGM+1wKJRbyWhWWoj2CsZTZpI51ravkhda0UuvPaTrAwnZtixSIdTakbYf0sOYbOUL\nOTYqWSXwsQYp69tOO7I2cYzrVT7H2tVSk7VsVSFCVByVR/Qz7ooHFAqWw9ErUWtLMoQdC7sshQeF\naCNEc1tjYEENgwQxRrhwRTbKSso+glJ4YutvvPDX3m5isVgcp0wO3cetBxDEsqsmxvxXrHqcQiqk\nrGzLcQ7fPK3L2qNaHRhcVoEWVzw2IVwRuMzjlqyIssOTJeHZGqr44ySLxuiyOVRrm72QUD5UWE/C\nsZJ3Ej6EM9ti6lvlybZjV3fFU7uqb7FDYdG452AZWd8iv73om6v7dLhSyWSjXt+1oNf6KOKYT4lG\nULnlrs6ugszZkTBp/OuMN6DtZSdcuc5gGS4Sr3ZB3WLIt+EYNwhjj4uO7PYsRjbZJjG0DSNldZuV\ndyxaL2zuaK+wUzgPWhlxOWMeNbByldxmZeO5cn4hgeQqIHJl4XaFfG4duZBz9+l2mPm6jGUlRG6r\nVEKX5z+pn8CwFbDi9lN3Bt5nHR2mdhQY6P/XxWoglCsRiBAhKz6/FlcyIAl9qHEt4dtSr3OlpMx6\nL7R98LAQEilqjKUqbaAuZGzKtqf6S4zli198hH/8wf+Rd7/nn/Af/+ThFf/ItQVsRwiXew+0+X4l\nt3NvL/u6KOaX3CKxhiOzA2RuaAGPqg6V+XttWQF4lYA0RohsCVt4dbHwtT8k2B7W9jZM6Th+/DjH\njh2j3W7TarU4e/YsBw4c4OjRo9x///0uIZR1bLHoEsN1GM3yMxVYk27TbZdjZx3963/9Wfbt282/\n+Bc/z8MPP8Kjjz7Jz/zMT6zi1eUWG49xJNJNm4/tC4dsJ/pmjFtPo6DA+o7eLoNKBn8vRIyUy+tX\nwerhRc0jUHrF9Guj84VcatXyieX64uJPf/rTPPTQQ3zyk5/k5ptvHjGqj33sYxw7dowPf/jD3HTT\njQgRDI3iuHL4u/KvjefFbW0Y4o5vVELr0Uef4KmnTvCZz/yvANx55y0AtNsdGo06K9zjrd7P13bd\nrmiIjimv1GDxtVotms3mlh6t1vMuwe83yI3b9MW6wug+tUcEK7InrrAlBEMewq6Cvq2/hVoI6avF\n62Nqf+pTn+LBBx9cZjwAR48e5ZOf/CQnT57kIx/5CO1218esdk1h2pqS6i2Pk5bflK9//Un27du9\n7Of/4T98nqeeOrGOq7zJ8A09BKJc+Tm+BGQRIkSImFarxcc+9jFOnjy5xd6ni/ERwjAquBwZGvfD\npVQ0uyQzEUhZWzH8XINPjX1CfiVh8PXd1jLGdBy5tSWqx48f56GHHuK+++5bZjzl4+abb+b++++n\n1Wrx6U//rkNMtqSgyhZzwgY3aOnj0UefWPazP/mTh3n44UdWiBXUlodwxmRDU+jWDw6WvTYg+yWF\nhx56iGPHjm0D8lb2+4jxx7OuavUonVSIECkbq7iYNcToQjR8NT5jfJF0HcazpEhZVo3Xkgs99NBD\nANx7772rvu5973sfDz74IA899BD/9J9+kFotwpicTqfLt4+f4G1vfyMADz/8CO12h7e97Y3s3798\nx2+3O3z960/SbnfYt28399xz96qf22q1eOSRR/ohytGjR9m/f//Ia06ePMnx48f7HvPGG3egh9Zp\n6WHa7e6Itzk3cxGAU6dexFpoNGq0212sNShVJwgmOXDgwLLPK49reNcfft3x48c5efIkN998M0eP\nHh26t24G0GOPHeemmw7RaNT40pce4fDhQ/2QsjT2c+cu0mjUedvb7hoNMS0IqVCqzszMDGfPnu1f\nA4BmszmyES69NittkktzH2OSNRl3/5iWRW8rxcESpSZXDfPUv/yX//I31pT0Y1nbKAixrjzDGWGO\nlFdmJ3zsYx8D4Fd/9VdXfV2z2eTP/uzPyLKMI0dex8GD1/A//8//H/63/+3f8/VHn+TNb/4R/tW/\n+j949tnTfPWr3+CrX32ct7/9jTSbg5t/6tSLfPzj/5Y777yFRqPOb//2Z5mZOc9b3/r2sdXqmZkZ\nPvjBD3L06FF27tzJn/7pn9JqtfqLstVq8dGPfpSTJ0/ylre8hSzL+M3f/E1mZs5z6603EkURjz76\nBP/pP32Vc+cukmU5585d5NlnT/Hss6c4deoM7XaXdrvL6dMvIgRkWc7v/M7v8/DDXyOKIm6//fZ+\nbvGzP/uzvPWtb6XZbJJlGY8//ji/+Zu/SZZlHD16lJMnT/Kxj32MZrPJsWPHePDBB9m1axc333wz\n1moefPAP+Y3f+G2+9rXHufXWm/id3/l9vva1b/C1r32Dn/u5n6Ld7vAbv/GvaTbrHD58iM997kt8\n7WuP87a33UUURf1lKWVEEEzx4IMPcubMGWZmZti/fz9Z5lrvDx06tOK1OXv2LLfffjtxHK+4oIpi\nDmPSDQAUYvDvMhaFS0uCYGIZcFDe+/LrGg2oVL7MgWJDQ6xWZgKJfr/NajDn8ePH+cpXvgLAP/7H\n/3hN4d7MzAxHjhzhtttu4e67b+Gb3/wuly/Ps3//bn75l3+en/iJe4jjkG9+8ztEUcQb3nCLN4aL\n/Mqv/C/8D//Dz/PmN9/BwYPX0GjU+IM/+HNuu+11HDhw7VhgI45jfumXfolDhw5x11138dBDD/Gu\nd70LgI9+9KOcPXuWT3ziExw6dKi/u/7xH38OLNx5560cvP4a3vGOt/KHf/jn3HrrTXziEx/hHe94\nK+94x1vJ85ynnjrBRz7y3/FzP/dT3HrrTdx00yHa7Q4nTpzmfe+7r2+sx44d46GHHiKKIo4ePUoc\nxxw6dKgPvLz44ot85CMf4Zd+6Zd43/vex7333stDDz3E888/z0//9E9jbcZrX3uAVqvNiROnabe7\n/NRPvpObbjrE4ZsOcucdt/CRj/wmb3rTHXzgAz/B/n27ufPOW/gPn/k8zWadW2+9yec+AqUmkbLC\n0aNHmZ2d5fjx4zzwwAO8613v4tChQ6temwcffLDvjVbyPloveOBNbMiAypLPsNgJuIKplFPLNsul\nBrQOs5UIMeEKrOvp4rJXgLlteTG2r19IiBgpIhoNt5sMw8Hl96dOvTiSb7TbnX5I9dRTJ2i3nRzs\n889/b+xnzMzMcPLkyX54sn//fj784Q/3F/Tx48c5evToCPrk4Hb4k899iZlzFzd09m9721G/YXx7\nZPMYDnnLn91zzz00m80+3F+GwmUoNTMz4zc7jTFFPxy7445buPttd/H+D7yXD37w/XzpS49w6vQZ\nf32e5amnnmVm5sIgBPXJpUCg1OpNlFe6Ng8++GD/uJbC7EXRwhjtgJgtXToCpabW5NXW6fciEM1l\nrm4l73PFJH2k87PwyinjHwcOHBiJldf62L9/v4Oe11HEe+qpEzQadf7jf3yYr3/9CU6edMb1T/7J\n+3m7z5+WPu69915arRYf+tCH+NSnPtUPVYaPd/gcyscb3nDHisDBlbN1y+HD17N//96+0bRaLWZm\nZrjvvvtotVp9Izp+/Djve9/7+tfkk5/85EhuOXxNlzYRHj58cOTj+8bz9Am+9GVnTKdOn+GDH3w/\n73//ewdtlDK6Yufpatdm2KMuN6AEYzougoHlPT927WmGHSlgG5SaWHO5Ilj/bt7AUXF6q8LYV/I6\ndtkJGaxtAY2x7nj//v3s37+/v9NfKcEsb8yRI0e8S167Ac3MXOTOO2/hN3/zI8sxsxUMsVywJXjx\n0EMP8eEPf5j77rtvc7CtXbbTsFT25e1v/zH+43/8s35h+d5772X//v089NBDHD9+nPvuu4+ZmZmR\nazYzM8Mf/dEf0W63+wm7M0KLMcWqe+u5cw7Q+PjHP7zqoSt15VrPRq6NtZaiaA/NFloPYDAeNBjw\n9Wqrom6b9EDlkUwyOhpifSHbSoLkTr+rtSq6ttKOtPSmlAl86QUcDWNtTXaNRt2HbeP4emZFYun9\n99/PH/7hH3Lffff1a1bDnqhEocY9+nUfO25rHN9xM4DuX9P3MseOHeOee+7pn/uxY8c4duzYMuP5\n0Ic+BMCv//qv94+3DN/KKQwrPcpQ+NFHn1x1naxFeWct12YpsmhtgtbtNbVFLIOyVysoCIe6rYfw\nuqHigdNgm1xev7lSNX/V3wt/81YelnXfffexf//+fj1opceDDz5Is9nkgQceWAKCXJniDoPK/5/8\nyZfGQsLjDKhECJvNZt/zlAujzDXKMGvU252n0ahx5x23LLvLaytfKO655+00m00eeeQR9u/f388l\nyg3nt37rt0ag/2PHjtFqtcaWA1z+k62alB8+7JL/z33u4THQf9d7n7Uxr1e7NmfPnu2XA0aRtwVG\nmNPrcearIMVSTqwrUtmwAQ1CuRoDgfnV283XpmZZ1oV6K8LTv/Ebv8H+/fv59Kc/PdYTPfjggxw/\nfpxf+ZVfGRPmyX4IsNpx/czPvLcPJvzrf/1ZnnrqBI8++gQf//i/YWbmvF9gy1G/4UXQbDb7N79M\n2GdmZvrI0jBS+MEPvp96o7am9fDlLz8yEkYJJALBPffcQ6vV6htNueE4j9EYuRalgT300EO0Wi2O\nHz/e9wDHjh3j3Llzqx7De997D/v27eb06TN89KOf4tFHn+Spp07wO7/z+z6XsyjVWHGhlpvfzMzM\nFa/NAw88MAIuGJOidZcR+YEROsT6TKlcvELEKDWxbjtYM4w9PpQLgJ4XYhfrDNlW8lLG7wa1se+5\nc+dO3vWudxHHMb/7u7/L8ePHmZ2d5ZlnnuGzn/0sAL/2a7/G7bffPhKyfPrTn+aRRx4F4MyZsxw+\nfIhWu8snPvFvOHfuIufOXeTy5Xne9KY72LlzioMHD/DUU9/j2WdP8bWvfYPTp8/wz/7Zz3L48PUI\nES5Dl1qtFr/7u7/bX5DHjh3jE5/4BDt37hxJiD/72c8yOzvLmTNn+L3f+z0eeOC/493vfiMgeOqp\nE/zv//vvDx3PAgcPHqDRqLNz51T/OP78z79Ko+HgYoFAqjp5bjl58uSI143jmNnZWY4cOTKyi998\n880888wzPP744zz00EMcOHCAe++9l0ceeYSZmRkOH76eL3/56/z5n3+VLMs5ceI0WZZ7eBqiKOTW\nW2/i1KkXOXHiNI899iTf+tZ3eMc73sp733sPIAnDHcs8UAmlnzx5kq985SvEccztt9++4rX50Ic+\nNBJeAuT5xWXcwZX9yvj2Y7H0d8Idr5TRmjb5ka9pmtrhXXm95FBj5rB2ntU7UtdkOSPRfhDsW5N6\nS5nvrFYvGL0B5zCmu+a6QQlv33T4UH8olJRVwnD/shi8rLYvrbAvNbQycT569CjWatL05TXN92m3\nu5w69eIIEwAkUbS7X+1fmi/MzMzQaDTGkjdPnjw5EvKdPfsqu3YF6KK9ZrHtc+cu9kGXcsdUqkEY\n7hmbo5TnP+5eLb024+o+aXpuTXHb2ozJUU9VMEEQ7Fhj5LXFBgQGYy5gTG9wwdbldeyYaXIGKRsE\nwW62nuPVIs8vsSYa89jWBkeOjKK9W8LMttaQZWfHhoVruXZSRoThnnXH7uOPpSBLZzCb6b61hija\niwq2lm0NkKUzaNPb0N+KZcYkhu7lgTUzGTZRSF05jRJicoD3r9l4BiL2S7TyPVO7sy3sZ+fV1ibq\nvuIAeqtXDCOu+sPCVs5E0maTw5VFiJBb3zhnTBe9iZ6swb0UfUMHQRju3FSfktyaRVlFiPraxQwB\nrFhiOKOzQq3Fs2ztFhvQKoIja9RlGyBV/7U87BYZULapMSmuCFndhpH1lqIYP2Fho4Zk+1y3yqbe\nb8viI8cbqqzxQi/1OqWo93A4JzCms+5+oTUhJ6qxouGsba3aLfVAbsHZjf7xFslE2S3ZFLZDtkrr\nLlpvxToQ/bRDysoVmdZX1YBc38f0WqK2FXZNO+SVhi/e/DaEcV5wZCSEXIvVD8tz5evul1n5pm7s\nNrjDkWyFVJS1XkTRig2/gRTRluRio2/rdd625FqX2gZqLEr4QzYgtzClnBy/m65aJ7JYK8ZMqxYY\nMzzfZauO0wnj2TVd74HhjCrh5P+V5EFyy3IgY5INv5XFIlW8Jih4fcfUc3WfLfNqFqWamw7dtsWA\n3OKcRBCzstLnEnc6kjeNm89iMGarvVDJErarG84Stf5Rwy5gCwyoVLq0P2RtXzcKxGzwb8sIpMJW\nCjRYa9C6tUWe3t1YKSsEwdSWHec2GJBEqunBvmTHj4Uo3bNdpuFlx+xCmdf72srjLJnCdlXDWfle\naMyWeCCx6Vk5W5FzuKa0zSzMcMt29YEBJWjdWS6guwkAKQynt1TccVt0hspQbsWakhVDult2FEQY\ns8Cs1WjdYisROYfG1QciEms1nCHX4ThxP0zXYbdsMbj8h409KbUD4i00HktRtNz92SKnJmVjrDTV\nZh7bJFQsEKKJED1fy5ErhHN2FcNZvhsZ0/XyQltzjG7HnO8bztLH6dNneOqpE5w+/SKHDx/iAx94\n75IwLsNas+FFPDMzw7Fjx3juuWd5zWv28YEP/MQPzRSdCunGHo89dpwLF9o8/fQJ7r//fo4ePcqx\nY8eYmZnh+PHj/Z+t1/sURXvLED1XcJ7elgx0e0xIhCg5TTm4a3XjWX02peh7ofaW7vhSOtRoterV\n6dMvrkDb9x5ok/H52bNn+frX/8t6gaRBn9AW5RqbA0Qkjz7618sY1WW36UY8a54vbOVq3DLU7aoZ\nEIAYak4aX2RdaVQkYzyW8PpfvS01cueFxifPhw8f5D3vuWfl22wKP8l77Y+Stweuz+VKCkOrzxhU\nW7IoNsv4uOeeu7n33h8f+dm999575XNbxRtq3XVMtU3vESXqtj1T8bZ7bDZSTnvOmB2DwomVvc+y\n4qbrWnWojNmynckZ0AbrMP3uzbU9jh07xm/91m+tYikrG8z41ENsiQFpnWzimorlhelNPvJ8bh2b\nyOqbjxTxtoRuV82AXLJeus81ijOu0rW61ewEKWOf/NoNnJvAmGTNBNyPfexjIx5o6a2wdr1rZmtC\nuM0wEFwX59bt7q7uk6x+DdZgTNZnBsE2hW5DIMK2iSsPLdIaxtS95sEVFsAVu1adFxKickUS4HBr\nd9nEVfaXHD9+vN+V6TxkQrvd67cvjLYMjH+cO3eJxx77CkpNcNddb1xVp2FY9KP8fvT17h6cOn2G\np58+QaNRWzF8PHfuIo895vKyN77xLbzudW9Y8bxLoGJpuFgKKh49epTrrlubATz99AlOnz7D4cMH\nueOOW/y9rW6haLwlz+dXtIxxMcz4H7pfBMH0lhr3WAOytr3hCQnreSi1w2th50OOT4yELmua1SME\nRnewasIL049frKUewQMPPNDXSSsff/RHfzTSDSllhT/+48/xuc89TLvd5YMffP8VDehLX3qExx57\nkve//728+OI8H/rQh0ZauZeGbqU003DPy7ABnTt3kY9+9FP978+du8iXvvQIv/3b/6+R9/ryl92k\nhg984L2cPv0Sv/iLH+5/bimu32q1eOCBB/pGcvbs2b4Yy7333suDDz44Ysi/+qv/PXfffeeKG+nT\nT5/gM5/5PG972xt59NEn+MxnPs8//+f/iPe85+1bukCLor0uzpsdbzdYLEpWCIKJbV/XcjBycXvr\nGc7VT4/3wevpH/J8uX5f/JjH0aNH+52Zx44d48CBA3z4wx/m3nvv5Z577uGP/uiPlhh3jb//93+S\nf/7P/9GaDuHRR5/kM5/5PL/6q7/AnXe8jn/wD/4e9913H5/+9KfHhmj33ntvX+fswIED3H///dx/\n//0jTW7nzl3kV3/1F/j4xz/Mv//3/wt3330Xp703Kh+PPTb43DvuuIUPfOBvc9997+1/7tGjR/mV\nX/mV/nm/733v45Of/CT/7t/9O/bv38+DDz7IF77wBX7lV36l/3OAz33ui6saz0c/+ik+8IGf4P3v\nfy8f//hHaDRqfO5zXwLUlhlQqfO2Ucb18IoSCFQwuekC9Vo+VZYojBPz2G5AoY6UzdGEdQPDrgaI\n3Mq7Vbk4m80m999/P/fddx+//uu/PrYz06mihn21mSs9PvOZz7Nv325OnXqRp57+Hk8++eQy77Le\nx5133k6jMfCob3ub05877TXYhj/39OkXefrpEzz11LPLPrc8v1LaqvxZqZVw77339l9z8803c+ed\nr+f06RdXPK59+3Y7YcW77wKcIs/hw4c4d+4igapvWZ1G646/n5sf5qWCJkFQ3/b1rHWHwAl5GC/w\nrtbckrBRxCYIdniD9cov4zptxxmVGI15LQKtF1bcAcsbe/To0VVvcl/jWNX7yabjpy1p3fU724wP\nr/bt283nP/8lDh8+xMTEFAcOHOCBBx7gyJEja5j0LJZ97/KIQWvCsEi7EKIf1vU/9zUHaTab7N+/\nf+Rzx7330s8Wy4ZQseLC3bdvDx//+EdGQsjSqFWwfGS9GNNeIa7QcuHyWhcFbS6fsggREUXT2zbM\nqzwPZ/C9kongIGJjFv3i2T4jEiIgCKbI84sre5rVvNAS+NWxEzYfRjhyqRgfFwx9O+OnJLz3vff0\nmQNCKKrV67cVjBn53Pf/hGM/y4hKZf+GQxUXCVzZ/587d7GfH9555y0cPnyQp58+gVLxlu3kRveW\n133WfTlLMZOQ7XwY0+uzJOTgiN0EBmMWriist/lQruFVK+2GjcefikdttgpuD8cazmhouFxU0LV4\nb5YxLFaO/y00h8QMR2tjG99p18LlO3fuIr/8y/+TBxt+YQkyuBVFXO00rq3BLpnNs976j1I1gqCx\n7caT54NOaTkYYz+g1jilne00IuEVIKNRjbZVssOV60IZWm+Mqb004R9W0lzpnh0+fIhGo+4pPk8M\nXdhslRrPGg1ohcVigdcMfe5jjz0x8tuNfq4jkK6+Mh977In+DKWlYd9G8p+leaLWPbTujdRqNlL/\nEUIRRTu32XhSZzxDm6UUY/ThXc//whb2YYw74aivgG9XMZ4rbz4bY2rffPPNnDx5so/InTx5kocf\n/ktgIJ6+0qMklf7O7/w+n/vcwzz11Am+8IUv8KlPfWrVxdxsNvvQcqvVWvG1dg2f+/nPf4mnnnqG\nhx764hU/d+UFkXMlFYsyF/vSl9wwsqeeepZz52b7SN9qkrzjHh/60Id44IEH+MIXvuCQt3xxXQjb\neCuzhOGubUXdrC0oigXntYf2DfXRj374N+zQbPVB72UBZH5X3p7YXsrYd3Zm68uFxsTyrh/FdUN+\n4Qtf6EO7J0+epN1uj+ifgROdP3bsGI8//jh/+qd/ShzHHD16F8eOHSPLci5fXuDcuYt85jOf90Ot\nzvRzgFtvvYkoCvnWt77D00+f4D//52+Qpikf/ei/vOLw3OPHj/OFL3yBmZkZZmdn+exnP0ur1eLU\nqRcAuOXWm/nylx8Z+Vwh4JZbbuKWW24ijgef+7WvPUaWZfzar/0azWZz2Xk3m02OHDnCpz/9af70\nT/+ULMt45pln+nN5Pv3pT/Poo98C4MSJU9x6603LhhgfPnyIEydO8a1vfYcvf/nr7Nu3i3vueTuP\nPvo4Z8+e5ciRIzz00EMj7x9FEY888siynx05cqQ/eOzd7343112329F2NpPwW00QThJFk9u2Tq01\n5PksWrtBXs7zOmBE9HpnrbUGrPHGbHwsbrynqHnBELlNB5eTZTOjbOB1qpliDSooxfzWd5zlbJoy\nvHjllRc4eLCx5pvx1FMn2L9/N/v376dave6Kf3fy5EkajcaycR5FsUiSnF8z7eSpp57hmmuu54Yb\n7tjwjpokFzxp88rX7PTpF9m3bzf1Ro1KZQ8XLrTGjiRZSwg3MzPDTTfdRJK86hflRhe+8UDKgW3z\nPs54LrvrJOSQAclRAyoRmQEyY3GTCNy8FCmnts3CtW6TZef7I8rXX9J1+VsU7dt0Yc/agqT3Cnbd\nBT1JpbJ/w01lRdEmSc6ueSG4+1KjWj2wsaVnEpLkPMYUg9HwV7zKFiUj4sreTWsfuPM9vwnjcask\njvduK3CQZZd9iuA0yIUc9kByta1n0Kej9eKqY0e2AkJWqr5usu1wAj7on98cU1uIsrpu131Dr65W\nnEDKje+6xhSeSS7W0XhqvHDIZmFix3kTm9roDEEwccUJeFtjPGMGcg2wa8tqU+bc4sQPc21v22LY\nbMOTQKKLrWBqC1RQ34DEscWYdFOf62DhK085L8cnbuZ6GZOzPtqM9ZvL5nPiomhjdLYceVzjDmqt\nRakKUTS15Rp0g2NcQBet5ZfejtY35JUOdBiuLIrLXph9e1C5IJhmw+qTAiyGPN+8F3KdquF61hbW\nWoxON3H+EinVeFR5I70wV9i9N+ItBw2Im/U+C9jV9CdWPV83vDgMp7atYFoULfJ8ftVZwHa4DjTY\nbe0VT74oLm1bjUipssBqNrwItW5vgaZ2gFK1KxvisqY3s0njXV9T3cY9gcGanPUVYUvlnXCTi7O9\nzHhXdUJLfmEtBEGdYBvE610+3iXP51Yf2dNXlVrxCtpVojpDnl/YFiMSQhIE05uTugXfT283cRzl\neEJ7RcMZFVs0GzbeMjFd62bsjnFji3n92t4Wx7zeXL7hEK1Fv2GLNe1NdsmuL2W4bQVTY1KybNYj\nwmJZvjNOTVeO/aUdHdS6fCBwTpFf2hZlTikjL3y30UhOoPXqTO21h3HxaC60guEMby7rafFeiuIJ\nT41Zeyeq2OBCKbymnVjH9ZAEQXVT19T1+6TrPu7haxFFO7YFsra2IE0v+o1Frh6RLQcRlrimEeMZ\nAzJYgbGJD+e23oiUaq6uHLqGcGpZX/26DSj0CbNZg+F4sMWYDedBQsjNFRTXCXasN/mWMt7UwnX9\nPu2N57hYwnBiWyBrZzwX/HWRS+OKZVYznBvJK0fky0MLnz5hTMeLv2/1CBLpJ4YFa4Rlli9urctZ\nmpvA9YYER9aSw1vMhodTWbtelEBsqLhtrXUI3LpE5MWm+2u07qB1b4Ne0yJlQBRNb8uGkmWXPB9P\nLIm0GArj7LL8Z5kHGj85YbUbK9F6kaKY23IjckJ4U2xsipwLp4pifpPH4MTS1z71SG54+JYzBrWO\n67hRSWCPwK3LA8lN5T/WFuR5qz/UaiOPKNq5DaGbJU0voIvuUDF5BUDNjsHh7JphGDHyR8t3l3nf\nELW1jyCYdL0+1q7TeNwxG71xpvYgD4rWhay5BD3fkAFJIdc5WFZsYDGbdechQbA54RCtE3TRgw3V\nrTRhOLkNBVNLls1TFJ2RlOUKguhjtpYx0Nx4L7R6IlsUl7bFiKJoB4gl9RF7JeMpf6d9n73dhBFV\nkFKteTlbs/Hxj1tY6lkFQMjWaXh2U+FbH3nb2NEiZYUwnNjygmmWzY/kySM9VuO8zQp3S1prPfxq\nVzCklexoNF50YuCXtmGWT0QY7lhmMWtdbFonFMXGvVAQ1BGEq3uG/sEILBsf/7ieRSJgQyGNMesd\n47g54RCtexRFdwMG4KDuMJza8plDRdGmyBeWsU0srBquW2uX5EPDHsiWL7BjKllX3u1LbYU8v7Bp\nCHn5InaoXBlK2XUsM2sLX1zdaHE2QMpw9Yr5kutjTLEBKtA6c5o+K3h9AILW6Xr6RAiDjQuHWGvJ\nsrk1k1WXXttA1bdcHETrHml6CWOLFaWD7VqS7tKArDVYYzFDKJAZw0xYviDGJ1nGaPJ8q9kKot/r\nbtcZDAix+bqQVDW/iOzY07dL9qSNT69bX2i10XxkrS7IYlBBbcOJv9M6SDcwXc4iZEAU79jSNhpj\nMtL0AtbmrpFzc5fS3W1jJMZqSkNa271aWctAULa+zm5pjcgVWCc2tChLzbGNeqEgaCDKPGwNNSFj\nNmpAdh0v2wiAkC1pV1n5aa0TLdm4cIhL0u2GN8ytDd2MyX37Rg4Mcurx93DNLhpZTte21nkhY8yK\nxjF2pxzLWhCeU3R5C4XgHSrn4vH1vWfJkduoFyr1n4f7lVaVHzbFBg1IsSZgVAikWP/ics1ra0Ax\nrEvgA1Vjo8Ihed4eyrfWQbe2FqVqRNHWqYpaa8awDEYuJ+MDrNUcSp9MKoAmUOnnQANQwa6uUrzM\neEaBBa0XyfPLW4YtCSGHWLh2nRfRUhSLGzZopWqsddqGBbRefwgrpVoeKm5FtFfuwmX+s8qkuZFz\nDqobzH8849raNVjqaJogREAc72SrmjettSTJ+VWLuNauYiPL4rySRy5QqoZ0Hsep5PRHHl7xLi3p\nHLXLSED9fEDrBV/Q3BojkrJKoJrruZe+f0ZSFJ0N9+woVVtzPO6mNuQb9752DSe0kZxklXNfEsB5\n+H5j4VuetwZI5Jr6fQa/iOLpLWjYG3ieLJtdMwPC2rXcDOujoQmiaIczIGOMq6rKCZRqjqGVjHmT\nAQV5iU7ZcmPL88sUxSJb9QjC6dXZ0isk+u7mbsyYhSjn4KxJAt8DCRtRNRJr2q3XC2G7HqBiTc6n\nbFjbCEzukNgr5JtjDsB1mDa2tE0hz+bXzMwXq1z54bUOiiiaIgwnyhDODuBrnBG5xjax+pDgde2M\ngjyf27JCqxDCU9rVFY1nybJD6+66JgCM5mD1NRuB24HXm6spjw6tIhBn3fVf7+J27AO7js2isqHw\nbSnjek0Gi0WIkDie3rKCaZ63yPqim2vwPqt5f+HFdoQkjneOgFkjBjQwogZBsMJQrCUM7bXv5Zos\n27pCq5QxYTi5SgC78rHl2dyGP9PpENg17cTrpfSU+tgrJ/abg3DXmsEpGaPU+jtPnfdpwxrGXi49\nrSia3jLUrSi6pOnFNfUdrWhEQ+vKmFL9Z++yovJYA3KLpU4QlGJ140ADMXSAawtrBka0NYXWIJhC\nqurynp0roGTaJBtiarudee1eaD27/loc+sgIj3XWR9xE8TUJDiBVZUOCJUVRMq7Xc2yGIGj2Q6LN\nPrTukSYX/PR0saHLPuIsrEWpiDjeOzYnlEsNZ9QTVbzWWtUhc2NZCesjPxqTeXg73/TFcqGcL7YN\nMSiu2HZg7QY1tUtav1nTsa150Q6BLksNY5wDEoJ1J9rlHNTy/pa579KnRSJljDHLX7PSZuuuabEB\nPQpXa4rjrREHMSan1zuPtXpTBdjh+CpQNS9XNv56B+NGYow+Y6JoN3l+yYvwObhaiHWOhrSDu+8E\numeJoj2bnl+pVJUo2kGaXhwZRbKaRyoXt9addTdoKRWhVNWpyojVjFRgTT4yKuXKIWLg86DBWYgV\nDLm8P+VCHmeo5c+0zimKHGPMyN8sRZ7cbquwNkRrPXK9lh+rHHmfPO+S5+2xxNuVz18QRVMbCheX\nn6trigPTZz6IVfGZKxXE3GYZx7vHjnApvwYOe7/SPJuAMNwDzHqdLNYRuo1bxK6wmeeKKNrNZjH/\nIGh60mJ79GRX8UjWaoq85ecCrefznbST1sl4RU87uDrGI3Hr2yTsWCMY/t5a0NoAesQbjPvq6l9d\nsmwUFVwmJONzW2urFIUBslWNZ3gxuVrLPFprhLDeuJcvtuH3stYSRU2iaGpL4Ope74IPmcfs2WN/\nsIIDsBYEhOHEmupRaw50hZBE0S7yXK46XnFty8ItRAdtS4+obdyInDL/FMYkGKNHyIur5UKF7hGs\n0wu5PKgGzK96ggNGRrLm5Nh61ZmSDbLUEFyYUr6vRetsmdGUfzvMKEnTNlmWYH25YiVjQwjiGIRI\nxp73sBEMfzUmpdeb91p1om9gQvgBaqL8+eBvXIfp1DLptI0YT5Jc9LnXFYKfFX8weC+3zqfX3P26\nzkxREIY7EUJ5hsGGLGck5i+KeYRQhOHm2nWlrBIEU2TZ5TVnZ242TXtdRdJBGFdxXkiIlTimQ+gX\nq3qV4f9rbSkKs4pBuMJ3lhUjhrb0Ofx3abJIlrf7bdwlLX/kOPohJGRZe1m4stTrDIxC0uudx5gU\nKdzrBr+X/v/0vwrh5HErlWmMUd5DjzfOtTyy7HJ/I15zFjEaqY0YTxzvJgzXXovaUI+sU81R5Pms\nhyzFGkO38UaU53MIJEE4uSkjCsNJX+dZW+VZCMdOCILeumjzTqGzgi66DNei7NjkPR3RGBv2DMOL\nvFz4eW7Isxx8e0hZ5DZmOPm3QLef6C99j6UG1O0uUBS9Ie9jxuZNStUxprNq/rI0R7Y2J0kuI6Xo\nC69L6QxLSomSwz9TCCmIwgZQIc9zlFJ9Ax02yivnT46smmULbETlp1+lssLXoQIqlT0Ewfp6nzbc\nZB4ETYSQZNlFN3BIiA0Yz9DFyC8jZLCp1l3hC11Jcg5j1sYCKNVilFpP27LoV+rH9iqOJNc94tj0\nd/yli3vp91nWI0nSIaMw3lC88WiLRWFtp280A+Px/9emb3zGZPS68xR5D1MUCNyxCOuSbZN2sEWK\nCGvE9T1kYYbNewhjQAXgQQEZNxxC53McqQKElKTpQJlJKTlkCN6AVGlMCqUkSgWEYZU0zVBK+ZBY\n+deqfk51pXmvRd4hTS/7nGUzcLUTLKlU9ngVJq6OAZU7VhwH5NkFtMkGJ7ku43EL0vGWLhFFYlMd\nkFJWCIIJsjUWS50XahMEzXXtPkpWkCry8DDLvMrAG0CStFGqsgwSLr/XWve/7/VS0rTX9zrGFBhd\nGpDGGIuQIVq3B3+nC4zRLscpMihSTJGCUEhy8vYrhKZDIDSRtMhAosiphAmKi1iREQmBKqqIQmGS\nDqGZQwqwVqFtjAl2o4NJtIkwYRMT1NAWlJAYVaEnanQThTYWpYRnsEtvHAKlXHhYr++m18uRUhME\nAUEQoJQaMaLSe8m+9xr1SEXRoZdc2LDxjK7hmEpl74b5d5uWOZEyJoz2YrMLI3pj6+7HFAJjCrJs\nljgONlWVDsNpH8qla/RCljxf9F5Frun1CIUQIcZ0HGTdz1lsP9wqx8ZY2yEIWGYww19dt6gmTRN6\nvZ6f3qYx1qIL7bQWTAFZAkVBLs8RmIyQLlXTQtoeoegQ2nlCfQlVdFC2i9IL7GpexprLLhdRIIIB\nhiokkAMdYM6Db2XEqYYi1LKNaOnXUh8+jLkcvp5cTFBUdmGCmF50gHZ8PXlQp0cEqoaU7loHQUAY\nhiil+oa01KBKYyo9kpTSAxYX3YeLzaK3dSqVzU22ExcvXrTDFt+PXZVaVzLnPMgFr4Kz8ROzxiBV\nhUpl36ZOzF3os2sv7Fmo1g6s6MbHJf553qLbveB2/z56NvAUxhiKQqNUnTCcpiiKESMaNqDy2evN\nkfYuokwOukDkPao2IzYdItOizllq9lUi5phuXIJ8DptmiAKEXnLlAyAceiq/sRXOaEQGpP7/Zqgy\nUSpsBf45rDVo/OuHjcj/vS1AFIPXlpfeBrBQfz3diTvIG4foNG+jF++hEDFKKcIwXPYcNqQgCHxI\np+n1ziGE2QRyZ/spSKWye0MF1xFofqsMqDSiPJ8dYl6L9Z+bcG3hYdj0hdaNV5SzbI4sm13bcVhQ\nQY1qdd8gxVzChyp/VoZgWme022cxpofW9BP8gXFYiqLAGkWlupeiKNBa9w1Ja43JU0zeRnQvELRO\nEuVzRLKgGlmq5gKxniHkAvXaJYRHuoT12E2J38ih7/3/bSAgiiAMQQSIIoReAmkChXEWIhRIgxUW\nIS1Wag89CxDGU4aCwRtnKWjrPssugbXK4xguD1rv3bT/Wrh02Raw2LiF7p63sLjr7bQqN6IJiKKI\nKIrGGpMQliK/jLXZANWTYp1r1LdMRNPE8Y4Nb/TbZkCDhXvJ14rWYURL8iZrtS9m7d1UgS1JzlEU\nnfHE2DF1mGp1f98LlYYy/P3SMKzbPUeWtSgKjdZmxHi0LigK930Y7sYWGbZzAZucRxRtAptTVSk1\nfZFq7wdUzMuo4iL1uIMKU1dDCQZyataCMH3wEqslaRIhIklYBWljUBIbWAgFiDrkMaKroKcgy0Bq\niAWEAQQKG1oItA/VvCvRGnKD0AqbG0ThaVJFCnkKOnNWobwVSTMwngJMBjZ3RmML98S/xHpvZrR7\nOxNAZ/dddA+8k870XXTCa1BBQBzHxHHsjSigKOaxNiGKQgRiBLBgLWyPfp1rx6YVTrfdgNwYlAVf\nk1kD5Wcs6OCqimE0vSk1fmMSet1z2FUYwsMVfqUqVCr7RzzNSnmLy1kW6XTO9/9fFNobk6YockTn\nEjJvE8uQsPsKTfMqNbFIVS4SZWeoB5dRIkFKEPEgZLIKkAKhhYNaTYQwTj87N4rjp6sc2BVRdGP+\n03dC3nir5G13hSAlBBaKENpAS7swDQWRhIrEVgNEJNzrJC7ukv4CFAabaURmIbWQ9SDtDaSAhXcj\n5N6AANuFJMF2CpI29HqQZyAFBAqUhFCBUsN1F3eLtYaicPYoFbSvfSeXb/onLFQPEUURcRwDHaRM\nCILIeySH6gVqFGQQUqxiPJJqZQ9BuHlt7atgQB5qLFpk2aWhAHsdxjMCCkxtyoiybI40nV12Pksr\n/e4piKLdSFlZ0WiKouiHY3me02q9Qp6n6DzFtmcRJifsXCaa/x5NNU+1qqiJDpX8NM3ovIt2Ym8w\nXgbBShwwgcISAVUQMcKGYBWWEJSLlf7ikZCujfjJvxUQVRUzswG1qZBdO0MoJCQa2y4QnQK0cqs4\nCrCVECoCEVgIrUua/IBpjIDCQqEhLbCZhaRApBkUPg4LLHjDs2gwBqEtJD1YbKMXE9qdHlk2uN9C\n2n6EZ4X7GGH7sgsI6aO/ofxKa2gdfCftW/8pC9E00KMSV4jiiDiOPAChUCrwtabl7IfRBR9Qqeza\nMomsES4c2/gIgiZSBk5KyBQroib2CtSFPF9AipBgg5R3V2DteYFFMZLXlFDzoMZiKfJLhNHuvuEU\nRUGe5/3cpTSgLMsoki69+YvYxVdQrz7BRDHH1FSTqpontGeZMK+g2gVhA+QkEAORMxgrJIjQ/6CK\nkCHWhghqIGOsCEAEWAIQAlEPaF8O+O55w99+S0D9UAXCgOtfI6BQ0HbGQ5aBiKARQBA5AwoEIpI+\nVNNYaRwh2O/ObgSQAZGDTRHKJzqRhsS5ChtpiC0i0g6uKzLoFZAH2LyGtYJqJaAe5yAs1qQUhSXT\nkBWQ5aCNsxPpUy1jPT2ptLIyGjz1VWrPfBVx83to3fGP6GiLNg6trFSs59LRd9kWgyoRu/IeC2c8\ntdq+DbenX3GNr18AcP0UmzjeQ5rOLh+rcSW5rCFPkWWzIMSGWn5LMRJdpL6t2Y4YjtbGjSYxhkJr\ntE4IMgFUyLLMf35GUeTkWU6RZ2QLF8gv/oDs2S+za1Kxo55TCy8Qc4F6e5aoArICqumcCSHYEFAS\noWKEiEG4ijwidMmAUAgityhUjJAhiBARBs771AJalyQiKmjsjWEicgmSkJD7WCiTQAURK4hClxMJ\n6fIoT5RE+XBHWe8B/T0pLIQFeZbw8qWCCQrOtzTXTMDUFIggg7CAUDsjTy026SKsRMgIEcUoU6AC\nDTIj7/TIiy6GAqlcWhbiPIwpbdc/tXb4hPXonS1h9L/5MuHZk6i3/zKdiWv76GalEnlAYGBEfSIr\njhgbyCqV6u4tVzYdMaCimEP2t8btM6JKZR9pen4Zf2wtfUWO2azJsjk/ZnDt9Pfh3iYp6+T5HMYO\nAQJ6kPznRRme5VibodSU8z5Jj3ThPLpzGd2Zo/Ps11CtS+zb22Bq6lUaxXmavbYDvaZA1JxToeIN\nR7lkQKiqj90aIF2Ihghc3kLgvAYheMNBRqBCh6SFChpgpgwiLugEMUzWIFXQ05B5j1ETICJsECBU\n4Nq/jQ/TBBAICIwzGuWfwlFaEM4Dyarg/PmUlpFkheFiIJk6HLiQT+YumigKhNGIWEI1AJWhbA9D\nwee/Lbk0X3D/kRaVyNLJUsd5UxphXS5UgnjaQpKALhywYBgYkcDhIGrhBXp//j9R/fFfoHvNHSzt\nkCqNqETnDIYwdDD1ZiaZr9EDJeR5gbUThGGD9XUTrscLBMTxXrJsliJvOcrGspESq8V3roiWJOd9\ng1N0RaNZCjtLNYE2LYqi66YU+IQ/zwvyIYg5ywqKbBFJG9NtU8x8j+TE/02tEtMIDDvFWWrxi0z2\nNPU61CdA1YHaIEQjEtggQqgYZIgQVWc0QQSiCipy2bUKnKHIyHsilwMJobBSIeIA4tA9JyT7hGLn\nnoTkcgjdyIVXPeXeb6paKty7ekxiXXIhwEpH4iS0fsP2eLPwLgHrELpAoHbAjXslc4nh5glDGgvs\nTomQBkyEyHLophRpApUqaneMyFNsoZBCc8thwde+mVNUDHFDErQKjC7QpusL3AajB0ZSDSGQkBeQ\nZC7c66PjBlQM9WyWzmP/hsrNP0565z9Yds+dESkf4k1Tqexa81CAjSG8BXneISgDTzcoK0OISa94\nsz1G5Pp/pK8VXQGhG/FSThHF6Iw0vUilsndZoXVp3WaYe1YCAFI2yLIFitzlMXmRk+cOMcvSlDxJ\nyHsdigtnUBdOo84cZ2J6mslgDnnpBZoB1JtQ2wnVClQq3uNUgEqAjRWEMYQ1hKphRex07GTovE8Q\nue+VR8xUACrCyhBhJdYIIMCGASKOoBE79CwKIQpQdcENB0I6HYudkYi6hFB6L+XeU7cL9CsFUR1o\nuM8QgYJIOQMPpasF5b7yKrWvhHpgwYTYMOD6/ZbLPU1gLGLat/YnGRgFVUXr1RDTMuy8EcgjRKqg\nSNgznbGrKckqNZJ6RKVaoDopYRqAiUAsYnoFRQFp4dK2SEKlCrFyP8v8U1tn63EMoZ2l99TnkaYg\nuevn+vHJMLk1jncQe0ngtfS6bQwc65LnCy7UH4F8dZc8z4EmSm280HSlfCSKdvmWiFUGc62EzgmF\n1l3viQ4s67AcNpxh9GxQxLQURUynu4AuNEmakyUdsoV5Oi9/DxbOo85/j+k4oBJoZDRHPPcCU9PQ\nuB4qNYhcCQUReSStGmCrMcQNRFx1W6bw+YsMPFAgfYhW8eGaK3A6IEG5cAu/0MPIeZxKCHEAgQ/p\nCrdN72wYXpqx2CxC7PSFTolLLLAksyFpTzF9wEWIyBBiidWSZBYKJI0aiJp2BpNLkouahTnLnkMh\n53+Qc6En2XFTQDOx5LMZNgJRFKB9+B0HTO8LSRZT99k7BPQspJLKtKJZEzz3suXsCcEdBwW37jcQ\n5pw9F/OdVyZ54+4WnQQqoWGqVpBk0MugXnEpIxbSHBJvYNJHbdFO6D37nwgjycLtP4ubJOjg7Fpt\nF0Ew0c9thzl0W+N1NFk6R6E7WOvePxgsbCc+aExBni8gREEYTm8LeuG0DKaRMiDLLjlNbnEl4xn+\npfQq+xeIY9fROs5wSqMp4eYsy9BakySQJIb23AWS+VnaLzyDmTnFhJmjUY2IwzZx8iLTE9A4BPVp\nt6YD4aIu4QuZRApbiaBSR1RjUFUIXMgGoUvwjQQT4lZg7Mlo5e8DkN5oKjFUIlfgLL1JEA7yoqSA\nTgZdy45ayKshFLJKVIkcjFUYn40HJAuCYEIidoT98My0JL0FCZWAF58vuOGwoLHHVzRjQyCg/UqG\neEZTf03I4ddZwp0QYeCaEEwBufLom+ClZ1POvKg5PaPY/4pm976AG6+rMj0ZEExHzFjJDVHAG2/O\n+Kvvaq7ZI5iaEFTzhMsvxPyfz1Q4OJVycLrD3r0FWRtOnA95+6EcqyGzbpOqWzi7AGdbMF1xKVvU\nhOzUI+zYdZC5A3ejVEC1uhuo+ihDjmysW+GFiqJDls15eWTZR/qCURrNwOVp3cWajCCcIAgmt8Eb\nCa+vJb1Sj14XN9BavIiFJQx3LTOcEnLOsqxvOGmakqUpnbnzzL96mrnnv0H+gyfYv2cXVdmiYl9l\nMuwyuQ/qUxDWfdTl17LyG411GD2iugMRVb3HiH0e4wlkVrkajA7AVhw8LeSAWiDc60UcQi1y3iYK\nfJLv8yIi0BLahYOLtYQ4YPeegGBGk6QBUcn4FPhKpWSumxPXYyYbFZdodCzd8wVqd0R1f8z+Toaq\nSWes5b2owv47u8w9u8DOAzX3e4oBWU7kEBXu2NDoHa54dW2gsHlKqjQ6Vw6GtrCvXmHPPsXNtyge\nO1Uw07FM7YHpWPL+ewv+338Rcd2ejNtuTCm6UKQSZSQvXAi5eUfO7CLkuYsY8xwuzMFlXEQrBNSC\nWcQjv0/tp27G1vZgTECWZX0CarmOncaD3VTHa5rOuhGVPuUYbsgLxlDR+qC8RXtBxB5huGNbvFEQ\nNJAyIEkuODFyVmdzDxc/nbEsUhRusrfWA+MZ9jhpmpJ023RmzzL7wrPMPf9NWs89xqHDr2Fyd07N\nfptde53RRJFLS4LQpSuq5gxJxeXFUYig4rbBaNItqKDikngReXqydLB0HoGNwUhEIZxBWV81lYHz\nOjUBkXU1GIXnrsXOxWU5tApIA8fIjCKoBsSTFisz5tuSiczD0UL5PEvRmFAY43lAQY1UF7SDDjv2\n7oRqTPPAHGG9DtQ9Sc1VMGu7JS+LHguzkh21ijegwDNPe277zxWEBTfcZLjhJkHyfYW5LKkdLiA1\nkOUYC1FsaFYFaEE9lkyHnvotQuI9KUf2G76/2OCN+xdJF1Ie/k6Dr59U7FCav33IsKdq6PYs/+VV\nQWws1VAwX1h01Tnj5+Zgd2WW1/7FJ9j1j36PXq/XJwCUXmeYyb0xNk3Pl1+yEVracOauPvzhX/gN\nwWjvuoMDB0Q9a3O07vjfRVuemAkR+H6ZFGOLsd5uqeEMs52zrE2eW4yRzliShDRN6fV6dNuLtF4+\nwaVnH+Glr3+exZNPsLeec+3ujF2V73Pt3jZ79jokKMSFDWEEQdPF29GO4QJojK1MIao7IJ7wZM2K\nC9uUD7+EcuBASTUQkQvhjHDeCIkNQ0QlcI7Kagc11/zfy8gZS0fDnIYsgqDqwzvl6D1WcHFGkquA\n/QdjqDYgrLnXNZpEVUWrZ6nu3OkEUHpuRk91zzTWwJmXetR21AmjuI+6ZonGmIKwIlAXclQkcG1Z\nTs8PW3imgnWZfeGMQ6QCOwcq9EIiRqKN4NWzlkC43xc5HL7BooSlKATzc4LuvOWlWcm1kWJqUnPN\nNT2uPVjwg/mAC5HizbfkLASC4y8rDu40CAQ93yy7tw7PXoD5DJrJIr3Lr9B43T0Ib0DDPUXLNBrW\nRP8qPHvlkhdiGRX+HWUilMU1xo/47v/fN7wp1fOzWypbakRSxlQqB7ySfmcETl9K6NTa9MmaZZim\n9XnclImQNE1Jkx75wlnmnnucV5/8S3R7kT37JpnYNcN02KLR8EajQXUhqIFqQDDhjEbtAFX3u3sB\n5AHYSYRt+N6AMhyTPjD3bADpmQUmcAmTlSAFVgaIyPcIKD9PQxnSuYDzZwMOvL1KqCIXji1qmNfO\nY1UrUI+doRoHScndEZPXdJlvG5ja4YolQ5FDuEMgZnJMT0MkCISiQYHNnMxWI4jIFjTVuovirTG0\nXu2gapbpayaZ7Qnal1Omd4Z99NPlcAEob0wmh0ygqmCv897FSDAFsYAfOWI49bLmlQW47XUQVQLQ\nlqST8VdPGN58WDKfK/7kW01+8R2KnZOXeWvcZcddOTccTIknLQtnQvadU/yd9xZkieW5Z+BvvueA\nxQMTzoCCCM799X9mx+1fQdz23pFWiDIfWo8XKooOaXIZbZIrdgLYMgeyy4bwrQQvCz9nJyUIJgmC\niS2dICaEolLZQ5bNkuftZV7HyTmNAgRZ5sK1NE0o8nmwdYr5c/Re/Q6vfPvrtM6/yjUHJmhOzDId\nvUg9djUHUbicO2hCOA1q0n0Nm+5JRTjUa1FBGoFtgKw7KDhSrrovJEhJ0hVceElwYKckmHTAQGk4\njlEZuMp/gSt2aOHylUqA2BWTfl9i2gJiS3EmQ+gAVa/DdAzVpgcTYveewhlJY7pgbi5FJwGqhK0c\nSQahqkztyMjaGZXJBmpyisvtFpdPF9xweII9NzTIM+HdaoEQMLl/CpQrwEzeMAnWM67xEldSeIi7\n8NJBnjYQWoKmT5Uy018+O3db6g2BLQKqymIzCVZQrcPdd2p2VAVva2pu2m+QoYReE20h0IaFS5I9\noWFfrUCIgAuJ4MB1ljv3walCokLD2e8LmoF1m+AkXH7yz6m99h0kSbKsMa9sG7+y15knzxacwEgf\nwVt9QkkwvidHrMJXk76INIsxXZ8bVbY0nIuiPVgr3YQzO9ADKBkDha/d5Hnez3WSXg+9cI5s5ntc\n+u63mDt3jl17dnFg/yWmojNUfJ6d5+7ca3WIpiHYCbLpvI+quUiMXGDbEtGLsHkMso4IfT3GBmAU\nwrh+mvkLIX/8RUgWLP/sHymCHcLXVyzahohcIQX84PmcuXOGN9wWIqZCaFTRYUw3DeiiOfblFKYM\nE3nAHW+uUd3XHHizvscbaGfvmoo5nSYstlOmq9GSxhxFbd8ktt2BJIfKBJPXVmnkEhkFvl4iBt5F\nWIJa0xtMRqACz6PxTTylcRoPlYvQIQXSuJBTu4qnlaHj1wkLRUQlcO9vc4Gwheu5Uoa9O0NINJPV\nnMlrUseisAIlYq7Zm7jTzKDRtFyz2/CVx0Punss4fCNMThp2HxQceFUiLmt0Dpc7wHe+zfTrvwh3\n/FS/pygIghEvtFIYl+dt0nTOS06LIeNZzZl48cV16ouOWJ/WPYw5RxBMEoZTW4LUlScahjuwVtLt\nXvQ5zwCOTlNH7EzTzCFr7TmKV4+zeOKbzJ69THNqkhv2LTAVvkoUuDphljvHUKt7hG3KhW2y7tHn\nwG3AMnPsfNFzzAARhdho6EKaAIrAEdtsTF0p9lcsRilEy7cASIUtFM89ZTjzXI87DgnaLUFYC2Ay\nhIk6RTfkO9+2nD5bEIaSOFTceVeTiekKlb5BlF5l6TYmUFMhKIVI7FAnW9lKqpBBBSYqjlhKjpIV\nVDzcedcn0zDaWlo+9dC9LttTS/q0cnC88hQgo32eh6MJ+QkSWAfJiSBwncHWIIx2by+FK8gaX8PS\n7tirkXHhgXEds+85mvIXT4S8cEFx+DrNoSnozMHtN1mkgqkWVH4Af/I4qC8/yBtufSdZFveNaDUv\n5PrFZimKNsYUK0RTqyuYBitHd2JNhmStR+qKDlG8c1MshuFcxxXCGgRBQa93gTzPyHNNljmjSdOc\npNuiOP886QuPM/v8SaLJneyZmGdK/IA4dOsgT51XqVahNum8jqoNqGYy8Euu642nB0JLBydXnSqN\nsAJrBCIL3I0WvrmlKghrLoGOrCCqKRcWWQmFZecUfLdr+PKTkp//uxHqhtiBC1WBlIYdRxQ//qMx\nu7Sk87KgudfnTctunhkyDhcFBHHMtTtiHEAkh4KJsgdbukVeqTB+1pMZ+r8e9BI4N+Of2v8sc0TV\nYqiRh9KQfKFWSYS1WKM99075Wpc3ssC3p1rtEEcrHVWJ0P0ssCUHCkzPnXriIub3v9nrqGvodmF6\nwnLDLssfHBP8vR+zvOMOeEVD5wcv0v7eI9R+5G/32fNBEPSLqsNeqCi6JMklJ9GMWCUVWd0WAoYi\nNofGDVEj+rzW1fWNsRZjM9L0HEEw5ccwyg0bzwCiLhyzWEyT9F4lzXrkeU7S69F79RT5979O+srf\nkKsdTE4V1LKniPzGWPQcIhw3IJ5yX5UnAeALolKCzEG0wXZceB9IoKLpphZtIppTEnSIMJHLe6TF\nBhahLFlLM3vGcuaspBJbRNMTMlOD0IJ9Nynu1iGPfE2wmIZMV3xPjwC5Q3LDHle30fOK2QWNXCio\n7wiHFq9cYkRF31hCBfUpSdI1S/qt5NBz2BCHPc24x7DHsUM/04P3Ff5zxND3/YHHjgokhMRKiZCe\nn2ctKO1aj1BYoRAycOGe8SFgULgWVoEzOhP68NF//II/nRhqyqFwWQjX7oGvPy245X2WN7wBLu6C\n5MRfULnt3SO1wLId361hTZLMk+eLXhxGruoqRuW0xdCXMTmQHQsnrF0D2wltXEbrLlG0c006W8sR\ntoHAhmshKEhTg7F1er1FurNnSb7/BNnpv6JSCYknJwjmn6UmjKs/CudVohpEDUdLCyIf4Bi3fmXg\nmRcdMF3XcKmEK8sQOuZ03gv5mxciDAFvuCmgMel3X49UL1yE587A7p2SyZpkqirJL2aEoXHoGQoK\nwe6m4sCU4OTzhjdcbwmVgZ3GQcEYUBrZgB23CcKa77PpexvNQBpHDn0NEVISNy3FZe0SflHmP8WQ\nEYgluZEc+n6coRhG5HYIBscRaLfrFL5HuxRmKHWmbZ/OMhgsbI0L77TBFqbfv4cxCOtCXXIXCrv+\nBf/Zoga0HeI3zDdO4eZ97s9qMfy377G8cME1zZ56CeIq7LFPk559jvDQjxDH8YhkmCt3zPnBAHJs\nXWfpD0Z+N8YZydXjvbVNdrLLkLoeSTJDll1edczhSsbj8pyUNE3pdDquntNJaJ95gfnH/5Ti+a9Q\n21klzU4h2t+jVjWoBogmqJ0Q7nZwtAhcdCAzl/8LH8rLDMxlSM5Bd9axXVzhVLhai1FMVhW3HTCc\neCXk//prQb5oEYWEQmBzwXdPCNqp4NARQb1q2BFqQm2gZ7C5wUpN2rWEHcNb7oBT53P+88Mp5N5w\nMl94TN1imthniSIfQ9rEPRl+ZkO5iUvua7Eh6+XorIvTpWoPfW0DPf93mf+bce+ZDtgG5P5nwwal\nB3Ugo93TakaUQ4Rv1BPDK8p6xK5wXXRlGKzVoB0V48K5klpS1pdy6Z7FkkjTgCwPM3XEiNdeA40G\nvPUmqOXQ2An62T/wQFPuPVFGt3uRdnuGokjG1xmH1/ESnzHScmOXhXC2rwu8/E2v3G4wriGvZMKW\nA16jaHqZWOLSfMcY0z/h0oCSJCFJErpzl7jw1MPMPvF59lyzG6YWSTtniDz9rOxBk57+LrM+aQAR\nuXtx5pLk2l2GaQ29eVfGSArnoaY9QdR5+Ig8j8mLClM1eNMNmj98Mua2l+DOIy72W2xJvvOi4e43\n5kitmV8IyEOLsQLbMagJQeus4LHjOXfcHLL/TsFblSQMBDQMdAqHYikx6GWWajQK6y9Iz1IQeogZ\n4DyDUQW91GDy3AMES3KgvncRSzyLHOQxrvoxBCIM50P5gGdXFIOmHV2Azl1R1RgvtePRN+xQ5Clc\nbQgQtmS3CN+7E/jOOTno9bb498PlUKYY8m5LUje83WsXUbzmBjjkBqkTn/0rZnvz5HGFJFkkz3OC\nwBBFMdZK1/q0pphtfCbk9Ek8CheGO4Ee1qZjfNeVPdCArbDED3nGpdZd0jT3U8im+8blULyBoGAJ\nSed5PsIkWHj5e1x66i859+QXOXjL9STZU0SRQ9CEHqwV4TfZ/s88AhxW4eV5wZeeUPzDuwwt4TZ/\noeDFVsidUwWBcjep1ZU8OxNz/JUq104p7rvNcvOOnEas+JuXJXfeaiE0tOYt7W7AdENhWpbLLcuC\nEDz+hOVH32q9qoHmpusFU9dYbKK58bBwMWQv9yBE2R1qB4m5Ko3Fb7VlohZ41EtI32ynQQRUAsuO\nwNFnBrdXDxmGXBLCjfuZHELePGzdNxLtO131wIByH4fp1L2uP8/FuFAtc3/j7ofFFtZ53cI6dR/t\ni5pWYa1AWOmdkTckG7t8yNZd8da0Rnd+y6gWXc3zEwWoCefAD98IaedJ5sM3obWgXouRsuo1AuUV\nOZZCjDckOxz8GmcfgevUrCJE4Wf/ZH6nWBsO19cxRizXibYDhneWzQ9x6ioj8lClvkCWZX3j6Swu\ncOnE13nxr/5PlBDsf02dXvdpKk23jnTer/u5ml6ZgwaeIOBbqrFAx5J1LC+fkxzea6jW4AezAedb\nEc04J8vhYivkmy/V2FkreOplSUVZhE2pNwJu3hnywoKkV+RUlcIEiksJvPyqQXYEU7GhXQjCHYaw\nqqEL8YTk8G7fYtmx0DOefW37Omx9dqrwoUxRohthP58oEa5+56oy7sRDCLVkwhpEUnj0asgohkGf\ncoX1d7alT+1csi58oVcPWsSLIQMyvhZkXShnbeF1FfyKKgpE5t8j09g8R+TufW2RQ547GNs6gxXW\neGPJ3Gfb/socCh+jgRLQUhwkcXuRjcD6znjrI4kdnb/gYu0WNwTAREPglO23fq8pN1km+e7ONwgb\nRNFkicJJpKz4pD/FmEWE0Gx6si2DOTmOJtGjKM6iVBOlJjHG9guhwxy29uIcM9/6Aqe/8gfsuPYA\nsX2ePOsRNr2XT0H4DVB6JLXkVYgYbNVdVJlDMu94kEGgONOCO25wYMNL84peLtDG1RoffrbGVFXz\nhmt6fPVUk13NAtlsQVDjNXsqvDAfsdCGasOwZ1pzcIflC0/AP7jb8oG/Zcgt7JguiZ9+p+v6+KJs\nn5YOyRAydItDaawqfB9QmX0HzlMhfSjnk22pXX5GAbkALen1BDOLcLCwrq278NtzaXxllCaXGJAQ\no8G+Mc5Icu0Wf2EGelNOMdKrgfhwU3vEDTFQSvTvYfPceaC0QOQFpM44RGmM1mBNmZNphHUiJs6r\nSp9jAXTdTRZyELZJRr+XQ1FX4FutcF5onzrOjFokMTFFYQgC17ovpR3Z+NdQ7hwRkAyCKnG8oz/F\nPFgajklZIwwbWNvDmBZGZ15TTawcwvUnd6+ILPQHErtwbRZrWwgxMUIA7fV6LF6aYebbX+X5r/wB\nBw7twXafdry0ykDbTyUuwinXpvB6z8RuJwoD95qZS4K5jmBX07B/ytBOJYEEYwUvzkbsqGuyDF6d\nl7w0J/nxm9sEAVhtUCrDCo2goFLNaYQx0kc4lcDwT348p4tgx3SOCvwC7Sksxvf7KM8VkghZOKMo\n60fCLxIRIgJfoJS2j6tbESCUJ6UqXwEOFIvnJQuzgmuvV4hJQedlizYgyRzUa8wSA5GDMFzYQRG0\nfI0t8w7vZbR2xmOs/1p49Mz/TpdeyLrvMd64cqwxCG2c0Rjr2AVZDlmB1Zo8014ov0AXmZveR0Fg\nC5RwG1wQCIRKvRqj5xiWDIhhFVQ5pDlR8WIt3ltI5aITWRjq9lVa+Q4/qcP6sTBXNp7RbMQghUKq\nmDieJghqI38brNZmIESTomhRFC2McUNqBWIkPFhN1ccuec1AsROKou2pOjWKQtHrpczPnOHZL/4+\nl049xf5DDaR+lsoeZxzGushF9NwiVt5ojKeblTmPNHDpvODpFwXPnpfccZ3lxj0wVdF893zESwuS\nayctuRa0eoJmBeYSSZZn3DCtudALuNQRnF+ImZ3N2bXXrS8lLLWqcYiE0dRrOXVhIHF31ElQhQgp\nsGVYJgIPV3tPROHzGA9NS+t3ghLFkq4gKQOsclA1UrnqvlG89D3Dn39T8/bbFLccDpg7Z7n2Jokq\neo4BUYZkYtjbeDjZTb9y1X9KpoBvqDM+v9EuV7G5L4Yaj6CVYZz24iRaO/lR7RG5IkMUPlwtCmxR\noIuCQhdordDakBc52hjyQmNMTqFdCK9sSmAzAhUSR4K40iMKc5Twa60kO5sh9maIa1utDlhOfXCy\nlD7uwMTCE5xt3tIXuhwI/q8lOTFIqZCyThSVeiErFFJX79dpEgRNimIRrTtoL8jR70VfIfcZj7ZZ\n37OTk2WOktPrzZNllu7leZ77yh9z6QfPs3tvD+xFgimfEntwwJaIrGfSGNdZjHL0NGQB52YFf/U9\nicVy72HNzXstUsLeJvxYraCuDNrAdLXgfEsSKTcrZ7YjOb+geGVRUpiCM5cVCu2Inzm8/toeVdmF\nrkeIyoKiDLEidGtWuuRfCOsKhkaDcMVDh3CU7dve4KQnnKJcCKeUFxkpcyQ1BCtaXnvQEih4eQ56\nC5IbbxSEoYVF64q8S4N2n+1a6wZbubqM39G1NxyjnXCi9vUaoxHah2lFgShy9/vCexZtfL6isdpg\nTY7ROaYQGK3IjG+dt4a8kORaoE2KtplDKbVBW4PVvmPUpkhrECiUNEShoVKBalwQR5aw3CR9u1TZ\nr0js8AakB47KLuYyGskgnD2LmmCkFlTKma2867uZtkHYIAwbV5xWt2bNnyCYQKkGWnUpijZat72I\nnRxrRHaE6TpqPCWfzSFtGe2LL/HMFz9HZ3aBieZZZKVNWHV5rSjrjSWqiotCtHXaGPOpE5qZtNBL\nodOx3LbPcN20ZaLqXqMsvHaXoVYxWNfVzC17U545W+HsLFw34UrIH/5Cg394V87/8+0L1OowXc+Y\nvRDS7Xb50UMdVJL7loWKo+TIyDM3fFgk6UPBQgQ+Xrfek4gBBC2VC+sC3w4hLDZXCCWwSntD1N7Q\nLMJvv4EUvPag5LXXea9SGOyC9Uwfj26WMJLPUdwGVkp+miFvUwwhbVkfKBDaGZQ1BSYr0HlKkRfY\nQlOYAl24HixtIC8suYHUWLJCoq1CW+s09qzAGIU2BiNyLyXmQkbflYHE9plLQkiUMCgBcQT1qtdH\nqLh9JPKNun3Wkhpavdlgxpv1YKWQsHP+e4TkGBO7fcMbkVLLwzhXyhGE3tuEYX1NMNq6RLOEkARB\nA6VqaN1wXqno+rH3473PaA+P9swCZzzdbkLn4lme/8s/JW23qckTVJoFQei8jRUDyNL6TVDFbn2F\nCl6dgy8+K3nXLZaduy3tDlSk40pFgaPlxMrrqIce5PLvd2TasLNa8NdnFPfdpvkXb2uzmEiOHtRM\nNvxJ9KCa59y2e54qxnkfGXr4WfswzdP8hWcAWM8VsulA4KxU4aHwaJpX5JGFVyfRCOlaJPo6bVL1\njccOY6uWAZJl7WBMjvWUK+wg7NGFY0GbFPIeFAloi80LTG4pcicUmeWaIjfkWeGkvnJNWhiKHHIz\nUMcxZf3Xpze5dp3maQG5cTFUWQ/Vw8m+z00C6QxGDlGpRClPJ43T0PYyc40eNGNoNqBec02OVAY1\nvz47yb+/8CSOUmTV4RtdItOlq6v9EM6YpWmHu15uYviEn1S4dlL0hlTnhg3JhAlZdtmLLQxB9UO9\nPIM2BGc8SZLQ7SYsnn+Fl//LQyzOzhMV36G+0/egeeUkz3Rx4bYviwRefcko16QZSJhdgG+2BS9d\ngh+7wVKrOImCwIu1G+FuqvB1wUxCI7a86fqCb74ccGSv4fUHXGXcaMjaDi2WOKk3lMGm5c3KHAvE\nhP7OJc6QrN8abTp0B8VAsFAWQ3WcwhuVb1CTmfdKJYO5vLdOKMRNZPDJu8FX+J0BizKPwSJM5g1L\nYwuNzlJMUZDlBUWuyfKMXmpJcuillm4POokrTWUZpOkAiEvK+qkv45QSvAUBWii0lRgVkA9AOfop\niwDjicZFnpMmmStzCXe/qhWIY4EUllA5owmkb5GSUI2gFkI9hGYH9pQMk/oA0QePbg8TrHN/C8pw\nvzDExWXaaro//rL0NiWkFwZ1onhqzcPVtsSAhg1JqRqVSgWte45nZLI+jDEcumk9aD9I05SF86/w\n8uNf5OLMWar6u9R3ulpaUXjE11+Ewq+JoGQKGE/yDeH6aTgwDU/8QBIKw+lZyY17NAf3eYBBesPx\nUrLa3+SSYfb2w5pqDE+9Kgml5tqGL8mUoNWgvcbnOGCldTYhMw+1+m3WeoMyws8wjTBGYKxBYN0I\nQRm5XVcZH6b5XnvpjaysgfQTZyc5jLW+n8aHQibDGNcVqo1L6q11ox7TQtPLXTjb6zkhn8WeGw3U\nS6HVcwbTTb2Hj0O0it2M1F0HiWo1wuYOJib3ENQaBJUGQilUWCGsTRLGDVBuNmy3M0uvM481hqjS\nJIir6CIlS3q05y8gZYAKYnqLs6TdRWyRo3WB6nV4+utfodDaSUpId38jH15XA7c51gKYTlyUKWJo\nVZzaVyOAWA8iYOnBROkDAVH4iQ85yKyHjfxcWuuvJwqlqlSrO5ahalfVgEY9Up0gqHt0bY6iSLBW\no7Vrvc6yEjhIaS/M88Ijf8biubME6Q/4/rylmgtu2udgWeu9TuFj2zgayElZPzeqq0GmUI8NSSb5\nqTssDz9neKUtEJF1+XI2xACxA/DLdxsQCHjrIU2764wmT3wJxn9OwVDtUpU6zsKT6ZwemkUirPJj\nHSW5gUJLCu0n1VmNFYpQCZSySJk7JV/pK/pGYsVA2FD4rdwaJ2esPVxsrcHYglwXZIUlzayreZae\nQkMnhW4PFtowu+iFfAKXthnRoLrvCFOvv4U9e64lmphEVZvIqI5QEiElhdGEYZ1abeeyadxlyUII\ngTWabm+WRmUHjZ27loyBqRDUGoTNKYpCY22Mal5H0OtirCtZqOf+EjKDUdDquOusvPEEofNIldAJ\nrWoJsge9BcfErhfQ6Dp1nnrsDCoqSe4enSX35S1AmNRPEHQhrlQR9fo+KpWJEfWeH6oBLYW/laqT\npnMkyQLGtCmKzBtPRq+bMPvCCS6/+H2iYA5DwsVE8Jpp64rSPTe/qewcjn3KUfjSQBzC2Xn4/NOK\n1+03vGa3pVGx7NwB1++DCy1BnlnXcuJLIKYkksp+Xu9oWKlbt00fOeU99/+0BMR8MhoypAlnLbI/\nnkNgrKQoDHlRuPBHW/Lcok0Xi8Ra6eHQwhmO15+2aEdjwWk5Y1wtzehyajduPqrvAs8LJzTYKyBJ\n3ffdnvta8lITDbK5h/p1R5i4/g6u338T1em9BNUJRBAjpXIpZdEhSeZQKuyLbggBSgXU63tQKhor\nxFFqrfV6l6hVFZZGP68YkRTLc5RyUJnWiiRJMFYQk3Pqq5/l1HeeRFY9z7RkMfnkPzNwqS0ojGWq\nDgsa5gQ0JUzkMNWBiRo0I2hWoFmFWgWqsVdKTiHKPPik8EVbgZQVKpXd1Os7CYKt66DecgMqdyIp\nG0RRhTwPMeYyWdYh6fVoX77Iy098nSgusN0FFgW86bAlFi73EL53C+uaqQrPWwy9XsdfnYJLPTiy\n1/DyZcnr92ky63Q4Du6Av3lJMDML1zUHuZIeHp1hXfuJHGKLFLafbjij8+WX0MsblOFfUDZkethU\nG0tWFG4BZ9ol23qAFAscNOTe0/Y15dwsK4EVRX+nLGuVeVmbtC5Rb6dOsbObuDCsa9z/USETB49Q\n23MzE/sOUt93kHByD1Y4UmutNkWlMrls5hNYer2ESmWiL41cepZ6fRdR1BjxOsPqntZa0vSyK/+E\nNW/oJYu+8B7H0W+iuEaeg9YJUgoqs6f56wf/v8zOt1BVZ+yJp1+VSq9SOECim1l6OSymcGER9rVh\nYsoBCjtqMFVzhtOMYUcDphuuYbJed1IWJnUbno0c0hfHO6jV9qxrCvsPzYCGjUhrjRAVhJgECtJk\ngXPPPgm6h+28Qk8JRGEJc2ckNnc7rbXOYJKiXKhwoSPY2bBc7AhyC3ccsMzMGXIB0xOCF87BgYZl\noQenZgQ3NC25H+cprAfJKBNc9zNjBgx947su+qpUPrVR2su8+eMoScaFH8OT5a7onucu2dZmkGs5\nHGAU4C8HTGGcd9Ha/V2JbvUS6PRcONbzxqMDQXXvQSauv5nrbj7K9PW3UpnYhQyrICx5toDWKSoI\nHPc0iGk09hEE4bKR8UXRwVo3Bb00DikhihrU63uXhWvDj15vDkipVCpDsmKFR80dvKlUSBg2vMxY\nQlXknHn43/LcXz+KiRwQkOSe/2pd3qPKGi/ufK0P6YQAUwjStqWrIUkE8xWYjC07Gi7E6/bc30xM\nQiJhSjuwsRK6jhCZO/rNdmhkb7kBjRuL6NoTCnQhWXjlVWZPfY/u5b8hjmBh3rKj6nYMUy5C3xW6\nkEI7c239L807adddXcGtuy3PzgiM11GeS6EeW554Ad53i+BfvMWwfwK6uW/bN6MMF1M2TxZDRXgz\ngENLpE964y2BMu0J0WU+leb+eHO38HPjK0C+UF+2vJR9ZsYOxnnkvqhfWLeY2j2X6Le7zmhkNWDi\n+tuYPniYm29+A5Wp3USNaeLqTsIw7nsT51E0SZIAoddDE4RhlWZz1PuUm0e7PUe9XnXytH0NwIBm\n8xqkDMYaDkCSzGNthzAIMdYihHZsaiH8VPIcIUKiqE6WaXSRUJw5zqP/4RN0kpyg6RZ6mg007eMy\nTPbhWzdz11WbQVlN+ZlhNQtCWzIDF7vOM7fr7j53gV2h680zCUwWvsi6CLmaXBaG/lfvgYZHIfaJ\not0OJ//Lw+S9F4lFwXwXvn9esPM6i9EOQsWzWXILpy/D6Ytw8y7BfAq37LY8dwkqO6CdWopYUKtZ\nnnxB8IbrLDfWJYcnDXHome6eT1nG2CXLxfohbNrXMawv6okhMEx7TqO2HmWWg24CYwfeJ/HeJ/Nj\nSI0ZGI0dKDw54zLeU3nyai91yX6r5+7C5PW3cO1b7uLa2+6msfsaZBTR680hpEApQRTVaDQmCcNo\nZASntRlSxiOqnPX6bqrVxognkVKSZYtEkfKjYcpCoqVe30sc11fs9UqSRbJ03oEcUmCL4SHKOUWR\no3WAUg3SNMfOn+HFL36GU48/ivaMgV7mIgqtB9xaMSBikPlrUphBmOvuiQt9tR7049rQcWdnuq5l\nMHXNv5hkABLpEMIU0uqekWswrhXnvzoPVHqfvuxUmjL78ilIL5MsnKXZcAhapt1FDRxkT6h8gV3D\nxQ5kRrBvwrLPwnwPilwgK5bJKcH3zlt21wVVAT+yFxrSkOQuhg6U06gQ/mbpobb/4V6w0q6UL7Aa\nMVrTENYRn8VQGaYonPH0vOfJSmaMHZAQjfFyHJ7gnPhiYy9xAEC3gGhqJ9e97R0cue4mdh96HY0d\nB/vKmk7TTKKC3HsQiKIa9Xp9xICklOR5G4iQcgAINJs7kDIYQZmEgCTpEYZh3/O4WTqT1GqjGhbl\nfRRCkGVdet2LaF2g+7rjpVh/QZ5naB0gZR3TXeDcV36Xk3/1JZI8RzbcufdK5Srj6sl9oriPCvxY\nVnJ/7eXQfYkCB1fboU4MIQXCgEksc6knc3fBeDKx9IrLImyQVw4QbAHatqIBad1GiJqbYbOJ4VrD\ng3qX9vmkSZeX/+YxOrOnXKXYlzn2Na3ruPehUlHAbMfVAfbX3YXdW4PFxHUJXDNtOTEvUAouLwp+\n7AZLQznUbhGH5AQ+UddDBHLhjce3sTjWPwPPMzw5uigno5Xj2IVHBX3fWlIMPElhh2qbZUeycYaV\nFs6rdjxiplHse+1dHLztx9h1+HaCRg2DJQiUM45Goy8IWC58IapIqRDCUqlM0Gg0PaJXStYKoIu1\nFYRQCAFhWCOOq8tQtCSZQ0rr0TF3v5RU1Go7UCroC28Mb4JFkbCwcJY8T72QpemXI5xKUoG1EZEM\nWfzuwzz3Z/+W7sICODlwOpm7FgYfTqtRQS3BoHCr+2Uwr7WGL7L6dhU7VKQtB4NJATpxdK4gh3DC\nUX4qqatvM1nFBLURid+l0PzmHIYmyPMFjGmhVIUwrBMEfn4nG5vuNbj4fjBvnrM4e5504SxJa4H6\npNvZL7Whlwknvuenky324IVZwY3Tlj11eGnB7V4vzrnCvwrgzAV4961waJdFFi40kL6SXcZMeomU\nWjlbxuIZDnbAwhnWpBEjd3YwtLq8wakP1zxp2c2oMgPB0V4O7aHKPkqx/5ajvP5N72XfzXcRNaaR\nSiGEJsvmXY1JScIwplaLiaLqyHQBa6veMxhq1QqVSqU/dc0ZiCHPIQi8V8FSq00ThuEyXrzWXRcu\n+bDNWqhUdyBEOEK0HEQPKYuLM6Rpm6IYmtxXuHJEluUEqop89bt87//6V8ydn3M1p4rLZXpeShvP\nYbN2tCXa+FwwK5wXz3yxWw71AJZAgpKD9qSoDI/toG+wKGCu44qvSnqt/grUpUIGwYjxrFcne/n6\nLrC28L1tHQLh/aK1KVmWUBSKMKxhbRWlKki5NorD0vCtT93JUubPv0zr4ov9Xb0kFJ5rCfJ9lhhH\nKXl6Bq5p2v4cmFDAuS4UgeA75+Hth+H+w5aJiiuySl/gRAxynqI0GDEIqYQP40rZgbJ3awjd7rfo\nlNTLfm9Z2Zxph/KY8uZrV39Z6LiCoJYQ1ifZd9udHLzzrey4/ibC5k4ajT19kb/ya5pajMmdAQUh\ncayoVmsjAoBFHvXpF2FYIYriEZTM2hwhNEFZsALieHllPU1baJ33uymN0YShq9cNM5UHxpPRas3Q\n7S54rzNsOCnCSioLM5z/2u9x6bnvkgdgKj7P8d5ZCN+XZQfqV2aIDF5y7EoqkNb0RdSkGHis0ogy\nDWkbJn2bvi08Q0pCIQVJbrncdqjepGfqFwd+FIHse/WlRrQeo9E6ReuUouhiTNrXEQmWMgocCNAF\n26OQgR/OG6JU1XesijUZUX/ESJqSzJ9n9uwLTNQH+cFkCGlhaSWe1Ow9Ryd16IwEdtbg0VcF977W\n8oF9Tg8sFg7mDTwbV5Rwpw+cjafi9OXKys6DAbXMFTSHpkQPMWcGO6M3nDLPyb2uRmpcGNdNYbEL\n7Q409u/l9nf9FDccvZeg0aAwPQ8hK8JAUq/HRFFtRK85DDV5vuhvrCCOFXEcj+QtcVxHmxQQRHHc\nBw4GYI1wiprSxcVh1Bgz9tKQpoue0UC/FSWKJvscxfJ+OWGXjHb7Aq3WrMt1spw8dzSsWOTEr3yH\n1rf/klef/xs3zSR2CX2Se0EtOTRHyZcRyutq8ZC9Jwanvs3IDmmQKDEwvtAbUDmNMtVgLgt273Fx\nsxN8EgTCOl17j25qfFPd/rsQUvXzyvUYj7WGouhSFAlaJ2idulYPIRBSOQb+OBBBDDI13OzUTr8B\nzo0hiVGqPqL5tjT/KYXfjTEknRYzz32TIjFuyrRfmM0KTFahlThPI4EDdbjQdqHcRANuPmipTQuu\nb8B06Hasns+XjG+2XJrDyJLHKUvumg8NSgq9z2v6f2YGzIQSWs79Dct8db/Me3oZtLrOgEU15uBb\n3sXNd/8U09feiAwr3rtAns9hrXb/l4owzGk0GiMFzUolpNvN+sm8y1/Ckbk2YRi6BrUyZ1ty87X2\nVApcJ2xZBB2+J2m6SJZ1XIjm2Q1xPOUlDtIRKbGiKGi3L9FuX3R5TlaQ5TlVcqLTf0X7yYfpXrhI\nTzvIOLduUWsGk7cphXZKKW1/LXPjpRKKfuuRQ9xKVSw16EYP5MB4rO23JmGta1cJ510B1RWtHW3L\nljmsdlB5EYDceQTlN61h5HLl8M2S512KoovWietz8uN2SsNZJwrnP8xarC1cS65JnDGhkKpKGDYR\nIhrxPn0PlGXkvTYXX37O9fCYQUIYSLcgzy8KpgKLso6ecaonOJdYJvfChIIfiSw6gbnEUdojNcpv\nG467jAcRGKK0Gw8WGAaTSgSDRs3ywpe1G2vceMEEx0ju5E5OttMBE1fZe8ebueOOu9lz0xuI67uJ\nopggCAjDkDB0hUtjKuT5nL9hkiAQKKWJ4+GEtoLWtT6LvezgHpks7dEyt3Etz2uMp6k4SNoVR8tc\nxhlYQa+3QJ5nWCPQRqOk64NOkmTEcPI8p9udZ3HRySjrvKCRXkJ972G6z32DdKHtDCZwVKfMs7SF\nLzobMTCaYkgJK9NDA4PNIIwr/P0RPkIIPMtJeeBAlSCBN4qSDa6BuQUXpcTSGYsbhCHIretPSnoQ\nvu4t6Ma1xENefxSVHBiRGxrcoSh6PscxlDNLSk+zCowtlrypGBm0NdArHUCf1hosGlPkFEULkAhR\nxZhwaJKCi6UXZr7PpYsXmag67yO8elG5o3Qzl9BmXh55V8PJtkoBRcflOrke9I+YYAAElOBASTKV\nwtdwGArNRH/Su4OazaiyS4miac8ELwoPvRbQWXTepnHNazh89xu59kffiaw3USpABYJKRVOvNwiC\nsG9EzmgmyLKQPG/1QzQhUqJo50hCW6lMkKZzQ5mX9jWa4YYv4UVf1JIGMIv2us7GGILA5arDYECS\nLNLtLgzlN5ZarU6SJOR5PqL+miQtLl8+i8RS7c2Qf/MPaX//2+7eCMj89Oy0VI7znRol+lgCAnmZ\nJ3qjKfVJdOHLCXYg1dDXSRUDuQglfIuUGEjSOeBGYLyqnNZwYRZ2Tnol5cIRdSPlPic1MPGGD6CC\ngCiKiKJoyAu5+6F1Qp63KfKuMxrsQGGqL2s9otE27Fb6u/i660Cin5yLoZ0wR+vE1wUMaUp/DMmr\nJ79NlrkpCOWwr9xrBDYDf9Fzh1yd78KPHLJMNRwvzvhuYoOnvCsPQ7uGTac5IYYgaTuoYosh2ows\nazRDhuN70Rw4UAwYBUkCbT+fc/eRu3j923+aHTe/gVz3EALiOPICGAqlNEplNBpTvrVjsNNVKnvp\n9YQPs9yUP2OSkTCrWp0gyxZ827UT3Ri+zlIGq5QLNHmeeP6ZIQxj8lwPhdE57dYsSa+HsYKiyAnD\nJr1e1vc4gzpdB909R+MHx+g+9RCt2QuuCTF2IWyW++mNPofpF4bLp994CgPtfMDrK1niSTHIa4cl\n3oQYdI/2dSR90boEcNJBt3kf9VG+XrfQEUzXLYFHFQVumMDULbdTuf6ukTEnSgmMyUiSlp8qko+I\n4pQTGgdQhlhdfNEOPOdyUbkNwXvWJ14pvV6HbrdLr9Nhfva8Y8kKd1GER2CUgaqynFt0tIw4gP27\nHbPWJgOemdEDBkHq+9FC31pgGOrTMYNwrQwr+gqUQ2FeWSjtMwoK5+WSFNrzIMKII++8n4Nv+kkq\nOw4QBKHPTTRaO7kv52nKek0K9KhUdozUaNxzJ93uBa+dZsjzFnHcHPL4EYGKKHyC6jzK4C5JqbyQ\ni+orGpUGVBQJSdL1CKoDFNI07XubJGmzsDjrBTUKrA2wVnmRGFefQ2dUFp5BnvhzOs89ztzllKgK\ndU/E7XnDSa3PBz3VKtEDCD8tBp7n5UWX0E/EHokDZnvu0te9znypn1iOTJVygNL1NRP9RpiZgSGV\n3kf6cE0IS6wsUSzodSzCy+zpHrz2Pb/gowKFEIYsW/CKPLn3QApZwrCU9YvlExr7Px0nkrjUAwmx\ngvHYlQ1wuTLP8CQ5Q7d1mSRJHdOgGOwcWe74ZhXl2ccWpqagUnWFsU7mdznPbGZYmNaHdypyN0LL\nQeu3tB488L0/ZUd1Hzr3O6f2OU+WQ9KBtAvVqV3c9d/8Intf+yaC+s7+7lW6f2dE07i6WY9AhajA\nTalzqkUVomh6pM6g1ATGpM7LCIEuEvK8QxQNFF6iqEneTTyCmHsCbqmj5xe/VBS59nmoM5A07Xmw\npkDJGnlusDbp/6zVukC320ZrS1FoomiaNF0AnRN2z1L5wdcIzn4DOX+ahTnn7XftdL01qfb3oNQq\nLb1MPqjZZMUAHBAWLnXhxKzllh2un8caeP6yC8tunHAL39qBnlufPqUGEHdu3GfkJYPDt5QjBuCQ\nG/rnWsOrFYGxlk4CjQgWL8KRe3+MxrWHgdSL17i5vlJGLvT2fL816fluC5XHrqylNYzEWWMweUHW\nnnN9HoVjyObaabsl2gu+CydPFEVuIWephzbtQG98OOQSyWDDCBnAz1J6OeVyRxsCBfDvY4YQnV7P\nTWWY2n+E23/6Z5k6dDtxdYJabQdRFPdBgTKvkVJ6KHSCNJ1F6y5CKLeDIsizBcIwRqnmSJJaq+1C\nFz20yTC2IMvahGGtn6+ooOp2ZmPIsoQwzBFC9cOwotBIoSmiwm8ozoA6nXl6PbdI4qiCNr0h9keX\n+fnzfYAgCptEvXPo7z2MOPklVHKRHdPu2l/quR2/WnMATZK5ZsXc12JC6wZzB8ohW/1pjz6PUd7r\nT8SCZuR2cyGdx6lGjkVSDb2R+PcsDaEEBUr6VupZ2tp6ao8XAiojKykESti+2nEUWnqZe3+Zw/Te\nnfzoz/4ihW4T49DiIKj4/iYXMaw2bWFY1kOIK6uULjegK+r52itSeYyHxoyxSCFJWvN9KFJb33ef\nOY8yUYXJqmvSynzbca596GUHs5n63sMPgGOoUKqMg7XL15UyBFYOzWBzwwEcQpM4I52+5iZ+5J6f\nYeqGNyCVJAwDwrBAyg6VSp1qtTHCeh6e/BzHB0jTObJsYUjay5Akl1AqGOk7EUISV3bSbr/qi5qL\nBEGt/xqtQYiYokgpigSluigVOwPKLWmSogKJTHKfRzkR/nZrnl7Sxhjp4/l232BarXMUaZsob1M7\n+wz6+a/SOXuKWgzTEzB1wHX5XrzsSgZ+Egudnlvwie97CgPHXavIgdGEHkyQvkcr91LeAkvhuYex\nBwGumxR8q2O5mMLu+pAhDUnNlXqOZe2tKJE8j7wNCLEW6Y2n30MkXTG9JiGuxPzkL/+PiDigUgmJ\nogpB4LyOY54PddSuYETD2teMj+rW6YHs2n48LCBSfs3zlPbCLElvEeNh6yT3EGMAjSrsnICprqVI\n3VCORA8AgX49Z8iQcm+EthTWNO5ClpP7ykjSygE7oZw7kObOeHZed4ij7/x5pg7ejlABURR643Fw\nZ6AExixgrSCKdi2rYg88y26kDNxsTS84WRQ57fZ537xV7fPLlKoQBE16vTm/0cxRqymfv1isDcmy\nFGN6fiqfR9HSnG4vQSmB1p3+kOU8z1lYuEyepyAitM4crcRkmMVXCX/wTdSznydYvEyAu9bxbjes\nbnICGnXH/Ohkbvh3HDkjyLRDOAvjclCTuXAsUl6zIIBLCdQV7AyglbnXzvZgIYN6JKhGlqqX6d6p\nnBGdnoddTafKk+UDelQ+FGkMU3eMFejQJfL9qXI4DySxBAIaFchzgc4tSge867//Rap7r6NSqRJF\nFeI4IopCzy+UQ2jogCy8Re0Mcgh5KGXlV7Aeu7ZhW9ZarLEIqTBGOm0EA0nX7U4TTaeak/lpf6dn\nobHHk0qHEI6+uA0DCogpZa7897kP3/qjacTQiE5vRFkXart386M/+2F2HX4zhhQpc0fkDAOCMPQG\nFCCFRCqJLlokSeGbzCpjVVjjeMo3ms1SaFdhKooeeTZDrb6770ncLlr3XqJNns2CDZGq4j2KJk0L\n8izFmHnC0HiIuUOn00EpS1FU+lPXiiJjYbEFOqNhCvTstyheeYr0le9Qab9CbKDmlWysn1ZZCaHZ\nhKlpd+ytyz6sjhyAk3mFmyj0Sje5q7GUIZ0K3O/me4Jvzkredr1hom6ZT+DsrGBXA853BUpaarFj\nnJ+atVwzAQcm3X1P0gFaZxnkRX0miP8a+DAwUk4jQ5tSDNHlPvWKO+bZnpv+/a6f/Rn23XYX1WqF\nSiWiUokH6JuUzvCGoGlxpZF0dpWIbARpEwRxvAshSiX8DDBD8lRm+diSNSZJUiniWoMsMy5+zt0N\nmGr6RNWHck0Fp1KXhO6seQlfNQRDewChP2HQJ7XGkz1D7duB5SjlXfr6Q1CJ+ZG/+wscuOt9BGFM\nFMdE0TRB4IdwkiHlYMKE9BfcIsjzhIWFl6lUpojjyWVFNVc3qBGGliy75AubYE1CoTVxvGuA6FiL\nMRWSZA6tc7L8PHG8yyNqBWkKSa9Hls0TRu71SdJicbFDGFqSRGF0QWS6cPklKt//Ovn3v03ROoMy\nOc0Y4gqEOx1SqX3OqISgGlom6g6oCZoxrYs5nY5xRhE4I0tSZ0TGc9JC6ShWuYeU08yFbrtjy7cz\nwxNn4R2vgU4h6OSCW3cbTlyCyym0Cl/QxgmF1ALn7bSPMJQcsBb6lQVfTC43R+UBByWdF8p9qBf5\n6KXIwLQF7/qZn+LGt72barXiDajSz12FkAg5qLuttHjHuQXLoKnLUdx8FIJEqQgVxCgVE7gqt1oS\nphQIYXzMnWGtQ4DcV73ko8cjGkIIdJaRJJqJhot/Yz/UN8l8LpK5JHR3BVo57BaDwprxoZseMng5\nBFdr69oMcj8RUfrRi4H/eVSNOfzmd3LTO/9biBtIFY5w0RzMWUdKx/1zYvqFZyqLwVxYC618hiRp\n+Wnk1ZFNxXkYiZRN0vQSedZziFunSxj2qFR29kECBwxE9HottO5Sq4k+GzpJclqtNlLmTkTQFBTJ\nPEEyS2X+Rcyrz6BfeYbuhZOIbpdq1ekDRDsdAKNC13jnJjm4rjIlJRVlqMU9apMhYsrJGS22LVa6\nieWBcnoLhkHBuaTUSB96W+XY8I+/pLhh0nDbDsvfXBDMLkCSWS614HLX5Zrn24LXTFmiGG7c4e51\nOx3kLWYony0XqjGjG3uZs1oDBbZfd6yElumaM8rLs4If/6n3cOO9f5tqvUG1WqVacdO548iH44Hn\nvvkeonFuQPj3tz5jttb9jfKzXB34EHogIkKpaHVxeVcpHyUuOsPJPZUn89/nWKOdyr4t+iBC2eko\nlUQoh1LFyiEyhXauvfDhQeGRuIYnJPYl1kqGgB2a0MGAoiftAOIuC6TWt2fbFG54w53c8XcegPoe\nClUhWsIhG6YbOaNqYG2FwnbJ8i7GJJ5dISkn+HW7swgx54XGmwihlo2otLZJmnUpih7WWjqdHkHQ\nIwwnhuo3ll6vIE07dDo5cTztfpd3kXlCoOepXfou4sIpzJlv0nv5lJPCC12NLJ5ShHsUUey4cqFS\nhDJAqgClIjc0t98ObQlDi6w10fUKl5OAeP48hXFcwyjwUL73Cipy9yO0rp1eCcfI+MoLiiiAayYM\n105C3IN0RnJ2UbO75rzL116Q3LHXUgsttcCRbQtf7A7DARJatiWU4bgxwyguLJld4MYCWXcu1dB5\nM5sK7vnpv8O1b30P9YlpqtUqlUqFKI6d8QQRgRL9utwoh3CwTj3329f0nKEMvobeWOTmYWzXrFVC\ntuUJF756nqNUghAdtJZIUY4JtARRSGOiAbZNryyMmoH0ayncsaMK359zN61ZcbWGsgO07Aw15WwY\nTw61JY/KG1rSgdrkBHd+4L9h6qY3kQYRMYyh6uf9qXhKKfI8H6LXOLVyYxRZ1sKYFIErlbsQTGPt\nIspzAIOgOqID4YypSpr2SJKWT/oXCcMFgsCLlJsMmywSJ5eIdYtq3kX2LpH/4Ankue9RDZL+sLCw\nCuEhiQhCVBAThBWCULmO20ASKGc4UjpdNzEci5SCdjWDjgTfOBXyrecMRyo13rK/QxTA5W7IK/MB\nU0FCHLj6yoIRXOoIqtJgcQqh105avvGK4o0HNKFyLQU765aOERwILG88YMmN5YYJd+96uZdVjj0D\ne6jY2t/0GIhXGgZMem0HYV15KgpXM6xKCIXg9p/8Wfa94R3UJyap1ZzxVCoxlUpEEERDoIEcGm9f\nbu7Ko3MltF1+DcYyP7atpVuIwBMYY4SoAnXfHdlAmzppegkhLlGf3M3CubbTOiiGNMBESZ50cOhk\nxVF5qpHnyYkB21r7REh4wqFlyHgKyBK48abreMPf/Rk6yQJi/klE7RqM2YE1jrSZMdn3OkuZucM7\n1KA/qkpRBGTZIkWRDjYOA8Z2EVwmjGoEQcOFfKUHtjk2aWG7FzHpAjVRULU9YpMSF23E5ZOwcJ6g\nPYPN5px6ZuB2aTXlYGMVVRCygpAu1pZRAyndaHulBLKc4lBi+NLP95Al1uP0u0QsoGbodQuu3Z0R\n5z3O/KBKoxYjhOI7ZxpUTJd9dRdSn18MOT0X8MwFwfte03PJvIGjBwyPv6x49oLklp2GQMBkxbrJ\nGApumHJ5aSdzh9CI3SHlnsGeDXUBDxfsS0yqvKcl6loCRvgQUgqINExM1Lj9J/4hu2+5i+bkZN/z\nVKoxcRwSBKFjGgiXxzpEVxFElaHwq2SQqA1J+W6TMqlPvmXoEqugRqUyRVSZJq5P0uq6UfPaj6mJ\nGciyGhzjuemLbt180Epdthv0L3pJDPVi4oV2gMR73wk/8d55Cr5KK91FJmrk9gJpUUMv5hgbYyv7\nIWwgigQZNbCVHU56N08QRYKt7YKwhpChm+9jMoROkHmboMjJS06bcR2gqIBwsU0cBoRSEekOQTKL\n7J5DLT6P6LQITYsoW4Rex2GdckiOtglBpNyALREiZANkgBAhVlSxouLCMRUighiEQSqBCNTQLCF/\nQcvx9sK6EYehwYbatW+GblTIDRiiSxHXvCYjbk5wdi7k1JzkngMLVCLLhbmYM62IvY2M5y8HhKED\nYiyuK/iOfYbvnpeE0nLbLheq7aw4sCDzpYfp6oDH1htS2PGBhiOg2kGOO8wps3Y0rZZezNJ4ldr9\nr7uRO+67n903HqEx0aRSialVq8RxTBQHhKFjxUdRzRe0I8KwVB+SW2Is2yoqMjCikq6vaEzuZNeB\n63j2+NNUwsEFKncXKZ0RfONVwXRsuX7CEwftANK0ffqG35H87pVpODAFf++d8GPvANloQfYd9mZ+\nLEoOxsQw0SBJm2gbY3VEEdbQucBmMcJWXVOaFtisihAhwliEdnmdAci76CTHFAWKHFn0kEWXiu5C\nMY/IeyjtJGlVMMjhUfQHQclp6cdKRIgwcKPDpR/iKsPB9AYR+RUUDKRUpe+JLscaSIkVxrPa3dQ7\nJwessWQOvqoJRMU4BUmboxKLnoN2L6ZXKNS8ZCEtaKeSaigIJDx3ucJUtaAeGrLC9rXZLifw3CXB\n7bs1e2uCeujqdVUfykXSoX94j1NKU/Ub5cQgt/U6k47gK4YAoiE+o/XMe4XLZwOpuPO9/w8O3/1e\npvcdoFavebStSqVSpVptEMd1KnGNMKp41vqStpBtfGy5rNWwEakwYu+hm90uZEtp3EEXqfYX+IYJ\nS+Jli5Ji0GIwjAaVUkhlH8nRa+FnfhRuPAScATsJYsqvPeMHIJCCTqnL2XIkJzYZEEuFHoiNkA+U\nSvFD5UREX9LHeJ5WySCWMYjq0MAnibMiGQ2mMEjhjaThMnQZuj9Uke8vV35OpRttImQ5+Kac/aH6\nRWGQbkPxhTIrdD8/tLZwSvwSRGRd225NgCrQ86CKHjPz8H+/qIgjy0/thlAL5lJJbl3N5Qdzkp94\nTUGSW15eVLzakhyZdry86aqgHluO1Cxp5gqoBydhMnYonsYhbWWn6YBN7pscS1rVMB/Oo6x9r+M5\nb2Hov09gz3V7ue0dP8m+172BHXuvoVqt0WhMUKs1qdUaxHG1T7UqkeRxjYf/f2FAI4ajBm201cnd\nrsvQx7PGDi6sLtyus6fu/p8Ug52r/74+Hw69t4oi+Ilb4P23Qi2C3ktuB5QdIPWGFPhpzYEfCK39\n4CU/nqdvKGYJqFnCfQaI4OJCQGgM7TSgEWmm6toZGnj3Eg7iMhmCakLQwKoAEURY5T2JDJ3RqNDX\nrv0MVCGwUnrkzFmhFao/x7SE0YWlv+JEScEg9wlZ4QTvhYSKhqrXIA5yLp81fONxWHg14HW74J1v\nKjhYNdRjyaw3wAu9mJt2pggpeOTlCq/bkXJ4h2W66oxjf9Oyp+Fa7/PCIXd7vAB8KQyZeEZCn0VS\nehBf0ymR01IrrwzRtCxpQJ6JYJ0+eajgyN1v5fq73sG+w7exc8811OtNDxZUiON4pP/qh2U8W5oD\njQvlVBBQm9zpksBw0N9ufQMWXqij1FAr23wZ6g0pvVaeuwLa378D3nerm6RwzrN969rN8VF+BhBV\nv+gi70UYFGFtOJh614d6FEMNKUAMM5fr/B9fn+bnfzzn6bMRp1+S/NO/ldJsCIdq2Mi5oDByOtHK\nFe6sDBBBCFHgpnELH54pL7Qt3HAtK33LgwVE4EZCClcXGlZfESVz1rgEzOKH/lrlh+AIV6QJLMli\nwvmXM/a9TpAtKBZeFBx5jeB7rYA9u+DaXcZzpiw7mpo3HxQ8MdPg7usXec/hLg8/X2GqYvhnb+xS\nFMahph5ubkQuCi0lw5JsMNAbr+FWKsGWPVll8Xu418fgWxrMAKIuvCqtTmHfwT3cfu/f5cAtb2HX\nNQepNwaGM1wkDYJx9UvB1X5sqQENQ4flCTand1GtSoQ1fXGPchB02aZQdjCWzNtQuZ2u7Isv1Xfe\n/Rp41w2Ov9VNnKCHVY5+jxwYEX42DDkwAbbuvUyp2u8jJeujJeGLhUIorKogmjF//WQTS8yBQ4Yd\n14TccpMkaE5BoLA+wREqwqoIEUS+munmnzqELPbhmlcGLD2LH8smUP2hwgjptR3kkBKKw3k7l3KC\n0BJPurZdoR1EabAUi9CbM0zuMXQvZMxnir/+riE4Y3nNfkHPBrzldsFNOzT2XIJd7CL86Auh4N23\npnxqJuLRF5u87YYWd+5LSfwArsS6a1lRQ306ZqBrXZhBHqt8ZBFIL4HsQ8s+2moHTh8/YrVsiUhd\nWxK1ZsSt997DwaPvZPehW5jcsXvE48RxPNI2P6qf98Mxni0P4Ya9T3mSlVqT1x59K6eeeIxKfdCI\nVepRW9+UJSzUYj8XMxoyIOV2vx+/HhoFfP8VOBzD5H4neXVhFg4IuFTAZA4T1iv2hFC0gQUIpoCm\nP1vtGTwCRAVPNZagA6ysIqiDrSJEhcIorFY06iGHmwpbRFjt+0kCF5YJFQ+YlmHshBuUjx/LsK2c\n3VGuKCEHjU2lPKfRg0piyUsKLDIPmP9+RjUxTFwTgAkwWc4Lz1r27xLU4gw68PwLMHFQcv3tMYeu\nNcz/IONbJwquvx5EFlEsVNg/mREmqXMh3YTpMOOf/SicOq843w7YXcv7OgVhMOgEzXyrQe49hTEe\nLBHO1I0/XC0cE8SIgVEVdlADsnrQDl4UkPWg1qhy81vfxDWvv5udB1/Ljr3XUas3+kYTx3G/N6tM\nCzYjUbXlBjRsxcOLfyPDh8oTLBvRwjAkqsQcuvUOTj7xWB8QEENkPaNdftSoQbPmx//52lCl6l5/\nbQN+5Fr4vf8Ciy34uQhUy+3Vr3Tghl2uQj3XgvkuLFyEGw868mT3PMTzLman6cIzCqCNE1aeiNwH\niYrzGiqGXoW7ro05/p2A1nzMjmYINkJUfA6j/DyOMvcJY8dTCiouCw5Cj5z5sXrSE860clt6X03D\nDNivwn1vtcDgevy7sxnhbsVEEPD9x7tcv0MxsV/CnKZzEZ46b9h1CG4MLKdmDO+4DV5zVJBeKJjc\nnfOk1Pz6b+e89gZ4/90R4Z4mzFl3kUyK7Xa5tmHYX3XFTyscSVOkkHqwJffG002HNA7MYGZqyRYp\nu4Oj0OcyZtAQNyxEmWROoEUquOH1r+fQ7W9l35Gj7L7uMLVGc5nhBF7XYGlLyQ8j3xkXeW0pCrd0\nFo0zpog9B29y7Qh+VGNJFi0MFEoQVyyV+iBkK6vYKoTXNeCamhso/HdvgS+egGdm4JWX3M2akPCN\nM/D3bneTnS+14PPfkry5bXnfj1lkFVotmAg8BN705XUjsZ0c0Y5ATCLi2v+PvW8Pkus66/ydc+6j\nu6e756GRRpqRZMWWPSMbx3aikaGAylr2LkuxseIUW0vFik1sdlkHp8I/2LHX7B8QEmSoWoyNxKOy\nhRPB7h+sbQmW5SHLsMBCNDIbkk00k+A4cTJjx7Ze/e77OGf/OOfce+7t2z3dMz16QVe1ejRz+z6/\n3/m+7/e9AJKDIBZISLGt7KBNCN5pOpiwXAg4II6rwJGTvg5VBTOWJTWPqzUQk0Aimp5zgHeFRHki\nIVU5XySmTcIgwLeWmthaJGABQ2gz5LbaYOMhqisBytsp6KiNGz8gcOYrAn/7fzy8PRli9zbgf7zU\nxu6dAcK6j+9/P8G/+zEb26c4prf42DXThmg3gTyR55VzQap58EoTvC0nV7d0Dwo/Lm+otyR42n7c\nmdUP4847EZh0eEF1aG2pgjhPWRjtAGjWpXLdedMcdt3+w5jcfRu27ppDwfBzdBMQEzhZJSWXy2Tr\n0EBB0FSdMC2VbSwZISHM8iLS0XwxC42mJosbCNqY3H4jJna+B8vffF0OQXJkfpwlCDgVsHNxmMOi\nqsaHACUBzE0Bu0alBrEDYP/1wBtvy+zh23bK6XJ/ukjwtbLArinJyOVc4NtvAagA+QnZL5m3lPZh\nkN1MNjkgbh44lweattQorgNi5yAYAxu3ML2V4Bvfy2H2jqIEgm3LohrmgFBlqulPpjQNU2kFRI+U\ndlC/SNE872PTeF6mBgFATfYza1QFChMWSJ4CCMBsioIb4PXXmtjzAwVYRQDwsXWbhcp3fPA2AXUs\nFFyO993sYKoQ4Fv/GGD2doaGRXHxHDC3nWDE4qDtAHfdphoLvNVWQ4jbEMIDmA/kczIeU22ifZ6j\nXlXJuUxlEbTlfW55cb9vz9A+vo7rhTKXsaEmMGhiyAvi2UmUANfN7sKWG+exbc8PYnr3LcgXinBT\nwMkiCS4XyxanAJFUclHcNckKgovgnMieBToNgun2TEilPFAjpZ+oYBVNNmJQ7WYZheqHRpAbKeKW\n778HX/3S70AoNk72LxAycTiUsQLbkiaEReQQ2S1loFCUcjjiAM2alN+pceD0eWB+p4xS//lrAn//\nFsG7TYHFCuBzgvE8gIbAuQbFl5ct3DbugzUJSi4H9VuoBi7erk3ghpKvetLaQA4QjII4OaBg487r\nBf7ydQv/BhaI7UhTzXKBvItWYEFYNvJ5V/ozloUgZKCWA8IttC4QeC2K0CHIUSZnENO8zLWreRDN\nEGzMAX+jirotUMyraXHUxuTOAqrvhGg2gVJRBqWsPMHFkGIbZ3BEAL8lcOG7HI5FcOv7GEbKAj80\nz8DrDLQZyI6VXlupgZacOiUCSZpAALwJhG2Z00hEFJ5qKBPL0/0oWNzrTRcy6l4GVHXcaaqpGKFK\nemWQvyMUcC2Krddtx5bZf4HyzPdh2+6bUR6fjEw008fR5r+pcdandVSFm+CpZFKeBIkuBI3+pv7P\nwygYLGvcVOwNBFwEEkCUaKDQON0ZYZRCLssXRCqTlRj/jzWQEETV5cuZoWHYghANAA3ceMc8fP47\nqNWUP6IWfUsNrCZUOqBMyM+iA2yZkNaNFwC+JX9381bgewXghvPAa+8Ac5NAwaFoBAJv1QlePwvc\nOMElMB2gxAXeqlr4+zdcbBvx8eN7PTglB61mDq+9mccNP5QDznKgSST1ZCsVaNkojRO439X8rOLE\nHRd+w8G3XyN46wLBnvfaKDoOfG7DGnXAQhv+BQJmS23UrhHY4zZ8wQHkZLebc204RRvMtiGojYJr\nJfgchwbYMkZxbrGNHBOwJzgsQTCVBywhh6XaJY7Ns0J1geQyzb0O0CaHaPggLdVW1fOUXUYAYUH4\nHgK/At9rIPC57PCqBnNYIwALZCym5cVAybvy+QRhPIFCA4Q6UuPr8u56U/a2IHYOU9fNYXTnHZi8\n/g5M7rgepbFNCW1jmmta43SrAJbCzlPCH8YpQKnaNSFCI02IJ8CU3I6nqoG6Fd3FCXxCJaUCBJbZ\nG5cQqkwMEdWR67Lj+EJER584o1AgJgoIB2MCjAlYDChNjuOWfe/HPyy8ikKOgAkBlicgekitkIE1\ncEmMjZdl2a7KVon7KvgygPq+aeBLy8D1k8C2EofwgO/VKQIBnGsINATQrgO5SYEf/D4Pv/03o/jI\nrQ3YPkHlu2N49cIIzjZC/O+v5XHzDMPkhMo+kAQxCFxsmnZR+CpBvZ7HyGQe4BYC4uIfFwl23VbA\n5iZD2LLRdGwsfjXAzI0Odu6y8U7Fx/g2F6OjIxiFDb/JIdACgQU/EDjrWZh0R2AHAk3PQklpJiBA\n61wDpOGjfIODi0scXsBhq+lsYzsBavM4XT0MJTiCQNVy+BCBmpXJPUk30raKanKIdhPN+ruotxsI\nfCKHVrF4/o7HJA8yMgaQmkwwBZG/c3NS42gKm+RiEtH3gcoFmRHPaR5ju96Hka2z2PSeWzCz+xaM\nlMfgOLZhplmwLKY+KSjlICRUg7QChKHR4JAIAwgiVeDJI9mMza2M5m1AnKlu9oJWTSu79T9MVqSS\n5F7VfiwdPdRNF0DiCjx9Qt1H5MUN7QRINLOGUzkr07I4HMeFmwvgegF+9Cd+AotfelWWE6iBL76n\nGFxbAsgiQNkFxkbkg4Xqz8FDSZO2PFl/TwTw/dtkFrdlE/ihwO5Jjm9WCP72LYatZWDprRC3WALj\nToi2YGhMOyCFNsTrTQhRwDtNCv5NYNqyMH6TC0YYBKcgIQE8ii1bHBRLwHcrFLMTtgxYtih8TiGo\ni4mdBQA2uLBxQxjitcUQ3AfG8nnwC1Q2/waBnRfwbI6gJmCNOBgrOGifC5DbxOCWHFR9jrLMO5ec\nwpgFlqe47nYq0ytCAXecgJRtGakkej6L0bKIypwZQkOgFUK40sMnnpAZus0WSNCAnQPy1AF3fdkP\nXMT9CTyVKkXz0hQLWxIwvlBNFTnQcmN/qNECKueBRgWwR3Zg263vAxvbiokdN2Hbjd8H27ZUhyMC\nx1EEpcXBGFcugi7SpKqYkRodcQmEQM/2U5HlJER/yaIk2VV0dZYt67Bxw0XFwpEEWaBPhBipJKJH\nS5GoSWCEaDkuPQwFbNuB74dwbBeuG2Dmht245Y734rX/92UUC3KMRautakS4nLDsWrImqFAC7KKU\n2bApxwSGRNncDeBCVdLeFxvAZFGgWJb1Inc0gB1jHJ4gON8E/uY1iq9XLFznNPHyq2PY8a/bGL0p\nxI+SEDe9aWFskmBsOwG1CcAsEJ4DAqltBAhalKDZIJKCdlxYdh6TWwS+9ZUQe37IQdhiYDbD1HYH\nExMO6m9zjIyN4O03PHznyzVMbbIwOT0Cd6KIxrkWyiUbpc1lVC42IRyG8q6iHHMPOd06N8p0NzZl\nDci4EBm34sQ8JgCXx5WEhEvbiwWAE0IEBMQnshNlI4SwWyD5NtAmsJsUdttH4HPZIFEpq1DF53w1\nlc9zAd+R7lOjpUATyqG+tbrsqdBoEpS37sZ7fvgDyG3ZgdGtO1HaNAXbduC6uq+erRg1TQzEs1xj\nxrabn0P6aRWV2eQg211KdhsVEF38KtJnmypi9sY2QaTNORF39zQaiwhj57KlU8xU6OG1jHHV2cZB\nGIbIqWHDH3zwP+C/PPY4eFAHbOWYGrN6cqrU2C6rhE01wk+4cRZ2U5UJN3xg82Zg33Vy3uj3zgOz\nmwRu4ALMAsYLwLstghIT2LelgS9fABrnCJxtRcADRnMemi0Xm0ZsORbPVXXnLA9QF4Q6KIxyXGyr\niC6XXU8mZwv41l/4+Os/rOGmW0uYfE8B588KjJYsjO+Q/tK2m3OYaAdwLAcgOVgFghELQNgGsW2M\nTuYiZodGdziMM12je6qb57E4WY8ovt9RKRfCkzlMFgccARJwyTsjkOCzXYgWB8EFCL8OXwi0lenl\nQ/W+1l1HuXQFdQyn7ct7ffEiUL0gFy9hjWN013tx/U3vhzOxHcXJbRgpT0Rmmm07cBwZwpBtkGUn\nV8ayY429CQJD6FchEbQs6oEI/Wy/qsrq+V1DA0nApGhrQrvsQqTqyk2bUtbhMmbJER+WA98K4boh\nfD/E1M5d+MCP3Y0v/tFxuI4kCFyV7WKrzi9WMZ4ZJGTfD9lhR/nE9ZYqDRfy580TMvxi2bJpoxdK\nIIYArp/kuHmrdJZ/fGsd7vmyZCk22xjb7sCr+BBvMpBRGxiHnLUyQoARBkZc7L0N+OZ3lIeNHAAb\nTt7Bnf+yiAvnGMoTLhijmNzsKCJAxn4YKAoFVZCj7ilzcoizUZkBFhhJeULx7aqBeGLsl05V5vKm\nWIqyzAmpbTzpxYtWHaRZA9oVoM0hvBCkVQX8BgJjskJbqPEtftwJtNWMYz/VBnD+vGoIYo2guHU3\nNu/aC3diB/JjWzE+tRN2BBjdHsxRbJqlQCOBw1RuJNEdcig1yKvB+0wRsgooVm2905fFl/Efkg6k\n0hg0xFwRaDZwovZAIru3iZC1GAIElApQxpQW4sjlZFn1j3zkp9A6+zqW/uErEJSAMgHblsmihRFV\nqcqV+V8DwoLKnVRZKDqYJ4hcIQUkU1QakavoRaMtMKHSCQ4pcDEkcC/4KIODEhvW5CiszXmINldN\nzhyINgEJVM79CEG+TOGEKhefuDJTFQ6YZWPTFl304yihdxTIDG0R3V9z8RFGF6TAuJeqFkjOGTfS\nxj2VNtFQn00AdUlF83ZcjxHKG0QEV+1faxCNGkhTphT4XHZDarbiz5ZqXdVsA426nLZ3vipN45ag\nKG69Bduufy8KW3bDGZ1BcWwL8iOlCDAy1mdFoJGMmqPGutDEWJFE1otucEgwAHiGETzt9KNEas7U\nQIFUDZaYOED00NNqNcmAkG5emmpqQVTrKKLKdPXYE/n+0Ycfx9mnfxZe9V1YKoGUC2kqjDuyHEGo\nfDmMyAREv6mmYou4PVJUJUqlJsu5KuCnOvb4HmCVgEJBZYF7FIFXgHNeIXKTDVJ0ZYYqs0FslXcf\nKBMgJHBcpsCjwVJUQLEygOIrgSep+2nWTOhM19AAlG9onZYCSUsCxQQOb8gkMq8tYztBCARN2fyu\n1ZBOTVgDgioQNkG8AEFLMmTNpmTWWmEcIK17QK0BVOrA2QpQ5wTO+C5M3nInclt2wylNYWzqOuSL\nY4kyAhM8shurbn/MUrlqhmVi+Myajk4TBYT0AgxZE1zEalqLrBWEBFYU/zGJg4wMhPjiBbI7acWE\nENGUuCIUdN9sCSL5Dsc2Y/99D+P4bx9Crii1TrUtZS/PgTEHKGyStWiwJCVdr0qzwtf0K4sL7nSu\nptnBxw+k09tqASMFAlZwkCvmALggwgXaNlAhknkr2UDRVjEgAEwKd2ECGHFVUphNEjcvTtQXkeMf\nm2TM2IYhOZs6gDkTKAaUZ4CnHgOINyVIWipA025BtJsggQJRvQ40qxC+BxJWAP8CEIQIAgFPlR40\nfBUkbckxmtU6UKkBlYtApQ2E+XFsvvVfYWr6FvjCxeT2GzEyNqn66DmJIKf51rEbM0/NzFczgZMO\naJoLc7w4c6PDLYz7idT3Sd9mHukqr/2SBd23sWLgpIFEI3tSQGSir3PnIu7hFrFzBILJWI/rEkAw\nCDV/ce7OH8E3v/IPOPVnf4LrtgNjZZkuZit3grtS1LwKULsoH3rNkyM3bCbbPBVyKreOSQ6g4EqB\nCVVv5VZbrq65nEDZ9UFyoap54HF/YM+HqLVAQjXByyeqC4YHh9oo2Q44D0AjgATqTdUtJEo70RSw\nOOKiDaOaTMV8JGi0ltEmWiPWOH5DXkDbN8DjAUETxG8BgQfRqoG0LwJeHcSvAe02eFvNcVUapq78\nmYs14OxFOdvVFy7C/HaUZm/HtsndIIUpbNpxIwrFMhw3l5hKkQaP2WxfN2fRg5F7EQP9DqtGV9Y3\nCSw9GlMu0NlA6wyUrtU0JN3KGTLYtygrgXRhK0QqVkQNzYUo3Ueo+l0WhrCsUHXE8UBoDoy1QGkd\nP/ZTT+DdszV85W/+Gu/ZAWwpAmOq2Z9zQZUMt2WEu6Hm1YACIxaweRSYKEvyQED2cM45siRC8Lj3\nXK2msh5sioKlGDdbdWG0BGCrgUVQoXaVdA0u4LcA4TBQlxlMmX63I/rZjJvF2ihMGxEKXKHhy1RV\nanhDfdakadkOVDJaS16I7ym7tCUT+4KmBI13AfAuAi0PQRNoVoBaUy42588D756VI+CrHtB2x+BO\n3YCx2+fBRncgIHlsvu5G5PJFBZpkpadZQtBL06RHJ64n0bOf0SNyE9YVaEJ01yLdwGUGYhM9DiOW\nOfuMLAkYFo0QlP2xmNH2icWUdWIF6e8m6dSfBDATN4rgJ5/4Zfzur/xnvHriJBpT0v/1PWDrRWCq\nLJnlkMp75hDZ5XSiAGzdJPtsw1LjTBTmtXnnW8pnCoCwKvXHZOCjPOqDli3AEhC2BeLmZJ6bKoo7\n/zZQ2iJgTRD4LY6L3FMCrtgv+Ao8TsoP0tdkaipibKPB1DJAU09qnrAp1UfLh2i3QdpSC4lWE8Rr\nyIRAvyadmkYbQd1HswY0asDFKvDOeeDd81LTNAUQjF2PketvxfjOPWgLB4XxrRjduh2O46rJ39r5\nt9Wno9g0V9HPehpf9/y0KyM7mvTh05A1dOcRiaRSIWJrghACi7F8ogQhvklsKDcl3XstmYcU//yx\nx34RxWIJX/yfx+AwqTkqLdnYfMuYzINzXemmjOVlk/SSorsFMZSCkluCuDI6UClAfoWg0W5hokZR\nrhLkSznYJS5rwt0AGGkDAfBnf+ajavk4cE+Id95g2LnbBmoB4BTkG54iEdyU5tEP0swfZEajBX2S\nhpmGlupRXJPkQMuDaPogrRZIvSZVSvMiSK0BNGrgDR/tdohWU46iPHcBOF8DztaACzWgXZqBGN2F\n0m23Y8SdQG5sCyZ37IabK8B2HOXkkygmY9tMLZimlpGTDGTWAJU0NNOLEzXGhdArpqxgI4GZzMRJ\n9hAk586dE1kAMlv7DuOlu3fqIVB6zGC73Uar1UKz2US73cLXTv01/vj5Z3HhO9/CphFgelwWzO2Y\nACZHZYpPcURmKjgO4KgeGkJFzGsN+dn0VdBV9WBglMngKCvAsi3kHIaCm0OpkEc+78DNOXByLsiI\nha+fdbF4LofrNrvYOuVg6gZX2oajthoNoBuE5DJiOcRg22zDF9JkQVNqH78hgy3NhvLs1YCkRk0i\no1EHmh6a1ZYalylwsSr9mGpTmWSCoO5sBSZ2wxrbheL0HPKbr4OTK4DYFlw3h1y+qGIzdpekTaHG\nfkhqmbJkdgBAEiaazCCwIvCYlgVZKxd8tUJr2AV1/di22tk0bWazBPzWH/gXuOmOffir4/8dr/7p\nMbzxzndhUxnjGZHZNgiYDATmfdmExvakn9RUrZV8nZaiXBqhR9VRgEKoIccUARPwmyHyQRs5T6DQ\nFsi3bdxUAm6aAoTFQVwP4p0WSNGRB27JcgY4alirniOpe9a6kMVOEamgzT1PJpf5TUkM1FtAvQHU\nL0r6udoAak3weh3NC23ULgIXKtIkO1+XCrAWFtHOb4E9thOl627H2MwctoxtBScEtuMily9FIKFq\noi9jRAFIBjxt20kslnFvgZjxEoLHuZEKNImsaB6CI0ysyrEZpxk48k9CQ10yDWQ6Z1oTZWkj/dlu\nt1E//zZe//Jf4bW//WMEb34ZU+PAtilgQvUkKzAZhLdVMnLgxUNv22Fcgqx9I2pTEOrCYjYs2wZz\nRuA4OdgWQc6iyNsMedeGqztdOpZ0uPSMjrwlOwq6jkrehCr8V86oA6DMgFFLAok3VHymKVViU1HR\nzTZQbyCoN+BXW2g1fVQrkuy4UAXO1YGGz9B2d8LecitYeRfyk+8BcUfBiQ0nV4aTd5HLF2HZjhLw\nAIw5ajKbbvckZzPJ4VUUlm0rTeRmdrTRP2vnWgiu+oFzw69IkyIioXzjDBqaCItIlyA7vng1a6BL\nCqAsEOmm73r0uud50acGVOi38c63vopvf+kvsfJ3/w15CJQdac6Vi6oviB4kHBidTZX1pCdBMwZQ\nNQaEUAKbOWC2C8sicC1p1uUYg+3mQJkF27GRL9hwcgTMsWQcyFIsnVA1zYGQDhZpAWXIKPCIJf9f\nuwBRaSOoc3iVAM1KC82qkGBpyqh/pQV4YAhzU2iN3Ah7bAdGpm9EftMuOCNjoFYOlm3BdnIghCuW\nLAcgVOMmC0rwBYQIYVkWXLcAy7Kj7HhJ9Uq/TPo/lsqWdxK+bhYZoGtwOA/BeZiIy/Q217IyVYiR\nbR3P2yGUXpWm32UBkEkemH6Rnv1pgkm/Pc9TwGrDa1RReWcZ777xGr73jf+L1/7uj0HVoFlXWVX6\nHfX+UEHWnOo2Y6tOuZbZG0SZM7alUppAYFsWCnlgxBZwbQLHpmBUTqFqBwRNjyHwQjC04eZCsBEg\nzMtcs6YO/FbUuESWRzO3B6IwA3t8O+zRbRDuKKhbArFdOIUSqJ0Ds2xQwmE7haiFE8Bh244yqwRc\nVw4pFiJQQU432g4IQIilKGknQeBwHkCIwDDPqMoicPt41mqOjggNMIm1PP0EoKKfqDb/2Ib2sr4m\nAJQFIvnJEQTarPMRBB6CwIPn+fD9NoIgjAbpysIrDr/dQqteQ/XsO1j+xlfx1uv/iGb1HVz49tfA\nPR9BO5QTnS055tBlavoaldWWjuplHbVzU40c9RQJV3WsiuZ3qjShpi+zmC2Loli0kC8WEJR3wCpO\nAHYB9vj1yI/vQq48BermQZgLoVZc280rwbWUj0TgOAUl6KFix3JxKAECtiPBwHkAV31fahUOx8kr\nmpkgDOVANEplYqceCGXOeuLcN+IhKtFVzcgx43mrWxKhmhnFU3l+65Gb+LtSs9Irlqi4rACKVzR5\n88PQhxASPJwH4GGIkGtfKUAYhAjCEL4vwcNDCbaQx76UEBw8lLZ74HvwWw00azX4rSZa1QtoNSvw\n6lX4rQZ8rwERtOHVKwjbTbTOfTcCT2FqF9yRMizbBoFAvjgKN1+GUxyHnS/Dcgpgbh7MscGsHIhl\ng1iOnKRghAGYmo4m+0QQFXPJRYOfZDQ9TAg654Gc3erkI+deCB+WlQdjFGHoRX6MrOBsg1JmAFCo\neymbVFuW1ESm0Emt70UT+cy6G0qleTeIBojBFBol07x3zmRCE/VnBpqsX1JLXR6/6pICKDEVTAWj\n9M3WzRoAYkx7i5NPtZ8kTQf5cxjIvwXq9/Lvwvh+iDBMarc47kSVs8sSZSNCO05CxCMe0dkJJh1A\nTAcW9T2UJlOoqF892MmOgBEEHhijsO28Yic5OPeV9om3078jhMqhX4TAtiVgpMYJYFm5aEAUIQRh\n2FJmlgRFGkTapNMLVzovLB46xQZ+ztlgIkPSHAJmN/pOUJGEv3VJaOysqPL6ossiunHxJ49ApHOY\novQhFqf+aJqbc66ArADALXDBwblAEIQQjqSPw9QEOs7jqXSaTZI/EzWtjCj/AUbSougrtSQ9iCsN\nMDNtX3AfIbeiURuOk1MCqQPKPoSw1EQ1V2kfH4IzOO6I4dwLBAFU1rOtph9wWBZTJQN5+H5LAdU2\nKorzCIJWNN9W9j9IjiyUILXAuY8wDBLmlwQ/hxBMaUyrb6GSvpVtgEnGweSnWDOY5NqWThfToA1S\nz4Umcjy7l+is72UNR7vEGkVrGD2WPEuVxxciVhVWIYQSSAGhwGDbFrjSLmFC6yQ1Tpy4qTUOTbCA\nJniyQJTuBWGyVWlAxdnHCggiXoTikYI0yqcLAplP6DiFaLswlH2kJHnAEpMY4s6cDoJAzmLRQi1L\n6D1l3rmRwFiWC99vqUUkAIQAs9yOaLoedxiG7UhrafBy7oPzEJQGA49BlNdlqWkcApTyhHbqmuuW\n1jcEXdN0SEahm1DzkrgezoZ4QlukHECj+rdLCqDeYMlyIuma1WPiZzUSRWskRuWQX2aAIZ5VSg3z\njCZAkvVzVmpROtibPqc0aHTAMQg8CCErU6UGtRPgEUqLUqrjMXrqswSPZAPt6EELQUC5mbApeyZw\nHoKx2NzSzBjnASi1o4XKtnNKEwFccIigHWme5LVSMJYDIT7C0E8xZSIyn9cCpBhMTF2jlhsNJtGV\nS1gXHUEieyju/SaSeZhpM3BQ089a3W/hHT5Ltk2KNajmbs6kSGkrkVDhjJEoascNQEgWyUqo9nT8\nKZ1eNAiQs7RRcn9tWFbcfFIyYbkEAMOwrR6SrQgFTTFLX4lRyabFjSrDDu2tG/1JgZamHKVM+oSB\nD9tmhilHwZiDIPCi+xAEnqLurY7r0tooCNqGFo/9oySQ7DVNgkuDSWvIBDXeF5nXKT/EGBe5Og5E\ngp435ZhSbQb2BpUV7ySOPEfMRpeQWHeFuz7asvvvTAESkXkEQmGpsgr5IEmmNskCTzdavZ/VJyvY\nGIbtyMyS4GFgzE2ATfsVWsuYZqoGc2dQkWSYujRawXVav9ZCmmGzrJyhKS1YFiIQAVAgEpG2Su/f\ntvPgodRGIuM5SD+zrQgSW3WwJWu0NCRwGRMQnIOL0GiamF0FTZL/dDHr1ip/sujTdD/M5qMmpW5x\n7kdN7WRZA1EFb+wKiw6LBGUpV16rZ6/ubqbZsBiYCDyB30EwSPDQxDlw7id8g+QD68ZUiS5amSsh\nE5EJIrVQoITbT4BD0tNckQUaRL5qfmlnPmvKbBDKEIa+sbCmta4A555iHq01Ayl6tpSBgUVaWV4j\nR6ILLtamndYKKqJuv4hyBcOYhZMrGUlw6nGTEW1EissMHDNKzYz+3IP7U8MNBoeSRk79Pg0eKQy+\nWtUQZTOb+4lbgtEMNrNTQ5iUsQYjpbahhfyOUe6MOSrmFoMoDAPFfjpdzFUKy3Ijpi5mUNFhDg8P\nSIi0OMAiVyL2l0TGeZA+tUv/f1/t9IUQej4QrsBXTAZoQbiS0jtkDMXrAKpJJZsA4TwwcsDS2sdk\nvkjGA+4sjc4qZZaaz0YYeLIVcuhFZqQJItnkJYieuzy+1zOAqs00rY3SGQHxWssRhp5RpLl+IGny\nhDHWERZZvWR7PSBZ/byt+AaR/lZwgY4S1+GbRzQyz67EnCipTfwOp1U61VbHKhWzWjCykk3/jGcW\nqMW+G8n0G6Q/yBO9yyll4FSO/tPOPiF2SkPaEXB1cqd24NOxok5t5KjAtd/F0zdM21D2vB4WkEww\nSZZVGEywGbpYBRIDpAOtdspWOr7RXw3HsFWWpmOZMkeu3JR3zj1FBpj0tgClTia1K4y8M10y3xkW\n6GVqioh1S/gKEZGQNOM0rS1NOGmipU05zbYBXsQ+6QbtYeitwq6RyESTgd+wU+Ki9A5teslA6jCB\nlFxIaAaYRGaMaFWJJhhI9i0TNGZj717fJ334+qLvm2CaaVdySnscVDT7nMlryI6LcB6CizAeV58S\nZL2NFN7B7HiZxmOOGjfPh4GQMJFnmPZxInMvVAV0HWSH6Bnr0SDkJDRy6tLLNkndvyACUpo1HSaY\nTFZZTjYfXLP026nHMjuRxrEDGIG8Ac21rACYSDe3owZwrvy0dSlUXqovWSys0iTK+k6QeGJZ5p3Z\noCL7XvAOwEYgQQCh8gcJEakqX6ZMKBJR3knmT8eIbMMci5+bPvfVAqbaJE1mePcWQB30HbZGSmpo\nYpAtPOUriYGB0tWESw8yMjvnqFPpOZ1hdeHT6RQ0CqANyqJdXvDwDOGIxEdRxSTjewHiJEqR6c/F\nwbve+WGmn5U0BXSsjnf4I1oLQTVbl6RB5zlkgQgJEGlNRFbXRjxMLhqrmsMhCOEGSbQxFoh53VIr\nCcOPXyvVHZlwZllvRndSggSEdDLf6j6NtpepoXEorqZXEjykgyHsRv3GAWmS8BuytkuumL1NuOSg\nMyTAJ4kImmIEmRJoElHWkmkjPUDUKeTaTF1NwLU20ik65iLcazGX0+RC2R1zg/soEDUKhERxJdFl\ncewTQP2OmOhpO0YmmjC0GLsqQdMJniymiWYKYtLWN7bO1D4mwya67qtbG2XdRYcLGGaKSPk5DISY\n6Vci05TTz0wCLux49tJE9BWVvRotTCIGVYhQlYj0t+QKEYJAN0Tf6IYkxKgIIIl8zn7cFn1uVlZX\nyRhMYgBkI6IXr/bGESZ4NAFg6tVe8ZI42GcIcqb2CVMLFOnjYad/TdVkhvREaVOYWZTqL1lBDkF4\n5vlrLZnUnrEpLrMbrL4WxcgVoGG279jVqxdRYFkH+DdelkzyLG3aidVNOLMBeLaJsMrB1bTua6Hb\nii6CS9DKxkcv4iNy1k1Dj9Luo2IAYxXM3ob0sH2IGgityZ60GRdrFhprAiNxMut5aRB1M2vie0P7\nWqUJsRJxmv5CJCSlDcgllK8kE52cvdrZKMWKc7jEqjZ458O7ek207uDhPQW2OyslYlIgApzIJEy0\n+da5WHVuB0IM/yebbdLCak6jNoVYCAqQMDqMrpfJMuU0iJL3In3uQd+aKHbiCTgn6L9vQmd9T7oH\n+6V4mcfrHGSsTDjJSqT9nOwhWuke1/8MnqQP0o39QQ8msx8CoftsG9KReZ5Vt8R5Z2P1LI1lEgKy\nVyTvQpT0r4liIoV1jKof1LTWNV6XGkjZYNKpPCRrWqRIqflrS9sknX7Z3YZkMkSxg939wYqogWHy\ne6yrICTpadL13HptowvuTOshGxQkUVcVnzPvIYjEOH/RRUPyDsHqVxvFeWz9m1bJ45p9Dy5PQxHl\nA3VOodM15ZfzBC8NWSCi1lC9HvhqUfNOQkB01T5x3VFsb/demEjPqLkubchm75LbmSaeJomyNFZS\nSFjq+rK0Aona+fbvZ2i5MjU36UFQmV1PTcLBdD8uvZxa2SsVueZ7GifB041CphGr2EuA0gJ76vTf\nY3HpG1hcWkKlWsXhZ55JE7bolmndffXt5TsQ9I4XpUEUfy/WInTNINL1TIMyZvFCHVeG9h5N0vt5\nXg4gdQzYutq1TaVaxaeeeirxu6QAm+ARePmVv8SLx45Hf9s3vxcP3P8RxKUUZBUQpv0mgVMLr+Kl\n48dRqVbxiY9/vIv/Q1YlavoDWIbAiOzYSyeAYJh93QVvcWkJzx89irvv+gDuvuuuHiQKXwNbFqeM\nEbL+xoyXGki0s5/W1f0ql0o4/MwzKJdKOLWwEL2TJodcTavVGp478ls4dfpVLK+8ic/+4i/ggfvv\nR/+TBXi0n1OnT0cC8YmPP4K5uTkAwMz0dAf7ll2egMGBguwp1yIjwTRp8qGraVmpVhP3CwCeP3oU\nJ06exIvH/yh1LhnzdDP7ZvSnjYZJTvVTxj8UAF2r/o0puGeWlhLMk369qLQEANx9110olUqrsGed\nrNup06fxwMP/HovqGFoQtBDuUUDKYt/6B08//kQ2IDKd+C6U+RdPncJHP/ax6H7FWnke++bn8YlH\nHkmmC2VDCP1G83uRDMMiiMQaAT0AgK7N14mTJyPzaXl5uQM8yysrOHHyL7BndlZqrnJxAPDEpttz\nR34LyysrmFP7AQjOLC5G2tAE8iAmWvZDH5IgZJXvA3juyBEsr6xE90S/PnzgAA4/8wz2zM3FpS9a\n/WW91wki0xe/0oFkXYvgWV5ZwZ65uUijnFlc7LD9P/v0r+LRR34an336VwEAc7OzmeBZXlnBmcVF\nLK+sSI0yO4v5ve/H8soKlldWIs0DAAunX8WePXuibecM7VOpVvDnL59AuVRK+REkOsdTp0+jVCrh\nnv37USoWoy1efuUVAMA9+++OzKwTJ0+irLbVIDh1+jQWl5aUD9fJxpnXIoTA3OxNuHPv3uhaTM1z\namEBc3NzKJdKarE5iQcPHox9KWW+SpPvNJZXVrBvfm8KfBJEC6dfjfY9Mz2NPXNzfSwsZuMWMUQg\niaH6+9ckgE6cPIk9c3PYrh7SmaUlVKvVCFAvHj+OUqmEfUp4pAYqJ8BzZnERzx45gjvn57FndhYn\nFhflfmdn8fznfgcvv/IKzix+PRIKCSSKO/fdGe3zzvn56Hw+c+gQKuocTAAtLi1FxwGAzxw6hBeP\nHcPnP/c56Zc9/Ss4dfo09u3di3v2340zi4v41FNPYXllJQJQpVrFEz//FE4tnI4Wgzvn96pcst7X\ncud//RxOvPIXWFxajK7la4uLIIRg3/w8nj96FM8ePhwtHvvUeRJC8btf+AIWlxZRKpUkEXMEePlP\n/hfK6j4/f/T3cOr0Au679wBKpRKeO3wYlWoVv/zpT/cFoDTJMDQNbHb4WSeQrkkT7osLC9i3dy/m\n974/4QcRAlRrVXz+6O/j0Ud+GguR4w/cPHdzAjw/88lPYs/sLB48eBD75ucjX2bf/F4AwAP33x8J\nwX0HPogHDx7ET370o9HxtTA+f/QoTi0s4AG1epuCsbj0dfzMJz+JO+fn8eDBg9EKv7y8jEq1is8+\n/SsR6OdmZ3FGsWEf/tCHEqzjEz//87jv3gMxkVIuRYKy+rUIPHjQvJYDePDg/Xjw4EE8e/hwZI5q\nX0i/nj18GC8eO4YnHnsMT6r3fQfujcDzmaefxuePHsWTjz2Ge/bfhfvu/WDkb5r7GYxkGDbRJRIj\n7f8ZQEqglpeXMTd7I4TgkWBoU+vzR38f9x34ILbPTEcPVD/0NA3+oAKECYq52ZsS2iMmLOIHu6iE\nbnllBaVSCU8+/jjKpWK0ihPlxj/3m7+JSrWK+w5I4X/h2DEAwKMf/zjKpRI+++lfiMBQLpfw4rFj\nidV7bm4On3rqKXzikUciYMtjzPV5LXOxCZm4FkmSPPjRj0bCbgr9qYWFCMij5bIC3r148rHHIs3z\n4rHjeODgwWh/WjvumZtN3O+1ESbD78mxViBdcwA68fLL0cpKiHxgUti/jjNLSzhx8hXcd+BeJeBv\ndvgqLx47huWVFdyzf3/iQWtQSEdaPkhNXWvnWmsvDczl5WV8+MABCCEis27f/F6AAKdOn8aphdPY\nNz+ParWK548exfNf+AJ++dOfxocVoCQVL4/x8slX8Ogjj0TH0Of0kwcPYs/cXLRdDCSCF48d73kt\nN+/ZY4AiFnD9KhWL0bZ3GgDSQJf+TpIFrFSr+PzRo8pnu6uDCZVky/pMsY3RRmsD0jUFICEEziwt\nYo+hJbTGOLO4hOeO/BYePPiRSJgWl77eoYFeeOmlDlC9cOylyH+ZMfyqmGnb3iEoM9PTePLxx2NT\nSv1eO9n6/8vLy3j28GGUSiUc+4M/UKSA/M7yypsR8J54/Oei89TfNTVEBNC984nFoPNajqFSrRoM\nIUldy3RCoLS2is9L+nRJrRSD6OWTr6BSrWJmejqxL30uM9MzQ/JnNjLNrH8gWdcOeGQD/JdPvoIH\nD34k+r1+iMsrK5iZmY60D0AjTaF9gkq1GgniduN7z3/haMfqvLioVtS52cQKvLy83CFwMjvhdLQ9\ngEh7ffhDH4p8n/TrzGIMOm2WaRMqfQy9P3293a/lCwlQEUIS15JmIJdXVhJgSAdZ02zi8oq8/pmZ\nGDzPHTmCqr7XagEZpBd5f0zdEGn+TLKBXLsaSIPnxMlXEloCIJiZmYm2e/D++6PLNoOdadPGNEd+\n6dChyBTZt3dvZBaZK35FmWCmdtCgFCIGjzZ5tOloAs7UEPq8NDN2twkU9be0ttDnvm9+L84sLUWg\n0OcQX8v+yCR7QZmrndfye0rTvBIB1TRNzftjEi8Lp0/jjNLqseY5jlKpHG07Nzcb7b9SreBrqXt+\n5WmjdBxJXFsA0uCR9PQfKjMnvpl6xbvvwL3YN//+TPBopssE2wvHjuFTTz2FRx/5j5GAvXjsOM4s\nLWFmejoCysuvnMRHP/Yx7Nu7NyHgsXDH5tvyygoeeOhhVKrV6LxOnDyJF44dw4mTJ/Gpp57C4uJi\nZBppATZjK3pfplO/vLISCegDDz2MxcWlhAZ48fjxiGzQ1/LCSy9hcXExeS0nT+KBhx6O/CitTU4t\nLODZI0c6zMHnDh/GqYUFfObQITx75AjmjNDB4uISnjtyBGeWFhMEx6Of/NmYyXzoYTzw0EOR2bxu\nGJFLAaSkaUevBfC8eOwP8aF/+xM4tXAaZ5aW8MBDP5UICu6b34tHH/npCDyfOXQokXD63OHD+NRT\nT0VBPr26PvnYz2HP7E2RcN6z/y48+djPJfymUqmMw7/+68qRX4iEO5nCQ6LV9zee+TXsmZ3FfQc+\nhJlpyQR+5tAhPHv4MO7Zvz/ym7Rm2DM7mzCtvriwgJnp6QSAKpVKBNrPfvoXcd+Be+W1KOBVqhX8\np8cfx565OeNa4mNF11IuReeX8Kvm9+I3fu3XUC6VUC6VIpPzhWPH8EuHDmFmZibKPzTPq1Qq48nH\nHkO1Uo3O74nHH+vIdCiVSkMMll6KEpwYSITrkQFXrebpt81WfwmzMQ0+G2k2LUgz0zPR/irVGlZW\n3kwARTvnpukkt61mpMgoJm9hATMzMx2BRSF4x/4AoFqrZ9LApxYWML93b8LESB5XHi++luku1ywS\nmi25bUwWLK+sYHl5OTOmc2ZxETMzMyqbQkb+Ty0sKM1DUue3bNyXYZfRiA3yjYyneLUBKFafHIMU\ncA36cLLqfJKAJH0lnPZ2fsnA3137Mfu5/tXy1wYX8KxuQfE97HYMDFWDDDeLIcXCXU2Fc8nGGnRD\nwaNbEK/PTOjVzZOu6burC1efUza6frebsMU9MgYtmkuCsp9OoMMFUVx9O3xtRK8m8MQtbNdiEw9y\nHGC9w5k2LoV+7efVX8PAzsUnKfiDr+aEZA0LJX0668O7bxvhG9GrCzyDX97gGlYMIBAbBQKxrvNb\n/7mRDG0Rv9ci17FGMfu+rVbWPvyiuGEzdfTKBw9fI3jWYq/zAQUMl1zQV5OnYVjk/Uy3HlywtVkm\nOnzJSw2iYWojeuWDR6zxBtEBjyX6FC6y7n1trNuZJZBZWmU9iwRZkymXrX1EH/sSGzYoer1AotcO\neMiawTOYYG28H9NLVvoDH8kQ2P402CBkxdpMOYLBOhJtLIjWq42uQAD1OziWZNrUawHPMLXP6mAk\n61xYNsLnWvt31tpApH8T7lKAaO1NTeiVB54sdZ7dumK9Pk8sAMPUPpeLfRvMhxk+ybNWTSR6XCdZ\n4wK7PiANcq+tKxM8ZMMvfFBh6hecw10gyRpB1GuqhohKvfu55o3saJOcy5N13mJV0G5EHHMQWboi\nNFCS81+rubFW7bNRJlA3LXm57zYZUJg2Tgt1aqJB93Fper9d0QBaf5rFWvOn+j/uYL6PGJIAbzTS\nhr94rB1E67neywsi+k8TPBujfbrv8spLlxq+zK33OQ7D/P8nBKD1O4KXAjzrsbFXIz022FAjw9xX\nPzEkgvU2U1zfvbo8IKKXDzy4LOAZzNYma9hvr3k7V5qvI4YASJFBXqzXH1oPiDaOobsiALR+8KyP\neel/kRpM4HsPyroyX4Mt2N1oZ3PxEOs2D4eRYrOR5QuXEUBiSOChl/DGDhsQV3cj/3hB6VXysF5T\nbnggukTTGS4VeMQQHuD61PsgpttgxxJXKSTWsqCQjOsmGWbs+rTAcJI9Nx5E9OoCz0aabmvfv7hC\n8dPPGjDouWfvU2QCa73PfThBUnH1jjcZlholWC94BLKLubKYMrJB0e1harPhNeBY23ey8tdEj3t/\neUz2SwEiupHgGcaDJomZM8MQGLIO4VmPMA8TlMMOxooNvHZxxWui9O/1wm++ze3M7enqIOh+kN7b\niiEL/HqA3L8wDV6Ed7l8l+HtY3Azbi3P5fLE/LJBJFb5veh467+nP2k/GiR90F7/HyZ41nvTLiWd\nOTzNvRGgFRusEfsR3Mu/mPY+l9XOUXR8CtFFA5nBqHRgqtf/hxfEGqYfMujY9UutCS47ZNfkqwyu\nhYZlypEBnjnp8jfRxS8WA+yTZGugXhe5mhk3LIEfBnguRQxgsOrOy0FIZCVqiqt6IegEUT9dikim\n/xuXUpAe5BLp8nf5SZMrxGoaRGwwG3T5wLOx/fHIZQFu9rF7xXGGoRG6Cfj6A6y9QUTWRBKt93Ss\nYanX9QmRwEbRx1e2I3+pzzddSk06Fp5BnwEh3dKYuoNoGItKXIx3eV//fwC0VWZuzsA9mQAAAABJ\nRU5ErkJggg==\n",
+      "text/plain": [
+       "<IPython.core.display.Image at 0x10853c7b8>"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from IPython.core.display import Image \n",
+    "Image(filename='../imgs/Mathematica-ring-a.png') "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Limits"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Recall that the definition of the derivative of $f(x)$ at $x=x_0$ is $$f'(x_0) = \\lim_{x\\to x_0}\\frac{f(x) - f(x_0)}{x - x_0}.$$  Write a function that computes the derivative using the limit definition, using `limit`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def lim_deriv(expr, x, x0):\n",
+    "    \"\"\"\n",
+    "    Computes the derivative of expr with respect to x at x0 using the limit definition.\n",
+    "\n",
+    "    >>> lim_deriv(x**2, x, 0)\n",
+    "    0\n",
+    "    >>> lim_deriv(cos(x*y), x, pi)\n",
+    "    -y*sin(pi*y)\n",
+    "    \n",
+    "    Note that we must use this trick to take the derivative without evaluating at a point.\n",
+    "    >>> lim_deriv(exp(x**2), x, y).subs(y, x)\n",
+    "    2*x*exp(x**2)\n",
+    "    \"\"\"\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "lim_deriv(x**2, x, 0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "lim_deriv(cos(x*y), x, pi)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The function you wrote above to compute limits using l'Hopital's rule is very fragile. And even if you try to make it sophisticated, it will still be unable to compute many limits.  Try it on the following limits, and see what happens. Then try computing the same limits with `limit`. \n",
+    "\n",
+    "1. $$\\lim_{x\\to 0}\\frac{\\log(x)}{x}$$\n",
+    "2. $$\\lim_{x\\to \\infty}\\frac{2^x}{3^x} \\textbf{Warning: Be sure to save the notebook before you test this one, and be prepared to kill the kernel!}$$\n",
+    "3. $$\\lim_{x\\to \\infty}x\\sin{\\left(\\frac{1}{x}\\right)}$$\n",
+    "4. $$\\lim_{x\\to 1}\\arctan\\left(\\frac{1}{1 - x}\\right)\\; \\text{Remember that $\\arctan$ is called }\\mathtt{atan}\\text{ in SymPy}$$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "lhopital(log(x)/x, x, 0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAACMAAAALBAMAAAAHCCkxAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIs3dRBC774mZMnZU\nZqvpz9EoAAAAeElEQVQIHWNggAHWABBLAMYF0qzp3xsYWKfNbECIsS3g/hQQ5MAggRDayMBwXlWL\ngYFHgEHIGARMGDYwMHB/vwBUAmRAAYiVjymU/gsojlB1Faix8XsAA68ATB8DJwPDPgb/EoaTcBEG\nxpeTLjAwvi+fgBBigLseAP1wHBzUhNGNAAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$$-\\infty$$"
+      ],
+      "text/plain": [
+       "-∞"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "limit(log(x)/x, x, 0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "ename": "SyntaxError",
+     "evalue": "invalid syntax (<ipython-input-23-daf458c59400>, line 1)",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;36m  File \u001b[0;32m\"<ipython-input-23-daf458c59400>\"\u001b[0;36m, line \u001b[0;32m1\u001b[0m\n\u001b[0;31m    lhopital(2**x/3**x, x, oo) XXX: Don't run. This hangs the notebook\u001b[0m\n\u001b[0m                                 ^\u001b[0m\n\u001b[0;31mSyntaxError\u001b[0m\u001b[0;31m:\u001b[0m invalid syntax\n"
+     ]
+    }
+   ],
+   "source": [
+    "lhopital(2**x/3**x, x, oo) XXX: Don't run. This hangs the notebook"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "limit(2**x/3**x, x, oo)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "lhopital(x**(1/x**2), x, 0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAAoAAAAOBAMAAADkjZCYAAAALVBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADAOrOgAAAADnRSTlMAEJl2Mt1EzasiVIlm7xEe\nOPwAAABJSURBVAgdY2AQMlZhYGAIYxB1YGAOYGAuYGBtYGB7ycCnwMDyimHeBgaWx2DyNRL5GCz7\nBqSS6yVIF3cAA0MUg6wDA4PQ5hYGAON0EpMbNABcAAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$$0$$"
+      ],
+      "text/plain": [
+       "0"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "limit(x**(1/x**.5), x, 0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "lhopital(x*sin(1/x), x, oo)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAAgAAAAPBAMAAAArJJMAAAAAHlBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAACGjDitAAAACXRSTlMAuxCrdpnvzWYiHG0BAAAAI0lEQVQIHWNgYBBiYGBQ\nnMTAoGwMJBhYSCVYw6ZHAPUxMAAAQGkI1Fjz0FgAAAAASUVORK5CYII=\n",
+      "text/latex": [
+       "$$1$$"
+      ],
+      "text/plain": [
+       "1"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "limit(x*sin(1/x), x, oo)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "lhopital(atan(1/(1 - x)), x, 1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAB4AAAAlBAMAAACno0T/AAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIs3dRJmrdjJUZrsQ\nie92pBgeAAAApUlEQVQoFWNggAHW/0CQAOMxMIR3Fq4SRHBZJrALFCK4QBY3QwIKX4zBAIUfxfAB\nmc/zh+EHMp/dgOEvMp9pAcNWZP4AsYWMQcCEgR8UHP//09AVjKHaDsjGizGw/0Tm5zAw2CPz3x1g\nyEfWoH+AIR6ZD1RrfwBIIAAHSgAzMDBtQMiBWNGoXPYEVP5UBkYBJBGOAAYuZL7w3bvBSNIM9v//\nf2YAABDvJavRuLWzAAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$$- \\frac{\\pi}{2}$$"
+      ],
+      "text/plain": [
+       "-π \n",
+       "───\n",
+       " 2 "
+      ]
+     },
+     "execution_count": 29,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "limit(atan(1/(1 - x)), x, 1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Series"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The Fibonicci sequence is rexcursively defined by \n",
+    "\n",
+    "$$F_0 = 0,$$\n",
+    "$$F_1 = 1,$$\n",
+    "$$F_n = F_{n - 1} + F_{n - 2}.$$\n",
+    "\n",
+    "The first few vales are 0, 1, 1, 2, 3, 5, 8, 13, 21, …\n",
+    "\n",
+    "The Fibonicci sequence has a generating function given by $$s(x) = \\frac{x}{1 - x - x^2}$$ (see http://en.wikipedia.org/wiki/Fibonacci_number#Power_series for a derivation). What this means is that if we expand $s(x)$ as a power series, the coefficients are the Fibonicci numbers, $$s(x) = \\sum_{n=0}^\\infty F_nx^n$$"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Write a function that uses series to compute the nth Fibonicci number. \n",
+    "\n",
+    "Hint: `expr.coeff(x, n)` will give the coefficient of $x^n$ in an expression. For example"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAAgAAAAPBAMAAAArJJMAAAAAHlBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAACGjDitAAAACXRSTlMAuxCrdpnvzWYiHG0BAAAAI0lEQVQIHWNgYBBiYGBQ\nnMTAoGwMJBhYSCVYw6ZHAPUxMAAAQGkI1Fjz0FgAAAAASUVORK5CYII=\n",
+      "text/latex": [
+       "$$1$$"
+      ],
+      "text/plain": [
+       "1"
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "(1 + 2*x - x**2).coeff(x, 0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAAkAAAAOBAMAAAAPuiubAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIpnNu0SrdlQQ3e8y\niWbzIQYJAAAAT0lEQVQIHWNgVDIJYGAQY2D/wcCQycCwnoFh9wSG/AAG+wkM+kAJoMgEIMHzF8Rk\ndgCRKiCCPQFENjEwCjDwKDDwCTBI3b2rBVT8//8vBgBR7Q/Fm5CwxAAAAABJRU5ErkJggg==\n",
+      "text/latex": [
+       "$$2$$"
+      ],
+      "text/plain": [
+       "2"
+      ]
+     },
+     "execution_count": 31,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "(1 + 2*x - x**2).coeff(x, 1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABgAAAAPBAMAAAAMihLoAAAAJ1BMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAilU6eAAAADHRSTlMAIs3dRLsQq3aZ72YDTSHvAAAALklE\nQVQIHWNggIMwOIuBIfUYgpNejsRh4CCTI2QMAiYMZBsAcxDnrEOzYWwwDQBP9Q53CSxxJQAAAABJ\nRU5ErkJggg==\n",
+      "text/latex": [
+       "$$-1$$"
+      ],
+      "text/plain": [
+       "-1"
+      ]
+     },
+     "execution_count": 32,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "(1 + 2*x - x**2).coeff(x, 2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def fib(n):\n",
+    "    \"\"\"\n",
+    "    Uses series expansion and a generating function to compute the nth Fibonnicci number.\n",
+    "\n",
+    "    >>> fib(0)\n",
+    "    0\n",
+    "    >>> fib(4)\n",
+    "    3\n",
+    "    >>> fib(9)\n",
+    "    34\n",
+    "    \"\"\"\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "fib(0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "fib(4)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "fib(9)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note: if you really want to compute Fibonicci numbers, there is a function in SymPy called `fibonicci` that can do this far more efficiently."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYAAAAAZBAMAAADK9+SzAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAu90iEJl2MkTNq1SJ\nZu8+uZRyAAADV0lEQVRYCe1YPWhTURg9zXtJk7wmleIgODTWQSgFA1KEgvBcHKS0WVKotRoEBYva\nLA5KoQE3lyrooC4BwSGDZnFxaRRE1EAD6iz+gG4VjWK19Xnffa/p+77vDaEKkuIlP/eefOd857x7\n01eCvoEsOnbEB4aQ6Vj32vjIlghgTpws8n3osjmC7RwZntzBoO76wyqFEi+N5xTBaH2KIXC1JRde\nA2llrr7TVbionnoHIiVzD5M0+22G4GCTIUYZs8zuMOLfaFXacWoUQQ7RBoNcbcn1GkgrRg4LBaWw\nSz11gBPAaapoVu7ZFMHhCg+QtBH5RKuWqvhMkcSRJxRAqgEzQzGtLbm6QYiVnp/oVQqxN0pFBxgE\nFrJUErM2AxDjAdLvkfxOqxZFgCQtUKuesgigtSXXbyCsWF6AA1eVmg7wFZhnZ6GdAIkmoiwAxBGS\nAawfdk+BxfIuDj9+fgMRQJHdI1RbD2CsqgBcUrLEDiidCN8VJMoKDozkqZlSYOlO+9fOMMTfXc5V\nVW4DaQW4CaSyJECNaUpWWIB5TptTymR02Sbfpaizm5SohdYWXPWB20Ba6X5aBg7hLwRwJeiIfaRr\ntbrLkFcXHH5gvYsTwnUbyADAuRJqNECBdZGskB2IbmMstVy2ObZUJEgqh9f85PnagqsbSCtAumkV\nWwHgfokbpElY7JAAM4yE/eqEU6U+YKlEytI2jDWCeEdIcgHdQAQwiuhaG8VGgEFgMcskBUv+GYWV\nwz5CMx2bB3gLHKfaY4oyQWg6QAjXbyCsjDdVgAeVyq87GzeyRzCppstSj8Bwd4AWnQde0KIVYG+W\nFOWAG5SWVnluU5q+OJIL3UB/B4iV3iuIfFHOWjeySNX8gPFMwKw+Qia9qboBSJExVH+coUVnEV+l\nRcOw3lHEugarRmk6gOTqBiFWYg0s1IIBzKMzRYy5mVojv3y9YS4H9z56bGWaFkUcx8nQIis/WaVF\n3flKliK4nJ8CpWltydUNIK3gfv6WcvrMmfaPkGf7Usv9+iQeDPBHRW1p6w6yUsMhVjxD+l8Jb9rw\n3gKvqcDcn26yqC2abiErNRxixXO0hQLE/GsceCsE5t50k0Vt0XSHkEqNF7z+8jWwA/LDTkD+B/jX\nuzSCgc7+XWjwN9UKBtQPwW28AAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$$\\begin{bmatrix}0, & 1, & 1, & 2, & 3, & 5, & 8, & 13, & 21, & 34\\end{bmatrix}$$"
+      ],
+      "text/plain": [
+       "[0, 1, 1, 2, 3, 5, 8, 13, 21, 34]"
+      ]
+     },
+     "execution_count": 37,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "[fibonacci(i) for i in range(10)]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`series` is nice if you want a fixed power series, but what if you don't know ahead of time how many terms you want? For that, there is the `lseries` method, which returns a generator of series terms.  This is more efficient than recomputing the whole series again if you determine you need more terms. Here is an example usage (**Warning**: since series are in general infinite, `lseries` will return an infinite generator. Here we use `zip` to limit the number of terms)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAAgAAAAPBAMAAAArJJMAAAAAHlBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAACGjDitAAAACXRSTlMAuxCrdpnvzWYiHG0BAAAAI0lEQVQIHWNgYBBiYGBQ\nnMTAoGwMJBhYSCVYw6ZHAPUxMAAAQGkI1Fjz0FgAAAAASUVORK5CYII=\n",
+      "text/latex": [
+       "$$1$$"
+      ],
+      "text/plain": [
+       "1"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAACcAAAAvBAMAAACS3s5rAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIs3dRIl2q1SZEGbv\nMrsbSYq4AAAA5ElEQVQoFWNgQAWs86pQBUC8WQyTMAUNGeQvYIieYFjvgCHIwNC/AIugKhYx1gIs\ngluxiLEE8GLafq+jfQGSWsawwrZpDOf//0cSY1jKsHnDYWQBEDuAIZ+hF11wAUMduhCIfwyLIONf\nBi504Y1sHxiy0AQ5fvMdYExAE+R6FhWajSY26LlCxiBgwsD/Hw4+DIyjGWfqOWDYLM7A9gNDEJiy\n7TEEzyxgqMfQr7+AYT6GIFCr/QIggQZ4v6IJgLhMD7AIzsMixoYtwXcyMAqgq+WdwMCNISgcGjoZ\nXSGD/f//n0GCAFRmOfCpSmWyAAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$$- \\frac{x^{2}}{2}$$"
+      ],
+      "text/plain": [
+       "  2 \n",
+       "-x  \n",
+       "────\n",
+       " 2  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABYAAAAwBAMAAADnb5cjAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIol2q1SZEGbd7zK7\nzUTvhYErAAAA80lEQVQoFWNggAJeGANIxxfAOez6CDZzPYK9FYmtgGBzCCDYxQwIdlhafgbcTAZ5\nkDlCJqJmBgwc/q4MDOwKHDO4JkDkmRiYP7BugLDZGVgOQFggkssAwZbfwAAyAwg4BOwZmKHs+IZT\nDMIQYYYaoyLlBiib1tR/BKDMKrHccyADtgAxowODfQCQngPELAUMnB8YGJjXANlcyxlY/jEwSNwB\nsnm/M7AB2QogNhBwfgeGBpS9X4GhmAHKBlIKUDbbAQZg4ELETRgYihggbNYEBsEQF5dfzkBTtjEw\nNAIpkF2Mk5TUJkDZnEA/Atkq/5HiESgFAEGkQFKV6+ITAAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$$\\frac{x^{4}}{24}$$"
+      ],
+      "text/plain": [
+       " 4\n",
+       "x \n",
+       "──\n",
+       "24"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAADEAAAAvBAMAAAC4bj/EAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIs3dRIl2q1SZEGbv\nMrsbSYq4AAABXklEQVQ4EdWSvUrDUBTH//1Ky21Dg+LHFl/AD1BwEGneoAGJoCAERUonO7uYSXBK\nQSq62Dg4uNSuTr6AQsAHaB/AIaCVOsVzK8WkOe76H+495/87595zSYCE7ra7Ce/bWFQDnuSawuRJ\nyeF9QD+tazzrmeoKT3QDQ56UfXzwJO3gnSeFRjZ5z0xtvm7jYceb7BFmcaOUrKeyHJSg4E/Wy1wg\n36eNVclmbTJ1Hx7HitoRFJa43VfMci3oHN7++jnZhv9lTq1KraEcxhX8pWe8tCzLTF0tGRAX9dh/\n8khTN+agDJExxGZ05l0gj2OgggNgP0pMYA9PHk6MdaCqRRGyNpY9tI1PoOfESGeUVW4GROwYuZSZ\nOkhJQmf/SAQyTveTRFmQ5BojYst4rEyDIoUWOUF37Mr9vknLGVIaTe1qUVIlojZR1OilW1EAl8i0\nZZ0j44jnGJFnV8LwDaJV84EvR7hiRhgZDXAAAAAASUVORK5CYII=\n",
+      "text/latex": [
+       "$$- \\frac{x^{6}}{720}$$"
+      ],
+      "text/plain": [
+       "  6 \n",
+       "-x  \n",
+       "────\n",
+       "720 "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAADQAAAAwBAMAAACsx0TOAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIol2q1SZEGbd7zK7\nzUTvhYErAAABnklEQVQ4Ed2TvUvDQBiHf2ka2/TDKoiIizEVnYRKBcWlFbuIDoLi4lIRP0CEUqGg\nCLajWxCcFBUcRHAIIq4WRNykgm4F/Q/6ITVFofUubUqOprt4Q/g973N5cy9cAGY5g8sMm2AEeyZi\n4hO8DJtgWu0yERN7v9YZNgH/fmwiJq66z2JMoQGODLzJBjGBS4NvofACe3NDzj85v4KE3M+00SGO\ng+RVc5lWJISwZK1imLUWtHrRUnE/cFjLFJ/HmKUSyp5zLmCpHA9D8ril+X/Fasv1h2a9BRLBTeBG\nfgS6t57rSE94ApxiR+WiyAW4MEJzOlLDX4NXwGdsJfgUcnnFvI5U9WQhhtFeEKhyXcJe0ZEqKQtf\nFO4SibmAV0NbxUBnRxZ9EtyfRL3SraJm4DZqqgj3cJiqe4mqIklSQwETH6Rg7ISg1jNt6NKAtrTR\nP0630e+WORWeMjCKGgILkcj3FDmtUNjXqBKi6NSRNAH0kW2KLwOxgDsgRUa2KXWFI+yq5AfPSdyh\nPKjoSNVAdQMJ/wywuPYGkdwHpYb6a9aPX900isnj4kp0AAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$$\\frac{x^{8}}{40320}$$"
+      ],
+      "text/plain": [
+       "   8 \n",
+       "  x  \n",
+       "─────\n",
+       "40320"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAFoAAAAvBAMAAACRacBDAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIs3dRIl2q1SZEGbv\nMrsbSYq4AAACSElEQVRIDe2UMWgTURjHf9ckR3pJmqCIOIjiIojYiAUFCcnWTQOSDII2KKnUDqZ0\nE9SDgOAgCUpTI6gH0qHS4cTJKYLiosUgKLioILhqG1JrQznfvTb0BZKrXYqD3/C/7/v+v7z73ntH\noHd8hkC23NvvcD5NQp7hjp5HUYQEUcuDUK0ixgo+U2155EUigs55EKpVxL8lemtrGwuETfV1Hrk4\nk3miMQ9CtQSd55Ta6Zpr2YmbFXYNVtBH73cl1OYMz+yXasMzT3OF256EalpcV8tN89ebEgqgrWIo\npXf6VP/JZW9kww22Bl5ouY3aOzO+n82MeyP/3e05gR3H3Bgi6vxFbM9I/85bIpnzJsxMnUOrHkmJ\nLHNvXWZHH4BRGasrw+7Bv4SWYJLd6MtQpt9ekyEe1/GljIRCj5g08KU5wFVIErIx4lL0OPp+LsIF\nhS65dM0SnbcWN1KBgqCl+Ar4FzgOpzv+EsUkh92fD1o8SgV/WYGclGiZyDK/4Yvpuu3oK7D4ccx0\ny6TFj1YeKfvSRJa0pqBzrrUeHw5iNGxOijIivH7n6Jq4dFPS6TbqPvVXhgMjFvR9hefvHVNKD5p3\nTxpQM+EhhMrUVqR0nWSvmNJeFHQOvQBhC60lxd1lS+7SFgOsheGIjdnf5Nq30GJzol2RIk4wKE+w\npJygWDYZK7lzR8qEYmFhTUgRtxOIu7dzpr2yeI7jbzKQNt6wM5O5S/AQwbQUTjAnbt405hU6WL1j\nwvR0iqTjiN0OV8VXJWU2e018VVOX6vwBf37U8ArfDb0AAAAASUVORK5CYII=\n",
+      "text/latex": [
+       "$$- \\frac{x^{10}}{3628800}$$"
+      ],
+      "text/plain": [
+       "   10  \n",
+       " -x    \n",
+       "───────\n",
+       "3628800"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAF4AAAAwBAMAAABqAtB3AAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIol2q1SZEGbd7zK7\nzUTvhYErAAACYUlEQVRIDe2Wz2vTYBjHv0lM0jbdFhRBvDR0QxARgxsFD8OBBZFdclCvldrDUA9l\njoEyWP8De/DHYCK7CII7BObNgz0ooqeCF5EJRf8At86tm7LV53mSg/A20F6GB19IoJ/vJ2/e93nz\nvhTo3ZwGcOpttXeoUqdSh1W1mmqSQMw60q72OyFVMfmZwD5QgwRCPmB2ElIViz/kqUECEX8sIeyB\n2U95PYIExP43vE5IVUy+8+7aZTVQyNGJ4wVfO7vjZ7rdDSVVgO2lljJczD6bDmPDDPuUSbNxpNG/\nzWbGH8zPhaj2/0TKvQhjAL9U+4hj/XePhfOzo7UB/P/q4VagO1g73MH9G297BedxPp/HXHkamB+/\nTZv4ZoG3/Hu6ZstnYigJj/gpUlTUn9pznHTxDPdCpFv2MrBAx7O2jCuIoCSkG6vQaQNOZVfoaDDq\nMJq4AExirkh+2sNXCIwS8k+sQwf0cKQJvZOewvAmHgI/XBjkP+CtLDBK6Je3Tjd8x2IDxsHIDTjb\n2AHeBOJ/4UxglNCp7bJvN8D97+Y8OFtam3xf/P21QgCBciPzLti3AlgryG4xbYvvsW/v1bAkflsS\nMj3xF+kVn3Fd8bvAuaqosU9nK/c/SVdqfG2b6V/jsfdoyoFAudF6QHyqCDW9w7PalfnWovGT7wuM\nElwtFn9dgk0VoTbUpKqZUs9SVM8P3L/AKGFrFRgm39hErkWrotd5vU4ToPqXePwCoyT2Tfaf4BPw\nCPfpewjsl5Gf9ewXMZSE/LHuDI+Z/o/cCejTGp2mUpUnQli39meASqUVQ0m4/0HaH8rI7cFFVzeG\nAAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$$\\frac{x^{12}}{479001600}$$"
+      ],
+      "text/plain": [
+       "    12   \n",
+       "   x     \n",
+       "─────────\n",
+       "479001600"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAIUAAAAwBAMAAADN86TJAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIs3dRIl2q1SZEGbv\nMrsbSYq4AAACqklEQVRIDe2VTWgTQRTH/5t0t5vdrEbFLxAi3vRQI1ZUPDQnBU9B2IqnBqUWD9J4\nqgqaXHtqUFBDqxmUKoXSrhfBk3gVweBJT+bgQaTQD1v7BY3vzSRpQCOhU0/1wb7973/e/DIzL5sA\nrYRXpqpQK5VNa7yHCRobEk0LWhmwieH06DOsSX3Gp01gpPQZbkyf8Rz6jMFCcbiVFjat4d4ivtG+\n7O7bdy1tXFhOw83ebPoZfx1wUu6ZKC9CI0xYM3ZJA0BTHbSX6aYZ0bQmgKbHSxB6FDfWD0uTMRRM\nYY/eMjDRO9odaDL+T9/qJ7DzOEcnUNlozGz1I/zH+x/1H8E77fs+sE1UFXswCh1JOLcu8m/zd7r2\n3/sKjF19XE2Ny8ojErjU4EU40wJKsYe9sJZwIGe8BSZWCJlBfw6deFZSqYHhBnASpgAyzkBWQCrp\n4TbQhSngLl4MEKNdIDxjJWAdlAkNYWaYAZi05H5isJIe3gtkk3NAj4BFjOg7tM+HM2iblakBAXtR\nmGkyztJFDKmUd1SgeH6N3KRkhFYQmd+eh7ckE1fWY3q1l7RTpiQZrJRHexG8jkAyaDy8Ek/B+ykT\nPa5HpHKMHiI5SpLBSnnwFjBCwHSN8SXF0xdkovL1eP2xkgMm2ZAMVspDqIyngV2sMzrwZ4abxxs6\nsct1BqmqhydkvrpOHeUzpdWVJeP3vUQFjFXgZJ1BqupZGTZrfQH6AD7OVZnkUDWN0/0BnGV+5L2w\nUh4GYcTIPQS1DjuPHdRWm3trz3J9LaJUdgNtdQYr5Xl50P9uzJivMj4DL+nrZSZkqs3nu30Edgp2\nncFKebt8/z6uiFBaMYwT/qUETmG8pFIj5FyB3i+PjgSFD4cDpaTXVan8gFn4Roc5MjeMML1TCYx1\n36F3jtOmxC8/qCMkO/cynAAAAABJRU5ErkJggg==\n",
+      "text/latex": [
+       "$$- \\frac{x^{14}}{87178291200}$$"
+      ],
+      "text/plain": [
+       "     14    \n",
+       "   -x      \n",
+       "───────────\n",
+       "87178291200"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAJIAAAAvBAMAAAD6AY4WAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIol2q1SZEGbd7zK7\nzUTvhYErAAADFElEQVRIDe2XTWgTURSFv2Q6mfz0Z/wF3XRIpSIiBC0FF2Lc2EUXDgrdSUOrRbFi\nLCJUBCNCcWcURUGwdSEF3QQEwYU0axdacKFgoVm4b2utqZvG++4ku2IDE3ChD3oy99x7zrzcuWle\noImVKsP1nkITlVuUpM4V4WtqeYuyZtJ2kWjO8Zop3aJGnJL+FjXNpcWp+0y/21zxH6vEac5LSbNC\nL7OnCmuhfUCcukqstsapw2ejNU52tjNcn7b37erPRA79zDDVmw+zJ8eLP0mG20v99lGsZbsUZi8N\nrUNbuXEd9jWZCevQ0HeXCNXphk/cPY7VEqfhwnt2NGxDvd48PNGKf5Wh9vBf/I92oNaq9Y/276++\n7d2XP8g568gluDYyCBpGxhYqvB1Jpz0n3evXMxPp86CgpDPaX6oLVU0ky3GfZ0yWIi/Y6wbhTqw1\n7sl8ZGNwAc2QI1YIQMlExXmKCgOgLU9i2SpizbfPyDeJhgzANPuhjbswiWbiBZyiQkAehWOoUAGS\ns7RtJLJ0rnTNE61qyMs8pyoeHGSfcdJMNCtOCgH5EJZcFSpAR5XYRleO1NqtMtaGhizmuVKBzgzD\nA/SgGftHPppRCMifMOerUAGzEtVuj9SqufO6hoaclq+Um9Beu+Ppntb5uH6YAAwZ+S5OGRUqGI2c\n18z199gM7eaMNOcJpKQQeVZc+eUSZGK1+6BgSHUKhKqWUlhAr50vDBmnBcN1lMFZhvilxTWCzNS7\nmo+CITdzipXVaZX4kddyApRQ1rj8WfMwRbyW10w8x72qgpJXN3l3fWB6ZloUrYKEYpIVkGfCLHQX\n5Fqeap7IukJAmo4XVNhQ2zm2icZekfqOeUwIQ0RcbuVwZmSTGc3cEBxVCEiZgmEzBfZKQ/0Gbsts\nRYvWijnhmpBUjrjLUg6ey3i6mkm6cEIhIGUyD5jJFKEBiDxI9xZ5xI2S9ZhP9XBPOn1RbilOZ/Oc\nRjP2Z2xPISATvvMKFQZAQj5dRfmlNAi94349nK7Vfpk2yHCeHPODDN/GZCoUlHRG+krmJ5YIFX4D\n1xNlQbFLfTUAAAAASUVORK5CYII=\n",
+      "text/latex": [
+       "$$\\frac{x^{16}}{20922789888000}$$"
+      ],
+      "text/plain": [
+       "      16      \n",
+       "     x        \n",
+       "──────────────\n",
+       "20922789888000"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAALkAAAAwBAMAAAC/PMZ/AAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIs3dRIl2q1SZEGbv\nMrsbSYq4AAADeUlEQVRYCe2X34sbVRTHP/k1+TGb3dFStYo2b1qK6YAtCEU3/8GGwmxZQQ2CW0qF\nrlBbWpAGQaQgbKiUGkrtYKlQKE18KYgPruBTkW6gFOlT90FBRDDrtksaK/HccxMzT6WFnYfC3oeT\nc+73nM+dOXNvMoHHHsUVuHbQe+y6RyoonvVxvIIsEcvI+UyGlGJhg9CzbyQW4qMnlpthfHTeW+vE\nR8/Xb/bjo38NO+OjvwSH4qMnPU5sOH3rgecO1hL77tcKZ4INP6uFqrt3wt/wax4CMzjdXFw7kQLZ\nleFCsXxM1GLBDqHbO4Rx8V3vME5s9MX2nzwT16Vz9f1Ls+3Y6JvgzQ488R14+jUzdsNg40f3ie/O\n5g08vAOFucD8JP8Cl+fPw7bTv8Kt4He4eSYIqsXgnbr1rLwz3DqME81yhUIwVx8WarWa6HpbOllf\n4jdhNxc78gp9uJ5oMFPjB9mrC9tIr1tPZZYH97Dxszg98nDOFlrZIKJw9pAsgXMDR/5clLIhqW6m\nx5TPW5Dl3Tpr1lOZHR9JtSryVjbN93DRFqpscyJ4t6/BC2VSC6RXJ66TvZtTehXeZtHQ1VOZBZOt\n8c8hJyv7DV2VsYnASS5pVC0z1aDYS/bJ35UZ6Qyk1axbT2VLV2VXyIXK4glmbaHKNkfyR2Pq1fkv\nwfXKbK9SNKSUuZuXjX7VmKS5XPGsfHT+iJlUhelwcnCtahWVRwiToqO1l1Sbb7B0eWTckVX2aQdk\nWW7pOuKZynv8Qasis0YxIRfWPKuobHOMNhytLpm+dHJMLxvlgwoUusZzfrLeqDK7NFKSK7jnd/Ue\nSvdxe/IS+n9n8iuGOSHtcUrGYzlUz9BN4zL/jpSv4DvcQajK2GjR0EyVcNcvIXTzSP6BA5DoMCme\nbANehL/a6qk86ZORh24UHDHXpWNtVcYmSpd8t/fZsWMPjkpJbpVcg6dafaW3GhQGoaGLZ4i5VXmP\nz6+iMadIPL8E+ZoqYxOl57TvoKcp43MbvpX7SQljRph/y5nx1JOTkvHlbJqzZ5RiQ3baj3LiPFXG\nJkrnN660ZeIGvM6VTmJPMOc7bWaqsCiMQ6RlZxjPyg0+92y8JQi+4JOQT62isjVRfP642cH7B+e4\nPPsxKfly8TnVfEXm7rTl/3vzdN16KnP77IdDZXowWCN9vCmyKYwYSYhz/AcfkpFQNTd5DQAAAABJ\nRU5ErkJggg==\n",
+      "text/latex": [
+       "$$- \\frac{x^{18}}{6402373705728000}$$"
+      ],
+      "text/plain": [
+       "       18       \n",
+       "     -x         \n",
+       "────────────────\n",
+       "6402373705728000"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "for term, _ in zip(cos(x).lseries(x, 0), range(10)):\n",
+    "    display(term)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Write a function that computes the number of terms of a series expansion of a given function are needed to compute the given value near the given point within the given accuracy. For example, in the expansion of cos(x) near $\\pi$, suppode we wish to compute $\\pi + 1$. Let us see if terms up to $O(x^6)$ are sufficient (remember that due to a limitation in SymPy, when computing the series away from 0 with `series`, we have to use a shift)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAALoAAAAPBAMAAAChJ8gEAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIs3dRBCZdjKrVIlm\n77sGqe+vAAACHElEQVQ4Ea2UMWhTQRjHf8nz2qZJ06Lg4BScXISCDhU7ZHFuFgeRmk5KGsVgoaWD\nEHBwtFARMkjfUuiWgChihkbBOYqLgsMDcXIpqa2gw/O7u753Z3ijH+R39/5/7v8u310CJ6XurLf1\nNP8+90aGqS3Bd/ncbL4G9arf9mBF44zZznnU7Pd7st5WUFULejYTx1oMIrh1BLkFtuFMuzDvwYgO\nmc4wjmO9Q1tr8EDP8g3ZKzyMuNGR9KDHebhKvuLBiA6Zzkso6CBbV2BpTqZWyr2LYFLShzXRSjLx\nYEXjjNmeIw0w25SVUsfwJJTRphfzkU2/KBL5D/8AIzo423PgVEuvNZX7I+n6sbCxWYW3Sfro8XrI\n7IWNVQ8Y0cHZniPHZpM1Tbp8G8o19RPVOklXhwMWqS8SDByM6ODZngirGekiPadIkh7Dfq1+QPHI\nQWnxegrPdk4NdSBRpy/pupx2RqT99l6afigHG9bnKf12UFrcTeHZzgmZrEhUUvpUB/LwTdKv9ZJ0\nRhLUmq1Q+uVgReOM2Z5DsJVEyyg3sjsn4ye4f67T2fnSMjdSXjYMy3rvDnoHw9Ah06G+4qWvwQsU\niCY/H2YieyO7uu/Tuu8OGNEh02FJktIKQvUZ6e1Zpj+KmKSXe+or/GB54MGIDpkO3ZU0W/6omptt\nliOmbnekQcWd48HEvdFdaDSqMPHsqQ8rGmfM9hxzit4L/v/0L9iNQMEYAVEuAAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$$-0.541666666666667$$"
+      ],
+      "text/plain": [
+       "-0.541666666666667"
+      ]
+     },
+     "execution_count": 39,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "a = cos(x).series(x, pi, 5).removeO().subs(x, x - pi).evalf(subs={x: pi + 1})\n",
+    "a"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAK8AAAAPBAMAAABgoIKoAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIs3dRBCZdjKrVIlm\n77sGqe+vAAACyklEQVQ4Ea1Uz2vUYBB9SZr9kex2V8UiXiyCYD1IxB7UCu7Fg6cuCILIuksPW60W\nFwVL0WLw4KWHriDiHkpzEm8NFqq4YKOgVxUV9GRAvejBtnZbrAtxZr40f4FzSN7MvPfyZfJ9AeIw\nR6+7DPVX2jO6ZZqQSqb93APOTFwA+ka+AdPtH1AdRTzXHqN8se1CEPCdTUidhFEyj3CSjyKfbkYI\nqfShZwMYxGlXa+KWp9Uw3FAdRawhFWCHm3UgCOc7JGZ1EteAq5zoF5/ybSqEVJY8/EbaQbo/W4ax\nbG+i4KiOEHMBTAdD0PsVOtsSY1IncRQYLlKWlYr2MoRU5tnYaKJnJf8R2TVLjKUjRJsm5uTYTBCQ\nZszqJNaBGY8yZWzrIeIKjaJQQ2ZT7yC1RgQahXSEaP0p2w39LZUFxcas3grtLxk3KMtOTJaAF3q4\nVdGb2OMjQ5OGwcsZgOoo4q/uDRT2T4wBjGJjUhNUIWT+ar1lcw1mIzb2MT0AMaYHY4Ye8LipjH0h\nIhUdQvU4jECQMma1cqVrYkx4FjYSY6Q/JMYHmT5VSrizwOvbkVddht0RpIxZDWw/zDGoXo+FwJL7\naMuYh/OlHI8iFXI330m4S26uhjedqoPcpiBlzGpmquAPEhD8SsYnfW5JZRcNL+CP1wUm6cVc9HZV\nh4mlfBlat9CP3IYgMTZFHduCN9d8kbL3wJXdrdbc5wZXdkZlMqbtZq3AqmFbtcPGwmVisUKK0V5e\nsSAxtkSdGNNxWIAJOkDYS8W8HJAFrAIninRAbAd3aLPQ4owVPiALipintdy1eMaC1ChEnRgbnvkJ\nNK0+WO+UsVRuoof2wzFUXG2oveikAwz7kI4QrX2wfPxEJVBIHRBeVhLmpUkXlRCZeotWYc+tB1Kx\n6iMe/YSePIARRZGDh/UD9NNhriKeqtMWTt2/Byg0vnpZqRPj/w3+AWrzIIzvy1iMAAAAAElFTkSu\nQmCC\n",
+      "text/latex": [
+       "$$-0.54030230586814$$"
+      ],
+      "text/plain": [
+       "-0.540302305868140"
+      ]
+     },
+     "execution_count": 40,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "b = cos(pi + 1).evalf()\n",
+    "b"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "So the expansion is accurate up to two places after the decimal point, i.e., within `0.01`. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 41,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "abs(a - b) < 0.01"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note, with `lseries`, we do not need to worry about shifts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABgAAAAPBAMAAAAMihLoAAAAJ1BMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAilU6eAAAADHRSTlMAIs3dRLsQq3aZ72YDTSHvAAAALklE\nQVQIHWNggIMwOIuBIfUYgpNejsRh4CCTI2QMAiYMZBsAcxDnrEOzYWwwDQBP9Q53CSxxJQAAAABJ\nRU5ErkJggg==\n",
+      "text/latex": [
+       "$$-1$$"
+      ],
+      "text/plain": [
+       "-1"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAFoAAAAqBAMAAADBpFHwAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAuxCrdpnvzWYiRFTd\nMollB7CEAAABv0lEQVQ4Ed2TPUjDQBiG36ZNamy0gg5iB7O5+Tt1suiioNRBcfIHcVLBHxDEqZsU\nHAoi6uakgyIOgoMIziIiiKM0qF2l6CKCxO+S0MvFKpfVG+7e78lzafL1AiBiQn4orSFspac3hA1k\n/7ldamQvKPmWqqkuydtGQf+St7VT5VPeBhJvYey4BYwtruZoD1CbcZZqU80+o8/+S/f+IpAnqK6x\n/HDFXwRynOoTPHIay/D8I9F961IX3ZxrJs8/kjINzbbLnB/yWCWlAmySav0lfTYq8inbtt+Bkkix\nRnU7NnMLAleHz3bzBeBcoMAc1RayuBT4EQZjJOPApfRD7uOzQ2Ciy6E7N2xcO7khypaik/nEbGCW\nAzfpnQYLQXueQTqUClv5UHNJVnhPUuHNlPKxMvoqxAkdZvKOwoZIWY8SH5FpPSPyISQtIsEOHgNK\n09PrgChTYyMjhNY9vD3e4iSNNeq3Qf+8M/ROZE9ZEg+ke7Ey12fcGDVhlJ3414lt8/ZpM4i6rd7y\nSLUl7cH4G1TXDnbDtyt2xwuDfcvSo2hJqyQuh5HVhjB2fxg5MYI9ef+Bjp60rd++lq6kbYM+NGn7\nG0/gY7SgevO+AAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$$\\frac{1}{2} \\left(x - \\pi\\right)^{2}$$"
+      ],
+      "text/plain": [
+       "       2\n",
+       "(x - π) \n",
+       "────────\n",
+       "   2    "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAHcAAAArBAMAAACwWwo1AAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIs3dRLsQq3aZ72ZU\nMonLrI/bAAACDklEQVRIDe2VP0gbYRjGn8ufSy5eTNpJyXJLJ5dA7VoyOjg4lNIxS6l00DhIOiqC\nFkQMnWodjBRDx4QWupVMrUshW+nUmzQuIiIRWyS+X87c3ftqNLmsfYfkfX7v85Av33dfArB6ztRg\n4mVrML/f/ao4RBjx/2H/Zt7sLYEG2TBTbu4g4blhwqtDhJPfhwiP6iJsfDjddrdwyu1uNF+I1GTY\n70oW/Ir3RgP60l3hUJ4HmLJgbm1dVBnzi7d+IftvBDTxnf2eil/I/jWBr+d1ibs6YnW7296j9duo\nywybFtZc2H/vkk6z0263z4HREsdChWg35vC5+pFxY2M/U0sDpsWwFIkcYGMTP9lgGstxyiJSdvDD\nx6omAVrQdZ3QJJUD8ljseFwLqZmYQkll6V0qDHySBq0QVuiecKJOHu0SuvJ6ZVRTSnSX7Q1YF63S\n4xs/wSqjmM+nGkRGLI6FosMw/0XL2hLnK0jZRO45qkgW+ouD43WexQSiJUKhHL2wGn/3TOlfDtxl\nMyHU48lKK2CzTuSJQ9Wz37OachLLI0zHF99zBnddSd2S4UQFsTMg88gZ0EJ6ViwtR6EWDArb12GM\nSYOnN7zW68ItjKS7YQ/31/2xMYugYcrZQcPGDMxG0PCauv8Bw2YJD34Ui3/f9LdB3PWb7hGRPU77\nU9rT46Ns0HCYfoQofNj2/q76+9SArisQh4Bog/FyCAAAAABJRU5ErkJggg==\n",
+      "text/latex": [
+       "$$- \\frac{1}{24} \\left(x - \\pi\\right)^{4}$$"
+      ],
+      "text/plain": [
+       "        4 \n",
+       "-(x - π)  \n",
+       "──────────\n",
+       "    24    "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAG8AAAAqBAMAAABPfhiMAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAuxCrdpnvzWYy3YlE\nVCLumKMEAAACRUlEQVRIDe2UP4jTUBzHv0mbpknzp4OjYJa7QYeLOLnooQU9B1tEETnQ43AS/DcI\nLkLmU44sLi4XEBc9IUhvytLhJkEIeIvbDYpOWu4U7rie9ffy2qYpSa/p7I+S93vf3++Tvvf7vReA\nm2D1nJyDeGI6UDxzfjoQqP8Hk00SFy8PhFzFkd216cANnJoOvD/A8vXROKzdHqB59qgc4FUfvPHw\nidP3adwc8kfcF4DRgRmOyHyq2KlyJEousA9zPjVDtlJlLj4CnsFspWbUUtWe+Bz4jI/pGcvpMldn\ngfLitdQMjVaTbUKYGZN8qlzz3Nb1ZMadbre7C1QaSXloJjugM7Xi3BvSAGlh68fqNqBnr6fUAnzU\n8SUBfsLVInHQlrhM/58wUlmtLZyO4t/fMluP/GqBDUo7mqQ9eJPujoYMW2XSGLAUUtzYh5hEJcdk\nQn+pyWA0ExxgtdjGhWRszjJdUsrZxaGC63vCkjGfBK/A9EkZ0w7Ng3jsQxB/V/gLnkJokCe3+FR5\nEwQBvt08DszUbnHtAR/Sn3TkIitTM3YNG/UQ6zjJNgHQOc62Zi9UsQC7YEFtFz0U+cbHXSuRp9Be\n6eeWllHoqDa0v9HraAGZVtiOQ5uQdyB1zAaUQ65+jYOj3kIsiFXmqzu/fCi/Y/loTwpZzprPwIOj\n0+OMuch9jNzgJQZK1QjMtdTXDLxIt4mKs8f8CU38Q4l6Az+pHTpvx2SkxsCX7D54qHiTMVGWTqDx\nLtjw8B6zbg6Q7UulA+thpnl2cu4fXiCRCxxGVLkAAAAASUVORK5CYII=\n",
+      "text/latex": [
+       "$$\\frac{1}{720} \\left(x - \\pi\\right)^{6}$$"
+      ],
+      "text/plain": [
+       "       6\n",
+       "(x - π) \n",
+       "────────\n",
+       "  720   "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAJUAAAArBAMAAACDTNd5AAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIs3dRLsQq3aZ72Yy\niVR4peFTAAACwUlEQVRIDe2UPWgTYRjH//eRyyVN0tTBWhGMiIiTBxZcqs3o5g0iOvVAHFoQIiJZ\nhCYKNlohsYOk+EFFqQ5CU3UTIauDJiJKHII3OhRatZSUttbnvZiU95I7cjGjz3C8z//5P7+7e7+A\nduEz2qldacpYz1hKcrJnLCD7n+VpQb3PV1/mrsMbvLPSuNgz1lmIPWNdKQ72jLV3/V7PWOrRkfas\n2YUjBXvllF3YyV/T8FFo1NhR3EehhHM9UIQSg9jyeqcO0XCqkB6DoEPtmJVxQeEtcAB+t7dx3fNc\nZksmgPHqR5vomMoxxxIVfKZb1V4LlAGhcvl7ni8EtikSCOd42T1ji3QJrwpPeFv+Q/rNABCJ8bJ7\nFowDZWSxxNlkU42mSZHn6vKuYyyG0c8+t22skLE/Dhi4arUIB60WUmimkKBniFk6DsYCnrf4B6GR\n5o0VNKlF2IRio90H+6TGP9qKDqmvACyqK7jJ15U1bJLSF+Nl94xWPbLhmxNSvE3VsEWKtz0ha1DO\nfalO8yh2ns+TJMbpwQfdBUr+VhGh6mcTGJo5Q0cj86Duecxb+YzOkD0kHVJcGcEQ5BqEBLImhnGh\naNno+DpHpbV0W8cN4Dq+mfjFjr20QvOhxiyjaLT6GwpdXvYQXuo4DpyOLjNWcB7+VSkB+Yflo890\nDH+0pRQWdawDJZM2TA3iGgKr/TmEfteNe1r8TeFOc9QcLIq6QCtcStHCWF8hre0vI1RrGjofKKm/\nrDLeH7baSmXGYhvIa4TRZEF9yroPoVvWUoOVIsyCAQR0i9XFPyplYllzX9gHjNH5m6KrhuZ+g9Ae\nI5JMTj5L0Z5Y3r1tMFYkhwHaE5H6nvBIQ9Daq5/wExiN4h27GTSENa8Yy08syVReYBryFoQT1a8a\nTmKi2A0rPLleUB5OFRGZnTEh0X2tYbxyrRvUv/f8AbPRzoUQwhp7AAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$$- \\frac{1}{40320} \\left(x - \\pi\\right)^{8}$$"
+      ],
+      "text/plain": [
+       "        8 \n",
+       "-(x - π)  \n",
+       "──────────\n",
+       "  40320   "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAKAAAAAqBAMAAADGyk2gAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAuxCrdpnvzWYyiVQi\nRN3cr+EFAAADD0lEQVRIDe1VS2gTURQ9mfymmemkiAtRxBGhgptExF2Fwbb+KG3A1k9dWKQbEaXW\nTUWE2YibogERwU0HsRSCSBYVcdWAiC5ECoIuBDOgC60fQmox2pZ434vYeZPfJOnSCzl597xzz7x5\n784MUBYbypjWiO351urd1Tv2rLMhAv8N3ZvccN7sHrZ1AKneCpdr0rDtqI2A1R4vd2zSEIoNLYkK\nLdKCYUzHl3Vd4ZSOj+tqmK1kGDz280T5VYhpNyrSjJTnCWgPK6+wWtmtahPEnywZxjI4V0Plmhp3\n5c40TAmtMJTEipOuOQ4YNaZlixtSH1J3e4yQXkMojUCdWTLQ01tLJRq8FVNXtsWVe0iHSaPe75od\nFLWni8XiIjAtsl6yCRLtwg3zgiAOHp59MZkBHgusp+Q8qSwM4Imgfoe+QIaYN2ssLblu5Ei+Sj8d\nu3nh8+8svvFxh5/9TfFxQ8AMgVF3jRrXGNWEIX8E1F+QRMugGWWE45bF+erZJpqaDOSwX5TE9GiS\nmOsi6yWjxlAKvhHVEMX9iFrENNE27wFp473UIdEPE/AliLrqoO+mqM2l6VQSz45vpV5LnfoL0mBv\nEhyYOpQhqBb06P0LNYGsgVdJv63GMZBGAkGzBNq89BkcmJg9/1UjYqxNRZYRtbGA8Jhfh5aTTUg2\nB/QDB0vA1bVeXzvX/KAwQ5l9rEJn4F+NxMmQAz4A2QwHLn/qKHIPu0Qia4RHiAnnEVxVFvWIwQFL\n1K9pDlzuPl+HR4B1jiMuIXq5h44C0PLYVjgCDupvMuxjYDi0HoZtM3HEPkEzSTtlIVj8Cg7c8AEz\ntDy4CJID87EcImwbLwLX7hTTHFowDOVjNuRlWlgH5ARu5jlww77Gb1lNwleIjkH+AXTTUetQCxz4\noZjsUEzhfuolsTwZ+vgKlQRedpJ+kANrmznWNnOZeh7CPC1OW1H4Ht6m90mIqrs4sJ5+WAKhoF4S\nMJG1sBmdprqQmraVcSgWB2hp6WwJ6nmI84+GrtBx7N0HjT4FNl4PUUdykIa76eXAoJH4A6F8EmVH\ndtj7AAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$$\\frac{1}{3628800} \\left(x - \\pi\\right)^{10}$$"
+      ],
+      "text/plain": [
+       "       10\n",
+       "(x - π)  \n",
+       "─────────\n",
+       " 3628800 "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAMcAAAArBAMAAAA+rYEMAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIs3dRLsQq3aZ72Yy\niVR4peFTAAADZUlEQVRYCe1VXUgUURg96+6Mu+4vPUUSLoFQSbSRFZHEPvpUC0H01kSEJchuSG0P\nQqZQSoISmJZJG2EEha7UazQvkj01EJRBSxM9aBD5U2hlun337pTddpxtfwqCPpiPPee795y597tz\nF8gRB3PUS1E+Nl8KFWuNhvhfMIHzv4l1G8TqP7BdY4C397T42iaoqJU8bgYu45KJrEgVZYI3wDZU\nqaJkNiraZBjRcLasyBRtAkwromQ2KoHJlmxVkXFdnRsQGQHVC0gA9xminsAbE/i8gcdivkslOWby\nIG9ZcUKZImIBBQmRiUPzqAKfL+iwmsBWQCZj7ycVq2E5a7esRjQC67f2YySdthqVs+YIWg2RdKvq\nb9dcGmCbODnVL864nk6nF+hU9Yh0gagsCTThXvKmMN/VNVU5GgB8QYEuFFSEAQ3deCcI7MM5J3nA\nkVih12xnUQvQIvMJUvCHAQWnuNYPGUKRckZ5Znih2MRMgNu/ythidkaVyKRCJy3bV8hMcyVcST8D\nP2/XSjHvXxI1ftQ5g/PizKjiV4lxB0W6QESH1LcoJWyt4vx2+DViSnSEHSHIh56lLooeqIHUQ1RZ\nmJJJPIJndyqVQsNgC3Ci45qRICk0uGnwJeT+TvU7SdQNelYNulZMYwfcdIoXbMNYF0AtjqqZJB9W\nqMF1aIY9LNchQzIBy1t8wtQCziF4SS4mJVAecYbgDPIkx88Sa9ewAe1AGzjJFayuejnIh2Slymp4\nqWGqPwjvvD0GxyxPQLcCPKQHu4D9AYMkaItRWiXKA+YFrZrx9YhG4Pzo74FnmaeMyWZW+ww80Q2S\n4bUsmUeXOe0OMBM5AraSxSoNnk88ZUzmxjt12xKZtBqkuUgu9jiYiUuHKwGJ6y8xPRKm7ZI/JLGH\nm2gGmUvOvK5xkygtpgZvs0zo/+3VEbaSokx8Kjdpozdwd4wv800xdoavhHr/uujtagI3oQNE4Z1n\n7V3kyegJmbSyxicNko/LN03G41/OQCYdirIgHVQfO8K+2YzJATLR6Q2m2RFmZKExRBc0mThnURWm\nT84b4iljMk09UehjfMo+Rm+oUAuATHzMZCc2AnvRqGYS/xglTb4Duy7fNSqFujxPD1AfaPaLXp2u\nwYkWI10Z2ZQE+vrCkAcvqAZZqMkfm/cNx+U5CyYfG4QAAAAASUVORK5CYII=\n",
+      "text/latex": [
+       "$$- \\frac{1}{479001600} \\left(x - \\pi\\right)^{12}$$"
+      ],
+      "text/plain": [
+       "        12 \n",
+       "-(x - π)   \n",
+       "───────────\n",
+       " 479001600 "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAMoAAAArBAMAAADLUwq8AAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAuxCrdpnvzWaJVN0i\nMkS9ILV6AAADrUlEQVRYCe1WTWgTWxT+OvnpJJm0WYm4sPfBQxEXjYobETpQRKRKIxp/kYiLtxB/\nUBBd6SwUXQgGtEhQMAtFXKUgD3y8nw74+56CBRHBjeEpCrqwtoh/0Pidm7bTVDuMSQkKnsWZ757v\n3PPNnXvuZQAfa1E+5ExRRkcTVIwlXU1QAXp/qnxjX/woXyyZ4sJa/RfX8FqS6/qpUFK+Mg2rIE4V\n40IzVMKdzVB53BSVvL9Kdu8Bx3ffgDZ72gSzTIr7Yrr+KtMW8IgHHvwCbWOEKr+iYZX9X9T2AnJM\nqHIpm9vkBetBYdtnlpnXKsB95ZMVgIr6zTe2wzr71obZtSxAKZ+UFz4cMMeXDU5uZuq/3f+tsGun\n5CqVygjQVxute3SI90fevBaV28qzyJqLd066wGUv1BDaA8QQHooP1lR5idVhiuC5F+Xi6rMh1hjl\nWhBK6Wq3/xT7R+NUSB5PNG7cUQWI2lMLWemEhGZKZacUuz8IJU/PIk67DCZ9MY+rA80Gr6lehFXt\n3E7VLjt1vDZa94i9WnJm4caUAj1ozzM0U538Cvhl1YIzzhSVQ2jJMHR4UnhBYQuSvxcKBaBFjSGj\n0FeEld1XhrH09CCTyeDmxrlsqfUrBquOUURduumMN4xnGUQck808AvkvrqIIsAnXEf6IW0VrF2uT\nsdLoLSJRNv6uOqkgF+K0FrM9ynRg9McUkNb/xRrhBLAQi4EBzAIWQTMhhcQQeoCVVadL+N388z0R\nxNKiwjPMD9OreJQFnRaV3xS6yu+AC3wFMtEdCI3iKvDa1U7XuD6p0lS4fFIgPqL00p4xxlo0otJi\nnMERhdz/bxgta6Z1GJFRvOVhK2onqbBs/fiaC8t+TljH+1XERopOqwhqqRzNS8KAkrU44/qJYesD\nVVaLs4UPbpHKX0yOFOm0ika5Ty7HyQ/YAHTY4ypP8lrlvKjot2BOQDv2qFIEOiVbqwgytx35yEdr\nCvOdeM4eV9mHelXMDE4NS+PQtIqgY+xoBawlPLqG/Tu2ylRVpY4vFuVJeA/pnbFagnbwDnQQTktw\nvMeAbg5k4x3tNBfUzWPiehicWFURJKc2YuMSLJfRg2NMPIN78jYl6eSSMMEt6gLL0TahohGPe8hN\nZuTCda1RFpNv+RA4KQfyXNUxGtzi+xHPIz6hotFlhSu4WyhsRY9qtVmMKtYfhb5+JIrG7qoLLiGZ\nT7Nb2LPcGuj/Yo3almaLGKhUPiGWlf8dYRK86/phbO7mbSnu+7PPCp1DTSYOx48AAAAASUVORK5C\nYII=\n",
+      "text/latex": [
+       "$$\\frac{1}{87178291200} \\left(x - \\pi\\right)^{14}$$"
+      ],
+      "text/plain": [
+       "        14 \n",
+       " (x - π)   \n",
+       "───────────\n",
+       "87178291200"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAPsAAAAqBAMAAACHPjAfAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIs3dRLsQq3aZ72ZU\nMonLrI/bAAAEFUlEQVRYCe1YTWgUZxh+Zn9mZ/Z32pM/0AwFS8GCWyrtpcpCD3oQ3EMRKYUOFRE9\nmJWixUNhYqCmlHRXoSXxZ7NSkB4URuxBKdShHmoPbZaKoKeMFDQ5dE1sukYSs32/d0wna3YXJzsh\nIL6HZ/P+PO+T+eZ7v28TwI/t8lMceO3eeuAtfTTc9/mqykN5Ke/jbQVc+uIs/i1ALn/tb3mCe/o7\nnwGh6thqyeM6MIGDqyl/wZ84gpz765DmBk74+wWCe/e0+Kl53PQlr556ePp5CdvbF/4oUvT008jY\n7au6yqQK7elqlXK09Z4gY7av6ioTMjrQdcqR/FvI5DpUdZMa6ET+mZIk/ys+6FTVTe58J/IB4LVN\nQ0iUv+tU1UUuonciR+1O2QByqgNI44duDDX3Gmk0Go+AdKk5HLgXskAn6mXr+6bO6uCN9Zc0IKk3\nhYN34jnAQRG/N7XegT6F1BGpeOFX3xG2GaCFCcaot5goA4dZ5X8B8vIxEUpNcmLlwB3oH54VkAph\nEVpx+bhNKtITyELNM9XKCGfx4nvJAH+K0ta7pEziy+aevUamSpGE3hwO3KPRSs5GK5LZ3LkfGYci\nKz54kSzk3fdqz36X24hoieRDOYIltvbkh8D+gbPAvvIXALsMN8u1miPXJmzIR+/T6h2snVkM8tBX\nVTC4bNH43JLuiwJ06C41qYCijc3YU5UuYJ3Grhu7RgNZUIHTWGdL1LgE1VoE4Zy8BQzM5s7iVmlr\n460yMQPhSSULRY9WEMuzy4B7QAw/AXvwEWiYExbkrAfoB465wGzuHTL4oyXIeqtw/Dxi0+ECIlMZ\nHek6uwx0fuFv3BfyD4EHRrpA8h7gPWCnxsBs7k3L1tZiWqtUqA51OlNCaq43D2WaXQYqjpgYPYJx\n+V+gmEs+MtKmB3gMjNkMzHZ7r3E/WuFgq6CIhes9DlIz4uln2V2AvUC0ccXhp7fwyew38ECaJ/k+\nASazRaPl2ZgjGsyrFURnqMOYswC00zHyj4ZTJGtCbbwND1j+rpB32VS6TNsAlpc34jchv0G0ESBP\n0lF1dtMcPrWSIyau/tmwPQhMXs2z/AwSA7fn6PnypMyg6MBVJBoGrgwW7UQJ1+oesHxfAIt/nG5K\n2nritafp/xjkPgXa0aBvbz0WBR4YcQPSrAe89Syx9awFtiD6tmQJr5BQcoqYIR3CdQG9JcgVWgmT\nMq9DHFpDHojBGxWDN6otsKnAv90Rt1QW6awyhZ4chOsCdpb4GI1pRY3+NolrwCEPxInzlwvM9i/M\nDGlrbSKL93GgqryLN8GuG8Moyf9i4A/0GyETyTeQdDxA2JYvusDsZcqH6WTPYv843TYT39pg143R\nW6WT5+iwjfTwx9R92zANogdy+ThdOQJcth/9/wDcHM89tyP61wAAAABJRU5ErkJggg==\n",
+      "text/latex": [
+       "$$- \\frac{1}{20922789888000} \\left(x - \\pi\\right)^{16}$$"
+      ],
+      "text/plain": [
+       "         16   \n",
+       " -(x - π)     \n",
+       "──────────────\n",
+       "20922789888000"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAP4AAAArBAMAAACqSyj+AAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAuxCrdpnvzWaJMiLd\nVET4aMmqAAAEhElEQVRYCe1XXWgcVRT+dnZ2Z/ZnNnlRFNRMwaYEhCxGfbBgF5JQS4WsNEsbUdr6\n4IN/yVZE8UEHURR86KoNMkXpgIgIlYzE4k8rHRGhrdoMiPiYBUVfhC7bVhObdD3n3l13V5Jh0t0l\nKJ6HO+ee75zzzZx777m7QFiJmGE9e+KnDGwqvzKyY1P5gYn/+XuyscIm/Y/VP9kPvDTuhv36bu+/\n5B4PqqvQS4SVLtff8BAxMROWvdvfD+KPnktlN5M/NV0wN5MfO1ec0PyF6aet0M7kmMmt662XCaL6\nx/zj1XWdOgXeDUjwgOTfBjwb4NUZdCggXJP8HwH3Bnh1BKm5gHC9JOqvubg9wKsjKG4GhCsHkHrr\nck6Zst0Ar46gXwOjbw5EuwFOUZLPRr8Yz7Uli9VIqOfMtll7MaGNrZT0M3GvLfnkh7tfPUmWH9us\nvZg8CSSgVgynNXnGV93dbPilaeWKdFkqlP0qfT+i/YLnk29ZzrMeAVUfmOOhp0L8QDz3T455eGzq\nPf8TTHPagcnPpuwDF6e1/k2sq9oNgO5OQDXbsipV/MmGV9qsvZjQCVu0rsfH7blVD8ts6f35+w3Y\nsmvoiNXOr1m4ji3Pt5iVWduhKd1XW8foYjqx9xYgab/u4/iUbZeElvzatm0Jay+m3pFIqlAsA0P2\nQ/VAEa1MjnMy2nqueKw9UP9tyikn6tHsS+A8bnPoF9GEjxPIXMJhOpZZoemkXRQw4rVaSSLzUFeB\nPGKWRDga6bJyTqTmK2ZdSeRaoLPQZgD1IGhx1JmoiXQFx3ys4A0gKrWECWQFDG3PUUiErq4F6BYU\nTyASvg/YKXMH3b/bWuj1qph8WkQ6i8yV+MOIXsUi89MXHJVagpqZI2B6IxKBPGJiRzmRJX6BSPgr\n4IIrEs6Lce1he4tZOyAmpSL68kiualXEuHdQ/eu/oYSGnyUs+QXygon9ZeOimciJQDHgMvUWXyRM\n5cRjrUF1Wqx9z43RDtLdIk6XkGTWNFdEy9Kwhf2ERn8UJBwdGy03ECyYGFjaJREBp+h0zeUIDy/D\nZ5C2cCskP5/OOSrvB09xBnqxuhbzBcsyIqbC5WEESfKO1b6RCPMvC34K34AMV5Co0oo2+YscrdIF\nplQaGoapmTIBG+5qIFo/8PL7NV8g18zvQV+la/Lv+scoK8m0SaehofGmZgJeHhxz6sj9tG55HK4K\nRAzXUP++GeiXhkD8vIOWgFGi+BwYsJDONjTQvpbwTcRfFghUguMmUksCkTDvP4tfMrRE+Pu/Hxn5\n/Q6iM67AyOOkUqONZWE4j7qmUF4JPw7sdxkBfkDKHaTnpEAkTO+56IbmZkdDrD8g+k/Cw3vAa/iD\neouLC8QitQzxU4MhmEzP0BmnRzIP3eU2u10gEqb+8/aG6IEbMWhRyEHgOww6qbP2rEd/CzK01RaJ\nRWoG8QuYOrPxmERO2faDMA7BKEmEo5H2lUc3yB+78x6KeLO2D1uP3I00tXoPRmGvL1dSarwvBIxk\nYYQ+mdd4oVZbAX4q0FHkQDkoU6MOuf575C9+Ztihp/kcUAAAAABJRU5ErkJggg==\n",
+      "text/latex": [
+       "$$\\frac{1}{6402373705728000} \\left(x - \\pi\\right)^{18}$$"
+      ],
+      "text/plain": [
+       "          18    \n",
+       "   (x - π)      \n",
+       "────────────────\n",
+       "6402373705728000"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "for term, _ in zip(cos(x).lseries(x, pi), range(10)):\n",
+    "    display(term)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Hint: to get the exponent from a term like `3*(x - 1)**5`, use `as_coeff_exponent`. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAADwAAAAaBAMAAAAZJyJqAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMARDKrEM1mIu+Zdrvd\niVTWGHL+AAABSklEQVQoFXWSPUsDQRCGn1wuuXwn/oIErEVBFMHmGusExMJGUtgJco2F2NjZCB5o\nk8pAmiAWgq1IsBG7IFiqtZ0Jh2kkcW5zMZsLN8V8vM/M7g4ssECEdX3dWImgLPpgy47CmaaQdVh6\nfwy1JPatD3gG6xTLpew3apYajeTmFqRd8kOKHY1Jmrh8FV+1SZUozOO46s7VWVZJ+PAxTt/RVnhb\n+amL37RKkPxmTTTjLbx71jZ7EPO4VyNt6Q3Zhoz12VVqygtB+Kxg9XiR1Stkf2bxg+AS5tDHVW8O\nn8O140/Lm4s1cgNsfd6FHTm2zyZk6pS75q+OjymcycsH3Ir61djDvHA0bjRWpZS9yxMxpuOxmK9R\nrAQ8OembxkSTeDcaVx2MToCbQdTCgeThj6LhJ8mPtHo2TbpSFyaXzzKpTpRyOKcHwlUU+Nf/AKUL\nQ2ycOKYsAAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$$\\begin{pmatrix}3, & 5\\end{pmatrix}$$"
+      ],
+      "text/plain": [
+       "(3, 5)"
+      ]
+     },
+     "execution_count": 43,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "(3*(x - 1)**5).as_coeff_exponent(x - 1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def series_accuracy(func, expansion_point, evaluation_point, accuracy, x):\n",
+    "    \"\"\"\n",
+    "    Returns n such that series terms up to and including (x - expansion_point)**n \n",
+    "    (i.e., O((x - expansion_point)**(n + 1)) are needed to compute func at \n",
+    "    evaluation_point within the given accuracy.\n",
+    "\n",
+    "    >>> series_accuracy(cos(x), pi, pi + 1, 0.01, x)\n",
+    "    4\n",
+    "    >>> series_accuracy(exp(x), 1, 10, 1, x)\n",
+    "    23\n",
+    "    \"\"\"\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "series_accuracy(cos(x), pi, pi + 1, 0.01, x)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 46,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "series_accuracy(exp(x), 1, 10, 1, x)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": []
   }
- ]
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 0
 }

--- a/tutorial_exercises/Advanced-Gotchas Solutions.ipynb
+++ b/tutorial_exercises/Advanced-Gotchas Solutions.ipynb
@@ -1,342 +1,343 @@
 {
- "metadata": {
-  "name": "",
-  "signature": "sha256:6cbe536c182f46c7cfa292cc81f32b31ba3ede18ef1a631b7d53fbcc10dad81a"
- },
- "nbformat": 3,
- "nbformat_minor": 0,
- "worksheets": [
+ "cells": [
   {
-   "cells": [
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Gotchas Solutions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from sympy import *\n",
+    "init_printing()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For each exercise, fill in the function according to its docstring. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Symbols"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "What will be the output of the following code?\n",
+    "\n",
+    "    x = 3\n",
+    "    y = symbols('y')\n",
+    "    a = x + y\n",
+    "    y = 5\n",
+    "    print(a)\n",
+    "\n",
+    "Replace `???` in the below code with what you think the value of `a` will be.  Remember to define any Symbols you need!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def symbols_exercise():\n",
+    "    \"\"\"\n",
+    "    >>> def testfunc():\n",
+    "    ...     x = 3\n",
+    "    ...     y = symbols('y')\n",
+    "    ...     a = x + y\n",
+    "    ...     y = 5\n",
+    "    ...     return a\n",
+    "    >>> symbols_exercise() == testfunc()\n",
+    "    True\n",
+    "    \"\"\"\n",
+    "    y = symbols('y')\n",
+    "    return 3 + y"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
     {
-     "cell_type": "heading",
-     "level": 1,
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 15,
      "metadata": {},
-     "source": [
-      "Gotchas Solutions"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "from sympy import *\n",
-      "init_printing()"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 13
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "For each exercise, fill in the function according to its docstring. "
-     ]
-    },
-    {
-     "cell_type": "heading",
-     "level": 2,
-     "metadata": {},
-     "source": [
-      "Symbols"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "What will be the output of the following code?\n",
-      "\n",
-      "    x = 3\n",
-      "    y = symbols('y')\n",
-      "    a = x + y\n",
-      "    y = 5\n",
-      "    print(a)\n",
-      "\n",
-      "Replace `???` in the below code with what you think the value of `a` will be.  Remember to define any Symbols you need!"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def symbols_exercise():\n",
-      "    \"\"\"\n",
-      "    >>> def testfunc():\n",
-      "    ...     x = 3\n",
-      "    ...     y = symbols('y')\n",
-      "    ...     a = x + y\n",
-      "    ...     y = 5\n",
-      "    ...     return a\n",
-      "    >>> symbols_exercise() == testfunc()\n",
-      "    True\n",
-      "    \"\"\"\n",
-      "    y = symbols('y')\n",
-      "    return 3 + y"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 14
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def testfunc():\n",
-      "    x = 3\n",
-      "    y = symbols('y')\n",
-      "    a = x + y\n",
-      "    y = 5\n",
-      "    return a\n",
-      "\n",
-      "symbols_exercise() == testfunc()"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 15,
-       "text": [
-        "True"
-       ]
-      }
-     ],
-     "prompt_number": 15
-    },
-    {
-     "cell_type": "heading",
-     "level": 2,
-     "metadata": {},
-     "source": [
-      "Equality"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Write a function that takes two expressions as input, and returns a tuple of two booleans. The first if they are equal symbolically, and the second if they are equal mathematically."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def equality_exercise(a, b):\n",
-      "    \"\"\"\n",
-      "    Determine if a = b symbolically and mathematically.\n",
-      "\n",
-      "    Returns a tuple of two booleans. The first is True if a = b symbolically,\n",
-      "    the second is True if a = b mathematically.  Note the second may be False\n",
-      "    but the two still equal if SymPy is not powerful enough.\n",
-      "\n",
-      "    Examples\n",
-      "    ========\n",
-      "\n",
-      "    >>> x = symbols('x')\n",
-      "    >>> equality_exercise(x, 2)\n",
-      "    (False, False)\n",
-      "    >>> equality_exercise((x + 1)**2, x**2 + 2*x + 1)\n",
-      "    (False, True)\n",
-      "    >>> equality_exercise(2*x, 2*x)\n",
-      "    (True, True)\n",
-      "    \"\"\"\n",
-      "    return (a == b, simplify(a - b) == 0)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 16
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "x = symbols('x')"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 17
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "equality_exercise(x, 2)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 18,
-       "text": [
-        "(False, False)"
-       ]
-      }
-     ],
-     "prompt_number": 18
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "equality_exercise((x + 1)**2, x**2 + 2*x + 1)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 19,
-       "text": [
-        "(False, True)"
-       ]
-      }
-     ],
-     "prompt_number": 19
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "equality_exercise(2*x, 2*x)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 20,
-       "text": [
-        "(True, True)"
-       ]
-      }
-     ],
-     "prompt_number": 20
-    },
-    {
-     "cell_type": "heading",
-     "level": 2,
-     "metadata": {},
-     "source": [
-      "`^` and `/`"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Correct the following functions"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def operator_exercise1():\n",
-      "    \"\"\"\n",
-      "    >>> operator_exercise1()\n",
-      "    x**2 + 2*x + 1/2\n",
-      "    \"\"\"\n",
-      "    x = symbols('x')\n",
-      "    return x**2 + 2*x + Rational(1, 2)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 21
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "operator_exercise1()"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$x^{2} + 2 x + \\frac{1}{2}$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAGwAAAAqBAMAAACkSaOPAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIol2q1SZEGbd7zK7\nzUTvhYErAAAByklEQVRIDe2Sz0sCQRTH37bu6q5Y9hM6JRaeJaSrHoKOCVHXPEVF0hYdPdh/IJ2i\ni8cgCDx16ZCHIugQHboEDkn9AxKERNQ26s7O22mNWc/NwXnf9/1+5umMAMHXbXCEEqX2INjB4kAY\nqP+YeN34SlLXlmj30wjTLf2hX0zsI8yIK5+i3U8jzMyHv/vFxD7CADTZt9e3vzb5SbEErzvVVPHe\n2/BXc962koNs3tvyU5GE0w3Hu0XIAqOFg3tYuPULXPZqLd3dzVMIeS5pxY2iInqzuuTBYm3Q/8TG\nMpMLadO2na/kTKNnGG3oer3jhGnhROTYrPDBHLtKYE/AhkBtaTU/rAHYE7AwhOocos/euxIAvQ7Y\nY9iI3VmUMFmQRgl5OickR7uQ6Xw4XpGQE0IeOx13zdTAcoU7TSvAKAD32DQnGYlnQfXBLgAOsSdg\n6+U7GOfD2DTlKJmqYE/ASvP7s+XfmEF/dwV7AoaIbunepGC4mLLRaAoelcP8Xj3mK1MToL6zOsBO\n/7vVAHEWPbNgucmE/P5swe4AGB1QRe8sPy/6Jp9FyVgdCflyRz6KkmoOCflyDZS4fJolowWIDIBN\nJ5Nb7IgAe9W2P+AHAIprVTpk+QAAAAAASUVORK5CYII=\n",
-       "prompt_number": 22,
-       "text": [
-        " 2         1\n",
-        "x  + 2\u22c5x + \u2500\n",
-        "           2"
-       ]
-      }
-     ],
-     "prompt_number": 22
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def operator_exercise2():\n",
-      "    \"\"\"\n",
-      "    >>> operator_exercise2()\n",
-      "    (x**2/2 + 2*x + 3/4)**(3/2)\n",
-      "    \"\"\"\n",
-      "    x = symbols('x')\n",
-      "    return (x**2/2 + 2*x + Rational(3, 4))**Rational(3, 2)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 23
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "operator_exercise2()"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\left(\\frac{x^{2}}{2} + 2 x + \\frac{3}{4}\\right)^{\\frac{3}{2}}$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAJcAAAA7BAMAAACEbwXfAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAiUSZq1TdIu8yzRBm\ndrsuMkCWAAAEF0lEQVRYCa1XXYgTVxQ++ZlMJpPoBN8UbZ4Ly0YWRFbcDbjog2AWqqUWZOOLCgqb\nslbxQVxt/V3EFd911SIlDxrpQ6GFbvrSBUF2xX0QFDboiyBiWrGiq07vz7k/M51xJpD7MPc73/nO\nl3vv3LkzAehR61ss9ciJ2NxI1npnVk84vTOzVvfOCyA50zs3B976zBJD231M3NCeNDs+7SYY9DGx\nw/uL0z7tfjjhp3yK6DBRQs1pmBUQmYjOFsuy0nVdPs/1qmSsqXAc9KXQ963jc0pUVNl1BSOQVVw3\nCpCfQdmMNcnQ1xiTTvdVbCCagORHktiCyYOwTJF5HmPS/algFPpiFP4lmiwZHmv82cw5GJJd7Fh8\n5pIJB2PczJhCyW91CrQ1v7prZzO83J9h04SbnMb7epJG5tptezbDJdf1V3wmzlVosp+NCH753SFB\nni3cXfirdYbm4rfLPzFtrsy6cbdG+kyFBg4swW4KumiFU1TMB4Nl/SUKmrAD4y66S2yB6QYRbSOC\ni4KI2R8DeNWi2q1awQ8cm+/A1thIaLtNNBvjd4BWWG9Y3VyhA48jHXTBe4BxZjO7IOkCu5nGhxWT\npiJl9jPgCST/ZulMW6pWTFJov1xTfCK5WMAYGBxlwnRH6rNtCQPBxODTQF6RBXX4zzqKDkBmBZb4\nAAKSnDL4qtOgv8Up/9WuMybdhIyaBqF+9QvBUhttPuR3jQVWlZ2C9D96/R49YNh+LamlaQk9AM1y\ny5CKMINPsnC4LqEHoBnhMsvw3eL3D/lI4f8jgwuysNqU0AOU2TXHdvKHsjWeDjDbJwurEnmBMrsN\nCSh0DFyOALMDspKb0dcetg5PSbNUmzy06bYoEGa8grE/ixwEjizVaNy60GhUqGqRXrJ8xQYbjQON\nBj8UKc1bhBkRiZEZZTgK9KsB11aMTDiRXk1zGEVakkFhdgVgLl9fgkK4mboBEVvD3FtcVRtrPYfj\n+GsBI1NbI2LTZshtqf3x4O7aVriZ2rTzJVSBOXBbYrVmIit6bWRWhZHa46Qe9MNQUM8/JPn9Ex6y\n75MI8FTUHnR1BG0n57BSxkCP2kykHUFZzhD6XBOqJZaOdzHvtZlQOxz5sU3ZO00YLrF0vEsi12bC\ndEfq+QsFw/GQTSfVOphDMzU38apjKou/bvSKcGwvoJn2qgN8CdMqzIYb6JmEkM/XFS0+DwgzpNho\ntFuY6Z8H/dOisFARKEZvO8JMX5tMWZR+BaY2YsGG9MbISPXHBZL0fFLlOyi3ypCPb0aK+G3MVbCe\ndRcxOFIsbtD5SMzN8DMU1d9gP+669Fs8dktUX7eI+JmnIOd4wi6D5JSnwDzrCbsMMqPegm+9YXfR\ngE+eKvuILkJjxi9+6Sfix/IvoixJlSTsEtgv9IL/AHT99A+60z6FAAAAAElFTkSuQmCC\n",
-       "prompt_number": 24,
-       "text": [
-        "              3/2\n",
-        "\u239b 2          \u239e   \n",
-        "\u239cx          3\u239f   \n",
-        "\u239c\u2500\u2500 + 2\u22c5x + \u2500\u239f   \n",
-        "\u239d2          4\u23a0   "
-       ]
-      }
-     ],
-     "prompt_number": 24
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
+     "output_type": "execute_result"
     }
    ],
-   "metadata": {}
+   "source": [
+    "def testfunc():\n",
+    "    x = 3\n",
+    "    y = symbols('y')\n",
+    "    a = x + y\n",
+    "    y = 5\n",
+    "    return a\n",
+    "\n",
+    "symbols_exercise() == testfunc()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Equality"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Write a function that takes two expressions as input, and returns a tuple of two booleans. The first if they are equal symbolically, and the second if they are equal mathematically."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def equality_exercise(a, b):\n",
+    "    \"\"\"\n",
+    "    Determine if a = b symbolically and mathematically.\n",
+    "\n",
+    "    Returns a tuple of two booleans. The first is True if a = b symbolically,\n",
+    "    the second is True if a = b mathematically.  Note the second may be False\n",
+    "    but the two still equal if SymPy is not powerful enough.\n",
+    "\n",
+    "    Examples\n",
+    "    ========\n",
+    "\n",
+    "    >>> x = symbols('x')\n",
+    "    >>> equality_exercise(x, 2)\n",
+    "    (False, False)\n",
+    "    >>> equality_exercise((x + 1)**2, x**2 + 2*x + 1)\n",
+    "    (False, True)\n",
+    "    >>> equality_exercise(2*x, 2*x)\n",
+    "    (True, True)\n",
+    "    \"\"\"\n",
+    "    return (a == b, simplify(a - b) == 0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "x = symbols('x')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(False, False)"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "equality_exercise(x, 2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(False, True)"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "equality_exercise((x + 1)**2, x**2 + 2*x + 1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(True, True)"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "equality_exercise(2*x, 2*x)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## `^` and `/`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Correct the following functions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def operator_exercise1():\n",
+    "    \"\"\"\n",
+    "    >>> operator_exercise1()\n",
+    "    x**2 + 2*x + 1/2\n",
+    "    \"\"\"\n",
+    "    x = symbols('x')\n",
+    "    return x**2 + 2*x + Rational(1, 2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAGwAAAAqBAMAAACkSaOPAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIol2q1SZEGbd7zK7\nzUTvhYErAAAByklEQVRIDe2Sz0sCQRTH37bu6q5Y9hM6JRaeJaSrHoKOCVHXPEVF0hYdPdh/IJ2i\ni8cgCDx16ZCHIugQHboEDkn9AxKERNQ26s7O22mNWc/NwXnf9/1+5umMAMHXbXCEEqX2INjB4kAY\nqP+YeN34SlLXlmj30wjTLf2hX0zsI8yIK5+i3U8jzMyHv/vFxD7CADTZt9e3vzb5SbEErzvVVPHe\n2/BXc962koNs3tvyU5GE0w3Hu0XIAqOFg3tYuPULXPZqLd3dzVMIeS5pxY2iInqzuuTBYm3Q/8TG\nMpMLadO2na/kTKNnGG3oer3jhGnhROTYrPDBHLtKYE/AhkBtaTU/rAHYE7AwhOocos/euxIAvQ7Y\nY9iI3VmUMFmQRgl5OickR7uQ6Xw4XpGQE0IeOx13zdTAcoU7TSvAKAD32DQnGYlnQfXBLgAOsSdg\n6+U7GOfD2DTlKJmqYE/ASvP7s+XfmEF/dwV7AoaIbunepGC4mLLRaAoelcP8Xj3mK1MToL6zOsBO\n/7vVAHEWPbNgucmE/P5swe4AGB1QRe8sPy/6Jp9FyVgdCflyRz6KkmoOCflyDZS4fJolowWIDIBN\nJ5Nb7IgAe9W2P+AHAIprVTpk+QAAAAAASUVORK5CYII=\n",
+      "text/latex": [
+       "$$x^{2} + 2 x + \\frac{1}{2}$$"
+      ],
+      "text/plain": [
+       " 2         1\n",
+       "x  + 2⋅x + ─\n",
+       "           2"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "operator_exercise1()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def operator_exercise2():\n",
+    "    \"\"\"\n",
+    "    >>> operator_exercise2()\n",
+    "    (x**2/2 + 2*x + 3/4)**(3/2)\n",
+    "    \"\"\"\n",
+    "    x = symbols('x')\n",
+    "    return (x**2/2 + 2*x + Rational(3, 4))**Rational(3, 2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAJcAAAA7BAMAAACEbwXfAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAiUSZq1TdIu8yzRBm\ndrsuMkCWAAAEF0lEQVRYCa1XXYgTVxQ++ZlMJpPoBN8UbZ4Ly0YWRFbcDbjog2AWqqUWZOOLCgqb\nslbxQVxt/V3EFd911SIlDxrpQ6GFbvrSBUF2xX0QFDboiyBiWrGiq07vz7k/M51xJpD7MPc73/nO\nl3vv3LkzAehR61ss9ciJ2NxI1npnVk84vTOzVvfOCyA50zs3B976zBJD231M3NCeNDs+7SYY9DGx\nw/uL0z7tfjjhp3yK6DBRQs1pmBUQmYjOFsuy0nVdPs/1qmSsqXAc9KXQ963jc0pUVNl1BSOQVVw3\nCpCfQdmMNcnQ1xiTTvdVbCCagORHktiCyYOwTJF5HmPS/algFPpiFP4lmiwZHmv82cw5GJJd7Fh8\n5pIJB2PczJhCyW91CrQ1v7prZzO83J9h04SbnMb7epJG5tptezbDJdf1V3wmzlVosp+NCH753SFB\nni3cXfirdYbm4rfLPzFtrsy6cbdG+kyFBg4swW4KumiFU1TMB4Nl/SUKmrAD4y66S2yB6QYRbSOC\ni4KI2R8DeNWi2q1awQ8cm+/A1thIaLtNNBvjd4BWWG9Y3VyhA48jHXTBe4BxZjO7IOkCu5nGhxWT\npiJl9jPgCST/ZulMW6pWTFJov1xTfCK5WMAYGBxlwnRH6rNtCQPBxODTQF6RBXX4zzqKDkBmBZb4\nAAKSnDL4qtOgv8Up/9WuMybdhIyaBqF+9QvBUhttPuR3jQVWlZ2C9D96/R49YNh+LamlaQk9AM1y\ny5CKMINPsnC4LqEHoBnhMsvw3eL3D/lI4f8jgwuysNqU0AOU2TXHdvKHsjWeDjDbJwurEnmBMrsN\nCSh0DFyOALMDspKb0dcetg5PSbNUmzy06bYoEGa8grE/ixwEjizVaNy60GhUqGqRXrJ8xQYbjQON\nBj8UKc1bhBkRiZEZZTgK9KsB11aMTDiRXk1zGEVakkFhdgVgLl9fgkK4mboBEVvD3FtcVRtrPYfj\n+GsBI1NbI2LTZshtqf3x4O7aVriZ2rTzJVSBOXBbYrVmIit6bWRWhZHa46Qe9MNQUM8/JPn9Ex6y\n75MI8FTUHnR1BG0n57BSxkCP2kykHUFZzhD6XBOqJZaOdzHvtZlQOxz5sU3ZO00YLrF0vEsi12bC\ndEfq+QsFw/GQTSfVOphDMzU38apjKou/bvSKcGwvoJn2qgN8CdMqzIYb6JmEkM/XFS0+DwgzpNho\ntFuY6Z8H/dOisFARKEZvO8JMX5tMWZR+BaY2YsGG9MbISPXHBZL0fFLlOyi3ypCPb0aK+G3MVbCe\ndRcxOFIsbtD5SMzN8DMU1d9gP+669Fs8dktUX7eI+JmnIOd4wi6D5JSnwDzrCbsMMqPegm+9YXfR\ngE+eKvuILkJjxi9+6Sfix/IvoixJlSTsEtgv9IL/AHT99A+60z6FAAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$$\\left(\\frac{x^{2}}{2} + 2 x + \\frac{3}{4}\\right)^{\\frac{3}{2}}$$"
+      ],
+      "text/plain": [
+       "              3/2\n",
+       "⎛ 2          ⎞   \n",
+       "⎜x          3⎟   \n",
+       "⎜── + 2⋅x + ─⎟   \n",
+       "⎝2          4⎠   "
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "operator_exercise2()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": []
   }
- ]
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 0
 }

--- a/tutorial_exercises/Advanced-Gotchas.ipynb
+++ b/tutorial_exercises/Advanced-Gotchas.ipynb
@@ -1,252 +1,252 @@
 {
- "metadata": {
-  "name": "",
-  "signature": "sha256:14b418e0557f6cf57b9eed7d7fbb2f98a1d5f1ded0a071ad93acff84f770aef2"
- },
- "nbformat": 3,
- "nbformat_minor": 0,
- "worksheets": [
+ "cells": [
   {
-   "cells": [
-    {
-     "cell_type": "heading",
-     "level": 1,
-     "metadata": {},
-     "source": [
-      "Gotchas"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "from sympy import *\n",
-      "init_printing()"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "For each exercise, fill in the function according to its docstring. "
-     ]
-    },
-    {
-     "cell_type": "heading",
-     "level": 2,
-     "metadata": {},
-     "source": [
-      "Symbols"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "What will be the output of the following code?\n",
-      "\n",
-      "    x = 3\n",
-      "    y = symbols('y')\n",
-      "    a = x + y\n",
-      "    y = 5\n",
-      "    print(a)\n",
-      "\n",
-      "Replace `???` in the below code with what you think the value of `a` will be.  Remember to define any Symbols you need!"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def symbols_exercise():\n",
-      "    \"\"\"\n",
-      "    >>> def testfunc():\n",
-      "    ...     x = 3\n",
-      "    ...     y = symbols('y')\n",
-      "    ...     a = x + y\n",
-      "    ...     y = 5\n",
-      "    ...     return a\n",
-      "    >>> symbols_exercise() == testfunc()\n",
-      "    True\n",
-      "    \"\"\"\n",
-      "    return ??? # Replace ??? with what you think the value of a is"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def testfunc():\n",
-      "    x = 3\n",
-      "    y = symbols('y')\n",
-      "    a = x + y\n",
-      "    y = 5\n",
-      "    return a\n",
-      "\n",
-      "symbols_exercise() == testfunc()"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "heading",
-     "level": 2,
-     "metadata": {},
-     "source": [
-      "Equality"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Write a function that takes two expressions as input, and returns a tuple of two booleans. The first if they are equal symbolically, and the second if they are equal mathematically."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def equality_exercise(a, b):\n",
-      "    \"\"\"\n",
-      "    Determine if a = b symbolically and mathematically.\n",
-      "\n",
-      "    Returns a tuple of two booleans. The first is True if a = b symbolically,\n",
-      "    the second is True if a = b mathematically.  Note the second may be False\n",
-      "    but the two still equal if SymPy is not powerful enough.\n",
-      "\n",
-      "    Examples\n",
-      "    ========\n",
-      "\n",
-      "    >>> x = symbols('x')\n",
-      "    >>> equality_exercise(x, 2)\n",
-      "    (False, False)\n",
-      "    >>> equality_exercise((x + 1)**2, x**2 + 2*x + 1)\n",
-      "    (False, True)\n",
-      "    >>> equality_exercise(2*x, 2*x)\n",
-      "    (True, True)\n",
-      "    \"\"\"\n"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "x = symbols('x')"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "equality_exercise(x, 2)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "equality_exercise((x + 1)**2, x**2 + 2*x + 1)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "equality_exercise(2*x, 2*x)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "heading",
-     "level": 2,
-     "metadata": {},
-     "source": [
-      "`^` and `/`"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Correct the following functions"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def operator_exercise1():\n",
-      "    \"\"\"\n",
-      "    >>> operator_exercise1()\n",
-      "    x**2 + 2*x + 1/2\n",
-      "    \"\"\"\n",
-      "    x = symbols('x')\n",
-      "    return x^2 + 2*x + 1/2"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "operator_exercise1()"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def operator_exercise2():\n",
-      "    \"\"\"\n",
-      "    >>> operator_exercise2()\n",
-      "    (x**2/2 + 2*x + 3/4)**(3/2)\n",
-      "    \"\"\"\n",
-      "    x = symbols('x')\n",
-      "    return (1/2*x^2 + 2*x + 3/4)^(3/2)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "operator_exercise2()"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    }
-   ],
-   "metadata": {}
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Gotchas"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from sympy import *\n",
+    "init_printing()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For each exercise, fill in the function according to its docstring. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Symbols"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "What will be the output of the following code?\n",
+    "\n",
+    "    x = 3\n",
+    "    y = symbols('y')\n",
+    "    a = x + y\n",
+    "    y = 5\n",
+    "    print(a)\n",
+    "\n",
+    "Replace `???` in the below code with what you think the value of `a` will be.  Remember to define any Symbols you need!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def symbols_exercise():\n",
+    "    \"\"\"\n",
+    "    >>> def testfunc():\n",
+    "    ...     x = 3\n",
+    "    ...     y = symbols('y')\n",
+    "    ...     a = x + y\n",
+    "    ...     y = 5\n",
+    "    ...     return a\n",
+    "    >>> symbols_exercise() == testfunc()\n",
+    "    True\n",
+    "    \"\"\"\n",
+    "    return ??? # Replace ??? with what you think the value of a is"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def testfunc():\n",
+    "    x = 3\n",
+    "    y = symbols('y')\n",
+    "    a = x + y\n",
+    "    y = 5\n",
+    "    return a\n",
+    "\n",
+    "symbols_exercise() == testfunc()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Equality"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Write a function that takes two expressions as input, and returns a tuple of two booleans. The first if they are equal symbolically, and the second if they are equal mathematically."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def equality_exercise(a, b):\n",
+    "    \"\"\"\n",
+    "    Determine if a = b symbolically and mathematically.\n",
+    "\n",
+    "    Returns a tuple of two booleans. The first is True if a = b symbolically,\n",
+    "    the second is True if a = b mathematically.  Note the second may be False\n",
+    "    but the two still equal if SymPy is not powerful enough.\n",
+    "\n",
+    "    Examples\n",
+    "    ========\n",
+    "\n",
+    "    >>> x = symbols('x')\n",
+    "    >>> equality_exercise(x, 2)\n",
+    "    (False, False)\n",
+    "    >>> equality_exercise((x + 1)**2, x**2 + 2*x + 1)\n",
+    "    (False, True)\n",
+    "    >>> equality_exercise(2*x, 2*x)\n",
+    "    (True, True)\n",
+    "    \"\"\"\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "x = symbols('x')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "equality_exercise(x, 2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "equality_exercise((x + 1)**2, x**2 + 2*x + 1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "equality_exercise(2*x, 2*x)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## `^` and `/`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Correct the following functions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def operator_exercise1():\n",
+    "    \"\"\"\n",
+    "    >>> operator_exercise1()\n",
+    "    x**2 + 2*x + 1/2\n",
+    "    \"\"\"\n",
+    "    x = symbols('x')\n",
+    "    return x^2 + 2*x + 1/2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "operator_exercise1()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def operator_exercise2():\n",
+    "    \"\"\"\n",
+    "    >>> operator_exercise2()\n",
+    "    (x**2/2 + 2*x + 3/4)**(3/2)\n",
+    "    \"\"\"\n",
+    "    x = symbols('x')\n",
+    "    return (1/2*x^2 + 2*x + 3/4)^(3/2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "operator_exercise2()"
+   ]
   }
- ]
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 0
 }

--- a/tutorial_exercises/Advanced-Matrices Solutions.ipynb
+++ b/tutorial_exercises/Advanced-Matrices Solutions.ipynb
@@ -1,952 +1,976 @@
 {
- "metadata": {
-  "name": "",
-  "signature": "sha256:e9c2b606824fcdccfd75e24007928b297798ca40036f1a3916def3ce46fa44d2"
- },
- "nbformat": 3,
- "nbformat_minor": 0,
- "worksheets": [
+ "cells": [
   {
-   "cells": [
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Matrices Solutions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from sympy import *\n",
+    "init_printing()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Use `row_del` and `row_insert` to go from one Matrix to the other."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def matrix1(M):\n",
+    "    \"\"\"\n",
+    "    >>> M = Matrix([[1, 2, 3], [4, 5, 6], [7, 8, 9]])\n",
+    "    >>> M\n",
+    "    [1, 2, 3]\n",
+    "    [4, 5, 6]\n",
+    "    [7, 8, 9]\n",
+    "    >>> matrix1(M)\n",
+    "    [4, 5, 6]\n",
+    "    [0, 0, 0]\n",
+    "    [7, 8, 9]\n",
+    "    \"\"\"\n",
+    "    M.row_del(0)\n",
+    "    M = M.row_insert(1, Matrix([[0, 0, 0]]))\n",
+    "    return M"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "M = Matrix([[1, 2, 3], [4, 5, 6], [7, 8, 9]])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
     {
-     "cell_type": "heading",
-     "level": 1,
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAFgAAABLCAMAAADDCbAzAAAAPFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAo1xBWAAAAE3RSTlMA\nMquZdlQQQOkwRLvvzWYi3YlsmQtEVgAAA11JREFUWAntmduCmyAQhjlJt1EEyvu/a2eGQ0QZuslu\n90ovEkT9GH6B+UOETHQo8U1HyDwhZNIGjuWbuGJHmkoIlt/FfHL2E3i1z2uXktfarY9Lda2QMca1\n9rsH2zVNwB7fgkn10cqr315D6ZFMPj+CrVJqBlbUaIA+Do9ITaZwBUONmYG3DckqMWIsb4Mdtao5\nMEU6lOJfEdOTIsw6JVydDUeNPwWWKeYGBp8yNq54GezWAfFZZbbyBl4F6zlXiK0o9SLYVAmfMbaS\np/m7pp1qXgMvOAe8b6xjwSaK9S2wRK7Yx2CRHF4NKV9+JWIfYDGIukwtpHSHQQ0eddB0YK235HTW\nqHsmn5R1lgOLRcMiVVeSDjyAvV11g5t0txS3FE2BVvi5USEnK67brfCxrgYtuFawUcdYXNUl4jBJ\nERu6PT7l+QBQNfYVwmwTsNOqBtSiPBQCtuloVYZVu/dufp8ly4lKgNw7X3ACR/E+2G2H6E8RQ9aZ\ngtH3MgZLQGqSxuj6aruILTjFGRg9ruUclk0Bcw99kDAH403iT14edVV1PX72HrI0nsSBr1hwCM4i\nJkpk/D9EjNf34p9Ril8fv7HK0gidgFd6MnJa5PS/F+f956NJsYDvBue9qeLJsbHu2Aisi3HoLuFJ\nbvcYcffjZjJByK60GXABL6zGdOsETD8ylo0xQhAyaGm3Yku64QbvVKXEOxaptVIsVwitdBvmJ/Cl\nf29X3OAm3S3FLUVToBV+ZFTIAH4Dj9bsqWDhWktqp2twapWOqviVLpnuefcpsVme1k12jfIbJFJf\nF7+jFDFv27DcnVZEW6zOJeKVkqEqObMD072814nUJAvOqWmUTIn74BKTEEvCXaHI3GATxWpKSjxG\njGA7y/5rSrthX22NOKeQM3jy0qFZnVJgM4gmjdeSpU9gSwmRNBl87Fq6xO67WQexLnoMNsWEDqjg\nRXC4wZjMg2dwC2xqyrrhd4o4sGMNOLTtJnzZQhmAsWo8KmzK3mH4kC2mTTPDIj80Nt6PGViUScUZ\nAIMWyVcD1kuxTMGLQ3UXbryZAJdd7U4PlnP9Hgr2UKqzvsoVtW67vN0idL31CzV9xF8AnR+9wU2R\n/ywF5aTZbG6BfKbQ/mCx+IeIMewvw8/AjvfQHyzGiL/a/CifSWQDggAAAABJRU5ErkJggg==\n",
+      "text/latex": [
+       "$$\\left[\\begin{matrix}1 & 2 & 3\\\\4 & 5 & 6\\\\7 & 8 & 9\\end{matrix}\\right]$$"
+      ],
+      "text/plain": [
+       "⎡1  2  3⎤\n",
+       "⎢       ⎥\n",
+       "⎢4  5  6⎥\n",
+       "⎢       ⎥\n",
+       "⎣7  8  9⎦"
+      ]
+     },
+     "execution_count": 11,
      "metadata": {},
-     "source": [
-      "Matrices Solutions"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "from sympy import *\n",
-      "init_printing()"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 8
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Use `row_del` and `row_insert` to go from one Matrix to the other."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def matrix1(M):\n",
-      "    \"\"\"\n",
-      "    >>> M = Matrix([[1, 2, 3], [4, 5, 6], [7, 8, 9]])\n",
-      "    >>> M\n",
-      "    [1, 2, 3]\n",
-      "    [4, 5, 6]\n",
-      "    [7, 8, 9]\n",
-      "    >>> matrix1(M)\n",
-      "    [4, 5, 6]\n",
-      "    [0, 0, 0]\n",
-      "    [7, 8, 9]\n",
-      "    \"\"\"\n",
-      "    M.row_del(0)\n",
-      "    M = M.row_insert(1, Matrix([[0, 0, 0]]))\n",
-      "    return M"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 9
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "M = Matrix([[1, 2, 3], [4, 5, 6], [7, 8, 9]])"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 10
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "M"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\left[\\begin{matrix}1 & 2 & 3\\\\4 & 5 & 6\\\\7 & 8 & 9\\end{matrix}\\right]$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAFgAAABLCAMAAADDCbAzAAAAPFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAo1xBWAAAAE3RSTlMA\nMquZdlQQQOkwRLvvzWYi3YlsmQtEVgAAA11JREFUWAntmduCmyAQhjlJt1EEyvu/a2eGQ0QZuslu\n90ovEkT9GH6B+UOETHQo8U1HyDwhZNIGjuWbuGJHmkoIlt/FfHL2E3i1z2uXktfarY9Lda2QMca1\n9rsH2zVNwB7fgkn10cqr315D6ZFMPj+CrVJqBlbUaIA+Do9ITaZwBUONmYG3DckqMWIsb4Mdtao5\nMEU6lOJfEdOTIsw6JVydDUeNPwWWKeYGBp8yNq54GezWAfFZZbbyBl4F6zlXiK0o9SLYVAmfMbaS\np/m7pp1qXgMvOAe8b6xjwSaK9S2wRK7Yx2CRHF4NKV9+JWIfYDGIukwtpHSHQQ0eddB0YK235HTW\nqHsmn5R1lgOLRcMiVVeSDjyAvV11g5t0txS3FE2BVvi5USEnK67brfCxrgYtuFawUcdYXNUl4jBJ\nERu6PT7l+QBQNfYVwmwTsNOqBtSiPBQCtuloVYZVu/dufp8ly4lKgNw7X3ACR/E+2G2H6E8RQ9aZ\ngtH3MgZLQGqSxuj6aruILTjFGRg9ruUclk0Bcw99kDAH403iT14edVV1PX72HrI0nsSBr1hwCM4i\nJkpk/D9EjNf34p9Ril8fv7HK0gidgFd6MnJa5PS/F+f956NJsYDvBue9qeLJsbHu2Aisi3HoLuFJ\nbvcYcffjZjJByK60GXABL6zGdOsETD8ylo0xQhAyaGm3Yku64QbvVKXEOxaptVIsVwitdBvmJ/Cl\nf29X3OAm3S3FLUVToBV+ZFTIAH4Dj9bsqWDhWktqp2twapWOqviVLpnuefcpsVme1k12jfIbJFJf\nF7+jFDFv27DcnVZEW6zOJeKVkqEqObMD072814nUJAvOqWmUTIn74BKTEEvCXaHI3GATxWpKSjxG\njGA7y/5rSrthX22NOKeQM3jy0qFZnVJgM4gmjdeSpU9gSwmRNBl87Fq6xO67WQexLnoMNsWEDqjg\nRXC4wZjMg2dwC2xqyrrhd4o4sGMNOLTtJnzZQhmAsWo8KmzK3mH4kC2mTTPDIj80Nt6PGViUScUZ\nAIMWyVcD1kuxTMGLQ3UXbryZAJdd7U4PlnP9Hgr2UKqzvsoVtW67vN0idL31CzV9xF8AnR+9wU2R\n/ywF5aTZbG6BfKbQ/mCx+IeIMewvw8/AjvfQHyzGiL/a/CifSWQDggAAAABJRU5ErkJggg==\n",
-       "prompt_number": 11,
-       "text": [
-        "\u23a11  2  3\u23a4\n",
-        "\u23a2       \u23a5\n",
-        "\u23a24  5  6\u23a5\n",
-        "\u23a2       \u23a5\n",
-        "\u23a37  8  9\u23a6"
-       ]
-      }
-     ],
-     "prompt_number": 11
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "matrix1(M)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\left[\\begin{matrix}4 & 5 & 6\\\\0 & 0 & 0\\\\7 & 8 & 9\\end{matrix}\\right]$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAFgAAABLCAMAAADDCbAzAAAAPFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAo1xBWAAAAE3RSTlMA\nMquZdlQQQOkwRN277yJmzYlst1IWYAAAAylJREFUWAntme2SpCAMRfmSnW1UZPP+77ohKE3Q4NTs\n1FRtlfzohr54CDEKpJUGKkZ9UwmFp5QG67BM38RVMdMMZLD+LuabE3uwHnhki16tSZ6ZTzal3cgT\nOMzvUfvakp2X+l9rew0INaG0e7BbBuDNmsOgSmsqIY+5bZfgNW4D8MBLSIvgm1E6i5P6OnhbGi4O\n00ZFXMfgHEav9vK2Dpt2zh63loG9Qx8NXDHjXD0IZA8h4jj0gd8MTM4fgMk+w2b8NtkDTl6ptHu6\nBU85BEcWEyUJjxNanPUIxRkN2FOEDsAzXZkkXwAFWgT0Jw1Qb95kcoHFFIVk9rEQ2MLKfq2NMu6F\nxaXH4AGx1ON4AirwqEyij6nHALxm8rQIBis1oy/9kkMDS+Pj3EwGwO5SbvOirTVG5Cplja1h3oE5\n6F9aD7h673HF44rqgVr5majwuNWyg13Rjc5kZnHA5cznXYdQbnQmt2BHL3K37zjO8Budyy040Ibk\nJa0Q6kbncgsGWiL0vhqeLb7RudyA17Lf0/tqeALf6J18BabV+sRV9cprvZN/FCws/9Wka72Ts8W/\nPn7TxA/vS4vpjc7lPx91w7KH03QTbqJewu2QGx+rEuGJHpPzvVN3Or+8BauA+zm/DB7psc4uZ2Bv\nkzMyV93oTGbgq/l/9bcHXD33uOJxRfVArfxIVOiACZJc6rBdxaNWT+Gdhk1vbKqvmtbiWLJPIKYl\naBUXD1Xrgi+/9TitteBUEhkiN9LS4qX39Uynd7Mf8hmYZicnZxINKYLLWfrq9E/c1/VSmbUJDM4p\nCR08kK1uP8O3FueL/ShdMQNEJ97aw+KyFvfgwU3HYS1AEI+8lnw8n9MKZDCd4HPtqkSrNxC3dn5D\nWyd7DZb3sDhQzOGGMdlmwdj4mNTU7pxhyX3K3oD1fjcWIq4gbWio53VU+LKbebPamt+zTFYIi9L3\nyJPwm/cagdX+UEkZC5e3UOuRMeLgaQietuyLSYo3F1DejulwsB7772WsHcRjsnYuuTEcn4Nbl/5j\n/QFXB/6vrqA1SVw56vQ+Wal/sPj8h4hzQsL5k7SmG/3B4pz6CyFBKjOQDmqMAAAAAElFTkSuQmCC\n",
-       "prompt_number": 12,
-       "text": [
-        "\u23a14  5  6\u23a4\n",
-        "\u23a2       \u23a5\n",
-        "\u23a20  0  0\u23a5\n",
-        "\u23a2       \u23a5\n",
-        "\u23a37  8  9\u23a6"
-       ]
-      }
-     ],
-     "prompt_number": 12
-    },
-    {
-     "cell_type": "heading",
-     "level": 2,
-     "metadata": {},
-     "source": [
-      "Matrix Constructors"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Use the matrix constructors to construct the following matrices.  There may be more than one correct answer."
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "$$\\left[\\begin{array}{ccc}4 & 0 & 0\\\\\\\\ \n",
-      "0 & 4 & 0\\\\\\\\ \n",
-      "0 & 0 & 4\\end{array}\\right]$$"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def matrix2():\n",
-      "    \"\"\"\n",
-      "    >>> matrix2()\n",
-      "    [4, 0, 0]\n",
-      "    [0, 4, 0]\n",
-      "    [0, 0, 4]\n",
-      "    \"\"\"\n",
-      "    return eye(3)*4\n",
-      "    # OR return diag(4, 4, 4)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 13
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "matrix2()"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\left[\\begin{matrix}4 & 0 & 0\\\\0 & 4 & 0\\\\0 & 0 & 4\\end{matrix}\\right]$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAFgAAABLCAMAAADDCbAzAAAAPFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAo1xBWAAAAE3RSTlMA\nMquZdlQQQOkwRN277yJmzYlst1IWYAAAAmBJREFUWAntmWFTgzAMhgN0OMUNsf//v9oWG/KWpnE7\n9M47+CCFkIcQyvE4qPNp6emgZVp5RJ0fXFguB3FpjrTeR3B3FHPjzCW4a3RkDFc26EVAeAee3rez\nlqPpjWicVDKES7C76WA3xTO5j/J839sYLsD3+UMHT6lLb/5eJ2O4AC/UAPshEjuvTB8MI3i+N8B3\nv6xgV624CAN4DCl6xZyZ+Dt4EQZwzPgN8CVOpB+AH23FmC5RB1O+O/OuDWkHhkUrLn1c/K2vV0S0\nzqdLe7rlsACvdZgPyJIek0rR6wOSw4+AaQozeLzpj7QMF+Cl935Qehigw+J6lYvhAly5wid3nWBu\n3NmKsxXcAR78zawA4+Bz46AhNJAOFYNxII+3GkID6RKMxsEoGDSEBtMlGI0DeHmjJTSYLsH5paUI\nSYS3hAbTBZjFQHvnEbWEpkivgetCEuptCg2D1/SHwE2h+QFYa0VbaBi8pseKX66v6a7n7isvU0to\nMP3zuv0PYgiJJTSYLnpMaBzpIvZ/dKHBdAm2hCSdRQdjOoANIQngptBAOoD3F/78nhPMvTtbcbaC\nO8CDv5kVYBx87m1gxcOR7DNQMRjHxuORFQ8Hss9IMBoH43hgxcOBm89IMBoH83hgxYmEz0hwfmlp\nwmLFwWcEuHjNcqF5YMXRZ2pgRVgYrMTRZ44Eg8/UwIqwcMVKHH1GgK1fUIx44TMSjMaR79m2bscL\nn5FgNI4NmEdWPB7H2iHBaBwZJ9bGLyw6GIxDAPPQikufgYoz4Ij1CeYu/tdW/NIHljF+EHEufDI4\nZkkfWJyjL7LpKbg2v/C9AAAAAElFTkSuQmCC\n",
-       "prompt_number": 7,
-       "text": [
-        "\u23a14  0  0\u23a4\n",
-        "\u23a2       \u23a5\n",
-        "\u23a20  4  0\u23a5\n",
-        "\u23a2       \u23a5\n",
-        "\u23a30  0  4\u23a6"
-       ]
-      }
-     ],
-     "prompt_number": 7
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "$$\\left[\\begin{array}{}1 & 1 & 1 & 0\\\\\\\\1 & 1 & 1 & 0\\\\\\\\0 & 0 & 0 & 1\\end{array}\\right]$$"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def matrix3():\n",
-      "    \"\"\"\n",
-      "    >>> matrix3()\n",
-      "    [1, 1, 1, 0]\n",
-      "    [1, 1, 1, 0]\n",
-      "    [0, 0, 0, 1]\n",
-      "    \"\"\"\n",
-      "    return diag(ones(2, 3), 1)\n",
-      "    # OR diag(ones(2, 3), ones(1, 1))"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 14
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "matrix3()"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\left[\\begin{matrix}1 & 1 & 1 & 0\\\\1 & 1 & 1 & 0\\\\0 & 0 & 0 & 1\\end{matrix}\\right]$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAHgAAABLCAMAAACMVLPjAAAAPFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAo1xBWAAAAE3RSTlMA\nMquZdlQQQOkwRLvvzWbdIols+ZZ2SgAAAeZJREFUaAXtmnFzwiAMxdOCzKmzOr7/dx20BElq2c0c\nqXejf1jOd81PHqX3lhUGPx8jKB3TwgMYvLHhOChx4Rppo4/gQYv54Fw5+Owe4pORQHbBV5OnyMDu\n7GtgkTydANyEZAJ24zhWwDLZTtFA+5VsJOAoVMAyeZp3zcnfFrIe2JtIHHzaPGrgm78vYKs84wye\n+QD6M94NrG014M11VV5jWLbTQX87LQ+Q+/wYCZNWu7kAprCD3eXpIxOMufgvk1ZhWYvyUyY7c7cj\nclczLjlNx9zqprCyeAeXbjQdd6ub2lsW71aXbjQdr6wWJPbwQ2tX90BP/2jrgZ7d2a8bknO1dsrM\n4N1y9W7gwuqP42deytcXMZaoXc0C/fdRdzv1QJ/WWJbYf7m6B3p6V+d91XqwCgKtgVi/g9GJ5udu\ndXOLEfAmVtPMjT8un2VyKFPkfTpj2kTPQBzIZCD9fQJmTXTk4Vkms/4+AbMmOgLxLJNDlTIZETDG\noo3/QMnkCjhH3xQEcabpLJNjka0Z58op+m6BX5LfG6xtNW+iM6uFcmWNeROdg1mP/Y9yDcya6Lyy\nTK6BWROdg4Xy9nYKnXvSRF+BZTLN++TJtSI1/KKDG5pLS/9Xq3d6AcXFF0KsDS8t6BzzCyjWwg/4\nWi0qKQH4LwAAAABJRU5ErkJggg==\n",
-       "prompt_number": 15,
-       "text": [
-        "\u23a11  1  1  0\u23a4\n",
-        "\u23a2          \u23a5\n",
-        "\u23a21  1  1  0\u23a5\n",
-        "\u23a2          \u23a5\n",
-        "\u23a30  0  0  1\u23a6"
-       ]
-      }
-     ],
-     "prompt_number": 15
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "$$\\left[\\begin{array}{}-1 & -1 & -1 & 0 & 0 & 0\\\\\\\\-1 & -1 & -1 & 0 & 0 & 0\\\\\\\\-1 & -1 & -1 & 0 & 0 & 0\\\\\\\\0 & 0 & 0 & 0 & 0 & 0\\\\\\\\0 & 0 & 0 & 0 & 0 & 0\\\\\\\\0 & 0 & 0 & 0 & 0 & 0\\end{array}\\right]$$"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def matrix4():\n",
-      "    \"\"\"\n",
-      "    >>> matrix4()\n",
-      "    [-1, -1, -1, 0, 0, 0]\n",
-      "    [-1, -1, -1, 0, 0, 0]\n",
-      "    [-1, -1, -1, 0, 0, 0]\n",
-      "    [ 0,  0,  0, 0, 0, 0]\n",
-      "    [ 0,  0,  0, 0, 0, 0]\n",
-      "    [ 0,  0,  0, 0, 0, 0]\n",
-      "    \"\"\"\n",
-      "    return diag(-ones(3, 3), zeros(3, 3))\n",
-      "    # OR diag(-ones(3, 3), 0, 0, 0)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 16
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "matrix4()"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\left[\\begin{matrix}-1 & -1 & -1 & 0 & 0 & 0\\\\-1 & -1 & -1 & 0 & 0 & 0\\\\-1 & -1 & -1 & 0 & 0 & 0\\\\0 & 0 & 0 & 0 & 0 & 0\\\\0 & 0 & 0 & 0 & 0 & 0\\\\0 & 0 & 0 & 0 & 0 & 0\\end{matrix}\\right]$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAOYAAACWCAMAAAD9lgRIAAAANlBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABHL6OuAAAAEXRSTlMAMquZdlQQ\nQN0iRM2772aJfKYutpMAAAUlSURBVHgB7V3blpswDHQuy5K9lv//2QKOTJBlDW7xOUFRXiDMoHg8\njiGzLg2nYX6dg8lXH9WFcBou1/H1ZlJl+Jm0nYdJ5smmwkXVD5D51S3cLXuVfI3ejWPsUjYAwGGF\n6zK7r6FKZiVfp/cfIXR9USeAwwrXZHbn87lGZiUf0K/9NHqun4UxBOCwxjWZ06fUyKzna+X7eeb/\nGG6yTgCHNf68MofLpO80FC4AAA5r/Gll3obfKPMqugngwPDnlzmrzaQmGTK8yIz4C8q8ffbLa5zN\nx5c2R4RKfh092WV70KY55CcbsPMBmmIKMDv9aQft/Yrwpl9QijA7/Xllxuv773yTIBgK4PvtAZ3+\nvDJDP14xu+/yzZ4Or09XZV4u38PnpTT68y6u5AN6d/m9nosqx1tzFV7jqsxcyFGPuMyjOie1292U\neuWox9zNozontdvdlHrlqMfczaM6J7UbuanlxVK9Sr5GX+XJ+WcB2ONo1mUgL2bs8VdTXXwN6Os8\nOfswAHscnfUYiLz+n68lahT2eBw9hfJy8LfktBEHM63W3YKZeuCZn6CUTwGmnDcDeJHpcfQUStuL\no9+H93w8xSPKqBJPqeRrdJqCCokbgFkc/Uf/o7zWDklnJV+jxz9QFvNmAHscLdijdbdA33GmDes8\nOf8wkFavT1cvKCAvzj66kg/oIG8GsMfRmT1mDqiD1ozK4DLteBncTUtmzm5216r1h0fUfxt/dvp6\n2iM6J7XZLyhzr2h5sdRtlXyNDvJmAHsczewBeTFjexyddQgd0H7Orpc30xlpC2BfHZ16atnRunth\nLXuVfIWeglg5bwbwktN6HP3P7uyYBSW7dk/d65Yvh6OtjvY4WpkjlpH9sFfJ1+ggbwawx9EPrtCu\n1t3EedxW8lU6yJsB7HH0oy+29v33piU/3U1383A98EKD1uPow43OQoNfaNC+7B8XUNTLhkYbOqgK\n4C1x9OpBF0yT8LYNHVQF8IaHdaCVx0xpGzqoCuAtq6NR1MtktqGDqgDeEkfTsr/CwmSmMq0C3JcO\nGgFg1ijpgpKyQzkJ5irb0EFVAG+Jo1MJOSItytyVDhoB4EVmeXU0KsF0tqGDqgCukmlr0GZxNH29\nCwuTmZvp274vHTQCwKxR4uroOFkXFyZzmW3ooCqAt8TR8dJLD7rgqrL3beigKoA3PawDRb1MaRs6\nqArgLXE0WnnMZLahg6oA9tXRzCRDb6WbPUPySIrLpJ6wsHU3LbhIGiY3s3taAu1sxXtaO/JIiX83\nqScsbGU3UdTLlLehg6oA9jiaTIq/5YqPbSYabdvQQVUAexxN7qQcZd98mcpTigOqAxqAmQZpCkrh\noK1kj/99M8ncNV8mMzdWBzQAV+W0tmTyJRapp+wM2vlf/PXsSfj09d43X6ZRu7E6oAE4TUFRw9v4\n0GL+3WRRLjWvuEXJMDtxIx3QAMw0SDMti3JZK/O38Uq9d3oNqgKYaRBlrqPcXBc/gpJhxt9IBzQA\nrzXIMlHUy9rdhg6qAtjjaGaSobfyoDUkMEpxmZYsdTfdzcP1gA/aw1mmNPil3URRL+u3NnRQFcAe\nR5NJKOol3n3bhg6qAtjj6GQS5SwgMCZ+GzqoCuCUBUUN0kxrMNlTZdrKaXmyl9x8EZl24mhp0Kav\nr504WpSJol6aYu/bNnRQFcAeRy8moah3Yc57beigKoA9jmYmGXorTkGG9N2luExLnrqb9twcptfZ\nkq5FSz+LG1dHd9f5Ff+jlwU3svcT1YW/C/V1CA+xeJ0AAAAASUVORK5CYII=\n",
-       "prompt_number": 17,
-       "text": [
-        "\u23a1-1  -1  -1  0  0  0\u23a4\n",
-        "\u23a2                   \u23a5\n",
-        "\u23a2-1  -1  -1  0  0  0\u23a5\n",
-        "\u23a2                   \u23a5\n",
-        "\u23a2-1  -1  -1  0  0  0\u23a5\n",
-        "\u23a2                   \u23a5\n",
-        "\u23a20   0   0   0  0  0\u23a5\n",
-        "\u23a2                   \u23a5\n",
-        "\u23a20   0   0   0  0  0\u23a5\n",
-        "\u23a2                   \u23a5\n",
-        "\u23a30   0   0   0  0  0\u23a6"
-       ]
-      }
-     ],
-     "prompt_number": 17
-    },
-    {
-     "cell_type": "heading",
-     "level": 2,
-     "metadata": {},
-     "source": [
-      "Advanced Methods"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Recall that if $f$ is an analytic function, then we can define $f(M)$ for any square matrix $M$ by \"plugging\" $M$ into the power series formula for $f(x)$. In other words, if $$f(x) = \\sum_{n=0}^\\infty a_n x^n,$$ then we define $f(M)$ by $$f(M) = \\sum_{n=0}^\\infty a_n M^n,$$ where $M^0$ is $I$, the identity matrix. "
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Furthermore, if $M$ is a diagonalizable matrix, that is, $M=PDP^{-1}$, where $D$ is diagonal, then $M^n = PD^nP^{-1}$ (because $M^n = \\left(PDP^{-1}\\right)\\left(PDP^{-1}\\right)\\cdots\\left(PDP^{-1}\\right)=PD\\left(P^{-1}P\\right)D\\left(P^{-1}P\\right)\\cdots DP^{-1} = PD^nP^{-1}$).\n",
-      "\n",
-      "But if \n",
-      "\n",
-      "$$ D = \\begin{bmatrix}\n",
-      "         d_1 & 0 & \\cdots & 0 \\\\\\\\\n",
-      "         0 & d_2 & \\cdots & 0 \\\\\\\\\n",
-      "         \\vdots & \\vdots & \\ddots & \\vdots \\\\\\\\\n",
-      "         0 & 0 & \\cdots & d_n\n",
-      "      \\end{bmatrix}\n",
-      "$$\n",
-      "\n",
-      "is a diagonal matrix, then \n",
-      "\n",
-      "$$ D^n = \\begin{bmatrix}\n",
-      "         d_1^n & 0 & \\cdots & 0 \\\\\\\\\n",
-      "         0 & d_2^n & \\cdots & 0 \\\\\\\\\n",
-      "         \\vdots & \\vdots & \\ddots & \\vdots \\\\\\\\\n",
-      "         0 & 0 & \\cdots & d_n^n\n",
-      "      \\end{bmatrix}\n",
-      "$$\n",
-      "\n",
-      "so that \n",
-      "\n",
-      "$$\n",
-      "\\sum_{n=0}^\\infty a_n M^n = \\sum_{n=0}^\\infty a_n PD^nP^{-1} = P\\cdot\\begin{bmatrix}\n",
-      "    \\sum_{n=0}^\\infty a_n d_1^n & 0 & \\cdots & 0 \\\\\\\\\n",
-      "         0 & \\sum_{n=0}^\\infty a_n d_2^n & \\cdots & 0 \\\\\\\\\n",
-      "         \\vdots & \\vdots & \\ddots & \\vdots \\\\\\\\\n",
-      "         0 & 0 & \\cdots & \\sum_{n=0}^\\infty a_n d_n^n\n",
-      "\\end{bmatrix}\\cdot P^{-1} = P\\cdot\\begin{bmatrix}\n",
-      "    f(d_1) & 0 & \\cdots & 0 \\\\\\\\\n",
-      "         0 & f(d_2) & \\cdots & 0 \\\\\\\\\n",
-      "         \\vdots & \\vdots & \\ddots & \\vdots \\\\\\\\\n",
-      "         0 & 0 & \\cdots & f(d_n)\n",
-      "\\end{bmatrix}\\cdot P^{-1}\n",
-      "$$"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Let's create some square matrices, which we will use throughout the exercises."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "x = symbols('x')\n",
-      "A = Matrix([[1, 1], [1, 0]])\n",
-      "M = Matrix([[3, 10, -30], [0, 3, 0], [0, 2, -3]])\n",
-      "N = Matrix([[-1, -2, 0, 2], [-1, -1, 2, 1], [0, 0, 2, 0], [-1, -2, 2, 2]])"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 18
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "First, verify that these matrices are indeed diagonalizable."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "print(A.is_diagonalizable())\n",
-      "print(M.is_diagonalizable())\n",
-      "print(N.is_diagonalizable())"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "True\n",
-        "True\n",
-        "True\n"
-       ]
-      }
-     ],
-     "prompt_number": 19
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Now, we want to write a function that computes $f(M)$, for diagonalizable matrix $M$ and analytic function $f$.\n",
-      "\n",
-      "However, there is one complication. We can use `diagonalize` to get `P` and `D`, but we need to apply the function to the diagonal of `D`. We might think that we could use `eigenvals` to get the eigenvalues of the matrix, since the diagonal values of `D` are just the eigenvalues of `M`, but the issue is that they could be in any order in `D`.\n",
-      "\n",
-      "Instead, we can use matrix slicing to get the diagonal values (or indeed, any value) of a matrix. There is not enough time in this tutorial (or room in this document) to discuss the full details of matrix slicing. For now, we just note that `M[i, j]` returns the element at position `i, j` (which is the `i + 1, j + 1`th element of the matrix, due to Python's 0-indexing). For example"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "M"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\left[\\begin{matrix}3 & 10 & -30\\\\0 & 3 & 0\\\\0 & 2 & -3\\end{matrix}\\right]$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAH0AAABLCAMAAABqfXinAAAAPFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAo1xBWAAAAE3RSTlMA\nMquZdlQQQOkwRIm7It3N72ZseWnCEwAAA2VJREFUaAXtmtmCoyAQRVGI3RPjkuH//3VYhOKylJrp\ncV70RUTqHinBVEFEp93RiyuP2UOF6LRU5nhcCRdvi+y1pXeXggn2Bno3juOL9cFrcLaD8ZY88cwk\nDJZAn6SRfmpFD5eVhpf29PkpxDAfxifCYAn0Udt+6zljhsuh73tPV66JWsKdvTMJoyXQHzzdMJSn\nz25+PPW0h93ukzBaAt215Twf6Nq+IjNa2SGykePJCaNlSV+4ee/7PunR09sjJDKpYIUzy4zejSx8\n63vUcA9B+kxpE84sM7qxV6sZz60j6/tx+ia8SxfrNqtqT5DRW56flpmO2BkjHOneEvo+uQn80u8a\n2NVtYz6MnXZDVCBhtEzpg3a9PkD38+ZxdMYlwmiZ0oV2n4+ZEd367r8ZY+uzhB03VySMlkBX1pNP\nP50KBVex0cVsZvqwHv7SJsJgCXTxkFIu7U+IlKtepH3EQY6qPwwXiTBYIr3e4X9Xe9NPvMEffQ23\n52/P/+iAOiR2j7ow6iDUb/iOEoNGg6K6rYqeh1C/UHEVSWJQb1DWtlWBjqF+KWNrKDGo3y9rGVWg\nY6hf6tgaSgzq98taRhXoIehq/8Jv2mzGkfMZ1ZSeBZy5SnLNB/1JQ1PkVKt0PkzfyzgQTvSK6gd0\no85mHH9LbyUJpMtlHNTKlfY8//X9y1uE8cElCZQYZJTmJaP6+ztZt8FQvyqXJAbV+5VKRjV97wJD\n/YqQqaLEoH6/rGVUgX4kSUgSgxJUr4EEApogHUJ9aEcXOxkHNYyltirSo8FFhZseoouLHB4xt+dv\nz8fBcFnhHnVh1LXjfnoZk1lYesX1R6rfL5V5CHq+HfdH7ckuYatza+PeuJKHAJ2J+yO9d1sjs9nO\nOXtU8hCgM3F/RK2rxff6vO8reQjQQwTGZROLW8uVH9BdBzAPSelc9Bn77gszs4qeNcVLzEOq9Erc\njxodt5aLTdOrIg/5jL68UtEzZcxDqvS9bEIegjc3KOhpU7oIo47LJoyp4natSDovVfIQoDNxfyL1\nsJtx09GNwGhYy0OAzsT9UUR0bifwfZpey0OAfiSbmGazTz3Kw5si9NiVPATp7bg/imz/GfiAnmxQ\nBDWkh9qrzjc9RBdXeTxwbs//z3/7DPaPN0qdj1bC6/vk7P7to5T4A0fbMY3IGYrVAAAAAElFTkSu\nQmCC\n",
-       "prompt_number": 20,
-       "text": [
-        "\u23a13  10  -30\u23a4\n",
-        "\u23a2          \u23a5\n",
-        "\u23a20  3    0 \u23a5\n",
-        "\u23a2          \u23a5\n",
-        "\u23a30  2   -3 \u23a6"
-       ]
-      }
-     ],
-     "prompt_number": 20
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "M[0, 1]"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$10$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAABMAAAAPBAMAAAD0aukfAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAuxCrdpnvzWYy3UQi\nVIln4VgtAAAAaklEQVQIHWNgYBBiYGAKcZ3AwMCg+ImBgWsD00oGBmVjINOLgcEdKMoCZC5mYNh/\nAML8ysAw/wKYyfMPyHRAMB9gZUIUMIC0NUBMABp2/wCECbTiFQOEyXWBKZOBgTXsewQDU5wzyDlw\nAACa6iZBpbQ2vwAAAABJRU5ErkJggg==\n",
-       "prompt_number": 21,
-       "text": [
-        "10"
-       ]
-      }
-     ],
-     "prompt_number": 21
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "That should be enough information to write the following function."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def matrix_func(M, func):\n",
-      "    \"\"\"\n",
-      "    Computes M at func. Assumes that M is square diagonalizable.\n",
-      "\n",
-      "    >>> matrix_func(M, exp)\n",
-      "    [exp(3), -5*exp(-3)/3 + 5*exp(3)/3, -5*exp(3) + 5*exp(-3)]\n",
-      "    [     0,                    exp(3),                     0]\n",
-      "    [     0,     -exp(-3)/3 + exp(3)/3,               exp(-3)]\n",
-      "\n",
-      "    Note that for the function exp, we can also just use M.exp()\n",
-      "\n",
-      "    >>> matrix_func(M, exp) == M.exp()\n",
-      "    True\n",
-      "\n",
-      "    But for other functions, we have to do it this way.\n",
-      "\n",
-      "    >>> M.sin()\n",
-      "    Traceback (most recent call last):\n",
-      "    ...\n",
-      "    AttributeError: Matrix has no attribute sin.\n",
-      "    >>> matrix_func(N, sin)\n",
-      "    [-sin(1), -2*sin(1),      0, 2*sin(1)]\n",
-      "    [-sin(1),   -sin(1), sin(2),   sin(1)]\n",
-      "    [      0,         0, sin(2),        0]\n",
-      "    [-sin(1), -2*sin(1), sin(2), 2*sin(1)]\n",
-      "    \n",
-      "    Note that we could also use this to compute the series expansion of a matrix, \n",
-      "    if we know the closed form of that expansion. For example, suppose we wanted to compute\n",
-      "    \n",
-      "    I + M + M**2 + M**3 + \u2026\n",
-      "\n",
-      "    The series\n",
-      "\n",
-      "    1 + x + x**2 + x**3 + \u2026\n",
-      "\n",
-      "    is equal to the function 1/(1 - x).\n",
-      "\n",
-      "    >>> matrix_func(M, Lambda(x, 1/(1 - x))) # Note, Lambda works just like lambda, but is symbolic\n",
-      "    [-1/2, -5/4, 15/4]\n",
-      "    [   0, -1/2,    0]\n",
-      "    [   0, -1/4,  1/4]\n",
-      "    \"\"\"\n",
-      "    P, D = M.diagonalize()\n",
-      "    diags = [func(D[i, i]) for i in range(M.shape[0])]\n",
-      "    return P*diag(*diags)*P**-1"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 22
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "matrix_func(M, exp)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\left[\\begin{matrix}e^{3} & - \\frac{5}{3 e^{3}} + \\frac{5 e^{3}}{3} & - 5 e^{3} + \\frac{5}{e^{3}}\\\\0 & e^{3} & 0\\\\0 & - \\frac{1}{3 e^{3}} + \\frac{e^{3}}{3} & e^{-3}\\end{matrix}\\right]$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAQwAAABTBAMAAACYDSQ2AAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAMquZdlQQ3SJEie9m\nzbtvuCKIAAAGk0lEQVRoBe1aTYgcRRR+s7Pb2zP7N6AgeNkVg6inNSwii5Fht/0LKHMQPIg4ZCMJ\nWWFHQTR4SJ9EhLADCaigOCRBIRBILoKguIe9iAdXBYPgQBDMwYNsjIFdEcaq7n7Vr2peVfXuDDlI\n+rD96ns/9XVPd1e99xZgGMfZpfYwwgwa45dKa9AQw/CPq51hhJExggvnmrZYlcdeq3O6M+9uJnDp\nEqclGBscvaXdbK/3V2Jf3ihvEUdNrGQ2GigGn/bmUqhidU31bPDM+1Svtw2zC9GTienI/OR26tP/\nt/Jt3A8K5OMPU7gDO6xegWzwzHszWhI0asq2ar2kSlsZacJH6Si4HFqvAO2Z4Jk3gLh+QmPVMhlA\nZWG5ifHo+Uz0qHimIthcqlGYk5ng0js5NBpH/+DcEyyMx7Y45XvwMpxuHuFUCfZr8/1GquSCS+/k\n0GhA+VqKcn+DGxwKsFb7LXqKVwn0m94/qGODr6U3UacR3kIf8zxVg12CHUf5B5hpW/glJj89rH4s\nDB7E6AzSOxlQGuvt8F9lYQgTtZC+Ci+g+gqsxzsQ4LDvPIdIHnysjhhI72RAaRyLJ79QFoZQbY7O\nEUjR+AyW4HdYISpdVE55cEJDeicH0ggXl+NSdC5OUebvxUUKKhrV8x044ng2DkQPAejBCQ3pnRxI\n48U4nKfzeGRFw2MH12GtDXpwQkN5ZzTCXSirZ0kp7UJhGgAjl43gDhojX20+Y056+i15nATokWM7\ntUIaM0TVIwHCq4mzfA2qN4zgSAN9ZcjsbszMkxg2sSJ/Z3Ec6nbf6XZ/tJlRfLoF1V0avNztXv26\n251Do2y7hDTqiDNnXKOn2h+gFu9GMj5x+AHEzfNEC8o7M3UNxruRgNl2KaMxISx1Y+KJa3QIFxHV\naDwOhxA3z2WAqS0juEYj2y5lNEa3YCU2Y+BYrdH3biGk0bgfvkfcPIvX76XYCK7RyLZLGQ04H9XN\nEGSMa/QniGk0AOxbr7sOPghGcI0GVJJLQxoYnz+LNfpEVK/CTJzpdRrBl7wbjyoacoOQbZcK0RBr\ndPhzMLcK6xj4LAryHDzfoUOfXKlnFmKDgNulQjTEBmD6QNScjO6zTPGEBXfDcoOQbZeK0QhvzdRc\nIdcbLq1NRzYIRWjINVo8FU1LOPGtXt+w6Jww2SAUoSHX6OlGMG+JGbwN3zUtOidMNghFaMgNQCCe\nDYyJX1Uc331YvJT7OMgGoQgNcwb8qpr4AOP90FBf1QHmNVz3Q0Ms3smnzwg1yHB/NMRXdbhHTmMl\neqRoaC7zKeAbLCzXLGY5jZNwzGbU58tmPn1WJjDeDl43sWysaIy2QCzIBQ/MfAqaZ2ZPAzxn8VA0\nxuegQhMii72E88zHYcSo3hDlkJjBBaRoiA1jyZo66r555qPjvtFNUdJp8EaKxnoHSn/zNhTVMx+q\n8cqhSKpn67yZRkMl37ytRPXMx27HaBIaHUYhoD3SMDIfPqYF9dB4tSn9iv0oRuZjmZCHXT9K2IB7\nYukmH1FrWUHFpZmPAosK8hHd4I3HWlntS7ywY/4X1sh8+Jg2VLywr8S8Uj0b4vNVbfE2BDUyH6Ip\nIIrP1+cWM0UD3oRV/8fcyHwsQS3weCO4YlHlNFYu2Pbd1NWdVlHLfjlYXLJdaE6j3+02Indo0Jt9\n5278b+/GwA2/4TwbAzf8hkNj4IbfHmiUrtGHSpO9DT/NmhkUp1E66Fj50goWE78fYsuXxWmA2BPY\nDm/Djziy5cuh0MAKFpnMLrLly8FpFGz4EV5M+TKn4c1hLT+Kq+FH5s5FrnyZ0/DmsBYaroZfPncu\nseVLRcOfw+o0jmNgUs9DyHNmypeKhj+H1WmoOjGp57mnH/tTHNeFDVO+VDT8OayFBqnnuWmkWr58\nqWh406Xw0s06mUfdDVLPI2pDlKlvCvHlS41GgRxWhVc0FOISSOrLli9vDw1v6qvRMAsLqunHXOie\n7oY39VU0nDks7S9uC06k6Uf7hwzbFPKmvopGoRzW1vSzzp8pvKmvouHMYbFKzjf92KVbY+ZNfRUN\nZw6rquRs049dujUa3tQ3p+HKYfMqOdf0Y5dujYbR9NN1cpTT6NdRJK2S25p+zNJNnf1yURpp79HS\n9OOWbv/U1KIgjaz3yDf92KWbTuKXJQ38LziXddp7tFkwS7fNlMNPyf+COxpFz3JKDXP3HpmlW/P2\nDDajqO4xSdTO3iO/dBcJu1cbZ++RX7r3OkURe7P3qPuwS7du4h/9BxacEqsH+c5jAAAAAElFTkSu\nQmCC\n",
-       "prompt_number": 23,
-       "text": [
-        "\u23a1         -3      3                \u23a4\n",
-        "\u23a2 3    5\u22c5\u212f     5\u22c5\u212f        3      -3\u23a5\n",
-        "\u23a2\u212f   - \u2500\u2500\u2500\u2500\u2500 + \u2500\u2500\u2500\u2500  - 5\u22c5\u212f  + 5\u22c5\u212f  \u23a5\n",
-        "\u23a2        3      3                  \u23a5\n",
-        "\u23a2                                  \u23a5\n",
-        "\u23a2           3                      \u23a5\n",
-        "\u23a20         \u212f               0       \u23a5\n",
-        "\u23a2                                  \u23a5\n",
-        "\u23a2         -3    3                  \u23a5\n",
-        "\u23a2        \u212f     \u212f           -3      \u23a5\n",
-        "\u23a20     - \u2500\u2500\u2500 + \u2500\u2500         \u212f        \u23a5\n",
-        "\u23a3         3    3                   \u23a6"
-       ]
-      }
-     ],
-     "prompt_number": 23
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "matrix_func(M, Lambda(x, 1/(1 - x)))"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\left[\\begin{matrix}- \\frac{1}{2} & - \\frac{5}{4} & \\frac{15}{4}\\\\0 & - \\frac{1}{2} & 0\\\\0 & - \\frac{1}{4} & \\frac{1}{4}\\end{matrix}\\right]$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAIoAAABNCAMAAABOtAxaAAAASFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACC\ngUnDAAAAF3RSTlMAMquZdlQQQOkwRCLN3buJ72bF9dPzbCjqGKgAAAPSSURBVGgF7ZrrkqQgDIXF\n285q27Z74/3fdEGURnIkwcWqnarxx4ziSfJ1VCBiVaU29UydBeeGZuyXFpwImpxTifJtpJp6eh+J\n9gatdZ1U7k6BUhnjU/suG2UZxiSJOemcDl45OYKqUrppzdZBB/koA/RzaNxQvHKx8WttUdRBeDjI\nRzG/q+kPPsjBhnJULsVRRnN5ugeJfmhwKJGyPIqN2afybM6/Ux0oy6M87NXW/jawZGRzKJGyPMrL\noIw6/RA5lEhZHmU2t2yb7li2CxQpGZRxfpgnnSQ42TDPzZwUeKdHJYOSdFn45P+KMj6m95Z+BraM\n5FucpzKdFTc0mL/nDuIzvIlX7DubizRKHOfWYw5lbp41M6AAPqbf3ywiFYNix7UmMgGho6ZOS+hj\nFYMymV5zZAaUiMOMQLMEhagYlJeZxPTMgEJQ2l6CQlQMig0TJ5KEjhpUJ0GhKgHKI92NRyBVNZs8\n8vcKVfEoMzO0xSjLKEEBKhZlycxJbwZPPitIxaEMhkQlpr5xTqquMZtuFnLi0IBUDIp6dl2X28ep\nH4J7xXYSxzuKQXmt48ThB3EHqnn81DWuZELbpY5UDEpoK95/T6LFJlb4hYLSdZKV3hZuOQ9O6Fty\ngUCAE5TJzOH66SKLBAUEwCjt+vqgzZ4duNwIUFAAjDKtnf3AFFbhRQn3BSgoAEbRjXWtNN87hAj7\nvgAFBYAoo14HHqUzi7GVxRdcOxn4DwOkUTKHQhAUN3mUMMCnQWEv0MWSzGclDGCz8u3je5TH/a5i\nhvrIaj3c66x0FYcC/PlA7+Lcs9ZdfJgRYdSGAsB7pXI90Jz7ntTFk1RxKABGqSZbdNi3QvmbrIoD\nAU5Q+mZu60sklayKAwFOUPKT4S0uVXHWujyK9ZpbxVmbm1Byq7j7UHKruJXklqzkVnGO5A6U7Cru\nNhT1bH9Jqjiy/Fb+CfotquL2lbItI/ZfeZRwXSMIRHbJXO8LxeRImhVQMZEMnzaQIFBJVCcXCFRM\n0B9sJEFkKoyCKiboDzYWRUEVE4wKG4ui7FPP20oy8xMIMLxAcEIOEwAaJSWZeftFl9/SKGHFBKKW\nbfo0KGHFBFNwsSSDvmBWqv22va8k2yu3AAqjoIopMLpnF6Ogiiknvux1VaTCKP9Skhlk2YQ/Vp2g\ngIpJnhWy/gVNieoEBRpLG8n6FzQkqhtQ6PoXQqGqG1Do+hdCoaryKGD9C6AAVXEUtP5FUZCqOApa\n/6IoSOVQ1m44c7mS+vct8fqXP3HYCVT+E73efiDXtqKvRA7OTg7I+hfUhar1E722rf4C5lA6Shcb\nFUoAAAAASUVORK5CYII=\n",
-       "prompt_number": 24,
-       "text": [
-        "\u23a1-1/2  -5/4  15/4\u23a4\n",
-        "\u23a2                \u23a5\n",
-        "\u23a2 0    -1/2   0  \u23a5\n",
-        "\u23a2                \u23a5\n",
-        "\u23a3 0    -1/4  1/4 \u23a6"
-       ]
-      }
-     ],
-     "prompt_number": 24
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Now lets investigate how this works in relation to the series expansion definition. Write a function that uses `matrix_func` and `series` to compute the approximation of a matrix evaluated at a function up to $O(M^n)$."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def matrix_func_series(M, func, n):\n",
-      "    \"\"\"\n",
-      "    Computes the approximation of the func(M) using the series definition up to O(M**n).\n",
-      "\n",
-      "    >>> matrix_func_series(M, exp, 10)\n",
-      "    [22471/1120,  14953/448, -44859/448]\n",
-      "    [         0, 22471/1120,          0]\n",
-      "    [         0, 14953/2240,    83/2240]\n",
-      "    >>> matrix_func_series(M, exp, 10).evalf()\n",
-      "    [20.0633928571429, 33.3772321428571,  -100.131696428571]\n",
-      "    [               0, 20.0633928571429,                  0]\n",
-      "    [               0, 6.67544642857143, 0.0370535714285714]\n",
-      "    >>> matrix_func(M, exp).evalf()\n",
-      "    [20.0855369231877, 33.3929164246997,  -100.178749274099]\n",
-      "    [               0, 20.0855369231877,                  0]\n",
-      "    [               0, 6.67858328493993, 0.0497870683678639]\n",
-      "\n",
-      "    It's pretty close. Basically what we might expect for those values up to O(x**10).\n",
-      "\n",
-      "    >>> matrix_func_series(N, sin, 3)\n",
-      "    [-1, -2, 0, 2]\n",
-      "    [-1, -1, 2, 1]\n",
-      "    [ 0,  0, 2, 0]\n",
-      "    [-1, -2, 2, 2]\n",
-      "    >>> matrix_func(N, sin).evalf()\n",
-      "    [-0.841470984807897,  -1.68294196961579,                 0,  1.68294196961579]\n",
-      "    [-0.841470984807897, -0.841470984807897, 0.909297426825682, 0.841470984807897]\n",
-      "    [                 0,                  0, 0.909297426825682,                 0]\n",
-      "    [-0.841470984807897,  -1.68294196961579, 0.909297426825682,  1.68294196961579]\n",
-      "\n",
-      "    It's not as close, because we used O(x**3), but clearly still the same thing.\n",
-      "\n",
-      "    >>> matrix_func_series(M, Lambda(x, 1/(1 - x)), 10)\n",
-      "    [29524, 73810, -221430]\n",
-      "    [    0, 29524,       0]\n",
-      "    [    0, 14762,  -14762]\n",
-      "    >>> matrix_func(M, Lambda(x, 1/(1 - x)))\n",
-      "    [-1/2, -5/4, 15/4]\n",
-      "    [   0, -1/2,    0]\n",
-      "    [   0, -1/4,  1/4]\n",
-      "\n",
-      "    Woah! That one's not close at all. What is happening here?  Let's try more terms\n",
-      "\n",
-      "    >>> matrix_func_series(M, Lambda(x, 1/(1 - x)), 100)\n",
-      "    [257688760366005665518230564882810636351053761000, 644221900915014163795576412207026590877634402500, -1932665702745042491386729236621079772632903207500]\n",
-      "    [                                               0, 257688760366005665518230564882810636351053761000,                                                  0]\n",
-      "    [                                               0, 128844380183002832759115282441405318175526880500,  -128844380183002832759115282441405318175526880500]\n",
-      "    \n",
-      "    It just keeps getting bigger. In fact, the series diverges. Recall that \n",
-      "    1/(1 - x) = 1 + x + x**2 + x**3 + \u2026 *only if* |x| < 1.  But the eigenvalues \n",
-      "    of M are bigger than 1 in absolute value.\n",
-      "    \n",
-      "    >>> M.eigenvals()\n",
-      "    {3: 2, -3: 1}\n",
-      "\n",
-      "    In fact, 1/(1 - M) is mathematically defined via the analytic continuation \n",
-      "    of the series expansion 1 + x + x**2 + \u2026, which is just 1/(1 - x).  This is\n",
-      "    well-defined as long as none of the eigenvalues of M are equal to 1.  Let's\n",
-      "    try it on N.\n",
-      "\n",
-      "    >>> matrix_func(N, Lambda(x, 1/(1 - x)))\n",
-      "    [nan, -oo, nan,  oo]\n",
-      "    [nan, nan, nan, nan]\n",
-      "    [nan, nan, nan, nan]\n",
-      "    [nan, -oo, nan,  oo]\n",
-      "    \n",
-      "    That didn't work. What are the eigenvalues of N?\n",
-      "\n",
-      "    >>> N.eigenvals()\n",
-      "    {1: 1, 2: 1, -1: 1, 0: 1}\n",
-      "\n",
-      "    Ah, the first one is 1, so we cannot define 1/(1 - N). \n",
-      "    \"\"\"\n",
-      "    x = Dummy('x') # This works even if func already contains Symbol('x')\n",
-      "    series_func = Lambda(x, func(x).series(x, 0, n).removeO())\n",
-      "    return matrix_func(M, series_func)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 26
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "matrix_func_series(M, exp, 10)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\left[\\begin{matrix}\\frac{22471}{1120} & \\frac{14953}{448} & - \\frac{44859}{448}\\\\0 & \\frac{22471}{1120} & 0\\\\0 & \\frac{14953}{2240} & \\frac{83}{2240}\\end{matrix}\\right]$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAANQAAABNCAMAAADpabqhAAAAaVBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC2drKKAAAAInRSTlMAMquZdlQQQOkwRIm7\nzd0i72bFIMexbJGvyfeD38FQ4ddwAnQUMwAAB2JJREFUeAHtW4uWozYMNWDoLCQhtJ3tbt/l/z+y\nkuwLhhgsk8dOz9bnzAgc+0oXG2wJYUxQuupUNnQOSYdnPq0bKtyuOPH/3TI34a7Gdl1Foq36ZrDG\nNJ3tRMUuxs2PAkW1Igdrq36GhIqbTq6iIsMr6gdJtfVIdeXI5WSKqrxsdEV10ES6WmI00F9LACU1\nqganAu11UqCoqYMkQg1dXEBCRQhViMWi8ULN+7EwkHxhhVRL5cRDVadIzU1cV0IzDWG0Q0vgdH2Y\n5BjqVxw7KFgjhtClByRUENDFcaEZNVaWSk11V/rXjO0kafKwQYZ/q1vWnkFKuhYjUxlr00p3hqDZ\njMnkTtP/nRWwprwUpqdR95CTCsKhiWltSdesYKZzWYx0UQsp+rWn+4GKnpTr2jtSA91TdCPwWNNl\nuwYEpSbxD1Z42V/HiqE85KQCKDwRVqTOnftRZCdThyvoynDRk/JdmUA/WtPTiNU8Qo09eQ0CqPkH\nKyDteaTBmiChAlC3pDpvvcihB6kilxS61nRH25GeDlQaPyeq9CMUBrIEFGRVm+LCdwUVhgxVcN0N\nqcFfRZENP4Jd78rXa0dq7tpayxPkzHOcblcuPd1j+gKoScodeR5mSK8CkGtSLdlekHon64rKyA9h\nc3HXWj39pq58QVsy48rzZex75tX7kYMV+xJQkL2Msx0AaaACMCtSxamu67KhJdZJata7kYIZ2pFi\nBdL1TKN9IkIdqbalaXi1GK5u7sCKtPRWeEh+oJKVHtJABWBWpK7ymKfL6iXpL8dSHvYycfruTM9/\ndI7KuYnrWtOGgmeeIclTuLC0o2CrcgqscLKpuq5jCA85qfCQK1I5ij5u2/9JvWZs+vNlLu5pmal4\nOVJu46T5v6lG09m12YRY/5ANuSS1hvuPnkdJwSHyEr5V1/EeP6dg3yrSO0E5/SNtNZARUnCIIOFb\nWXogt36zFNEWqVpsjS09g9kJuq+oICOk5k2rW2jhW/EW0riVWGdY3AnS9d1opYNUkPI+ltsDXjI2\nbXEnaMNcXbUOUkGK1dGoFzJIl/3tRGjahhMUNsk9VkIqSZFv1eaSgvMD6Z2gXCJhe0BBbkDqSLFv\nlTtScH4gQycoNDTjGFCQW5AqUs63Er+cbzBVmZwf75I18iwmJ+h4UUNqSHkfix0iI8w0dsH5gZyc\nIE3neBtAQW5CKkjBt5J1SrHQTGt19eP4k5gnztDbZwqHvrMfhbU9bvp+bdSvWneJkIJDBHmVvRd1\npOCTDwetUcJzrNVVQ86PzNbh5/G9Nu8Co4qHhnDL4w2/atnoNkax+j3/dFqraQfBcVHaR+THQ/PV\nhj0iIxX+fOD4IfHQA3qDLo8nxeCLHRpWTBo4t3IrwhyBhQcOE6QaDqtKhCEL++546IY2pTkJUhfy\nPBvZyW6oiVbfHw+NwlKcTmfOPikrrzgsfJgNVevqB8RD15DuXGvOPqmLuE+tesUV3Y+Ih8ZJac3Z\nJzWKp1tkBYmxVkOSfX7FzIiHxklpzdkl1Y8SQC/onYW+YK2GPBAP3VCmNkdHSrhtqHpd9UQqZc53\nTCpn+j1v5KaRSpnDI/XD26cNS3BnZnhB2ZHHDdWxaq05n9/Yp93aM7hnaJ33SI+Z85g6rTm795Rx\nq12XzjK4MRo+093x0BBZa84+KcMRsUZc3hA8eYw4KCR8rPx46FKV0pwEKXq9ZcutyblUuDzDTvzO\neOgS1CjNSZBagepPl6QOx0P1CsOWryHFGo/EQ0NLM45fR+pIPDSDSNj0ZaSOxENDQ3OOX0XqSDw0\nh8ei7YtIHYqHLgzNOXkGKV5w3dPvzJIyM79Qrslvv39qvvxhzJ9/HcrMJA/GpWMqMjsfT4oXXB8H\nrcdfzuPXr8b86neEJcVD//7nSGYmhVL9m0hFZufjSWGUEMTkjSW/sEMaZXkkM5MmH9IxFf2fSeqB\nmZlECumYfHMlMjufSMoFMae0yXsyM5kI0jHpMJXZmSCljB6y0rn4LZJ/3Ye0yXsyMwUbrw3TmZ0J\nUsro4UyIjxwpvO4L0yYPZmYKfPjaMJHZuU9KGz2MkMJrP8q9uDczU9AXbyITmZ37pLTRwwgpvO6b\n0iaPZ2YKOl4bajI790khKKB90evI+XvKBzGRNnlfZiZ9D8FZi2WjyezcJaUO34QjhReQCGJOaZP3\nZGaSAqRjKjI7daRS0cOQ1Ac4/o5JpaKHH2B0QhN2R8rgQfHtgpnp2GjIxh/vk9JGDyPA37Jqn5Q2\nenjDYE4QcR/OUQN5HZmf3Dl9cwdIBdQ+qaPBTAQvIckQeWF/IJgJCEgNVIKUMnpImhZlK0EkO7mT\n3l37HBNIuGl7UAlSC1P1JxsJIvnJnZvf3u1CPYcU048kiOSmDOIq5kI9j1QkQSQ7udOzyoV6GqlY\ngsjBkcqGehapaIJIk5fc6ccpH+pJpDYSRPKSOx2pA1COlGxGsj4OwD0cl0gMgaRWkiCiTe4MUAEB\nmYCaPl5u+INfaw991ROoDw6RGAIJ30qZ3BkgTd/cKaHk42Vrzb/tkKu7lZIW/wAAAABJRU5ErkJg\ngg==\n",
-       "prompt_number": 27,
-       "text": [
-        "\u23a122471  14953  -44859 \u23a4\n",
-        "\u23a2\u2500\u2500\u2500\u2500\u2500  \u2500\u2500\u2500\u2500\u2500  \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u23a5\n",
-        "\u23a2 1120   448     448  \u23a5\n",
-        "\u23a2                     \u23a5\n",
-        "\u23a2       22471         \u23a5\n",
-        "\u23a2  0    \u2500\u2500\u2500\u2500\u2500     0   \u23a5\n",
-        "\u23a2        1120         \u23a5\n",
-        "\u23a2                     \u23a5\n",
-        "\u23a2       14953    83   \u23a5\n",
-        "\u23a2  0    \u2500\u2500\u2500\u2500\u2500   \u2500\u2500\u2500\u2500  \u23a5\n",
-        "\u23a3        2240   2240  \u23a6"
-       ]
-      }
-     ],
-     "prompt_number": 27
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "matrix_func_series(M, exp, 10).evalf()"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\left[\\begin{matrix}20.0633928571429 & 33.3772321428571 & -100.131696428571\\\\0 & 20.0633928571429 & 0\\\\0 & 6.67544642857143 & 0.0370535714285714\\end{matrix}\\right]$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAjIAAABMBAMAAACFVUDyAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAMquZdlQQ3SJEzbvv\niWYEN0CTAAAOFklEQVR4Ae1cbYhc1Rl+d3dmdrK7M1lUEAqScRVrqSVr1lIwRqdxq1TSZlrpn9KS\nQS2WmrBrS78QzVih7Q/bDEX6d1PtBySi+0elYMm2UG1R6jSxCi1DBgxF+qMbNZtNtMn0eZ/3nHvn\nzszdnTuIUHsP8Zx7znvO+57zzLnnzt5nHmVbu/22pCmKwMF2+7Rsu2H+M9HmtCan5ncDmekUiT4I\nFFNk+qCiTQ6Z/NzRuuRuuJXbx8oDu/4qckXzGZfdtetKEevWPFERear6k8rIt5rNpshkVT2NlJz5\nquPRTRj6QC+tcJiNfeTG32Jk8x8VGyvyLPqIXCJCS05DTfwz/ze5fFez2fCh2Cea6Rzunr/eZWrT\nFno2p1wOF5E70dQJIsZGy/HI/EAyazJez92vPlnm75ePSn5WlsqW/VEerQm7jYncLPJK+4IU23p4\n545hDhi1bOZHK/k/ad2n0AdaWOEwZvmS7K3II7LljI2V+85y2ANiFoaaarcbsopQJR/Kuw5LzuH7\ncu+0MIOBLfRMp7YcLuJH06OL6PCAbLgcj8w1IgfldpE7NBjL8YYckcKabF1kNrkio8vCbv8WuVfk\niU9MS6EqUsrNbEchsseZnxf5uNZ9Cn2gxSpVDOPY0aqMn5aTFVk313fNEJnMS2IWhprYgc37msio\n+FDedVDSkFmUzGFmaLeu9EynXI4t4kGZOCyCGBsuxyPzclW2178pslSDV5arVVxlFRlmWw9L4ayw\n23EiU4K5gH/YmHu1a/5fy2Z+V+SkNvgU+kALKxzGbOoFGT0v+xQZupYMkfnpUTELQ42qJ9xJwMdC\nab07YQ7jJdlyjhmNOit6plMuh4so2rZEjI2WE5wzT1fllvo7Itsq8MrySRd7qYyLpfLCsmTOC7vt\nu0ZexYdu9sdQ7K0iK0ws0/zz99BQN6PPnQ+rsqLD5DGZOCtj53GFu4muHTKNo87CUEQGfcroyFAo\nexIMW2dlZI0ZrdYVnun0SW3jIiZWaEaMjZYTIIPOB79+AciU8emzfPeyWxUledwyhfuiXh6sTrZP\n4RO8ev5jqOWWkXEObwIZmnXPtPQyTM6HNWiFw5jJuH6EEyW1HawaMsUaZo2D66ww1Oj87jqq92mb\nLVevuhIMhxoycoYZbdZVPetG5HK4iK2/mP8k1m0xYpfTgczIBSKCNbN8bb0lD+Fw/zs8aza2IpOA\nX0YA2y3rNT3vFzDfsQradA65MpGB+SaRY2W0BinwoS2s2DCOlW2IeAWhU9e8m+4RIqMWDTVZzem+\nwnI2R+aCIgM/vis9w2luXZfDRSw8JOMtcTHiloPxRf99ZmI5ikzbHRd76ui1p557Su5UZLD+4vVP\nr+FKRlewP/VCkSmoheZvtLK3lHHZkZwPa9EKhzEzEDJ/hk0dEJmGNQIeH+o6QH9ah9tGMEeRHAaC\n0oWMqGdFhsvhIhZO64npYsQtB74DZHa6u8jtmdvWRVYr6DClux1Zcf4yxWOnyBt4WldxWXjLPct0\nul8wZGCWU5/GkziSvA82auUOvWI2BjiQXqnSNZHJThMZtfhQJ6fx2NF+Xcjkf/NdTXUaFJSeu0k9\nc89wObqIhUUprrkYsctBKI9MpmQnbwttegK3cFyslvPTMnmRGZqBtGi3F0QOtSYXpYA9jscYZ5Vr\n2EcOM1Lk2RTx4XxxGLPd6P4w7r8WXROZA0Jk1MJQz8FhXZ88SF3IaJMlGPTwvciMTdrVedZzRpeD\n9sJZHDbFMy5G3HLUgUfmTsnXMNV9NbSxxHxWKws4BC8yQ/PEYRF0++EKjpfy1KKMnZMcQOR0szMz\n2/9QVnMNDUfwX5AiPswXhzHLzsqPc9iBQIZj9W764szMf64WWlY01Is4bmqyMKsedbl9EwzALqtP\n7ew59kCL86xOuRy0TxzGZ1pcsxixy1EHDpmRWZzW+Ib3uuT4Te912acfPfAdP8csc04O1YXd8A13\ntIZvp0Bqi0cGnqaWzby3ltcDM0ihD8Hnqg5tGMdeKvKmfp4Ha3TNPYORL4nQwlCA5Ai+OGyKDL7k\nFRaZIZCBSM90yuVwEVmeM4yx0XI8Mj9qNj8l45Xc7wW3IcvJRu4vkmnJUsOy78gvRdjty1X5quRn\n5Ss1yUaRofn26kQZEwtS6CO3bg5tmI7NP9g8sSifly0XzHWIjFkY6hHJAqF9myIj35b908wQyJCh\nZzq15XARv5P9LdiB/kbL8cjgRc265Hbtnpb9y1bKjh11kTvnfuWyEzsr+Gi125ar5nB56Y5r8QzW\nrzhzrzyBSIXt77RoLsw9g8aOFPjIYTKscJhm4/hraFGyczdWzPXYTe/ejJHH2zebhaFG5mZqevLB\nYKFw0Z1ouPvVK/EXJTINxBZ6NqdcDhcxdpV+E0OMjZYT3E3dkdK63zMpEj0IuBO4pz1tSJGJ2wMp\nMikycQjEtad7JkUmDoG49nTPpMjEIRDXnu6Z9wUZT9XFOevfTk6NLBnsLMmFhQRdTrm7/qyYMXMj\nJUfUkUnrH2WzVj+BzfoF9kR7xlN1wehBLvIlZds8QcZSubB8QPIJubu+JJ9j5jzJlyeTNkjQ3j5+\nAr2WmJZEyJCii3EU2zyKd0qnPUFmpXJhHQTd88rdXYO/5KWL5BPHzO1xJN8k6cDYSBsZ/AQ26hO1\nJUIGL/uWatHxm9fIqeFV2xZ91caSXFgHQYf3SyerLysXeLyb5NPXcSHJh/de+sp1mOQnMPjYRMjg\nXROpusHdoyfZNk+QsZxYMQdLZZRL5dx7eM1Uf7oKLrCH5CMynuSrGx1ogxPmfgKDD0uCjFF0g/sO\neo6fPdTAe33UWRoXFpB8+rbzZAvGPiQfkQlIPt0z+q5siOQnMPjQxMg0Bvcd9NzW0IkpQcbSuLCQ\noLvJuLt+rJgiE5J8Y44ODBwPfuEnMPiIDwSZo4ZIgIx7R70Hr1NB8onj7vqxYopMSPJ5OnDw5QU9\nh0Lma9Vg/MYXw95N4NR0YsHdRC4MoQKCzri7nSHzFpB8ikwHyefowI2n2dfqJ9DX2LcxX5HLa30t\nfRr1BG71ad+kCZyaHoB6QrDEcVE8Q06OmY4Gd9eXFQMyuQjJN+yzyU9gk6l2mLOLCX7B6Km6jvED\nXCqnhocmCTKWk8qFRQg6JZT6knxAJkryKR04TPITGHxsknNGf4z1+uCufc9LwbZ5gowluTBsHEfy\nCbm7/qyY3k0hyWd0oPebqLQJJBmSCBlSdEm8a1/j1JQlU4KMbJlyYSFBJ+Tu+rNiATI0Z8ikJZ2A\n9WfgJEMTIUOqLol37WucmifIyJaRCwsIOiF315fkMxItIPmETFrSCVh/Bk4yNBEySRz/z/dNkYn7\nCFNkUmTiEIhrT/dMikwcAnHt6Z5JkYlDIK493TMpMnEIxLWne+Z9QWY4Js5p0ERLU8Kpng4TukQn\npRn1ajLi+bYDTWgM2Mcp4Z5FHzWbRA/XPnl6jWUgtzO6jw4oiqOoLqLfQ9CQ+es1j5QQINGeGYqJ\nE6dBY2kqOtXTIT3gMurV8KenE9XJrIy1qLlzSjgTysGcV/ZOB/nk6TUtaTT/bGYQiuIoqjNL7lhV\nxyJyyPz1mhEqITJDMXFiGjRhSSUc9XT4pT5+m8psXOV3oaiu2JLcovV5TZVwIR1H9g49ffL0GstQ\nbmfNKtozuR1FdYzsRHVRPVyPWeV9CZHBO72lmp/WoKXToAnLAl54T0uJY1WVJpqtVrUeiOoKJUWm\npG0NKuH4kkbNZO+03SW8qAv5vVBuZ80l7URR3KheWWT7eX5UD9dj1lAJkRmOiVvRiYGRW2EBJZxD\nRlVpotmTNAR8W/btaqHs+lAJR2TUjBS5mzy95ksaH+PL5rXAwRlsO0uIbMhE9XA9ZguV5JwZjjvw\nvJsrVQlHPR1VacxMfhfwbXLs4ue85o5KOCLjzI+7VbI41MlIoEWN8G/NJtpTuZ0T1VGDt7eK3VDT\nzyRg/rrNYqESI4MNniwZ7wa1F7VolMNRT0dVmmamVwv5Nhlrf89r7qiEU2TMbIq6IL5CoGe5lYHc\nzqom2lNRnBPVjVXQVZHp0sN1m91MPgBkHO+2YOUC1wU9HVVpmpleLeTb5I2PtHUR6GNKOEXGmZW4\nC1MUGbJ6KrfzzeqAojiR63DFyIpMrx4uYnahEiNTRoxEyfNurryDgwtvUZXGTF+cr1ZCvq04K6vA\ngpq7zGFcKDLObOwdXSBTCAJ+D3Unt/PNyueZ3E4gqjMNHpBhUBg6mL9Osw+VBBkTy2m0JAn0SVGn\n70o838A3Fc4fUOUbM+rVbgv5tqmq5C+yD39VQmSMjsurRK8jtqfXWDoj/LNqDh5Wud1zeHpjq8HC\nu8mChsxfl9kxf8m+6cH3vlrHzAa6xBSLqsC0UpVwU6qnoyrNpGmY2uqXQlHdfnS+gX1wB8yigj1j\ndJwp6sKonl5jGcrtWKUDE8W9SFFdoN/r1sN1mR3zlwyZoZg48m6CTcxzRpVwY9TTUXvFjHq1kG+b\nqolc6/pQCad3E83YdlDUhcnotaqwNKP6Z9UcUBQHdI9ACQ+Le2qr6itk/nrNU8vomehuGoqJE+Xd\n9CyhFo1KOOrpQmSoV+PSybdlfy3ZRt76UAkXIJNpQaIXAmO8nuf3zEiVnrJu5oCiOBPV0eKEmEAm\nZP56zcmRGYqJE+XdVKVG/o28P/V0VKVZRr1ayLf9bA5/UVof/YFBSMeZoq4Dmgi/F8rtyLrRAUVx\nJqpjZBPVRfVwPWadScI90zGnD/9lorvpww9HxwpTZDrAiFymyETg6KikyHSAEblMkYnA0VFRZNL/\nB2MHIO4SP+c5LffMz3+21/R/3nJqfr78Xyy+6sASX/WfAAAAAElFTkSuQmCC\n",
-       "prompt_number": 28,
-       "text": [
-        "\u23a120.0633928571429  33.3772321428571  -100.131696428571 \u23a4\n",
-        "\u23a2                                                      \u23a5\n",
-        "\u23a2       0          20.0633928571429          0         \u23a5\n",
-        "\u23a2                                                      \u23a5\n",
-        "\u23a3       0          6.67544642857143  0.0370535714285714\u23a6"
-       ]
-      }
-     ],
-     "prompt_number": 28
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "matrix_func(M, exp).evalf()"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\left[\\begin{matrix}20.0855369231877 & 33.3929164246997 & -100.178749274099\\\\0 & 20.0855369231877 & 0\\\\0 & 6.67858328493993 & 0.0497870683678639\\end{matrix}\\right]$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAjIAAABMBAMAAACFVUDyAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAMquZdlQQ3SJEzbvv\niWYEN0CTAAAOM0lEQVR4Ae1cb4xcVRU/+2fezu52pxsgITEhOxSCEGO6sBgToDLCKpGgHSV+MZpO\nAMVIm100/guBjpKAH9BuDPHrVvBPQgnsFzAmmK4mNhCIHVoCiWbTSegH4wdbod22aDv+zu/c++6d\nMm9m38b4Ad79cO5995x7zpnfu++92febszLT6bwjRetGYG+nc1Jmbpz/TPd0cSTH528DMtMFEj0Q\nqBTI9EBFpxwy5bkDS5LceDu3D/tk7Whd5LnGT+smrlh7AeZ7drwuyVVHYPboTb8XscnJhgjNL9+x\nttaiUNe+0cgs3Yp7dlzpHHAk8iJs1bXIUNVpRC7BYRqPQYe+s7a2htkeTXO4d/56J9RAZ5hLSA2z\ncBqiu1SHqm4ZNS4lj8yPZfS0jC0lD2Kx9SMinxI53DlvojwryzUpPygflSfq5ZelXJWddZtMDjZE\naH6i0+lUKdSNazQySxE7+LM80TQHOhJ5YB0adY3YK+Yaw4fcJONRVOC/98OCOfxQ7p8WCqzmDHMJ\nqdFpOY0uLlXE5DLTWErpnrlGZK/cIXInFlv/T5H7RZ7+OLaHiqnTsnVRxlryjLwk8jEZbsjYSU4m\n27Y3RGj+psiwUKgb12hky8XcTK7K8AodcCT3bAMydC1y14q5Fhl91U0yHsVUQ6Tq/cY9cxhdlNH9\nFFBZVswlpEanIbpPFTG5jBpLCR4qdp95rSHbl74tstzEHPsjRKaKQyZTIjInGjh8T+RYY8shGT5n\nk7ITszRvibwuFDDzjUbOUthv3S9T63TAEfIFMnQt5X+sCDUiPzvgJhmPYgrQ4kz1ashhrCrjZylo\noFkxl5AanYboLlWNyWXUuJRSZJ5vyK1L74rM1OGV/a5r5A13hqqMpFfTsxgl/xbZuTSxLiPncIRJ\nImPmMo5DE+jTpka01Jnl2gLO0Tk64MiQUdf44BMr4ly3gEwa7xcMCoMnafZ+sbMhW2dl6DQF1ZhB\nQ0JxanAaopuaMbmMGpdSigyM9n7zPJCp4eJmP9k5DsSvnr/OCZGnsF0uu73OPdPGgjGcaZ0kMmYu\nD+DQhA58UyNaWq+n5QKGY+tupHuGruXvQIYaqTSBTIine6aN00K1mlzUgMO+lgydoqDOkEFCUWrq\nNESHmearMbmMGq/2VxMeCueJCNBw/a1nmvrQWFgyMfTXqiRn2vKI3CJysAaPM8gEk4aM0Fw+gUMT\nOrBGI7NEGKwYWZXJU9DNtNwIyJjrpGbIwPV9ciCO54KO1L3Xi3qHzHn9iDizaIaMJhRSU6chOlRQ\nMyaXUePVAZmJlW5kKtc/f1oDDK96cddS0tFbzLfapVtrmMQ5xR1zyXIw8+QkpihUlzY1oqXOwM1z\ncrcig49uI0WGrqfEkIHrlqpDPBd0QT30ahnIaC5RanSaRrdUGZPIMBufXEDmZncV+avpbal0Gshh\n6l9ebFlPzuCmWJfjn95Zx3N6RTPcggtBz46Zj+7HFAX60NSIljqFg8r8ZUBdHdiIe0Zdf9GQgaY0\nrchE8SzoncGpjsq//b62JebAK4KCRtwzmktIjU6j6EyVMW0Zs7GUwn1mtGp33ja86h24fUhkX3ty\nUabOUZSnZfKC3mJO1GBxrCFyGxLjJJGhud7icftQERqNnKVfgWcTHcBKR7zPwPVnW4YMXO/hnozj\nMSgem70bcNC76AUKmhAZzSWkZk4tJmIw1YQx/TLNhikFZO6WchNhdzWh0f6xVZzU2pZFGTlLsbCu\nyPyOe0bwpUZKs/ITm1RkEprLwqyICfSu0chZiu8n9tMBTDAiMur6y9u2bf9TjZovbdv2n6vjeAya\n4KT1bsgBKJT0qV06SxMig4SSVf0kzMqcMqamz1RLjOmXaTZMKUVmaBYPA3zTe0sSftN7S17GLaaJ\nr48T+ylwyx47K7t0u+xslvG8vhQ3dZvknqG5LCsyFOhdo5FZ4ryqm9Gzsm+JDmxEZOga1xouMXWN\nxa/iBKXxLOh4P2TwbW1qkUIaWE5kNJcoNXUaovtUEdPWal4upRSZx9fWPilj9eSPsoBvutp/pSFf\nk/KsfLVJMdqW5ZZMtpK/yB2NiZqUH147umiTzIHmskuRoUDvGo0ocNuwg+/Jr5wDHdmeoWsiQ9eY\nBTIhHoNKqR8y8l3ZPU2h9ydDRnOJUiMyaXSfqp4NXTuqGgpNvWLfgfGi5owkO26blt0r1o9fNVfH\n6bvhWifunvs1zG+4YUmm5l7AFYo/YRaFk3OHn26Lmc+0YUOB3jcaqUjwWXlw9Oa6c6AjGbnlPfyJ\npq5lavu7bXMtRzpukvEocB/xTi/qmcO9b1yJPw0hNBBnmEuUGp2G6JaqxuQyYTYUcO+QuShQcVgg\nk70Hij2ThU2BTIFMFgJZ88WeKZDJQiBrvtgzBTJZCGTNF3umQCYLgaz5XHvGU3VZznrPk7MjSwY9\n+z1reMsYSL6htb/hr6eUdItJPuXoApPWh4nrHTqa9QlEU/2HuZDxVF1/lxdpSbmlBBmJslkZaQeS\nTx6V8VO9ST5ydCPKCZI0y2biLorZ49AzdD1UvadyIeOput6uMmaH8U7pJJkuGLCvtCVZDCSfHKvL\nmZ4kn3F0gUnLZOIyQkfTPoFoasAwFzJ42bfcHODwfWoSa3hnNq6v2thPVRWZqlpS7FJkTjRwSL4t\nJvn0PegR5QRbSvL1YeKwuG/zCfQ16lLmQgbvjUjVdXkYdEBiTd+zKhXBvvROY6oWIQO+7FQg3bpI\nPkUmZtIymbhBWfgEBtkFfR5kjKILazc8Glvf1wJLBnvrD174fDfJN1GNSDeYpSSfIhMxadlM3KBc\nfAKD7II+NzLY1rnbTEsTU4LM+pHOD2KST654KibdYDYDc1B29h40YtIkk4mDbd/mE+hr1KX8vyBz\nwCHikXn7Ix08piOSb/SViHSD5oDmeNeSIRMxabKgis20TSHz9cYGQ232agKxpomlV1NlVk7gKolI\nPjn8jYh0i0g+vZoCk+Z+xbLBdLvMfAJdk30PynW5vNnXIlLqHbgdHW9wCNJLb4D6dpv9loaUL0ym\nJJ/8CER5OybdAsmnyBxSTlCfamh4Om6u+QQ2vrq0mOMXjErRNTfu21kq6YXPRYKM/W4obgwkXwKW\n+GC7N8kHZJLVlEmTbCYOLvs2n0Bfoy5lnvuM/hjrra7VGzq4FMQamS5pGOO1pSlyLb7ZOpJPv8Xs\nbQbSLSb5dM+8rJyg8XvZTNygTCyBQVaxPhcypOji1RsZG7GmTJcSZNqXfiOlVjkl+eQLMn4+It1i\nkk+RiZi0bCZuYCak6QZaRQa5kCFVFy3e0NCINU+QkS37+Rz+ogwkX2nuJjyqepF85OgiJi2TiRuc\nCQMPNgsWuZAJyz4EowKZrJNcIFMgk4VA1nyxZwpkshDImi/2TIFMFgJZ88WeKZDJQiBrvtgz/xNk\nNsfEJUfXpjW89salBSaOIzJxVpXHQrxQuUYNy+GsEM9X1vlP4+k1119iBW9RECuKY60f02A886LM\nX6iZY3ZW42eh8v2CcVNMnDw+PbyoH0V749ICE8cRmThW5ZF0g+lDwvo04+hCTVyZhXkeFvSeXnO9\nWxYFIYFnaTMNjWdeWIMXauaYnWkYL+cvGDfFxMnD7kfZ2pNLC0ycjY4p33SNVuWRdMPb31dlclWG\nV4yje0lr8Ch8ZZ3HxtNrrvfLoiBv4t2Oq/XT8IxnXsa0vI9qC8rsWN7GUDmRwTu9/ExcBa9YtLEn\nlxaYOBvtUmRe06q8IyzE03I4/NgcNQDUkJ6j8JV15tDxejjACzvl+fyyKEhLCTymbeGVAzQvZP6o\nZlCqTcNQOZHZHBO3ah9kwvVPSmDibEQm7nmtynOkm69cw8LxU6zBS2vilmvmjdLTa66PlvkgcFCz\nGj+G9/Hg5VnzAzWD+uyWa1bzlw+ZzXEHW385j/dUeDluvVa1BSaOI7z3rKrF3oaRbnHlGjR6DvUF\n+rE2bJ5SQ9/2xYwECifSgrc0iFa9WdoW3sWDF6vB06I4BvVZqsZCVXJUsjMENmC+tvCIjLWxxPXK\npQUmjiNl4tCUqmP5WlS5pppbtAaPwtFzasymyAR+L1qWBtGqN0vbwjOeknzJGS3vs/o9DWpq0n8W\nKtezaZPInLSCoQXrlUsLTJwbjb6C2YkVV74WV65Bw3I4X4in9FzaupGJloUgyUmPDMO7eL68j/V7\nZPpcdkr/uVC590wtzWuDAxS/VJTsd/2duIJTJs6P5HBD5GZHusWVayijb1gNntXEpZV1DK7IpPxe\nvCwEGd3vriaG9/HS8j6ojenzWWr5noXKg4wVyzGnHAJPmYqm73o8KAITx5ExcaJVeYeUdNvj2Fs8\nm8jRYe2xBkXZavAwtubpNfbRMn0amWsSeCQQGZ6T5gV3kxM1qhmU6tS/xsuFDALmZ+Im3Z6xXrm0\n3fhcxsRxZEycoCrvsVUl3ULlmtOwHE6Fr6jDejY8rQO/F5aRsKNrVr2xxq/J8Jw0L8b8LfiaOapT\n/8/AfS5kNsXElXiBN8R65dICE8eRMXGsyjPSLVSu4cTubbIcjgIndgzfW9Jm9Jrj9zDrC97SIPj+\nNetq/Bie8cyL1eCpmkGpNo2V3+VDZlNMnPxBdreVhNOeVW2BiePImDhW5RnpllaumYblcBSjbS3M\ni1rM7xkyLLJTws5cs0DP0tbwnDQvVoMXauZUbRorv8uHzKaYOBm56jpWqWlvvH9g4jgiE8eqPCPd\n0so1oSaqiWNFXYRMF78XlpGwo2v+QsHSZnhOmhfW4OkPGCwo1dRY+V0+ZKKcPvjDXPeZDz4c0Scs\nkInA6BoWyHTBER0UyERgdA0LZLrgiA4Umax/qxWZfeiG+BJxUu6bn//ch+6TD/rAx+fna/8F5VBN\n7F3LwaQAAAAASUVORK5CYII=\n",
-       "prompt_number": 29,
-       "text": [
-        "\u23a120.0855369231877  33.3929164246997  -100.178749274099 \u23a4\n",
-        "\u23a2                                                      \u23a5\n",
-        "\u23a2       0          20.0855369231877          0         \u23a5\n",
-        "\u23a2                                                      \u23a5\n",
-        "\u23a3       0          6.67858328493993  0.0497870683678639\u23a6"
-       ]
-      }
-     ],
-     "prompt_number": 29
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "matrix_func_series(N, sin, 3)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\left[\\begin{matrix}-1 & -2 & 0 & 2\\\\-1 & -1 & 2 & 1\\\\0 & 0 & 2 & 0\\\\-1 & -2 & 2 & 2\\end{matrix}\\right]$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAJgAAABkCAMAAABNTAlxAAAAP1BMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADFBd4eAAAAFHRS\nTlMAMquZdlQQQO0wRCLN3bvvZol8bJK+89UAAAO3SURBVGgF7ZvtlqMgDIZRqJ0dtR+z3v+1Lkir\nJpKEzHA8zh78MW3lDTxGxL7NaJpp3lpzkm2MPMY0k3V+u5yEyzwCTTsFsOYsTCvHQwK7datYetdb\nO9w+SVXnT4ylcwCjBbDuNuWD9WGWuomcEqNn7kaKDEWzYF3btgqwdj6G0Z+D5ObGsNsNyUZjUDQL\nFvpRgN3vgaydiJM5zpf959SnyVB0SbBhPghLgU02EDXUqUbRJcFiJkYix/30jGAu6tJ/l+jiYE0c\nfz/sAjbz7dvnPWt0cbDhRoyZBbZGA7B+GNctTmFu8ifkxlJcZgFjTuUmGoAljpUDS8mZG+578j8S\ncXGX20SXBbuEC68n1oO4XFyo5cIYEF0UrJkXhAcBFhfY57zMppIGo0uC9ePTb5YcefQ3q+5O3pJg\nNA9m7X0aLD0p4IG/vkeRYJ19upbiMiiaB4MDH/qpgmnTXTNWM6bNgFZf51jNmDYDWr04xzSG1w/O\nyaGjTZFuogUwleH13x04f4wc7R4MRLNgSsMryJGjxWAomgXzsdqv1oR3CxTI0WIwNNiBYMjRngcs\nkiyO9mRgq6M9GdjqaDVgCQfLTX6lPJBsHG0G2HW6JlRxFweWCBLkW0crRH8JP3UKI+HeeTlwtDjU\nf95GH7hcGOhozwMm+WFNxnSG1/By5Gh3GYPR0qnchR+1o4JpM10zVjOmzYBWH+ZY5/ILWdr+v63v\n/Y/bv7Ne+e1D/mHgL1suhFosTkamXDC8sJd0xvhaLOYyeXLJ8MJekmBCLRaDZcoFw4t6SYIJtVgM\nlikXDC/qJQn2LkeRZXeIlikXDC/qJQWWU8DboOnklOHFvbBgXC12JVu6zJGThhf3cjQYaXhVYEwt\ndk1YVun2LacN7wL2GjRk7Prx5x0YX9/zMLPsli/nDC/q5e9H4iYu1mLhcWTLWcOLeknNMSPVYiFX\ntpw3vGjQJJjha7GIy2TKJcMLB02D8bXYHVieXDK8sJc02G7o43dUMG3Oa8ZqxrQZ0OrrHKsZ02ZA\nqxfn2KboKvYtOFpVswAGiq4SmOBodc0sGCq6SmCCo9U1s2CeZFtFkcAER6trLgkmOFpdc0mwmFHK\n0b7yndtcHIx0tBEsu7k4GOloI1h2MwBTlmwTcqGEq2gGYK9psH3RXJU+jnO0uuayYKyjRf+zvD38\n+B5EFwXjHa1U4YXRJcEER6tr5sFg0XWffLhHcLS6Zh4MDnzopwqmTXfN2H+WsZM+kdqFJ0CdI56l\n056Dn+vnJ1KdM/8A0rpFHAD89/AAAAAASUVORK5CYII=\n",
-       "prompt_number": 30,
-       "text": [
-        "\u23a1-1  -2  0  2\u23a4\n",
-        "\u23a2            \u23a5\n",
-        "\u23a2-1  -1  2  1\u23a5\n",
-        "\u23a2            \u23a5\n",
-        "\u23a20   0   2  0\u23a5\n",
-        "\u23a2            \u23a5\n",
-        "\u23a3-1  -2  2  2\u23a6"
-       ]
-      }
-     ],
-     "prompt_number": 30
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "matrix_func_series(M, Lambda(x, 1/(1 - x)), 100)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\left[\\begin{matrix}257688760366005665518230564882810636351053761000 & 644221900915014163795576412207026590877634402500 & -1932665702745042491386729236621079772632903207500\\\\0 & 257688760366005665518230564882810636351053761000 & 0\\\\0 & 128844380183002832759115282441405318175526880500 & -128844380183002832759115282441405318175526880500\\end{matrix}\\right]$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAABioAAABMBAMAAAAB9fJsAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAMquZdlQQ3SJEzbvv\niWYEN0CTAAAfjklEQVR4Ae2db4ycV3XGz/6bXa93NyuCWlQJeXBQSkWqmDgIiSRkCCZJo7Tegoqq\nqpVHlAIiiby0ailCkKVIUFWUrFDVr3ZD/0h2RPYLVJWo2FZqCAqqF4eGqtXKKxGhqh9qA/HGAezt\nOb/nvu+9OzPr+FNmpH1fJcez77nnnOc8596dmV3PYzu0s/Nja66GgYYBMfD4zs4lO3Tnsfc2hDQM\nNAwkBl48dp+fisWGj4aBhoGCgYXmVBRsNA8bBoKB6lR87p3/ZPbV7l8ujf3R5uamtZ7fXLTHNt9u\nMr94z+bmhj12z3fNfv/Y28zeuPk10xputu58z6JhSFF4Zn848x+GMTvYTdmoNbb530v9MfY6z7v5\nvHvCzBw9u5piiFaJgEG06oAlkHs3X/fowCIY4VE7gh5u4acJjN+pLnq2QIChuBAQ+MF73lRGt245\nH8+xkZLiyhY9mo213YQHxjIMYjIlBdWprMeoIhRFyrQmmkpsxBCoCCBRH2QxoyIlvCQsAQiA9ZjF\nk8hyoH2XIwGtiCYMfjC0QD0lCHci2sbamneV2ukkmg4L0oDHDiMl2ehQa4hRC5AYJg0jOC6oiTkU\nvWeoQFdMnh0pVSc4JbAYYEKdTsVM244v2bmdq7awE2++v7A4vmxHbGJL5qLfbM983H7Z7JP2kcWZ\nI3aqozXcnF5tfdwwpCg8czs7G4ax1je9m0ipWp+zAy/1xZh9ymzC7F0yf2aTlxWjaEpQkWjqCEsg\nN3tk24qUeNSOoIcb/IXxO9VFzyDAUFwIInDm3+yLK0XgF5dmnlVF9Ry8CKVjWJOHsgUMYjIlBdUq\nG3WoKIoipdbQuDwMIdoVIDwwxoxySvEiLABicPWYxZNmVhFQ/BlIQAvRggM/GFqgniYSWVWZerir\n1J8yRdNhJk3w2GGkJBsdsoYYrRGJ0baGwT7K1LA8915ABbpIq2enlNwEIIHFABPqBb2CGu/a9CX7\nyq8u2nzXrG2fttnTC1vWWsbYC2bjNr1hZ2xy2SZPz1+2m5ZZo5sPmD1kGFIUntk7/DsbpnX49q6R\nTbUuLNnLfTE2+ZzZ/5l9ROZWs8cVQ7SWA4No6ghLILcPHvZZZhh41A4xuMGfTbERhBoEGIpjCDy4\nbuNrReA3zN6qivSMRyjNHl6Th7IFDGIyJZlqoyJ1qAhFpNQamsJDSioCSO3CGDPKKcULWDBky2NW\noMgqSdBjkIAWohUWe0Ik0QL1SIBblSmFO6X2gSqaDjNpwNPmIi/Z6JA1Ssk2o2MMbjguqGF57r2A\nCnRi8uzECjcBSGAeYNo91SuouWds/BVrOyfz/t/iwnY8avupwNiG2XftYtdvTrftwJWpgMsa3fxD\ns1MrGFIUnnEP8QPFdbyrlKp1Ik5Fb4x96azZ+TgVmO907fZVITCP1nJgEE0dsFDWt5bDzinx0I5Q\n4gZ/NkKGFWoQYCiOIfCm0za/XQT+1OxCFw/F8RgobeZ//bkisAC1gEFMpiRTbSobMVSEIlIKP03h\nISUVAaR2IYsZ5ZTiRVgCENnymBUosgoSqoeBBLQQTRj8iCRaoB4JcAso9XCn1D5QFaXDTJpYiR2m\nlGSjQ9YQoxboGKNhBMcFNSzPvWeoBnRi8uyUkpsAJLAYYEKdnitmt21Cp8J5+SubXfc/pn7cne9g\n/IsDHXvK/7CbjtiYv6rxV1Cs0c2fmB1awlCg8OQtwI4hm2p5ypesN8Y2/FScuNW+J/N01+5dTQiO\nd03LnwoYRKtOYKGsdmJO6YvcE+0IpTZ34KeJqhNfwZWyBQJgPB3FMQSeXLPJV3Jg62fe0Go+FSnb\n8a5Hz8+uCctTJK5hKKakpKJaFclGRSiqADp+msKjlG1PDCB5YIwZ+f00PX8U3YMlDNmKMZNSZPnS\n3stPReowxkTY7LovwlTf5nxPkKAaqAOlHh2m1E5ncvujkrSAp+0Qef3ybNHhX0NsldJboGNMuFfZ\nR5maGmUncnjvsZFn1+ML9ggxeXZ+01NyMwH0svomw8ZON9Op8NXT2/bmY7/iD1pO4d8c8zfa37z2\n68n4y2T/3vH69yzZExs29pIvejKtiZszV/1UPBimQwpFs3z82H2rhtH3UVJSyxluE1jGLKyc9Xfl\nOy9uyHidx7uCEd8htJy8EZ0QBJaE3GdZpAQl7Qg6mw782fia6hJqEGD8vhfHxHfO+H5zrQiM71Fb\nOhVBW+LFUZr9T3UqEtQAGKzy3XerpKSmWhWjjl+Und5OKX1Naio8ShkVASQPjDGjYnrwIiwBKGWr\nxkzgg5oZRXebQKIOg2i/prfhRySlgT6SgfnmoUPqhTtBTky6m0cFacCL7aCUCX10CLFpjzhzdFwx\nGdQ4x5maCqXvz4SggupfC/rj3Tw7vxnDcCY/mnqPwHqACXX1Cspdhzb8xyYn/SxOLNnJz9j0lk3s\n/Kl/Fcbs7dZ6ecs+A56rNvZfba3hJrn+M6ooBdFafrDbesV/fORGpyJl84X2xidFahFjH7KzvvDe\nl1eSsTHPqpjqVLwAjIhOKANLQl6ditQJnmhHWOpTcTVIlfFq1aWeQSAYFMfEHplYt4MvFYF3+zeM\njk5F0IZHPbY66VSksjUMI6akxLEVZZVNZZ3LlNLXQLBTNnY1pYyKAEoeGPMZ+VWnpCxYMClbNaNy\nZhUDxZ/RsToMov06tAFQoU0DfXsNLLJGZaNUuBOwxKS7eVSQBrwYrVLGDvPL5601bKZYQ8epbVGT\nTkXsDK+Ylle9Z6jsMKXMs2PncrPiNALrAVY3F+rfV8R+tPF132z+3yV/EW0/+KWdJRlrXbLWTryS\nrsh9eJU13PxoHIh0KiJF9nQ95W3+P8a7SdnY+zb57QpEFePvXxzFwtuevizjp32tiqlPBTDMoxNK\nf4O36hUCeT4V+hqPtyPor3Yq6BkEGBUHQeyR1lft/eWp+NjW1L3pVESxxEv0OF/FpLIC6DBMMQUl\nNdWqGHVSWScipfQ1FU+za3XK8XUAyQNjMSO/6pSUBQumGlwaM4H1zCJw1xVIElon2q+zYlsbw7/2\nqXq9ChgDjQ7Vu7uTJzHpRXm0izQfW+ywlFLofd4VSQB9eJWOP5yGHtuheq7wTRcVtbzu3e8kqP4I\n6B6TZ+c32S2zawmgAqsBVv0sVKdiIgra/I/ix0l2ctkWLi8csYvbGM9/2g+tv31cCnLjFdTcNmu4\n+dtxKh4M0yFF9iz51xcWk/Edk7Kplp37aE/M1GLQ+wP/6XAXY3aXH5KAARdgvh8YnvJclzr+aC42\nUyCvTkUnfY3H2xH0+lSwuWV8YXWRDQSCQXEZduvCsddfpvtEwYvv9p9lax978XQzTsVv1qeighoA\nHYYZMQUlFdWporJ5z/5tsH7N42tovBNYUie0G4DkEVk+I7+qlP7Qy4IFkwBWYybwwYr/CIzrLz4R\n1ydhskZ7rgsc+Kkoj6l6vQoYWaND9e4dvoHUqS93p0claXPaXCml0EfvIklA57bp+AOJSahxjlMz\nUVHL694z1PAF9IipZ+eP2S13VdAVWA2w6mehOhX3+Qv6ZZv3lzr+Pvym07bw0py/kr+G8Rd5bV5n\nXuzE+5xrM4t28Bpr4mXdxU68R9nCkKLw/KMTtIphX6dsXss+669AemMei4Nuz5g9sYWxSS+bYmK/\nUYKKRFMHLAl57KoMAw/tCCVbGPzZOJDqIhsIBIPiycSx8524vTvwQpeU6jl4ocfWRnUqVLaA4Tku\ndEtKKqqrilEnejZziigm/DSFh+5Tu/F8jkdkxYzy9CgLFgFK2eoxE6i8EdZzpdN+oQvRghN7QqPV\nQKNeShADjX2jUrjxpL7cnR4FAZAGPEarlOyw1HusCQLEHB1jktt3QkGNF/blde8ZqnZYlTLNTim5\nKegReDD2vVKmfqpTMXXE/nxu2SauWMs9vm7h8qNe8E6MP3kcMfNmLy55lqkrJ7f9VLBGN52PEysY\nUhSeb/kbhBUMO0bZolZrx99Gb/XEvO/w4Z+/ubXu5/3+MB17v82sJATHu/B+YiVgfIBo6oBFyKE7\np8RDO0KJG/zZWL7IBgKMUVwm7ZHZ07sDz+h7KsXx0OPU4cO3/2uHYjBWwPBiZ6ygpKY6VaRO9GxB\nkVLGmthwJ1bAQsrUbvz+IDyfX4esmFGeHmXB8l4AKVseMymV18N6r9TxGY0JOPCj0WqgUU8JIiuV\n1TtuPOor3KnDIABqgMdolZIdJrZZEzFijo4xye07oaDGkXvKuvcMNUGHTn9ZqtkpJYkEPQKLASZC\nqlNxs//oxH9F6jwf8DFMxWvsuRWzt2DMTnnwiTiV/vuT+WU/3tNXWKObD5h9P34B8v34lfTs6cLj\nYWcMo+eKSGlRK76PPr7SG2P2nJn/ynh8BTN2xH90kRDEqWA5MIimDliEHLpzSjy0I5S4wZ+Nc1pd\nQg0CDMUxCrxiT6wWgcdXZvx5NXYPxfHQo+ebW5MHqAUMYgpKaqo9xhsnmyoGRUoZa9Q4HlKqYgCS\nB7KYUZ6eygpLAFK2yCuy4Anj+fuu6Au0EM3E4EckaaCxJ5SAgQKUerir1N4XbjrMpAGP0SbeIxsd\nak3EqAU6xoiaeF9RUKPlEa1RR6BSAp2YyXp2SslNAYzAYoAJdToVM5/efH555oj9rn+b+okX+Gd7\ndGvq721qA+MnwoMPbrT+3eyP7dHFyS07tcEa3Zxeav2LYZQiouX5nE09axh9H42U1LLfsANX+2Kg\n7ne69nuG+cLm5jssIYhTQQlgEA0CsKgsuyrDEEraEXS+AQZ+mpAp9gOotT1jj1Ico1PxJ/a36l6B\nD3RnO9rHKk7emJhfc2vyULaAQUxBSU21x1SngoqiiJSsoSk8pKTiJIDwQBYzytNT2XwqQF2MmUBM\nIO69girQQrTgwA9GA409QQK5AUo93FXq50xuOsykAU+jFe+RjQ5ZQ4xaoGOMhgHHmRqljGh6L6AC\nnRhRFTFKyU0BjMBigAn1gt5XTPtfdFq2m+94ix9Yf3lsE7f4by6+fNR/bIXxtw1+8447Vv3vZX3v\nTWbvP/p3aQ03W/fct2gYpSAaz9jRwyuGsaPnvrJFNtWaOvrOpf6Y8zvvsgO3HF2S8Y9/vJwQEK0S\nAYNooQQLyCfu/um7ypR4aAcsuIWfJjDeVnUJdSCwMBTHKPD5u5ZS9wTOH/2aUxAV1TM3QWnzt/9k\nSx4YyzCIKSjJVFORGCqKIlKyhsbFBilpF0B4YEwzyikpCxaZyFaMmUARWhGQ/wQJaCFaYfCD0UBj\nT5BAbhEdveNOqZ1JuemwIA14bC7xHtnokDWKUQt0HEYEwHGmhuW59wIq0BWTZ0dKbgogGxs6SZlQ\np1ORCWkeNQzsewaaU7Hvt0BDQB8Dzanoo6S5se8ZaE7Fvt8CDQF9DDSnoo+S5sa+Z6A5Fft+CzQE\n9DHQnIo+Spob+56B5lTs+y3QENDHQHMq+ihpbux7BppTse+3QENAHwPNqeijpLmx7xkY+qmo1LSG\nPwn0tbJQnPTfasW2Qn8MvTHJh6HghcwXNzEShau1vaTBVci4Zf03JLuIkZsYG2snZTg0xKT6FTEI\nr4kuKmYNMbAUWnQ5JR5JgRGD2BxuEo0O+d5dXEDTw2HaoZ+KSk1rmCRQe6a9WygOda6JWrEt649J\nKk3yYWiWIfOFShoGkbCs7SUNrizjRkqJdyE2RwxuYvzvoa6Z/+X7iS2MUBFTiMBFxRmiiQELZa31\nzW5SgiMlHkmBgTK74X1kyK+mDxnVF8P7c+inwv9G+0PDa7+oPN7dLRQ3HaJw6I9hpAIWil7+l/sn\nT9uF0LNiDcph3JQHkTA8cqPglmXcyHar/wVRQ7JLMbi1PDTWFrYsCdQJFTFIl4mugCHBL2LAQtms\nISa9Ojwv+AdWDJSFm0QjQ36ag8gohjKkh0M/Ff7pp1MrQ2p+V1mJebX93rz/tyiJs/O1Yhs3UfTy\nD4IduCINrotdX55vyuM70D8uGB6Mtf2RDB/UIOV3Qv8NyS7FsEbLQ9Jsvu2nAiNUxBANXVQsNMRO\nxAmlLJ9iKVLi2QiNO4mRxYcT5CYRJuCNyCVowwcz9FPhn3E6FK+Zh35JmKstHC749VQ8yopt/kXS\nH7vJP6J92b90+TDWzK77F9yUh+2JB9N7Kkj5dBfBL5fsUkzbUygbOmPIh2GESjJo8VEg6KKiB5xK\nGmJgyaeiSInHTSfpm8WpkJtEI0N+tO+XoOnxMO2wT0WlqjBMDurapVCc1LlKxbZK0uyJDcmczLa1\nBpkvbsqDhlih7YX2HIbv9knSzPXAvO6TSa4Ct6TA0FgrBeoclWL8VIiuSljsSZeYCOk6/1hw25J0\nmW97wVBFKYU94hsO4bs4FbhJ9GCvxkfNxJAeCPmQihdlFyqNj+Lea/mQ6fhT/EhcLuZVC8W1Xg5R\nuFKxbSJJmsXofDu5fJjWIPPFTXlCJAxPSkFK5eUzspI0ixShAqaYcGt5qzO75h/yKwTqHJVgVKdC\ngmVEpxIhZZaky9K2v5o6kciZf6YyiZFVbnjfWw9qSONI1A6pei670JyKTMbZeDi+7lvIP3u5E+IN\npWKb3zwZKg/V6Ca/rTX5ZuWx23Zpe5ESE6dCkmao44RkVxXjsmdUlM5YIVAXYkCKyaciYDjUpCHW\n9U+Jf9u/rLTockq/F57WpQSdtx24m1MRhO11LVyyP+ju5XwN7jOdzmtQ6AZKVApi/FRMemSlYpv/\nqAxFr9hVIRRn5z7snyq/uJRv1p4LvxCeStsLBbdKxk0icEmCzSW7qpj5H6kiOmMLhUBdoEoyaNUr\nqCQs5tGKCSxdNyFIV71E8i9DOA7P5OkEPbvh/cHmFVQw1H/N+D+Ss9J/+7W7E2/4tl67cterdB9C\nWEkoThJnz2TFttA+cuEUVwrzd9vXpMHl4iouHFfflMe1iy6s4sG43tH8KxgJf5ASna4ZxOYim9yx\n/H401uYKgTpHJeE43pVAFxWJFsrPhuIcZdn2wFBKPPFTJ0HPbumbjRD5DEYEXm9Gr41vannI/1qk\n7zUXABuFKyuIoUzmu+ziB9b9Jf79YTpZf8z32NQVaXDFmiXffwuXuYmRDBoeDBpcGE5FS9lCvAvJ\nLmLkjuW/haTZo1YL1AWqFBOvv6CLillDTJpx3/J3Hyts+5wyKYWdPMJ5X/CfnPlTiVCSaHTI94b9\nEjQ9Hqb1V1DD/TdU/RdJ3x8mAbn2zbWCGIJfCHM9Wyu2Zf0x/1XT/LJU3liDJhc35fEteEa6bLj9\n99KzpzF6riAlOl3+LX/6CjFysxxFpbmVWqAuUEk4jucK6KIi0arjTzKPr1CWbV+kxIN+GjHZLX2z\n0SFfYxCBeSTDejT0U1GpaQ2LgLou+lozWSgOYa6s2Jb1x6SShgYXayQXh24XBpGwrO1FSuVlX2f9\nt0nE5iJGbmULjbWpWqBOql+SQYvnCtEVwmKKJgYski6LJwMJotEJHumnSYyscivRyJBfTQECqy+G\n9+fCsJ8rki7V8BioKktfKwvFoayWFdsK9Tj0tKTThoIXMl/clHhXKMMRLUNKDOJjpJR4F5JdxODW\n8tAZywJ1QkUM0aKLillDDCyFFl1OKZS8cSMmS4yRaGTIr4YA8uqL4f059FMxvNabyg0DezDQnIo9\niGlu72MGmlOxj4fftL4HA82p2IOY5vY+ZqA5Fft4+E3rezDQnIo9iGlu72MGmlOxj4fftL4HA82p\n2IOY5vY+ZqA5Fft4+E3rezDQnIo9iGlu72MGmlOxj4fftL4HA0M/FSMk1HWwa4YoGfJkLSmTjbWd\nuTCIkuFJUl5f9w+5sSaLneGZOXp2VR4pqUVKaawhZNa65fyip/To+FSpSUQta6ER7a7XhT9MrAEB\nTEkLTQJp4UkoPZu00JBbw5AyS71Zho77VVXSbpSNNMABbODJbIjBwWzQZBiw5Zg+NsTbWNtUluWD\n2BDhuHPKgWxoKHe+x/+90zBcQz8VoyPUFQpiEiVDo8z/drf/+6holoWZQZQMj6S8Htn2j13EGnm4\niUEBDY+U1NquviaNNYTMvrg086yheCZJs1AzU1liiPa6n4rxuEHXDBgwJQk2sOARysAiLTS00XLK\nLPVmGTprXk0l7YbZ0AAHsYEnswFPdNrHBq1gwJZjetkQbzEPlaXTQWyoBNlyyoFswGgPG0M/Ff5X\n/B+KDTD0CwWx8a5LpS1suRqTBNL8s9FrjswNomR4/EMAk6cNzTLpp122m5a5Kc+toYCGB40yUs53\nQxIKIbNvmL1V0VREzYw1iiHaP4nxnJd1ozUggClSgEWerJ/2AlpotSSbUk7XUm8FdNaQbW/yb5iN\n+KDGQwPZkCezAeqBbFBM/YAtx/SwoTqZDcgbyIYIr9kwEg1kA0Z72Bj6qfCPg51a8R0wApd/9gBR\nsnl/fl628yGQZqFZhkGUDM90O1TS+KwEa7LYmTwooOFBo0wpEV4bjyb9g0AXukTzGSA/LP5Bo2ds\n/BVVJNrsS6GsgIlPRIAApkghgTQ+SiGU8cmLjdBCI1uR8mIEs6aA3vZ78aG+UyuY+GrA5XVvhA0l\nGsSGPJkNUA9mg1Yw7UCSY/rYiE4zG3Q6kA0p3ZENQ6KBbMBoDxtDPxXx0eEl73QELt8HiJIhTyaB\nNDTLZHwXdfDEh4v9s54xH6mXhYeb8jzddQW05HElNemchcYa8n6tn/lhWO05FYUWGtG+x+NUYByV\nH6nZNQmkMUO/caqjM5X109BCy6dCKZ/ypUJZQG/HTXi/Hvle90bYUKJBbMhDP5mnwWz0nIocw6OS\nDU5FzYbaHcxGEE6nGBI9FY2DpWADRnvYGPapGCWNj+PdYM1FydAokzIZmmWYkDTD84Q0PmI+leJZ\nEjtLHn8F1U2e2XZKaa6xZtJP8+eKreJUJDWzWgstom1hxU8FRhvGEYippIUWWPDU+mn+9SP+P9ly\nSkTUtCaaEsBwv7rGxw2ykQY4gI16tDUboA6Ce9nIpyJBzwz2sMGpqNlQu0ymj40gvGTDEw1kIxjt\nZWMkToU/+Y/CpX3gomRolKFMhmaZhMtC0gxPbC2XjGE+KJ7VYmfJgxuPNMosdM4mluLHSa1X7G4/\nW53iVEg/jTVZP+1DoQKFYdqBgMltSAsNLNpKxIDFXAtN2mh1ytbLWeotmhLAcJPtuippN8iGYA1i\nI3kyG0I9iI18KhL0IHggG9FpZkPtDmYjCCdbnXIwG8FoLxvNqcjnUfvAtyMaZSiToVkm4TJ/j7eK\npzgVSfGsEjurToW/3EkeqZd5yhBei+s2+9jW1L3lqfCnkHV3+JoU49H+JsG/xrBhAkG1ydBCCyx4\nFMOpaF2KAlmSzVMUUm8ldF/Tuw8I3WVukI0EKxD0sFEBzmyAOjrrZSOfioQ/x/SwEXV2sQF5A9hI\nJXBjZtf2YsNu62VjJE5FZ9c4hvYF+2DCd3RolEmZDM0yjKOa28YTe99V0mI+Ui8LDzeTx+7KnnNd\nf5rwbV79oM2FzF589/Gl4rlCamaxJmXz6KlF3zsY7f1AwOQ6nim00LyiPLV+mgM67feVDYE0T1lI\nvZXQ3U22B/078qEOUZWZ+YdPxLWq7AH9VdhIsAawUQEu2AjUg9goTwXabjmmh42os4sNlg9gIxGO\nO6Xciw278IYgomBj2KeCt2Rb1UyG+yen4j7fcV2buYYy2Q9Ds6yFcNlMSJrhiffU13QqngkRNTzc\nrDztpGv22VAvM/OU/MzHXPDpgu+3XT+DOhgialpDNvTTHovnDgy7UwjiHaG00KiofZtifK+ghUa2\nImUIr3VYk6HLTTZMoBtw3SAbaYCxW3vYqDzt0jOYjfpUJOiTVUwfG16nYIPlMzGZPjbiJ2C4i5SD\n2NBQetgY+qlw8CdWBgxlCLdiH4Qo2aNe+87Wun9be29olmE6iJLhmQ6VNE4Fa+ThZvK4AtrnI/r+\nnW6cikiJxpr00yzkovJzxdyyTVxhjbJZ6Ke97/Dhn78Zw7SnkE6DqW+FFpoE0mIrpZjYk3byiB/o\nyJZTxsgl9dbJ0OUm2/XI9+w3wkbsPh9g7NZ177lgI3kqNuQZzEZ9KoQtOPg82frY8DoFGywfzEYo\n3eHOKVcGsaGh9LAx9FPhvz8ZEZU0RnOzi5LNrbhGWVImC3Ump3ctFCmnr+BJUl6xE/2X1OMreLgp\nz9gR/+kRHmmURUo01sy37Rk7vjLjzw3s46jov5yePW2sIYZoL/mc/4+J3QkCmCIFFfXdkRhlO+U+\nshUps9Tb3Io3BUC5yXY98qPuDbAhuTUQgCWzIU9mQ6gHslGfCmHLMX1siDefB9BZPpiNULrDXaQc\nxIaG0sPG0E/FCAl1+T5AlAyNMpMyWX0qJrfs1IY8kvKK+bAGj6TT8Hxhc/Md8qBRJp2zKR+SIWT2\nQHe2U5yKmVAzK7TQiPa1/acCpkihimwloWSvnPBToWw5JSJqrMnQWWNkux75N8qGcgxiA09mA9SD\n2ahPhbDlmD426lNBcpYPZiMIz2wYiQaxoaGQTZ0497bQqKQFDXGFgphEyb581H/IiTKZoVmGQZQM\nD1JeWfHMstgZHhTQiEajTCnjnYghZDZ/9Gv+Xezun/pfskKzLATSCi006afZ+R33h2ENMJA0kxYa\nFfFk/TSJWNeSbEqZpd4kvJb1015NJe2G2SDRQDbwZDbgaSAbarJmw3JMLxviLeZBcqPdgWxAeM2G\nUg5kA0Z72Bj6qWBDNqZhYJQYaE7FKE2jwTIaDDSnYjTm0KAYJQaaUzFK02iwjAYDzakYjTk0KEaJ\ngeZUjNI0GiyjwUCcip2dH48GmAZFw8AIMOA/Dr5kHzp27NdGAEsDoWFgNBh48dixzv8DXrPOf+3n\nhpAAAAAASUVORK5CYII=\n",
-       "prompt_number": 31,
-       "text": [
-        "\u23a1257688760366005665518230564882810636351053761000  644221900915014163795576412\n",
-        "\u23a2                                                                             \n",
-        "\u23a2                       0                          257688760366005665518230564\n",
-        "\u23a2                                                                             \n",
-        "\u23a3                       0                          128844380183002832759115282\n",
-        "\n",
-        "207026590877634402500  -1932665702745042491386729236621079772632903207500\u23a4\n",
-        "                                                                         \u23a5\n",
-        "882810636351053761000                          0                         \u23a5\n",
-        "                                                                         \u23a5\n",
-        "441405318175526880500  -128844380183002832759115282441405318175526880500 \u23a6"
-       ]
-      }
-     ],
-     "prompt_number": 31
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "M.eigenvals()"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\begin{Bmatrix}-3 : 1, & 3 : 2\\end{Bmatrix}$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAIsAAAAaBAMAAAB1DbIqAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAMplmq80idhC7791U\niUQ5geeaAAAB5UlEQVQ4Eb2Tv0oDQRDGvxi9u+gZ8wKCRCxE0PQWBlSwi4gIouApNmITsLNxa5sI\nYicolhbGQlBQMPgC2lhYBPMGFuIfSCTO7F7uNtkohoBDcjfftzO/3b29AxAZRDvhjqruaa8dCrCx\nx/32Z3sU4IQBnbMapr94qCnEhK4ojxSfCqFlJRdLpA7Y0THWAF6ybKpwjkQt9e9riH+E1jrsCqlp\ndnRMbwV950GZM5URgVDJcwHl0JoBbkkZGLcOA+yIsEdm93WYU4FMqQmGSvVNmRjUbWpFYOwHzLyc\ndVceYjNMV5oL/HHalPBXE1MdPEgn8ZiW95x6Qsam0K+m8ccR+aJy+Wy6s7KxdtkuceYoaWJgn2nj\n6OI1TAjAYry1dM1RorRbfxubYJCnpiCGOetYAMYTgUe4BGKvmjYwq8BRKiyw0zLfzMK9DF3kPn/H\nOFVRh7mD5QHRG0LkNHrfLHreNSyvhn5hvNHZeIGMDCDqAff0h35SdgovD+QhPCmnzLoWW4jz2fjj\nm8XiCAnjLcZdcll2qPcimZ9LOXlPOuriJocKnKnx22qVJzExXNIQca/BMOSfMFGjrdH4T0y2cXJD\n/2k1RpdhSEzvseG3aFxwvaO+2RZbtfKOKymik5rXeurut97zU8c395Nyc2G4mDsAAAAASUVORK5C\nYII=\n",
-       "prompt_number": 32,
-       "text": [
-        "{-3: 1, 3: 2}"
-       ]
-      }
-     ],
-     "prompt_number": 32
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "matrix_func(N, Lambda(x, 1/(1 - x)))"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\left[\\begin{matrix}\\mathrm{NaN} & \\tilde{\\infty} & \\mathrm{NaN} & \\tilde{\\infty}\\\\\\mathrm{NaN} & \\mathrm{NaN} & \\mathrm{NaN} & \\mathrm{NaN}\\\\\\mathrm{NaN} & \\mathrm{NaN} & \\mathrm{NaN} & \\mathrm{NaN}\\\\\\mathrm{NaN} & \\tilde{\\infty} & \\mathrm{NaN} & \\tilde{\\infty}\\end{matrix}\\right]$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAPQAAABkCAMAAACGl+2PAAAAP1BMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADFBd4eAAAAFHRS\nTlMAMquZdlQQQO0wRLvv3c1mIol8bDogkc4AAAVESURBVHgB7VzbgqMgDMXrzFardpf//9ZNQJRb\nEHHWrpY+zKAhHA4RpEcbVnDxKdkHfJ6SK2MFr2r4NB/AmY3ItORIuvgEvivHUSNdlB3vW7SVPX9W\nayVGW7RKdrF4Phv2eNin/cc0Am3xtyTPBsF10hDzjsuZ3Q5Wi7TFqrgctjWbyr5ejrcKNAJtIdsM\ng1ukx5LLqa3HGZsuSAsJvNNAI9CWnRCquk267eUF7pKmLKqlo/+LkUKgLYmYNmn24B025ZKmLH7g\nVqwNwjb5a9hni5FCoC12G/PxFrhDmlV8BF9JGhb46iVaAmDDQsAp1K7nvXBsq66amwi7wAQyEVKx\nWbsJ7pJmTw6xEaSbJ5bEmoZd0iwbBDq4B9Z8aFk74Oo9yYELO1kIydhsG9xDuuBAU5Ae8Qb+wDEQ\ncYAburKE+1+LK7oB1oPcATTiRNhJkF4RUrFZBLiHNHvxWs3px6t+ia2L6JJuCTGY71M17/H6wE/E\nnctBSMNWUCFwH2m8jEWkp6Fs5/2a7NJikVSov4piJ5aHXaQXhFRsRZoFwL2kp3k/NuB0hk0qrIYz\naWWh6MrzC+lebXDVmYCfhZCKvZKmwb2kYRHC+1YLlzljDS8ehSI9WwJ9R9Mo71f1a5q3tWPsnAbn\ng9gx4CbpRi2zg7hZ97gnhTkN65BlQWqBj5gcNXg/eA/LdyOOA/XRZCEkY8vlKAiuk4Y9Lu/kLnQS\nW/Cpg++c7WuoHcsGgamsqkEsYlPJ+z6Cs4OQjA07/i1wnfQGk13mrU3Rrsb2Vt4C/1ek9/bz1PqZ\n9KnD/UawHOk3Dv6p0DnSpw73G8FypN84+KdCf3ykaVmdtqwRouvQljd5m5GmZXXaonX80KMCGoG2\nJGJbpElJP0Zwp+vQFq3b52HbpI8I7rQoT1t00qdh26SPCO4g+Bx4VHCit0PakPT3Ce6ocqU/KjjR\n2yWtSfo7BXfs9iW8PaSTBXdB+greHtK6pL9LcBekr+CNpL/417yIym6nCu6X8f6tvX4xP7GCB25p\nYv9M+v/39l3eqYL7TDpRrj/R2yR9THC/jLdOGva4B8T+C3nrpNct4c1LmfTNA7zQy5FehuLmhRzp\nmwd4oYeRbuv19b7FcOfCBK+VfPT73ncOrsHt4xcyWpSnLesI0nVoy5u8zUjTsjpt0Tqexf51MFCc\noH4xsNai69CWRG8r0oferqclfdqidzuL/eto4CuaxEOEtRJdx2OxI30RuX5lO5dQbIp+0OCSvoRc\n7yUd3XMP6SvI9X7SsT33kL6CXO8nHdtzJP31/UubGVBMfLMf59UlvP9861845m7//3K9GF39z66e\n+y7vLPbDPIl9sz+L/fBEbM/vAk59VGBe3vosuXE5k75xcA1qOdLGcNz4IEf6xsE1qOVIG8Nx44Mc\n6RsH16CmR5oW5WmL0Zh5EMykY1aFr7c/m0KIBcF10gB9SK43iYQz6Zh18egnseFBbCiHkEWaFOVj\nBHeXyJ4zNAJt2dO+VtcmfURw15pNKNIPBGhLAgy62KQpWR3kmE3BXe/C1u+29bqyTCPQFrcVcWYL\n3CEdL5kTiHh6O5OO64wqV7Rc77qvZ7bBXdLRkvkK45S2M+k4LjK/xg+kEMppfHBs3RxCnkjHSuZu\nsNSZOZVLKJOOqrr+x8sbE4wcTCGkkruEwH2kU8X+hYDKXxPIpLPUXQqS9GFsRTqn8VlGVha8kU58\nN39pOqfxyWl8lovBLhwT+43Wchofb3osc04bI3bfg0z6vrE1meVIm+Nx3yMZ6Q/M5N5idvO6jszE\nfe0LQGRyr2v2F9EolM42ZqoDAAAAAElFTkSuQmCC\n",
-       "prompt_number": 33,
-       "text": [
-        "\u23a1nan  zoo  nan  zoo\u23a4\n",
-        "\u23a2                  \u23a5\n",
-        "\u23a2nan  nan  nan  nan\u23a5\n",
-        "\u23a2                  \u23a5\n",
-        "\u23a2nan  nan  nan  nan\u23a5\n",
-        "\u23a2                  \u23a5\n",
-        "\u23a3nan  zoo  nan  zoo\u23a6"
-       ]
-      }
-     ],
-     "prompt_number": 33
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "N.eigenvals()"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\begin{Bmatrix}-1 : 1, & 0 : 1, & 1 : 1, & 2 : 1\\end{Bmatrix}$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAQwAAAAaBAMAAACwWn+SAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAMplmq80idhC7791U\niUQ5geeaAAACdklEQVRIDdVWPW/UQBB994HP95EQ5Q9wgNJAQ0WTJihJDUI0iOZEQUsKJMpYEQ1H\nASU0QAlVrktBEkV0dBFNKqRU1EgIiMTHsTM79s6uzfkiFCxWke3Z92bm7ezO5gDUzqPS8faQ068O\nKlWB6Bnlbx1VqwLo9I2C5jUto5382TLIxv2zE3HgqcYDy0C3F55rArPbpMCTEb9IFMu3CNjFozlH\nyON46NXWt4xjtIT1PRfA4qxAy4hXriaO5Fs03xqh5YqXx/FgRcvwLQrQTND9RB88BM/JANYTofDL\nt4DuEma/KkKIhyctd+46r9D85QJY/NgyTvdR++GiBKIJ8BP7loFPHaE+vYz4tc0VrvbuPmrfCBo+\nYUKIZzIEz8kwXl3aNkmgqtG2ETlsuinxd2uGaUjGT4Iej5gQ4pkMwYtknNk3rpJAyeiscUR5SODE\nmmGaTEZcjGcyBC+ScZNdbQKLN0x9ohtmOrr1hsZhWg1mmkeRDN4UIYR4JkPwAhl1XXzBFwZYnEtz\n8tsP7FsAHdHPih/iU8i4p9zTAx1tobel54P1h2lMw/b+qmHR6+OOSyjVWNwzp+2Smw63gWSYv2yY\n62tmlFmWnSi7qBpyTIQ1D1x2DlYGr6ykU9Kmsb7bGPImuk7x8bTMqlPk0/pHOx/e0zrynaIvc5zb\nvE7FkbYmK94c2Aj83Di4wm97L+Tx+oUv/OvF4mwN9S52x+Mxy+CLSdgFt6hKKZ+zg/ycninD8VGz\ni76nktEo8lRzZTiovBPH/yRjbeJKgDK8VeIvv3i8I1rqchIEVjDz8iRCHyemuRRNc9I/lUrHxYTS\nN5YrFYF3pa30z/T9BlpbuVQBNRoeAAAAAElFTkSuQmCC\n",
-       "prompt_number": 34,
-       "text": [
-        "{-1: 1, 0: 1, 1: 1, 2: 1}"
-       ]
-      }
-     ],
-     "prompt_number": 34
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
+     "output_type": "execute_result"
     }
    ],
-   "metadata": {}
+   "source": [
+    "M"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAFgAAABLCAMAAADDCbAzAAAAPFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAo1xBWAAAAE3RSTlMA\nMquZdlQQQOkwRN277yJmzYlst1IWYAAAAylJREFUWAntme2SpCAMRfmSnW1UZPP+77ohKE3Q4NTs\n1FRtlfzohr54CDEKpJUGKkZ9UwmFp5QG67BM38RVMdMMZLD+LuabE3uwHnhki16tSZ6ZTzal3cgT\nOMzvUfvakp2X+l9rew0INaG0e7BbBuDNmsOgSmsqIY+5bZfgNW4D8MBLSIvgm1E6i5P6OnhbGi4O\n00ZFXMfgHEav9vK2Dpt2zh63loG9Qx8NXDHjXD0IZA8h4jj0gd8MTM4fgMk+w2b8NtkDTl6ptHu6\nBU85BEcWEyUJjxNanPUIxRkN2FOEDsAzXZkkXwAFWgT0Jw1Qb95kcoHFFIVk9rEQ2MLKfq2NMu6F\nxaXH4AGx1ON4AirwqEyij6nHALxm8rQIBis1oy/9kkMDS+Pj3EwGwO5SbvOirTVG5Cplja1h3oE5\n6F9aD7h673HF44rqgVr5majwuNWyg13Rjc5kZnHA5cznXYdQbnQmt2BHL3K37zjO8Budyy040Ibk\nJa0Q6kbncgsGWiL0vhqeLb7RudyA17Lf0/tqeALf6J18BabV+sRV9cprvZN/FCws/9Wka72Ts8W/\nPn7TxA/vS4vpjc7lPx91w7KH03QTbqJewu2QGx+rEuGJHpPzvVN3Or+8BauA+zm/DB7psc4uZ2Bv\nkzMyV93oTGbgq/l/9bcHXD33uOJxRfVArfxIVOiACZJc6rBdxaNWT+Gdhk1vbKqvmtbiWLJPIKYl\naBUXD1Xrgi+/9TitteBUEhkiN9LS4qX39Uynd7Mf8hmYZicnZxINKYLLWfrq9E/c1/VSmbUJDM4p\nCR08kK1uP8O3FueL/ShdMQNEJ97aw+KyFvfgwU3HYS1AEI+8lnw8n9MKZDCd4HPtqkSrNxC3dn5D\nWyd7DZb3sDhQzOGGMdlmwdj4mNTU7pxhyX3K3oD1fjcWIq4gbWio53VU+LKbebPamt+zTFYIi9L3\nyJPwm/cagdX+UEkZC5e3UOuRMeLgaQietuyLSYo3F1DejulwsB7772WsHcRjsnYuuTEcn4Nbl/5j\n/QFXB/6vrqA1SVw56vQ+Wal/sPj8h4hzQsL5k7SmG/3B4pz6CyFBKjOQDmqMAAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$$\\left[\\begin{matrix}4 & 5 & 6\\\\0 & 0 & 0\\\\7 & 8 & 9\\end{matrix}\\right]$$"
+      ],
+      "text/plain": [
+       "⎡4  5  6⎤\n",
+       "⎢       ⎥\n",
+       "⎢0  0  0⎥\n",
+       "⎢       ⎥\n",
+       "⎣7  8  9⎦"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "matrix1(M)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Matrix Constructors"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Use the matrix constructors to construct the following matrices.  There may be more than one correct answer."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "$$\\left[\\begin{array}{ccc}4 & 0 & 0\\\\\\\\ \n",
+    "0 & 4 & 0\\\\\\\\ \n",
+    "0 & 0 & 4\\end{array}\\right]$$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def matrix2():\n",
+    "    \"\"\"\n",
+    "    >>> matrix2()\n",
+    "    [4, 0, 0]\n",
+    "    [0, 4, 0]\n",
+    "    [0, 0, 4]\n",
+    "    \"\"\"\n",
+    "    return eye(3)*4\n",
+    "    # OR return diag(4, 4, 4)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAFgAAABLCAMAAADDCbAzAAAAPFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAo1xBWAAAAE3RSTlMA\nMquZdlQQQOkwRN277yJmzYlst1IWYAAAAmBJREFUWAntmWFTgzAMhgN0OMUNsf//v9oWG/KWpnE7\n9M47+CCFkIcQyvE4qPNp6emgZVp5RJ0fXFguB3FpjrTeR3B3FHPjzCW4a3RkDFc26EVAeAee3rez\nlqPpjWicVDKES7C76WA3xTO5j/J839sYLsD3+UMHT6lLb/5eJ2O4AC/UAPshEjuvTB8MI3i+N8B3\nv6xgV624CAN4DCl6xZyZ+Dt4EQZwzPgN8CVOpB+AH23FmC5RB1O+O/OuDWkHhkUrLn1c/K2vV0S0\nzqdLe7rlsACvdZgPyJIek0rR6wOSw4+AaQozeLzpj7QMF+Cl935Qehigw+J6lYvhAly5wid3nWBu\n3NmKsxXcAR78zawA4+Bz46AhNJAOFYNxII+3GkID6RKMxsEoGDSEBtMlGI0DeHmjJTSYLsH5paUI\nSYS3hAbTBZjFQHvnEbWEpkivgetCEuptCg2D1/SHwE2h+QFYa0VbaBi8pseKX66v6a7n7isvU0to\nMP3zuv0PYgiJJTSYLnpMaBzpIvZ/dKHBdAm2hCSdRQdjOoANIQngptBAOoD3F/78nhPMvTtbcbaC\nO8CDv5kVYBx87m1gxcOR7DNQMRjHxuORFQ8Hss9IMBoH43hgxcOBm89IMBoH83hgxYmEz0hwfmlp\nwmLFwWcEuHjNcqF5YMXRZ2pgRVgYrMTRZ44Eg8/UwIqwcMVKHH1GgK1fUIx44TMSjMaR79m2bscL\nn5FgNI4NmEdWPB7H2iHBaBwZJ9bGLyw6GIxDAPPQikufgYoz4Ij1CeYu/tdW/NIHljF+EHEufDI4\nZkkfWJyjL7LpKbg2v/C9AAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$$\\left[\\begin{matrix}4 & 0 & 0\\\\0 & 4 & 0\\\\0 & 0 & 4\\end{matrix}\\right]$$"
+      ],
+      "text/plain": [
+       "⎡4  0  0⎤\n",
+       "⎢       ⎥\n",
+       "⎢0  4  0⎥\n",
+       "⎢       ⎥\n",
+       "⎣0  0  4⎦"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "matrix2()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "$$\\left[\\begin{array}{}1 & 1 & 1 & 0\\\\\\\\1 & 1 & 1 & 0\\\\\\\\0 & 0 & 0 & 1\\end{array}\\right]$$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def matrix3():\n",
+    "    \"\"\"\n",
+    "    >>> matrix3()\n",
+    "    [1, 1, 1, 0]\n",
+    "    [1, 1, 1, 0]\n",
+    "    [0, 0, 0, 1]\n",
+    "    \"\"\"\n",
+    "    return diag(ones(2, 3), 1)\n",
+    "    # OR diag(ones(2, 3), ones(1, 1))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAHgAAABLCAMAAACMVLPjAAAAPFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAo1xBWAAAAE3RSTlMA\nMquZdlQQQOkwRLvvzWbdIols+ZZ2SgAAAeZJREFUaAXtmnFzwiAMxdOCzKmzOr7/dx20BElq2c0c\nqXejf1jOd81PHqX3lhUGPx8jKB3TwgMYvLHhOChx4Rppo4/gQYv54Fw5+Owe4pORQHbBV5OnyMDu\n7GtgkTydANyEZAJ24zhWwDLZTtFA+5VsJOAoVMAyeZp3zcnfFrIe2JtIHHzaPGrgm78vYKs84wye\n+QD6M94NrG014M11VV5jWLbTQX87LQ+Q+/wYCZNWu7kAprCD3eXpIxOMufgvk1ZhWYvyUyY7c7cj\nclczLjlNx9zqprCyeAeXbjQdd6ub2lsW71aXbjQdr6wWJPbwQ2tX90BP/2jrgZ7d2a8bknO1dsrM\n4N1y9W7gwuqP42deytcXMZaoXc0C/fdRdzv1QJ/WWJbYf7m6B3p6V+d91XqwCgKtgVi/g9GJ5udu\ndXOLEfAmVtPMjT8un2VyKFPkfTpj2kTPQBzIZCD9fQJmTXTk4Vkms/4+AbMmOgLxLJNDlTIZETDG\noo3/QMnkCjhH3xQEcabpLJNjka0Z58op+m6BX5LfG6xtNW+iM6uFcmWNeROdg1mP/Y9yDcya6Lyy\nTK6BWROdg4Xy9nYKnXvSRF+BZTLN++TJtSI1/KKDG5pLS/9Xq3d6AcXFF0KsDS8t6BzzCyjWwg/4\nWi0qKQH4LwAAAABJRU5ErkJggg==\n",
+      "text/latex": [
+       "$$\\left[\\begin{matrix}1 & 1 & 1 & 0\\\\1 & 1 & 1 & 0\\\\0 & 0 & 0 & 1\\end{matrix}\\right]$$"
+      ],
+      "text/plain": [
+       "⎡1  1  1  0⎤\n",
+       "⎢          ⎥\n",
+       "⎢1  1  1  0⎥\n",
+       "⎢          ⎥\n",
+       "⎣0  0  0  1⎦"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "matrix3()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "$$\\left[\\begin{array}{}-1 & -1 & -1 & 0 & 0 & 0\\\\\\\\-1 & -1 & -1 & 0 & 0 & 0\\\\\\\\-1 & -1 & -1 & 0 & 0 & 0\\\\\\\\0 & 0 & 0 & 0 & 0 & 0\\\\\\\\0 & 0 & 0 & 0 & 0 & 0\\\\\\\\0 & 0 & 0 & 0 & 0 & 0\\end{array}\\right]$$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def matrix4():\n",
+    "    \"\"\"\n",
+    "    >>> matrix4()\n",
+    "    [-1, -1, -1, 0, 0, 0]\n",
+    "    [-1, -1, -1, 0, 0, 0]\n",
+    "    [-1, -1, -1, 0, 0, 0]\n",
+    "    [ 0,  0,  0, 0, 0, 0]\n",
+    "    [ 0,  0,  0, 0, 0, 0]\n",
+    "    [ 0,  0,  0, 0, 0, 0]\n",
+    "    \"\"\"\n",
+    "    return diag(-ones(3, 3), zeros(3, 3))\n",
+    "    # OR diag(-ones(3, 3), 0, 0, 0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAOYAAACWCAMAAAD9lgRIAAAANlBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABHL6OuAAAAEXRSTlMAMquZdlQQ\nQN0iRM2772aJfKYutpMAAAUlSURBVHgB7V3blpswDHQuy5K9lv//2QKOTJBlDW7xOUFRXiDMoHg8\njiGzLg2nYX6dg8lXH9WFcBou1/H1ZlJl+Jm0nYdJ5smmwkXVD5D51S3cLXuVfI3ejWPsUjYAwGGF\n6zK7r6FKZiVfp/cfIXR9USeAwwrXZHbn87lGZiUf0K/9NHqun4UxBOCwxjWZ06fUyKzna+X7eeb/\nGG6yTgCHNf68MofLpO80FC4AAA5r/Gll3obfKPMqugngwPDnlzmrzaQmGTK8yIz4C8q8ffbLa5zN\nx5c2R4RKfh092WV70KY55CcbsPMBmmIKMDv9aQft/Yrwpl9QijA7/Xllxuv773yTIBgK4PvtAZ3+\nvDJDP14xu+/yzZ4Or09XZV4u38PnpTT68y6u5AN6d/m9nosqx1tzFV7jqsxcyFGPuMyjOie1292U\neuWox9zNozontdvdlHrlqMfczaM6J7UbuanlxVK9Sr5GX+XJ+WcB2ONo1mUgL2bs8VdTXXwN6Os8\nOfswAHscnfUYiLz+n68lahT2eBw9hfJy8LfktBEHM63W3YKZeuCZn6CUTwGmnDcDeJHpcfQUStuL\no9+H93w8xSPKqBJPqeRrdJqCCokbgFkc/Uf/o7zWDklnJV+jxz9QFvNmAHscLdijdbdA33GmDes8\nOf8wkFavT1cvKCAvzj66kg/oIG8GsMfRmT1mDqiD1ozK4DLteBncTUtmzm5216r1h0fUfxt/dvp6\n2iM6J7XZLyhzr2h5sdRtlXyNDvJmAHsczewBeTFjexyddQgd0H7Orpc30xlpC2BfHZ16atnRunth\nLXuVfIWeglg5bwbwktN6HP3P7uyYBSW7dk/d65Yvh6OtjvY4WpkjlpH9sFfJ1+ggbwawx9EPrtCu\n1t3EedxW8lU6yJsB7HH0oy+29v33piU/3U1383A98EKD1uPow43OQoNfaNC+7B8XUNTLhkYbOqgK\n4C1x9OpBF0yT8LYNHVQF8IaHdaCVx0xpGzqoCuAtq6NR1MtktqGDqgDeEkfTsr/CwmSmMq0C3JcO\nGgFg1ijpgpKyQzkJ5irb0EFVAG+Jo1MJOSItytyVDhoB4EVmeXU0KsF0tqGDqgCukmlr0GZxNH29\nCwuTmZvp274vHTQCwKxR4uroOFkXFyZzmW3ooCqAt8TR8dJLD7rgqrL3beigKoA3PawDRb1MaRs6\nqArgLXE0WnnMZLahg6oA9tXRzCRDb6WbPUPySIrLpJ6wsHU3LbhIGiY3s3taAu1sxXtaO/JIiX83\nqScsbGU3UdTLlLehg6oA9jiaTIq/5YqPbSYabdvQQVUAexxN7qQcZd98mcpTigOqAxqAmQZpCkrh\noK1kj/99M8ncNV8mMzdWBzQAV+W0tmTyJRapp+wM2vlf/PXsSfj09d43X6ZRu7E6oAE4TUFRw9v4\n0GL+3WRRLjWvuEXJMDtxIx3QAMw0SDMti3JZK/O38Uq9d3oNqgKYaRBlrqPcXBc/gpJhxt9IBzQA\nrzXIMlHUy9rdhg6qAtjjaGaSobfyoDUkMEpxmZYsdTfdzcP1gA/aw1mmNPil3URRL+u3NnRQFcAe\nR5NJKOol3n3bhg6qAtjj6GQS5SwgMCZ+GzqoCuCUBUUN0kxrMNlTZdrKaXmyl9x8EZl24mhp0Kav\nr504WpSJol6aYu/bNnRQFcAeRy8moah3Yc57beigKoA9jmYmGXorTkGG9N2luExLnrqb9twcptfZ\nkq5FSz+LG1dHd9f5Ff+jlwU3svcT1YW/C/V1CA+xeJ0AAAAASUVORK5CYII=\n",
+      "text/latex": [
+       "$$\\left[\\begin{matrix}-1 & -1 & -1 & 0 & 0 & 0\\\\-1 & -1 & -1 & 0 & 0 & 0\\\\-1 & -1 & -1 & 0 & 0 & 0\\\\0 & 0 & 0 & 0 & 0 & 0\\\\0 & 0 & 0 & 0 & 0 & 0\\\\0 & 0 & 0 & 0 & 0 & 0\\end{matrix}\\right]$$"
+      ],
+      "text/plain": [
+       "⎡-1  -1  -1  0  0  0⎤\n",
+       "⎢                   ⎥\n",
+       "⎢-1  -1  -1  0  0  0⎥\n",
+       "⎢                   ⎥\n",
+       "⎢-1  -1  -1  0  0  0⎥\n",
+       "⎢                   ⎥\n",
+       "⎢0   0   0   0  0  0⎥\n",
+       "⎢                   ⎥\n",
+       "⎢0   0   0   0  0  0⎥\n",
+       "⎢                   ⎥\n",
+       "⎣0   0   0   0  0  0⎦"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "matrix4()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Advanced Methods"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Recall that if $f$ is an analytic function, then we can define $f(M)$ for any square matrix $M$ by \"plugging\" $M$ into the power series formula for $f(x)$. In other words, if $$f(x) = \\sum_{n=0}^\\infty a_n x^n,$$ then we define $f(M)$ by $$f(M) = \\sum_{n=0}^\\infty a_n M^n,$$ where $M^0$ is $I$, the identity matrix. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Furthermore, if $M$ is a diagonalizable matrix, that is, $M=PDP^{-1}$, where $D$ is diagonal, then $M^n = PD^nP^{-1}$ (because $M^n = \\left(PDP^{-1}\\right)\\left(PDP^{-1}\\right)\\cdots\\left(PDP^{-1}\\right)=PD\\left(P^{-1}P\\right)D\\left(P^{-1}P\\right)\\cdots DP^{-1} = PD^nP^{-1}$).\n",
+    "\n",
+    "But if \n",
+    "\n",
+    "$$ D = \\begin{bmatrix}\n",
+    "         d_1 & 0 & \\cdots & 0 \\\\\\\\\n",
+    "         0 & d_2 & \\cdots & 0 \\\\\\\\\n",
+    "         \\vdots & \\vdots & \\ddots & \\vdots \\\\\\\\\n",
+    "         0 & 0 & \\cdots & d_n\n",
+    "      \\end{bmatrix}\n",
+    "$$\n",
+    "\n",
+    "is a diagonal matrix, then \n",
+    "\n",
+    "$$ D^n = \\begin{bmatrix}\n",
+    "         d_1^n & 0 & \\cdots & 0 \\\\\\\\\n",
+    "         0 & d_2^n & \\cdots & 0 \\\\\\\\\n",
+    "         \\vdots & \\vdots & \\ddots & \\vdots \\\\\\\\\n",
+    "         0 & 0 & \\cdots & d_n^n\n",
+    "      \\end{bmatrix}\n",
+    "$$\n",
+    "\n",
+    "so that \n",
+    "\n",
+    "$$\n",
+    "\\sum_{n=0}^\\infty a_n M^n = \\sum_{n=0}^\\infty a_n PD^nP^{-1} = P\\cdot\\begin{bmatrix}\n",
+    "    \\sum_{n=0}^\\infty a_n d_1^n & 0 & \\cdots & 0 \\\\\\\\\n",
+    "         0 & \\sum_{n=0}^\\infty a_n d_2^n & \\cdots & 0 \\\\\\\\\n",
+    "         \\vdots & \\vdots & \\ddots & \\vdots \\\\\\\\\n",
+    "         0 & 0 & \\cdots & \\sum_{n=0}^\\infty a_n d_n^n\n",
+    "\\end{bmatrix}\\cdot P^{-1} = P\\cdot\\begin{bmatrix}\n",
+    "    f(d_1) & 0 & \\cdots & 0 \\\\\\\\\n",
+    "         0 & f(d_2) & \\cdots & 0 \\\\\\\\\n",
+    "         \\vdots & \\vdots & \\ddots & \\vdots \\\\\\\\\n",
+    "         0 & 0 & \\cdots & f(d_n)\n",
+    "\\end{bmatrix}\\cdot P^{-1}\n",
+    "$$"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's create some square matrices, which we will use throughout the exercises."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "x = symbols('x')\n",
+    "A = Matrix([[1, 1], [1, 0]])\n",
+    "M = Matrix([[3, 10, -30], [0, 3, 0], [0, 2, -3]])\n",
+    "N = Matrix([[-1, -2, 0, 2], [-1, -1, 2, 1], [0, 0, 2, 0], [-1, -2, 2, 2]])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "First, verify that these matrices are indeed diagonalizable."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "True\n",
+      "True\n",
+      "True\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(A.is_diagonalizable())\n",
+    "print(M.is_diagonalizable())\n",
+    "print(N.is_diagonalizable())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now, we want to write a function that computes $f(M)$, for diagonalizable matrix $M$ and analytic function $f$.\n",
+    "\n",
+    "However, there is one complication. We can use `diagonalize` to get `P` and `D`, but we need to apply the function to the diagonal of `D`. We might think that we could use `eigenvals` to get the eigenvalues of the matrix, since the diagonal values of `D` are just the eigenvalues of `M`, but the issue is that they could be in any order in `D`.\n",
+    "\n",
+    "Instead, we can use matrix slicing to get the diagonal values (or indeed, any value) of a matrix. There is not enough time in this tutorial (or room in this document) to discuss the full details of matrix slicing. For now, we just note that `M[i, j]` returns the element at position `i, j` (which is the `i + 1, j + 1`th element of the matrix, due to Python's 0-indexing). For example"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAH0AAABLCAMAAABqfXinAAAAPFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAo1xBWAAAAE3RSTlMA\nMquZdlQQQOkwRIm7It3N72ZseWnCEwAAA2VJREFUaAXtmtmCoyAQRVGI3RPjkuH//3VYhOKylJrp\ncV70RUTqHinBVEFEp93RiyuP2UOF6LRU5nhcCRdvi+y1pXeXggn2Bno3juOL9cFrcLaD8ZY88cwk\nDJZAn6SRfmpFD5eVhpf29PkpxDAfxifCYAn0Udt+6zljhsuh73tPV66JWsKdvTMJoyXQHzzdMJSn\nz25+PPW0h93ukzBaAt215Twf6Nq+IjNa2SGykePJCaNlSV+4ee/7PunR09sjJDKpYIUzy4zejSx8\n63vUcA9B+kxpE84sM7qxV6sZz60j6/tx+ia8SxfrNqtqT5DRW56flpmO2BkjHOneEvo+uQn80u8a\n2NVtYz6MnXZDVCBhtEzpg3a9PkD38+ZxdMYlwmiZ0oV2n4+ZEd367r8ZY+uzhB03VySMlkBX1pNP\nP50KBVex0cVsZvqwHv7SJsJgCXTxkFIu7U+IlKtepH3EQY6qPwwXiTBYIr3e4X9Xe9NPvMEffQ23\n52/P/+iAOiR2j7ow6iDUb/iOEoNGg6K6rYqeh1C/UHEVSWJQb1DWtlWBjqF+KWNrKDGo3y9rGVWg\nY6hf6tgaSgzq98taRhXoIehq/8Jv2mzGkfMZ1ZSeBZy5SnLNB/1JQ1PkVKt0PkzfyzgQTvSK6gd0\no85mHH9LbyUJpMtlHNTKlfY8//X9y1uE8cElCZQYZJTmJaP6+ztZt8FQvyqXJAbV+5VKRjV97wJD\n/YqQqaLEoH6/rGVUgX4kSUgSgxJUr4EEApogHUJ9aEcXOxkHNYyltirSo8FFhZseoouLHB4xt+dv\nz8fBcFnhHnVh1LXjfnoZk1lYesX1R6rfL5V5CHq+HfdH7ckuYatza+PeuJKHAJ2J+yO9d1sjs9nO\nOXtU8hCgM3F/RK2rxff6vO8reQjQQwTGZROLW8uVH9BdBzAPSelc9Bn77gszs4qeNcVLzEOq9Erc\njxodt5aLTdOrIg/5jL68UtEzZcxDqvS9bEIegjc3KOhpU7oIo47LJoyp4natSDovVfIQoDNxfyL1\nsJtx09GNwGhYy0OAzsT9UUR0bifwfZpey0OAfiSbmGazTz3Kw5si9NiVPATp7bg/imz/GfiAnmxQ\nBDWkh9qrzjc9RBdXeTxwbs//z3/7DPaPN0qdj1bC6/vk7P7to5T4A0fbMY3IGYrVAAAAAElFTkSu\nQmCC\n",
+      "text/latex": [
+       "$$\\left[\\begin{matrix}3 & 10 & -30\\\\0 & 3 & 0\\\\0 & 2 & -3\\end{matrix}\\right]$$"
+      ],
+      "text/plain": [
+       "⎡3  10  -30⎤\n",
+       "⎢          ⎥\n",
+       "⎢0  3    0 ⎥\n",
+       "⎢          ⎥\n",
+       "⎣0  2   -3 ⎦"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "M"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABMAAAAPBAMAAAD0aukfAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAuxCrdpnvzWYy3UQi\nVIln4VgtAAAAaklEQVQIHWNgYBBiYGAKcZ3AwMCg+ImBgWsD00oGBmVjINOLgcEdKMoCZC5mYNh/\nAML8ysAw/wKYyfMPyHRAMB9gZUIUMIC0NUBMABp2/wCECbTiFQOEyXWBKZOBgTXsewQDU5wzyDlw\nAACa6iZBpbQ2vwAAAABJRU5ErkJggg==\n",
+      "text/latex": [
+       "$$10$$"
+      ],
+      "text/plain": [
+       "10"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "M[0, 1]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "That should be enough information to write the following function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def matrix_func(M, func):\n",
+    "    \"\"\"\n",
+    "    Computes M at func. Assumes that M is square diagonalizable.\n",
+    "\n",
+    "    >>> matrix_func(M, exp)\n",
+    "    [exp(3), -5*exp(-3)/3 + 5*exp(3)/3, -5*exp(3) + 5*exp(-3)]\n",
+    "    [     0,                    exp(3),                     0]\n",
+    "    [     0,     -exp(-3)/3 + exp(3)/3,               exp(-3)]\n",
+    "\n",
+    "    Note that for the function exp, we can also just use M.exp()\n",
+    "\n",
+    "    >>> matrix_func(M, exp) == M.exp()\n",
+    "    True\n",
+    "\n",
+    "    But for other functions, we have to do it this way.\n",
+    "\n",
+    "    >>> M.sin()\n",
+    "    Traceback (most recent call last):\n",
+    "    ...\n",
+    "    AttributeError: Matrix has no attribute sin.\n",
+    "    >>> matrix_func(N, sin)\n",
+    "    [-sin(1), -2*sin(1),      0, 2*sin(1)]\n",
+    "    [-sin(1),   -sin(1), sin(2),   sin(1)]\n",
+    "    [      0,         0, sin(2),        0]\n",
+    "    [-sin(1), -2*sin(1), sin(2), 2*sin(1)]\n",
+    "    \n",
+    "    Note that we could also use this to compute the series expansion of a matrix, \n",
+    "    if we know the closed form of that expansion. For example, suppose we wanted to compute\n",
+    "    \n",
+    "    I + M + M**2 + M**3 + …\n",
+    "\n",
+    "    The series\n",
+    "\n",
+    "    1 + x + x**2 + x**3 + …\n",
+    "\n",
+    "    is equal to the function 1/(1 - x).\n",
+    "\n",
+    "    >>> matrix_func(M, Lambda(x, 1/(1 - x))) # Note, Lambda works just like lambda, but is symbolic\n",
+    "    [-1/2, -5/4, 15/4]\n",
+    "    [   0, -1/2,    0]\n",
+    "    [   0, -1/4,  1/4]\n",
+    "    \"\"\"\n",
+    "    P, D = M.diagonalize()\n",
+    "    diags = [func(D[i, i]) for i in range(M.shape[0])]\n",
+    "    return P*diag(*diags)*P**-1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAQwAAABTBAMAAACYDSQ2AAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAMquZdlQQ3SJEie9m\nzbtvuCKIAAAGk0lEQVRoBe1aTYgcRRR+s7Pb2zP7N6AgeNkVg6inNSwii5Fht/0LKHMQPIg4ZCMJ\nWWFHQTR4SJ9EhLADCaigOCRBIRBILoKguIe9iAdXBYPgQBDMwYNsjIFdEcaq7n7Vr2peVfXuDDlI\n+rD96ns/9XVPd1e99xZgGMfZpfYwwgwa45dKa9AQw/CPq51hhJExggvnmrZYlcdeq3O6M+9uJnDp\nEqclGBscvaXdbK/3V2Jf3ihvEUdNrGQ2GigGn/bmUqhidU31bPDM+1Svtw2zC9GTienI/OR26tP/\nt/Jt3A8K5OMPU7gDO6xegWzwzHszWhI0asq2ar2kSlsZacJH6Si4HFqvAO2Z4Jk3gLh+QmPVMhlA\nZWG5ifHo+Uz0qHimIthcqlGYk5ng0js5NBpH/+DcEyyMx7Y45XvwMpxuHuFUCfZr8/1GquSCS+/k\n0GhA+VqKcn+DGxwKsFb7LXqKVwn0m94/qGODr6U3UacR3kIf8zxVg12CHUf5B5hpW/glJj89rH4s\nDB7E6AzSOxlQGuvt8F9lYQgTtZC+Ci+g+gqsxzsQ4LDvPIdIHnysjhhI72RAaRyLJ79QFoZQbY7O\nEUjR+AyW4HdYISpdVE55cEJDeicH0ggXl+NSdC5OUebvxUUKKhrV8x044ng2DkQPAejBCQ3pnRxI\n48U4nKfzeGRFw2MH12GtDXpwQkN5ZzTCXSirZ0kp7UJhGgAjl43gDhojX20+Y056+i15nATokWM7\ntUIaM0TVIwHCq4mzfA2qN4zgSAN9ZcjsbszMkxg2sSJ/Z3Ec6nbf6XZ/tJlRfLoF1V0avNztXv26\n251Do2y7hDTqiDNnXKOn2h+gFu9GMj5x+AHEzfNEC8o7M3UNxruRgNl2KaMxISx1Y+KJa3QIFxHV\naDwOhxA3z2WAqS0juEYj2y5lNEa3YCU2Y+BYrdH3biGk0bgfvkfcPIvX76XYCK7RyLZLGQ04H9XN\nEGSMa/QniGk0AOxbr7sOPghGcI0GVJJLQxoYnz+LNfpEVK/CTJzpdRrBl7wbjyoacoOQbZcK0RBr\ndPhzMLcK6xj4LAryHDzfoUOfXKlnFmKDgNulQjTEBmD6QNScjO6zTPGEBXfDcoOQbZeK0QhvzdRc\nIdcbLq1NRzYIRWjINVo8FU1LOPGtXt+w6Jww2SAUoSHX6OlGMG+JGbwN3zUtOidMNghFaMgNQCCe\nDYyJX1Uc331YvJT7OMgGoQgNcwb8qpr4AOP90FBf1QHmNVz3Q0Ms3smnzwg1yHB/NMRXdbhHTmMl\neqRoaC7zKeAbLCzXLGY5jZNwzGbU58tmPn1WJjDeDl43sWysaIy2QCzIBQ/MfAqaZ2ZPAzxn8VA0\nxuegQhMii72E88zHYcSo3hDlkJjBBaRoiA1jyZo66r555qPjvtFNUdJp8EaKxnoHSn/zNhTVMx+q\n8cqhSKpn67yZRkMl37ytRPXMx27HaBIaHUYhoD3SMDIfPqYF9dB4tSn9iv0oRuZjmZCHXT9K2IB7\nYukmH1FrWUHFpZmPAosK8hHd4I3HWlntS7ywY/4X1sh8+Jg2VLywr8S8Uj0b4vNVbfE2BDUyH6Ip\nIIrP1+cWM0UD3oRV/8fcyHwsQS3weCO4YlHlNFYu2Pbd1NWdVlHLfjlYXLJdaE6j3+02Indo0Jt9\n5278b+/GwA2/4TwbAzf8hkNj4IbfHmiUrtGHSpO9DT/NmhkUp1E66Fj50goWE78fYsuXxWmA2BPY\nDm/Djziy5cuh0MAKFpnMLrLly8FpFGz4EV5M+TKn4c1hLT+Kq+FH5s5FrnyZ0/DmsBYaroZfPncu\nseVLRcOfw+o0jmNgUs9DyHNmypeKhj+H1WmoOjGp57mnH/tTHNeFDVO+VDT8OayFBqnnuWmkWr58\nqWh406Xw0s06mUfdDVLPI2pDlKlvCvHlS41GgRxWhVc0FOISSOrLli9vDw1v6qvRMAsLqunHXOie\n7oY39VU0nDks7S9uC06k6Uf7hwzbFPKmvopGoRzW1vSzzp8pvKmvouHMYbFKzjf92KVbY+ZNfRUN\nZw6rquRs049dujUa3tQ3p+HKYfMqOdf0Y5dujYbR9NN1cpTT6NdRJK2S25p+zNJNnf1yURpp79HS\n9OOWbv/U1KIgjaz3yDf92KWbTuKXJQ38LziXddp7tFkwS7fNlMNPyf+COxpFz3JKDXP3HpmlW/P2\nDDajqO4xSdTO3iO/dBcJu1cbZ++RX7r3OkURe7P3qPuwS7du4h/9BxacEqsH+c5jAAAAAElFTkSu\nQmCC\n",
+      "text/latex": [
+       "$$\\left[\\begin{matrix}e^{3} & - \\frac{5}{3 e^{3}} + \\frac{5 e^{3}}{3} & - 5 e^{3} + \\frac{5}{e^{3}}\\\\0 & e^{3} & 0\\\\0 & - \\frac{1}{3 e^{3}} + \\frac{e^{3}}{3} & e^{-3}\\end{matrix}\\right]$$"
+      ],
+      "text/plain": [
+       "⎡         -3      3                ⎤\n",
+       "⎢ 3    5⋅ℯ     5⋅ℯ        3      -3⎥\n",
+       "⎢ℯ   - ───── + ────  - 5⋅ℯ  + 5⋅ℯ  ⎥\n",
+       "⎢        3      3                  ⎥\n",
+       "⎢                                  ⎥\n",
+       "⎢           3                      ⎥\n",
+       "⎢0         ℯ               0       ⎥\n",
+       "⎢                                  ⎥\n",
+       "⎢         -3    3                  ⎥\n",
+       "⎢        ℯ     ℯ           -3      ⎥\n",
+       "⎢0     - ─── + ──         ℯ        ⎥\n",
+       "⎣         3    3                   ⎦"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "matrix_func(M, exp)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAIoAAABNCAMAAABOtAxaAAAASFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACC\ngUnDAAAAF3RSTlMAMquZdlQQQOkwRCLN3buJ72bF9dPzbCjqGKgAAAPSSURBVGgF7ZrrkqQgDIXF\n285q27Z74/3fdEGURnIkwcWqnarxx4ziSfJ1VCBiVaU29UydBeeGZuyXFpwImpxTifJtpJp6eh+J\n9gatdZ1U7k6BUhnjU/suG2UZxiSJOemcDl45OYKqUrppzdZBB/koA/RzaNxQvHKx8WttUdRBeDjI\nRzG/q+kPPsjBhnJULsVRRnN5ugeJfmhwKJGyPIqN2afybM6/Ux0oy6M87NXW/jawZGRzKJGyPMrL\noIw6/RA5lEhZHmU2t2yb7li2CxQpGZRxfpgnnSQ42TDPzZwUeKdHJYOSdFn45P+KMj6m95Z+BraM\n5FucpzKdFTc0mL/nDuIzvIlX7DubizRKHOfWYw5lbp41M6AAPqbf3ywiFYNix7UmMgGho6ZOS+hj\nFYMymV5zZAaUiMOMQLMEhagYlJeZxPTMgEJQ2l6CQlQMig0TJ5KEjhpUJ0GhKgHKI92NRyBVNZs8\n8vcKVfEoMzO0xSjLKEEBKhZlycxJbwZPPitIxaEMhkQlpr5xTqquMZtuFnLi0IBUDIp6dl2X28ep\nH4J7xXYSxzuKQXmt48ThB3EHqnn81DWuZELbpY5UDEpoK95/T6LFJlb4hYLSdZKV3hZuOQ9O6Fty\ngUCAE5TJzOH66SKLBAUEwCjt+vqgzZ4duNwIUFAAjDKtnf3AFFbhRQn3BSgoAEbRjXWtNN87hAj7\nvgAFBYAoo14HHqUzi7GVxRdcOxn4DwOkUTKHQhAUN3mUMMCnQWEv0MWSzGclDGCz8u3je5TH/a5i\nhvrIaj3c66x0FYcC/PlA7+Lcs9ZdfJgRYdSGAsB7pXI90Jz7ntTFk1RxKABGqSZbdNi3QvmbrIoD\nAU5Q+mZu60sklayKAwFOUPKT4S0uVXHWujyK9ZpbxVmbm1Byq7j7UHKruJXklqzkVnGO5A6U7Cru\nNhT1bH9Jqjiy/Fb+CfotquL2lbItI/ZfeZRwXSMIRHbJXO8LxeRImhVQMZEMnzaQIFBJVCcXCFRM\n0B9sJEFkKoyCKiboDzYWRUEVE4wKG4ui7FPP20oy8xMIMLxAcEIOEwAaJSWZeftFl9/SKGHFBKKW\nbfo0KGHFBFNwsSSDvmBWqv22va8k2yu3AAqjoIopMLpnF6Ogiiknvux1VaTCKP9Skhlk2YQ/Vp2g\ngIpJnhWy/gVNieoEBRpLG8n6FzQkqhtQ6PoXQqGqG1Do+hdCoaryKGD9C6AAVXEUtP5FUZCqOApa\n/6IoSOVQ1m44c7mS+vct8fqXP3HYCVT+E73efiDXtqKvRA7OTg7I+hfUhar1E722rf4C5lA6Shcb\nFUoAAAAASUVORK5CYII=\n",
+      "text/latex": [
+       "$$\\left[\\begin{matrix}- \\frac{1}{2} & - \\frac{5}{4} & \\frac{15}{4}\\\\0 & - \\frac{1}{2} & 0\\\\0 & - \\frac{1}{4} & \\frac{1}{4}\\end{matrix}\\right]$$"
+      ],
+      "text/plain": [
+       "⎡-1/2  -5/4  15/4⎤\n",
+       "⎢                ⎥\n",
+       "⎢ 0    -1/2   0  ⎥\n",
+       "⎢                ⎥\n",
+       "⎣ 0    -1/4  1/4 ⎦"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "matrix_func(M, Lambda(x, 1/(1 - x)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now lets investigate how this works in relation to the series expansion definition. Write a function that uses `matrix_func` and `series` to compute the approximation of a matrix evaluated at a function up to $O(M^n)$."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def matrix_func_series(M, func, n):\n",
+    "    \"\"\"\n",
+    "    Computes the approximation of the func(M) using the series definition up to O(M**n).\n",
+    "\n",
+    "    >>> matrix_func_series(M, exp, 10)\n",
+    "    [22471/1120,  14953/448, -44859/448]\n",
+    "    [         0, 22471/1120,          0]\n",
+    "    [         0, 14953/2240,    83/2240]\n",
+    "    >>> matrix_func_series(M, exp, 10).evalf()\n",
+    "    [20.0633928571429, 33.3772321428571,  -100.131696428571]\n",
+    "    [               0, 20.0633928571429,                  0]\n",
+    "    [               0, 6.67544642857143, 0.0370535714285714]\n",
+    "    >>> matrix_func(M, exp).evalf()\n",
+    "    [20.0855369231877, 33.3929164246997,  -100.178749274099]\n",
+    "    [               0, 20.0855369231877,                  0]\n",
+    "    [               0, 6.67858328493993, 0.0497870683678639]\n",
+    "\n",
+    "    It's pretty close. Basically what we might expect for those values up to O(x**10).\n",
+    "\n",
+    "    >>> matrix_func_series(N, sin, 3)\n",
+    "    [-1, -2, 0, 2]\n",
+    "    [-1, -1, 2, 1]\n",
+    "    [ 0,  0, 2, 0]\n",
+    "    [-1, -2, 2, 2]\n",
+    "    >>> matrix_func(N, sin).evalf()\n",
+    "    [-0.841470984807897,  -1.68294196961579,                 0,  1.68294196961579]\n",
+    "    [-0.841470984807897, -0.841470984807897, 0.909297426825682, 0.841470984807897]\n",
+    "    [                 0,                  0, 0.909297426825682,                 0]\n",
+    "    [-0.841470984807897,  -1.68294196961579, 0.909297426825682,  1.68294196961579]\n",
+    "\n",
+    "    It's not as close, because we used O(x**3), but clearly still the same thing.\n",
+    "\n",
+    "    >>> matrix_func_series(M, Lambda(x, 1/(1 - x)), 10)\n",
+    "    [29524, 73810, -221430]\n",
+    "    [    0, 29524,       0]\n",
+    "    [    0, 14762,  -14762]\n",
+    "    >>> matrix_func(M, Lambda(x, 1/(1 - x)))\n",
+    "    [-1/2, -5/4, 15/4]\n",
+    "    [   0, -1/2,    0]\n",
+    "    [   0, -1/4,  1/4]\n",
+    "\n",
+    "    Woah! That one's not close at all. What is happening here?  Let's try more terms\n",
+    "\n",
+    "    >>> matrix_func_series(M, Lambda(x, 1/(1 - x)), 100)\n",
+    "    [257688760366005665518230564882810636351053761000, 644221900915014163795576412207026590877634402500, -1932665702745042491386729236621079772632903207500]\n",
+    "    [                                               0, 257688760366005665518230564882810636351053761000,                                                  0]\n",
+    "    [                                               0, 128844380183002832759115282441405318175526880500,  -128844380183002832759115282441405318175526880500]\n",
+    "    \n",
+    "    It just keeps getting bigger. In fact, the series diverges. Recall that \n",
+    "    1/(1 - x) = 1 + x + x**2 + x**3 + … *only if* |x| < 1.  But the eigenvalues \n",
+    "    of M are bigger than 1 in absolute value.\n",
+    "    \n",
+    "    >>> M.eigenvals()\n",
+    "    {3: 2, -3: 1}\n",
+    "\n",
+    "    In fact, 1/(1 - M) is mathematically defined via the analytic continuation \n",
+    "    of the series expansion 1 + x + x**2 + …, which is just 1/(1 - x).  This is\n",
+    "    well-defined as long as none of the eigenvalues of M are equal to 1.  Let's\n",
+    "    try it on N.\n",
+    "\n",
+    "    >>> matrix_func(N, Lambda(x, 1/(1 - x)))\n",
+    "    [nan, -oo, nan,  oo]\n",
+    "    [nan, nan, nan, nan]\n",
+    "    [nan, nan, nan, nan]\n",
+    "    [nan, -oo, nan,  oo]\n",
+    "    \n",
+    "    That didn't work. What are the eigenvalues of N?\n",
+    "\n",
+    "    >>> N.eigenvals()\n",
+    "    {1: 1, 2: 1, -1: 1, 0: 1}\n",
+    "\n",
+    "    Ah, the first one is 1, so we cannot define 1/(1 - N). \n",
+    "    \"\"\"\n",
+    "    x = Dummy('x') # This works even if func already contains Symbol('x')\n",
+    "    series_func = Lambda(x, func(x).series(x, 0, n).removeO())\n",
+    "    return matrix_func(M, series_func)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAANQAAABNCAMAAADpabqhAAAAaVBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC2drKKAAAAInRSTlMAMquZdlQQQOkwRIm7\nzd0i72bFIMexbJGvyfeD38FQ4ddwAnQUMwAAB2JJREFUeAHtW4uWozYMNWDoLCQhtJ3tbt/l/z+y\nkuwLhhgsk8dOz9bnzAgc+0oXG2wJYUxQuupUNnQOSYdnPq0bKtyuOPH/3TI34a7Gdl1Foq36ZrDG\nNJ3tRMUuxs2PAkW1Igdrq36GhIqbTq6iIsMr6gdJtfVIdeXI5WSKqrxsdEV10ES6WmI00F9LACU1\nqganAu11UqCoqYMkQg1dXEBCRQhViMWi8ULN+7EwkHxhhVRL5cRDVadIzU1cV0IzDWG0Q0vgdH2Y\n5BjqVxw7KFgjhtClByRUENDFcaEZNVaWSk11V/rXjO0kafKwQYZ/q1vWnkFKuhYjUxlr00p3hqDZ\njMnkTtP/nRWwprwUpqdR95CTCsKhiWltSdesYKZzWYx0UQsp+rWn+4GKnpTr2jtSA91TdCPwWNNl\nuwYEpSbxD1Z42V/HiqE85KQCKDwRVqTOnftRZCdThyvoynDRk/JdmUA/WtPTiNU8Qo09eQ0CqPkH\nKyDteaTBmiChAlC3pDpvvcihB6kilxS61nRH25GeDlQaPyeq9CMUBrIEFGRVm+LCdwUVhgxVcN0N\nqcFfRZENP4Jd78rXa0dq7tpayxPkzHOcblcuPd1j+gKoScodeR5mSK8CkGtSLdlekHon64rKyA9h\nc3HXWj39pq58QVsy48rzZex75tX7kYMV+xJQkL2Msx0AaaACMCtSxamu67KhJdZJata7kYIZ2pFi\nBdL1TKN9IkIdqbalaXi1GK5u7sCKtPRWeEh+oJKVHtJABWBWpK7ymKfL6iXpL8dSHvYycfruTM9/\ndI7KuYnrWtOGgmeeIclTuLC0o2CrcgqscLKpuq5jCA85qfCQK1I5ij5u2/9JvWZs+vNlLu5pmal4\nOVJu46T5v6lG09m12YRY/5ANuSS1hvuPnkdJwSHyEr5V1/EeP6dg3yrSO0E5/SNtNZARUnCIIOFb\nWXogt36zFNEWqVpsjS09g9kJuq+oICOk5k2rW2jhW/EW0riVWGdY3AnS9d1opYNUkPI+ltsDXjI2\nbXEnaMNcXbUOUkGK1dGoFzJIl/3tRGjahhMUNsk9VkIqSZFv1eaSgvMD6Z2gXCJhe0BBbkDqSLFv\nlTtScH4gQycoNDTjGFCQW5AqUs63Er+cbzBVmZwf75I18iwmJ+h4UUNqSHkfix0iI8w0dsH5gZyc\nIE3neBtAQW5CKkjBt5J1SrHQTGt19eP4k5gnztDbZwqHvrMfhbU9bvp+bdSvWneJkIJDBHmVvRd1\npOCTDwetUcJzrNVVQ86PzNbh5/G9Nu8Co4qHhnDL4w2/atnoNkax+j3/dFqraQfBcVHaR+THQ/PV\nhj0iIxX+fOD4IfHQA3qDLo8nxeCLHRpWTBo4t3IrwhyBhQcOE6QaDqtKhCEL++546IY2pTkJUhfy\nPBvZyW6oiVbfHw+NwlKcTmfOPikrrzgsfJgNVevqB8RD15DuXGvOPqmLuE+tesUV3Y+Ih8ZJac3Z\nJzWKp1tkBYmxVkOSfX7FzIiHxklpzdkl1Y8SQC/onYW+YK2GPBAP3VCmNkdHSrhtqHpd9UQqZc53\nTCpn+j1v5KaRSpnDI/XD26cNS3BnZnhB2ZHHDdWxaq05n9/Yp93aM7hnaJ33SI+Z85g6rTm795Rx\nq12XzjK4MRo+093x0BBZa84+KcMRsUZc3hA8eYw4KCR8rPx46FKV0pwEKXq9ZcutyblUuDzDTvzO\neOgS1CjNSZBagepPl6QOx0P1CsOWryHFGo/EQ0NLM45fR+pIPDSDSNj0ZaSOxENDQ3OOX0XqSDw0\nh8ei7YtIHYqHLgzNOXkGKV5w3dPvzJIyM79Qrslvv39qvvxhzJ9/HcrMJA/GpWMqMjsfT4oXXB8H\nrcdfzuPXr8b86neEJcVD//7nSGYmhVL9m0hFZufjSWGUEMTkjSW/sEMaZXkkM5MmH9IxFf2fSeqB\nmZlECumYfHMlMjufSMoFMae0yXsyM5kI0jHpMJXZmSCljB6y0rn4LZJ/3Ye0yXsyMwUbrw3TmZ0J\nUsro4UyIjxwpvO4L0yYPZmYKfPjaMJHZuU9KGz2MkMJrP8q9uDczU9AXbyITmZ37pLTRwwgpvO6b\n0iaPZ2YKOl4bajI790khKKB90evI+XvKBzGRNnlfZiZ9D8FZi2WjyezcJaUO34QjhReQCGJOaZP3\nZGaSAqRjKjI7daRS0cOQ1Ac4/o5JpaKHH2B0QhN2R8rgQfHtgpnp2GjIxh/vk9JGDyPA37Jqn5Q2\nenjDYE4QcR/OUQN5HZmf3Dl9cwdIBdQ+qaPBTAQvIckQeWF/IJgJCEgNVIKUMnpImhZlK0EkO7mT\n3l37HBNIuGl7UAlSC1P1JxsJIvnJnZvf3u1CPYcU048kiOSmDOIq5kI9j1QkQSQ7udOzyoV6GqlY\ngsjBkcqGehapaIJIk5fc6ccpH+pJpDYSRPKSOx2pA1COlGxGsj4OwD0cl0gMgaRWkiCiTe4MUAEB\nmYCaPl5u+INfaw991ROoDw6RGAIJ30qZ3BkgTd/cKaHk42Vrzb/tkKu7lZIW/wAAAABJRU5ErkJg\ngg==\n",
+      "text/latex": [
+       "$$\\left[\\begin{matrix}\\frac{22471}{1120} & \\frac{14953}{448} & - \\frac{44859}{448}\\\\0 & \\frac{22471}{1120} & 0\\\\0 & \\frac{14953}{2240} & \\frac{83}{2240}\\end{matrix}\\right]$$"
+      ],
+      "text/plain": [
+       "⎡22471  14953  -44859 ⎤\n",
+       "⎢─────  ─────  ───────⎥\n",
+       "⎢ 1120   448     448  ⎥\n",
+       "⎢                     ⎥\n",
+       "⎢       22471         ⎥\n",
+       "⎢  0    ─────     0   ⎥\n",
+       "⎢        1120         ⎥\n",
+       "⎢                     ⎥\n",
+       "⎢       14953    83   ⎥\n",
+       "⎢  0    ─────   ────  ⎥\n",
+       "⎣        2240   2240  ⎦"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "matrix_func_series(M, exp, 10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAjIAAABMBAMAAACFVUDyAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAMquZdlQQ3SJEzbvv\niWYEN0CTAAAOFklEQVR4Ae1cbYhc1Rl+d3dmdrK7M1lUEAqScRVrqSVr1lIwRqdxq1TSZlrpn9KS\nQS2WmrBrS78QzVih7Q/bDEX6d1PtBySi+0elYMm2UG1R6jSxCi1DBgxF+qMbNZtNtMn0eZ/3nHvn\nzszdnTuIUHsP8Zx7znvO+57zzLnnzt5nHmVbu/22pCmKwMF2+7Rsu2H+M9HmtCan5ncDmekUiT4I\nFFNk+qCiTQ6Z/NzRuuRuuJXbx8oDu/4qckXzGZfdtetKEevWPFERear6k8rIt5rNpshkVT2NlJz5\nquPRTRj6QC+tcJiNfeTG32Jk8x8VGyvyLPqIXCJCS05DTfwz/ze5fFez2fCh2Cea6Rzunr/eZWrT\nFno2p1wOF5E70dQJIsZGy/HI/EAyazJez92vPlnm75ePSn5WlsqW/VEerQm7jYncLPJK+4IU23p4\n545hDhi1bOZHK/k/ad2n0AdaWOEwZvmS7K3II7LljI2V+85y2ANiFoaaarcbsopQJR/Kuw5LzuH7\ncu+0MIOBLfRMp7YcLuJH06OL6PCAbLgcj8w1IgfldpE7NBjL8YYckcKabF1kNrkio8vCbv8WuVfk\niU9MS6EqUsrNbEchsseZnxf5uNZ9Cn2gxSpVDOPY0aqMn5aTFVk313fNEJnMS2IWhprYgc37msio\n+FDedVDSkFmUzGFmaLeu9EynXI4t4kGZOCyCGBsuxyPzclW2178pslSDV5arVVxlFRlmWw9L4ayw\n23EiU4K5gH/YmHu1a/5fy2Z+V+SkNvgU+kALKxzGbOoFGT0v+xQZupYMkfnpUTELQ42qJ9xJwMdC\nab07YQ7jJdlyjhmNOit6plMuh4so2rZEjI2WE5wzT1fllvo7Itsq8MrySRd7qYyLpfLCsmTOC7vt\nu0ZexYdu9sdQ7K0iK0ws0/zz99BQN6PPnQ+rsqLD5DGZOCtj53GFu4muHTKNo87CUEQGfcroyFAo\nexIMW2dlZI0ZrdYVnun0SW3jIiZWaEaMjZYTIIPOB79+AciU8emzfPeyWxUledwyhfuiXh6sTrZP\n4RO8ev5jqOWWkXEObwIZmnXPtPQyTM6HNWiFw5jJuH6EEyW1HawaMsUaZo2D66ww1Oj87jqq92mb\nLVevuhIMhxoycoYZbdZVPetG5HK4iK2/mP8k1m0xYpfTgczIBSKCNbN8bb0lD+Fw/zs8aza2IpOA\nX0YA2y3rNT3vFzDfsQradA65MpGB+SaRY2W0BinwoS2s2DCOlW2IeAWhU9e8m+4RIqMWDTVZzem+\nwnI2R+aCIgM/vis9w2luXZfDRSw8JOMtcTHiloPxRf99ZmI5ikzbHRd76ui1p557Su5UZLD+4vVP\nr+FKRlewP/VCkSmoheZvtLK3lHHZkZwPa9EKhzEzEDJ/hk0dEJmGNQIeH+o6QH9ah9tGMEeRHAaC\n0oWMqGdFhsvhIhZO64npYsQtB74DZHa6u8jtmdvWRVYr6DClux1Zcf4yxWOnyBt4WldxWXjLPct0\nul8wZGCWU5/GkziSvA82auUOvWI2BjiQXqnSNZHJThMZtfhQJ6fx2NF+Xcjkf/NdTXUaFJSeu0k9\nc89wObqIhUUprrkYsctBKI9MpmQnbwttegK3cFyslvPTMnmRGZqBtGi3F0QOtSYXpYA9jscYZ5Vr\n2EcOM1Lk2RTx4XxxGLPd6P4w7r8WXROZA0Jk1MJQz8FhXZ88SF3IaJMlGPTwvciMTdrVedZzRpeD\n9sJZHDbFMy5G3HLUgUfmTsnXMNV9NbSxxHxWKws4BC8yQ/PEYRF0++EKjpfy1KKMnZMcQOR0szMz\n2/9QVnMNDUfwX5AiPswXhzHLzsqPc9iBQIZj9W764szMf64WWlY01Is4bmqyMKsedbl9EwzALqtP\n7ew59kCL86xOuRy0TxzGZ1pcsxixy1EHDpmRWZzW+Ib3uuT4Te912acfPfAdP8csc04O1YXd8A13\ntIZvp0Bqi0cGnqaWzby3ltcDM0ihD8Hnqg5tGMdeKvKmfp4Ha3TNPYORL4nQwlCA5Ai+OGyKDL7k\nFRaZIZCBSM90yuVwEVmeM4yx0XI8Mj9qNj8l45Xc7wW3IcvJRu4vkmnJUsOy78gvRdjty1X5quRn\n5Ss1yUaRofn26kQZEwtS6CO3bg5tmI7NP9g8sSifly0XzHWIjFkY6hHJAqF9myIj35b908wQyJCh\nZzq15XARv5P9LdiB/kbL8cjgRc265Hbtnpb9y1bKjh11kTvnfuWyEzsr+Gi125ar5nB56Y5r8QzW\nrzhzrzyBSIXt77RoLsw9g8aOFPjIYTKscJhm4/hraFGyczdWzPXYTe/ejJHH2zebhaFG5mZqevLB\nYKFw0Z1ouPvVK/EXJTINxBZ6NqdcDhcxdpV+E0OMjZYT3E3dkdK63zMpEj0IuBO4pz1tSJGJ2wMp\nMikycQjEtad7JkUmDoG49nTPpMjEIRDXnu6Z9wUZT9XFOevfTk6NLBnsLMmFhQRdTrm7/qyYMXMj\nJUfUkUnrH2WzVj+BzfoF9kR7xlN1wehBLvIlZds8QcZSubB8QPIJubu+JJ9j5jzJlyeTNkjQ3j5+\nAr2WmJZEyJCii3EU2zyKd0qnPUFmpXJhHQTd88rdXYO/5KWL5BPHzO1xJN8k6cDYSBsZ/AQ26hO1\nJUIGL/uWatHxm9fIqeFV2xZ91caSXFgHQYf3SyerLysXeLyb5NPXcSHJh/de+sp1mOQnMPjYRMjg\nXROpusHdoyfZNk+QsZxYMQdLZZRL5dx7eM1Uf7oKLrCH5CMynuSrGx1ogxPmfgKDD0uCjFF0g/sO\neo6fPdTAe33UWRoXFpB8+rbzZAvGPiQfkQlIPt0z+q5siOQnMPjQxMg0Bvcd9NzW0IkpQcbSuLCQ\noLvJuLt+rJgiE5J8Y44ODBwPfuEnMPiIDwSZo4ZIgIx7R70Hr1NB8onj7vqxYopMSPJ5OnDw5QU9\nh0Lma9Vg/MYXw95N4NR0YsHdRC4MoQKCzri7nSHzFpB8ikwHyefowI2n2dfqJ9DX2LcxX5HLa30t\nfRr1BG71ad+kCZyaHoB6QrDEcVE8Q06OmY4Gd9eXFQMyuQjJN+yzyU9gk6l2mLOLCX7B6Km6jvED\nXCqnhocmCTKWk8qFRQg6JZT6knxAJkryKR04TPITGHxsknNGf4z1+uCufc9LwbZ5gowluTBsHEfy\nCbm7/qyY3k0hyWd0oPebqLQJJBmSCBlSdEm8a1/j1JQlU4KMbJlyYSFBJ+Tu+rNiATI0Z8ikJZ2A\n9WfgJEMTIUOqLol37WucmifIyJaRCwsIOiF315fkMxItIPmETFrSCVh/Bk4yNBEySRz/z/dNkYn7\nCFNkUmTiEIhrT/dMikwcAnHt6Z5JkYlDIK493TMpMnEIxLWne+Z9QWY4Js5p0ERLU8Kpng4TukQn\npRn1ajLi+bYDTWgM2Mcp4Z5FHzWbRA/XPnl6jWUgtzO6jw4oiqOoLqLfQ9CQ+es1j5QQINGeGYqJ\nE6dBY2kqOtXTIT3gMurV8KenE9XJrIy1qLlzSjgTysGcV/ZOB/nk6TUtaTT/bGYQiuIoqjNL7lhV\nxyJyyPz1mhEqITJDMXFiGjRhSSUc9XT4pT5+m8psXOV3oaiu2JLcovV5TZVwIR1H9g49ffL0GstQ\nbmfNKtozuR1FdYzsRHVRPVyPWeV9CZHBO72lmp/WoKXToAnLAl54T0uJY1WVJpqtVrUeiOoKJUWm\npG0NKuH4kkbNZO+03SW8qAv5vVBuZ80l7URR3KheWWT7eX5UD9dj1lAJkRmOiVvRiYGRW2EBJZxD\nRlVpotmTNAR8W/btaqHs+lAJR2TUjBS5mzy95ksaH+PL5rXAwRlsO0uIbMhE9XA9ZguV5JwZjjvw\nvJsrVQlHPR1VacxMfhfwbXLs4ue85o5KOCLjzI+7VbI41MlIoEWN8G/NJtpTuZ0T1VGDt7eK3VDT\nzyRg/rrNYqESI4MNniwZ7wa1F7VolMNRT0dVmmamVwv5Nhlrf89r7qiEU2TMbIq6IL5CoGe5lYHc\nzqom2lNRnBPVjVXQVZHp0sN1m91MPgBkHO+2YOUC1wU9HVVpmpleLeTb5I2PtHUR6GNKOEXGmZW4\nC1MUGbJ6KrfzzeqAojiR63DFyIpMrx4uYnahEiNTRoxEyfNurryDgwtvUZXGTF+cr1ZCvq04K6vA\ngpq7zGFcKDLObOwdXSBTCAJ+D3Unt/PNyueZ3E4gqjMNHpBhUBg6mL9Osw+VBBkTy2m0JAn0SVGn\n70o838A3Fc4fUOUbM+rVbgv5tqmq5C+yD39VQmSMjsurRK8jtqfXWDoj/LNqDh5Wud1zeHpjq8HC\nu8mChsxfl9kxf8m+6cH3vlrHzAa6xBSLqsC0UpVwU6qnoyrNpGmY2uqXQlHdfnS+gX1wB8yigj1j\ndJwp6sKonl5jGcrtWKUDE8W9SFFdoN/r1sN1mR3zlwyZoZg48m6CTcxzRpVwY9TTUXvFjHq1kG+b\nqolc6/pQCad3E83YdlDUhcnotaqwNKP6Z9UcUBQHdI9ACQ+Le2qr6itk/nrNU8vomehuGoqJE+Xd\n9CyhFo1KOOrpQmSoV+PSybdlfy3ZRt76UAkXIJNpQaIXAmO8nuf3zEiVnrJu5oCiOBPV0eKEmEAm\nZP56zcmRGYqJE+XdVKVG/o28P/V0VKVZRr1ayLf9bA5/UVof/YFBSMeZoq4Dmgi/F8rtyLrRAUVx\nJqpjZBPVRfVwPWadScI90zGnD/9lorvpww9HxwpTZDrAiFymyETg6KikyHSAEblMkYnA0VFRZNL/\nB2MHIO4SP+c5LffMz3+21/R/3nJqfr78Xyy+6sASX/WfAAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$$\\left[\\begin{matrix}20.0633928571429 & 33.3772321428571 & -100.131696428571\\\\0 & 20.0633928571429 & 0\\\\0 & 6.67544642857143 & 0.0370535714285714\\end{matrix}\\right]$$"
+      ],
+      "text/plain": [
+       "⎡20.0633928571429  33.3772321428571  -100.131696428571 ⎤\n",
+       "⎢                                                      ⎥\n",
+       "⎢       0          20.0633928571429          0         ⎥\n",
+       "⎢                                                      ⎥\n",
+       "⎣       0          6.67544642857143  0.0370535714285714⎦"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "matrix_func_series(M, exp, 10).evalf()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAjIAAABMBAMAAACFVUDyAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAMquZdlQQ3SJEzbvv\niWYEN0CTAAAOM0lEQVR4Ae1cb4xcVRU/+2fezu52pxsgITEhOxSCEGO6sBgToDLCKpGgHSV+MZpO\nAMVIm100/guBjpKAH9BuDPHrVvBPQgnsFzAmmK4mNhCIHVoCiWbTSegH4wdbod22aDv+zu/c++6d\nMm9m38b4Ad79cO5995x7zpnfu++92febszLT6bwjRetGYG+nc1Jmbpz/TPd0cSTH528DMtMFEj0Q\nqBTI9EBFpxwy5bkDS5LceDu3D/tk7Whd5LnGT+smrlh7AeZ7drwuyVVHYPboTb8XscnJhgjNL9+x\nttaiUNe+0cgs3Yp7dlzpHHAk8iJs1bXIUNVpRC7BYRqPQYe+s7a2htkeTXO4d/56J9RAZ5hLSA2z\ncBqiu1SHqm4ZNS4lj8yPZfS0jC0lD2Kx9SMinxI53DlvojwryzUpPygflSfq5ZelXJWddZtMDjZE\naH6i0+lUKdSNazQySxE7+LM80TQHOhJ5YB0adY3YK+Yaw4fcJONRVOC/98OCOfxQ7p8WCqzmDHMJ\nqdFpOY0uLlXE5DLTWErpnrlGZK/cIXInFlv/T5H7RZ7+OLaHiqnTsnVRxlryjLwk8jEZbsjYSU4m\n27Y3RGj+psiwUKgb12hky8XcTK7K8AodcCT3bAMydC1y14q5Fhl91U0yHsVUQ6Tq/cY9cxhdlNH9\nFFBZVswlpEanIbpPFTG5jBpLCR4qdp95rSHbl74tstzEHPsjRKaKQyZTIjInGjh8T+RYY8shGT5n\nk7ITszRvibwuFDDzjUbOUthv3S9T63TAEfIFMnQt5X+sCDUiPzvgJhmPYgrQ4kz1ashhrCrjZylo\noFkxl5AanYboLlWNyWXUuJRSZJ5vyK1L74rM1OGV/a5r5A13hqqMpFfTsxgl/xbZuTSxLiPncIRJ\nImPmMo5DE+jTpka01Jnl2gLO0Tk64MiQUdf44BMr4ly3gEwa7xcMCoMnafZ+sbMhW2dl6DQF1ZhB\nQ0JxanAaopuaMbmMGpdSigyM9n7zPJCp4eJmP9k5DsSvnr/OCZGnsF0uu73OPdPGgjGcaZ0kMmYu\nD+DQhA58UyNaWq+n5QKGY+tupHuGruXvQIYaqTSBTIine6aN00K1mlzUgMO+lgydoqDOkEFCUWrq\nNESHmearMbmMGq/2VxMeCueJCNBw/a1nmvrQWFgyMfTXqiRn2vKI3CJysAaPM8gEk4aM0Fw+gUMT\nOrBGI7NEGKwYWZXJU9DNtNwIyJjrpGbIwPV9ciCO54KO1L3Xi3qHzHn9iDizaIaMJhRSU6chOlRQ\nMyaXUePVAZmJlW5kKtc/f1oDDK96cddS0tFbzLfapVtrmMQ5xR1zyXIw8+QkpihUlzY1oqXOwM1z\ncrcig49uI0WGrqfEkIHrlqpDPBd0QT30ahnIaC5RanSaRrdUGZPIMBufXEDmZncV+avpbal0Gshh\n6l9ebFlPzuCmWJfjn95Zx3N6RTPcggtBz46Zj+7HFAX60NSIljqFg8r8ZUBdHdiIe0Zdf9GQgaY0\nrchE8SzoncGpjsq//b62JebAK4KCRtwzmktIjU6j6EyVMW0Zs7GUwn1mtGp33ja86h24fUhkX3ty\nUabOUZSnZfKC3mJO1GBxrCFyGxLjJJGhud7icftQERqNnKVfgWcTHcBKR7zPwPVnW4YMXO/hnozj\nMSgem70bcNC76AUKmhAZzSWkZk4tJmIw1YQx/TLNhikFZO6WchNhdzWh0f6xVZzU2pZFGTlLsbCu\nyPyOe0bwpUZKs/ITm1RkEprLwqyICfSu0chZiu8n9tMBTDAiMur6y9u2bf9TjZovbdv2n6vjeAya\n4KT1bsgBKJT0qV06SxMig4SSVf0kzMqcMqamz1RLjOmXaTZMKUVmaBYPA3zTe0sSftN7S17GLaaJ\nr48T+ylwyx47K7t0u+xslvG8vhQ3dZvknqG5LCsyFOhdo5FZ4ryqm9Gzsm+JDmxEZOga1xouMXWN\nxa/iBKXxLOh4P2TwbW1qkUIaWE5kNJcoNXUaovtUEdPWal4upRSZx9fWPilj9eSPsoBvutp/pSFf\nk/KsfLVJMdqW5ZZMtpK/yB2NiZqUH147umiTzIHmskuRoUDvGo0ocNuwg+/Jr5wDHdmeoWsiQ9eY\nBTIhHoNKqR8y8l3ZPU2h9ydDRnOJUiMyaXSfqp4NXTuqGgpNvWLfgfGi5owkO26blt0r1o9fNVfH\n6bvhWifunvs1zG+4YUmm5l7AFYo/YRaFk3OHn26Lmc+0YUOB3jcaqUjwWXlw9Oa6c6AjGbnlPfyJ\npq5lavu7bXMtRzpukvEocB/xTi/qmcO9b1yJPw0hNBBnmEuUGp2G6JaqxuQyYTYUcO+QuShQcVgg\nk70Hij2ThU2BTIFMFgJZ88WeKZDJQiBrvtgzBTJZCGTNF3umQCYLgaz5XHvGU3VZznrPk7MjSwY9\n+z1reMsYSL6htb/hr6eUdItJPuXoApPWh4nrHTqa9QlEU/2HuZDxVF1/lxdpSbmlBBmJslkZaQeS\nTx6V8VO9ST5ydCPKCZI0y2biLorZ49AzdD1UvadyIeOput6uMmaH8U7pJJkuGLCvtCVZDCSfHKvL\nmZ4kn3F0gUnLZOIyQkfTPoFoasAwFzJ42bfcHODwfWoSa3hnNq6v2thPVRWZqlpS7FJkTjRwSL4t\nJvn0PegR5QRbSvL1YeKwuG/zCfQ16lLmQgbvjUjVdXkYdEBiTd+zKhXBvvROY6oWIQO+7FQg3bpI\nPkUmZtIymbhBWfgEBtkFfR5kjKILazc8Glvf1wJLBnvrD174fDfJN1GNSDeYpSSfIhMxadlM3KBc\nfAKD7II+NzLY1rnbTEsTU4LM+pHOD2KST654KibdYDYDc1B29h40YtIkk4mDbd/mE+hr1KX8vyBz\nwCHikXn7Ix08piOSb/SViHSD5oDmeNeSIRMxabKgis20TSHz9cYGQ232agKxpomlV1NlVk7gKolI\nPjn8jYh0i0g+vZoCk+Z+xbLBdLvMfAJdk30PynW5vNnXIlLqHbgdHW9wCNJLb4D6dpv9loaUL0ym\nJJ/8CER5OybdAsmnyBxSTlCfamh4Om6u+QQ2vrq0mOMXjErRNTfu21kq6YXPRYKM/W4obgwkXwKW\n+GC7N8kHZJLVlEmTbCYOLvs2n0Bfoy5lnvuM/hjrra7VGzq4FMQamS5pGOO1pSlyLb7ZOpJPv8Xs\nbQbSLSb5dM+8rJyg8XvZTNygTCyBQVaxPhcypOji1RsZG7GmTJcSZNqXfiOlVjkl+eQLMn4+It1i\nkk+RiZi0bCZuYCak6QZaRQa5kCFVFy3e0NCINU+QkS37+Rz+ogwkX2nuJjyqepF85OgiJi2TiRuc\nCQMPNgsWuZAJyz4EowKZrJNcIFMgk4VA1nyxZwpkshDImi/2TIFMFgJZ88WeKZDJQiBrvtgz/xNk\nNsfEJUfXpjW89salBSaOIzJxVpXHQrxQuUYNy+GsEM9X1vlP4+k1119iBW9RECuKY60f02A886LM\nX6iZY3ZW42eh8v2CcVNMnDw+PbyoH0V749ICE8cRmThW5ZF0g+lDwvo04+hCTVyZhXkeFvSeXnO9\nWxYFIYFnaTMNjWdeWIMXauaYnWkYL+cvGDfFxMnD7kfZ2pNLC0ycjY4p33SNVuWRdMPb31dlclWG\nV4yje0lr8Ch8ZZ3HxtNrrvfLoiBv4t2Oq/XT8IxnXsa0vI9qC8rsWN7GUDmRwTu9/ExcBa9YtLEn\nlxaYOBvtUmRe06q8IyzE03I4/NgcNQDUkJ6j8JV15tDxejjACzvl+fyyKEhLCTymbeGVAzQvZP6o\nZlCqTcNQOZHZHBO3ah9kwvVPSmDibEQm7nmtynOkm69cw8LxU6zBS2vilmvmjdLTa66PlvkgcFCz\nGj+G9/Hg5VnzAzWD+uyWa1bzlw+ZzXEHW385j/dUeDluvVa1BSaOI7z3rKrF3oaRbnHlGjR6DvUF\n+rE2bJ5SQ9/2xYwECifSgrc0iFa9WdoW3sWDF6vB06I4BvVZqsZCVXJUsjMENmC+tvCIjLWxxPXK\npQUmjiNl4tCUqmP5WlS5pppbtAaPwtFzasymyAR+L1qWBtGqN0vbwjOeknzJGS3vs/o9DWpq0n8W\nKtezaZPInLSCoQXrlUsLTJwbjb6C2YkVV74WV65Bw3I4X4in9FzaupGJloUgyUmPDMO7eL68j/V7\nZPpcdkr/uVC590wtzWuDAxS/VJTsd/2duIJTJs6P5HBD5GZHusWVayijb1gNntXEpZV1DK7IpPxe\nvCwEGd3vriaG9/HS8j6ojenzWWr5noXKg4wVyzGnHAJPmYqm73o8KAITx5ExcaJVeYeUdNvj2Fs8\nm8jRYe2xBkXZavAwtubpNfbRMn0amWsSeCQQGZ6T5gV3kxM1qhmU6tS/xsuFDALmZ+Im3Z6xXrm0\n3fhcxsRxZEycoCrvsVUl3ULlmtOwHE6Fr6jDejY8rQO/F5aRsKNrVr2xxq/J8Jw0L8b8LfiaOapT\n/8/AfS5kNsXElXiBN8R65dICE8eRMXGsyjPSLVSu4cTubbIcjgIndgzfW9Jm9Jrj9zDrC97SIPj+\nNetq/Bie8cyL1eCpmkGpNo2V3+VDZlNMnPxBdreVhNOeVW2BiePImDhW5RnpllaumYblcBSjbS3M\ni1rM7xkyLLJTws5cs0DP0tbwnDQvVoMXauZUbRorv8uHzKaYOBm56jpWqWlvvH9g4jgiE8eqPCPd\n0so1oSaqiWNFXYRMF78XlpGwo2v+QsHSZnhOmhfW4OkPGCwo1dRY+V0+ZKKcPvjDXPeZDz4c0Scs\nkInA6BoWyHTBER0UyERgdA0LZLrgiA4Umax/qxWZfeiG+BJxUu6bn//ch+6TD/rAx+fna/8F5VBN\n7F3LwaQAAAAASUVORK5CYII=\n",
+      "text/latex": [
+       "$$\\left[\\begin{matrix}20.0855369231877 & 33.3929164246997 & -100.178749274099\\\\0 & 20.0855369231877 & 0\\\\0 & 6.67858328493993 & 0.0497870683678639\\end{matrix}\\right]$$"
+      ],
+      "text/plain": [
+       "⎡20.0855369231877  33.3929164246997  -100.178749274099 ⎤\n",
+       "⎢                                                      ⎥\n",
+       "⎢       0          20.0855369231877          0         ⎥\n",
+       "⎢                                                      ⎥\n",
+       "⎣       0          6.67858328493993  0.0497870683678639⎦"
+      ]
+     },
+     "execution_count": 29,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "matrix_func(M, exp).evalf()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAJgAAABkCAMAAABNTAlxAAAAP1BMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADFBd4eAAAAFHRS\nTlMAMquZdlQQQO0wRCLN3bvvZol8bJK+89UAAAO3SURBVGgF7ZvtlqMgDIZRqJ0dtR+z3v+1Lkir\nJpKEzHA8zh78MW3lDTxGxL7NaJpp3lpzkm2MPMY0k3V+u5yEyzwCTTsFsOYsTCvHQwK7datYetdb\nO9w+SVXnT4ylcwCjBbDuNuWD9WGWuomcEqNn7kaKDEWzYF3btgqwdj6G0Z+D5ObGsNsNyUZjUDQL\nFvpRgN3vgaydiJM5zpf959SnyVB0SbBhPghLgU02EDXUqUbRJcFiJkYix/30jGAu6tJ/l+jiYE0c\nfz/sAjbz7dvnPWt0cbDhRoyZBbZGA7B+GNctTmFu8ifkxlJcZgFjTuUmGoAljpUDS8mZG+578j8S\ncXGX20SXBbuEC68n1oO4XFyo5cIYEF0UrJkXhAcBFhfY57zMppIGo0uC9ePTb5YcefQ3q+5O3pJg\nNA9m7X0aLD0p4IG/vkeRYJ19upbiMiiaB4MDH/qpgmnTXTNWM6bNgFZf51jNmDYDWr04xzSG1w/O\nyaGjTZFuogUwleH13x04f4wc7R4MRLNgSsMryJGjxWAomgXzsdqv1oR3CxTI0WIwNNiBYMjRngcs\nkiyO9mRgq6M9GdjqaDVgCQfLTX6lPJBsHG0G2HW6JlRxFweWCBLkW0crRH8JP3UKI+HeeTlwtDjU\nf95GH7hcGOhozwMm+WFNxnSG1/By5Gh3GYPR0qnchR+1o4JpM10zVjOmzYBWH+ZY5/ILWdr+v63v\n/Y/bv7Ne+e1D/mHgL1suhFosTkamXDC8sJd0xvhaLOYyeXLJ8MJekmBCLRaDZcoFw4t6SYIJtVgM\nlikXDC/qJQn2LkeRZXeIlikXDC/qJQWWU8DboOnklOHFvbBgXC12JVu6zJGThhf3cjQYaXhVYEwt\ndk1YVun2LacN7wL2GjRk7Prx5x0YX9/zMLPsli/nDC/q5e9H4iYu1mLhcWTLWcOLeknNMSPVYiFX\ntpw3vGjQJJjha7GIy2TKJcMLB02D8bXYHVieXDK8sJc02G7o43dUMG3Oa8ZqxrQZ0OrrHKsZ02ZA\nqxfn2KboKvYtOFpVswAGiq4SmOBodc0sGCq6SmCCo9U1s2CeZFtFkcAER6trLgkmOFpdc0mwmFHK\n0b7yndtcHIx0tBEsu7k4GOloI1h2MwBTlmwTcqGEq2gGYK9psH3RXJU+jnO0uuayYKyjRf+zvD38\n+B5EFwXjHa1U4YXRJcEER6tr5sFg0XWffLhHcLS6Zh4MDnzopwqmTXfN2H+WsZM+kdqFJ0CdI56l\n056Dn+vnJ1KdM/8A0rpFHAD89/AAAAAASUVORK5CYII=\n",
+      "text/latex": [
+       "$$\\left[\\begin{matrix}-1 & -2 & 0 & 2\\\\-1 & -1 & 2 & 1\\\\0 & 0 & 2 & 0\\\\-1 & -2 & 2 & 2\\end{matrix}\\right]$$"
+      ],
+      "text/plain": [
+       "⎡-1  -2  0  2⎤\n",
+       "⎢            ⎥\n",
+       "⎢-1  -1  2  1⎥\n",
+       "⎢            ⎥\n",
+       "⎢0   0   2  0⎥\n",
+       "⎢            ⎥\n",
+       "⎣-1  -2  2  2⎦"
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "matrix_func_series(N, sin, 3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABioAAABMBAMAAAAB9fJsAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAMquZdlQQ3SJEzbvv\niWYEN0CTAAAfjklEQVR4Ae2db4ycV3XGz/6bXa93NyuCWlQJeXBQSkWqmDgIiSRkCCZJo7Tegoqq\nqpVHlAIiiby0ailCkKVIUFWUrFDVr3ZD/0h2RPYLVJWo2FZqCAqqF4eGqtXKKxGhqh9qA/HGAezt\nOb/nvu+9OzPr+FNmpH1fJcez77nnnOc8596dmV3PYzu0s/Nja66GgYYBMfD4zs4lO3Tnsfc2hDQM\nNAwkBl48dp+fisWGj4aBhoGCgYXmVBRsNA8bBoKB6lR87p3/ZPbV7l8ujf3R5uamtZ7fXLTHNt9u\nMr94z+bmhj12z3fNfv/Y28zeuPk10xputu58z6JhSFF4Zn848x+GMTvYTdmoNbb530v9MfY6z7v5\nvHvCzBw9u5piiFaJgEG06oAlkHs3X/fowCIY4VE7gh5u4acJjN+pLnq2QIChuBAQ+MF73lRGt245\nH8+xkZLiyhY9mo213YQHxjIMYjIlBdWprMeoIhRFyrQmmkpsxBCoCCBRH2QxoyIlvCQsAQiA9ZjF\nk8hyoH2XIwGtiCYMfjC0QD0lCHci2sbamneV2ukkmg4L0oDHDiMl2ehQa4hRC5AYJg0jOC6oiTkU\nvWeoQFdMnh0pVSc4JbAYYEKdTsVM244v2bmdq7awE2++v7A4vmxHbGJL5qLfbM983H7Z7JP2kcWZ\nI3aqozXcnF5tfdwwpCg8czs7G4ax1je9m0ipWp+zAy/1xZh9ymzC7F0yf2aTlxWjaEpQkWjqCEsg\nN3tk24qUeNSOoIcb/IXxO9VFzyDAUFwIInDm3+yLK0XgF5dmnlVF9Ry8CKVjWJOHsgUMYjIlBdUq\nG3WoKIoipdbQuDwMIdoVIDwwxoxySvEiLABicPWYxZNmVhFQ/BlIQAvRggM/GFqgniYSWVWZerir\n1J8yRdNhJk3w2GGkJBsdsoYYrRGJ0baGwT7K1LA8915ABbpIq2enlNwEIIHFABPqBb2CGu/a9CX7\nyq8u2nzXrG2fttnTC1vWWsbYC2bjNr1hZ2xy2SZPz1+2m5ZZo5sPmD1kGFIUntk7/DsbpnX49q6R\nTbUuLNnLfTE2+ZzZ/5l9ROZWs8cVQ7SWA4No6ghLILcPHvZZZhh41A4xuMGfTbERhBoEGIpjCDy4\nbuNrReA3zN6qivSMRyjNHl6Th7IFDGIyJZlqoyJ1qAhFpNQamsJDSioCSO3CGDPKKcULWDBky2NW\noMgqSdBjkIAWohUWe0Ik0QL1SIBblSmFO6X2gSqaDjNpwNPmIi/Z6JA1Ssk2o2MMbjguqGF57r2A\nCnRi8uzECjcBSGAeYNo91SuouWds/BVrOyfz/t/iwnY8avupwNiG2XftYtdvTrftwJWpgMsa3fxD\ns1MrGFIUnnEP8QPFdbyrlKp1Ik5Fb4x96azZ+TgVmO907fZVITCP1nJgEE0dsFDWt5bDzinx0I5Q\n4gZ/NkKGFWoQYCiOIfCm0za/XQT+1OxCFw/F8RgobeZ//bkisAC1gEFMpiRTbSobMVSEIlIKP03h\nISUVAaR2IYsZ5ZTiRVgCENnymBUosgoSqoeBBLQQTRj8iCRaoB4JcAso9XCn1D5QFaXDTJpYiR2m\nlGSjQ9YQoxboGKNhBMcFNSzPvWeoBnRi8uyUkpsAJLAYYEKdnitmt21Cp8J5+SubXfc/pn7cne9g\n/IsDHXvK/7CbjtiYv6rxV1Cs0c2fmB1awlCg8OQtwI4hm2p5ypesN8Y2/FScuNW+J/N01+5dTQiO\nd03LnwoYRKtOYKGsdmJO6YvcE+0IpTZ34KeJqhNfwZWyBQJgPB3FMQSeXLPJV3Jg62fe0Go+FSnb\n8a5Hz8+uCctTJK5hKKakpKJaFclGRSiqADp+msKjlG1PDCB5YIwZ+f00PX8U3YMlDNmKMZNSZPnS\n3stPReowxkTY7LovwlTf5nxPkKAaqAOlHh2m1E5ncvujkrSAp+0Qef3ybNHhX0NsldJboGNMuFfZ\nR5maGmUncnjvsZFn1+ML9ggxeXZ+01NyMwH0svomw8ZON9Op8NXT2/bmY7/iD1pO4d8c8zfa37z2\n68n4y2T/3vH69yzZExs29pIvejKtiZszV/1UPBimQwpFs3z82H2rhtH3UVJSyxluE1jGLKyc9Xfl\nOy9uyHidx7uCEd8htJy8EZ0QBJaE3GdZpAQl7Qg6mw782fia6hJqEGD8vhfHxHfO+H5zrQiM71Fb\nOhVBW+LFUZr9T3UqEtQAGKzy3XerpKSmWhWjjl+Und5OKX1Naio8ShkVASQPjDGjYnrwIiwBKGWr\nxkzgg5oZRXebQKIOg2i/prfhRySlgT6SgfnmoUPqhTtBTky6m0cFacCL7aCUCX10CLFpjzhzdFwx\nGdQ4x5maCqXvz4SggupfC/rj3Tw7vxnDcCY/mnqPwHqACXX1Cspdhzb8xyYn/SxOLNnJz9j0lk3s\n/Kl/Fcbs7dZ6ecs+A56rNvZfba3hJrn+M6ooBdFafrDbesV/fORGpyJl84X2xidFahFjH7KzvvDe\nl1eSsTHPqpjqVLwAjIhOKANLQl6ditQJnmhHWOpTcTVIlfFq1aWeQSAYFMfEHplYt4MvFYF3+zeM\njk5F0IZHPbY66VSksjUMI6akxLEVZZVNZZ3LlNLXQLBTNnY1pYyKAEoeGPMZ+VWnpCxYMClbNaNy\nZhUDxZ/RsToMov06tAFQoU0DfXsNLLJGZaNUuBOwxKS7eVSQBrwYrVLGDvPL5601bKZYQ8epbVGT\nTkXsDK+Ylle9Z6jsMKXMs2PncrPiNALrAVY3F+rfV8R+tPF132z+3yV/EW0/+KWdJRlrXbLWTryS\nrsh9eJU13PxoHIh0KiJF9nQ95W3+P8a7SdnY+zb57QpEFePvXxzFwtuevizjp32tiqlPBTDMoxNK\nf4O36hUCeT4V+hqPtyPor3Yq6BkEGBUHQeyR1lft/eWp+NjW1L3pVESxxEv0OF/FpLIC6DBMMQUl\nNdWqGHVSWScipfQ1FU+za3XK8XUAyQNjMSO/6pSUBQumGlwaM4H1zCJw1xVIElon2q+zYlsbw7/2\nqXq9ChgDjQ7Vu7uTJzHpRXm0izQfW+ywlFLofd4VSQB9eJWOP5yGHtuheq7wTRcVtbzu3e8kqP4I\n6B6TZ+c32S2zawmgAqsBVv0sVKdiIgra/I/ix0l2ctkWLi8csYvbGM9/2g+tv31cCnLjFdTcNmu4\n+dtxKh4M0yFF9iz51xcWk/Edk7Kplp37aE/M1GLQ+wP/6XAXY3aXH5KAARdgvh8YnvJclzr+aC42\nUyCvTkUnfY3H2xH0+lSwuWV8YXWRDQSCQXEZduvCsddfpvtEwYvv9p9lax978XQzTsVv1qeighoA\nHYYZMQUlFdWporJ5z/5tsH7N42tovBNYUie0G4DkEVk+I7+qlP7Qy4IFkwBWYybwwYr/CIzrLz4R\n1ydhskZ7rgsc+Kkoj6l6vQoYWaND9e4dvoHUqS93p0claXPaXCml0EfvIklA57bp+AOJSahxjlMz\nUVHL694z1PAF9IipZ+eP2S13VdAVWA2w6mehOhX3+Qv6ZZv3lzr+Pvym07bw0py/kr+G8Rd5bV5n\nXuzE+5xrM4t28Bpr4mXdxU68R9nCkKLw/KMTtIphX6dsXss+669AemMei4Nuz5g9sYWxSS+bYmK/\nUYKKRFMHLAl57KoMAw/tCCVbGPzZOJDqIhsIBIPiycSx8524vTvwQpeU6jl4ocfWRnUqVLaA4Tku\ndEtKKqqrilEnejZziigm/DSFh+5Tu/F8jkdkxYzy9CgLFgFK2eoxE6i8EdZzpdN+oQvRghN7QqPV\nQKNeShADjX2jUrjxpL7cnR4FAZAGPEarlOyw1HusCQLEHB1jktt3QkGNF/blde8ZqnZYlTLNTim5\nKegReDD2vVKmfqpTMXXE/nxu2SauWMs9vm7h8qNe8E6MP3kcMfNmLy55lqkrJ7f9VLBGN52PEysY\nUhSeb/kbhBUMO0bZolZrx99Gb/XEvO/w4Z+/ubXu5/3+MB17v82sJATHu/B+YiVgfIBo6oBFyKE7\np8RDO0KJG/zZWL7IBgKMUVwm7ZHZ07sDz+h7KsXx0OPU4cO3/2uHYjBWwPBiZ6ygpKY6VaRO9GxB\nkVLGmthwJ1bAQsrUbvz+IDyfX4esmFGeHmXB8l4AKVseMymV18N6r9TxGY0JOPCj0WqgUU8JIiuV\n1TtuPOor3KnDIABqgMdolZIdJrZZEzFijo4xye07oaDGkXvKuvcMNUGHTn9ZqtkpJYkEPQKLASZC\nqlNxs//oxH9F6jwf8DFMxWvsuRWzt2DMTnnwiTiV/vuT+WU/3tNXWKObD5h9P34B8v34lfTs6cLj\nYWcMo+eKSGlRK76PPr7SG2P2nJn/ynh8BTN2xH90kRDEqWA5MIimDliEHLpzSjy0I5S4wZ+Nc1pd\nQg0CDMUxCrxiT6wWgcdXZvx5NXYPxfHQo+ebW5MHqAUMYgpKaqo9xhsnmyoGRUoZa9Q4HlKqYgCS\nB7KYUZ6eygpLAFK2yCuy4Anj+fuu6Au0EM3E4EckaaCxJ5SAgQKUerir1N4XbjrMpAGP0SbeIxsd\nak3EqAU6xoiaeF9RUKPlEa1RR6BSAp2YyXp2SslNAYzAYoAJdToVM5/efH555oj9rn+b+okX+Gd7\ndGvq721qA+MnwoMPbrT+3eyP7dHFyS07tcEa3Zxeav2LYZQiouX5nE09axh9H42U1LLfsANX+2Kg\n7ne69nuG+cLm5jssIYhTQQlgEA0CsKgsuyrDEEraEXS+AQZ+mpAp9gOotT1jj1Ico1PxJ/a36l6B\nD3RnO9rHKk7emJhfc2vyULaAQUxBSU21x1SngoqiiJSsoSk8pKTiJIDwQBYzytNT2XwqQF2MmUBM\nIO69girQQrTgwA9GA409QQK5AUo93FXq50xuOsykAU+jFe+RjQ5ZQ4xaoGOMhgHHmRqljGh6L6AC\nnRhRFTFKyU0BjMBigAn1gt5XTPtfdFq2m+94ix9Yf3lsE7f4by6+fNR/bIXxtw1+8447Vv3vZX3v\nTWbvP/p3aQ03W/fct2gYpSAaz9jRwyuGsaPnvrJFNtWaOvrOpf6Y8zvvsgO3HF2S8Y9/vJwQEK0S\nAYNooQQLyCfu/um7ypR4aAcsuIWfJjDeVnUJdSCwMBTHKPD5u5ZS9wTOH/2aUxAV1TM3QWnzt/9k\nSx4YyzCIKSjJVFORGCqKIlKyhsbFBilpF0B4YEwzyikpCxaZyFaMmUARWhGQ/wQJaCFaYfCD0UBj\nT5BAbhEdveNOqZ1JuemwIA14bC7xHtnokDWKUQt0HEYEwHGmhuW59wIq0BWTZ0dKbgogGxs6SZlQ\np1ORCWkeNQzsewaaU7Hvt0BDQB8Dzanoo6S5se8ZaE7Fvt8CDQF9DDSnoo+S5sa+Z6A5Fft+CzQE\n9DHQnIo+Spob+56B5lTs+y3QENDHQHMq+ihpbux7BppTse+3QENAHwPNqeijpLmx7xkY+qmo1LSG\nPwn0tbJQnPTfasW2Qn8MvTHJh6HghcwXNzEShau1vaTBVci4Zf03JLuIkZsYG2snZTg0xKT6FTEI\nr4kuKmYNMbAUWnQ5JR5JgRGD2BxuEo0O+d5dXEDTw2HaoZ+KSk1rmCRQe6a9WygOda6JWrEt649J\nKk3yYWiWIfOFShoGkbCs7SUNrizjRkqJdyE2RwxuYvzvoa6Z/+X7iS2MUBFTiMBFxRmiiQELZa31\nzW5SgiMlHkmBgTK74X1kyK+mDxnVF8P7c+inwv9G+0PDa7+oPN7dLRQ3HaJw6I9hpAIWil7+l/sn\nT9uF0LNiDcph3JQHkTA8cqPglmXcyHar/wVRQ7JLMbi1PDTWFrYsCdQJFTFIl4mugCHBL2LAQtms\nISa9Ojwv+AdWDJSFm0QjQ36ag8gohjKkh0M/Ff7pp1MrQ2p+V1mJebX93rz/tyiJs/O1Yhs3UfTy\nD4IduCINrotdX55vyuM70D8uGB6Mtf2RDB/UIOV3Qv8NyS7FsEbLQ9Jsvu2nAiNUxBANXVQsNMRO\nxAmlLJ9iKVLi2QiNO4mRxYcT5CYRJuCNyCVowwcz9FPhn3E6FK+Zh35JmKstHC749VQ8yopt/kXS\nH7vJP6J92b90+TDWzK77F9yUh+2JB9N7Kkj5dBfBL5fsUkzbUygbOmPIh2GESjJo8VEg6KKiB5xK\nGmJgyaeiSInHTSfpm8WpkJtEI0N+tO+XoOnxMO2wT0WlqjBMDurapVCc1LlKxbZK0uyJDcmczLa1\nBpkvbsqDhlih7YX2HIbv9knSzPXAvO6TSa4Ct6TA0FgrBeoclWL8VIiuSljsSZeYCOk6/1hw25J0\nmW97wVBFKYU94hsO4bs4FbhJ9GCvxkfNxJAeCPmQihdlFyqNj+Lea/mQ6fhT/EhcLuZVC8W1Xg5R\nuFKxbSJJmsXofDu5fJjWIPPFTXlCJAxPSkFK5eUzspI0ixShAqaYcGt5qzO75h/yKwTqHJVgVKdC\ngmVEpxIhZZaky9K2v5o6kciZf6YyiZFVbnjfWw9qSONI1A6pei670JyKTMbZeDi+7lvIP3u5E+IN\npWKb3zwZKg/V6Ca/rTX5ZuWx23Zpe5ESE6dCkmao44RkVxXjsmdUlM5YIVAXYkCKyaciYDjUpCHW\n9U+Jf9u/rLTockq/F57WpQSdtx24m1MRhO11LVyyP+ju5XwN7jOdzmtQ6AZKVApi/FRMemSlYpv/\nqAxFr9hVIRRn5z7snyq/uJRv1p4LvxCeStsLBbdKxk0icEmCzSW7qpj5H6kiOmMLhUBdoEoyaNUr\nqCQs5tGKCSxdNyFIV71E8i9DOA7P5OkEPbvh/cHmFVQw1H/N+D+Ss9J/+7W7E2/4tl67cterdB9C\nWEkoThJnz2TFttA+cuEUVwrzd9vXpMHl4iouHFfflMe1iy6s4sG43tH8KxgJf5ASna4ZxOYim9yx\n/H401uYKgTpHJeE43pVAFxWJFsrPhuIcZdn2wFBKPPFTJ0HPbumbjRD5DEYEXm9Gr41vannI/1qk\n7zUXABuFKyuIoUzmu+ziB9b9Jf79YTpZf8z32NQVaXDFmiXffwuXuYmRDBoeDBpcGE5FS9lCvAvJ\nLmLkjuW/haTZo1YL1AWqFBOvv6CLillDTJpx3/J3Hyts+5wyKYWdPMJ5X/CfnPlTiVCSaHTI94b9\nEjQ9Hqb1V1DD/TdU/RdJ3x8mAbn2zbWCGIJfCHM9Wyu2Zf0x/1XT/LJU3liDJhc35fEteEa6bLj9\n99KzpzF6riAlOl3+LX/6CjFysxxFpbmVWqAuUEk4jucK6KIi0arjTzKPr1CWbV+kxIN+GjHZLX2z\n0SFfYxCBeSTDejT0U1GpaQ2LgLou+lozWSgOYa6s2Jb1x6SShgYXayQXh24XBpGwrO1FSuVlX2f9\nt0nE5iJGbmULjbWpWqBOql+SQYvnCtEVwmKKJgYski6LJwMJotEJHumnSYyscivRyJBfTQECqy+G\n9+fCsJ8rki7V8BioKktfKwvFoayWFdsK9Tj0tKTThoIXMl/clHhXKMMRLUNKDOJjpJR4F5JdxODW\n8tAZywJ1QkUM0aKLillDDCyFFl1OKZS8cSMmS4yRaGTIr4YA8uqL4f059FMxvNabyg0DezDQnIo9\niGlu72MGmlOxj4fftL4HA82p2IOY5vY+ZqA5Fft4+E3rezDQnIo9iGlu72MGmlOxj4fftL4HA82p\n2IOY5vY+ZqA5Fft4+E3rezDQnIo9iGlu72MGmlOxj4fftL4HA0M/FSMk1HWwa4YoGfJkLSmTjbWd\nuTCIkuFJUl5f9w+5sSaLneGZOXp2VR4pqUVKaawhZNa65fyip/To+FSpSUQta6ER7a7XhT9MrAEB\nTEkLTQJp4UkoPZu00JBbw5AyS71Zho77VVXSbpSNNMABbODJbIjBwWzQZBiw5Zg+NsTbWNtUluWD\n2BDhuHPKgWxoKHe+x/+90zBcQz8VoyPUFQpiEiVDo8z/drf/+6holoWZQZQMj6S8Htn2j13EGnm4\niUEBDY+U1NquviaNNYTMvrg086yheCZJs1AzU1liiPa6n4rxuEHXDBgwJQk2sOARysAiLTS00XLK\nLPVmGTprXk0l7YbZ0AAHsYEnswFPdNrHBq1gwJZjetkQbzEPlaXTQWyoBNlyyoFswGgPG0M/Ff5X\n/B+KDTD0CwWx8a5LpS1suRqTBNL8s9FrjswNomR4/EMAk6cNzTLpp122m5a5Kc+toYCGB40yUs53\nQxIKIbNvmL1V0VREzYw1iiHaP4nxnJd1ozUggClSgEWerJ/2AlpotSSbUk7XUm8FdNaQbW/yb5iN\n+KDGQwPZkCezAeqBbFBM/YAtx/SwoTqZDcgbyIYIr9kwEg1kA0Z72Bj6qfCPg51a8R0wApd/9gBR\nsnl/fl628yGQZqFZhkGUDM90O1TS+KwEa7LYmTwooOFBo0wpEV4bjyb9g0AXukTzGSA/LP5Bo2ds\n/BVVJNrsS6GsgIlPRIAApkghgTQ+SiGU8cmLjdBCI1uR8mIEs6aA3vZ78aG+UyuY+GrA5XVvhA0l\nGsSGPJkNUA9mg1Yw7UCSY/rYiE4zG3Q6kA0p3ZENQ6KBbMBoDxtDPxXx0eEl73QELt8HiJIhTyaB\nNDTLZHwXdfDEh4v9s54xH6mXhYeb8jzddQW05HElNemchcYa8n6tn/lhWO05FYUWGtG+x+NUYByV\nH6nZNQmkMUO/caqjM5X109BCy6dCKZ/ypUJZQG/HTXi/Hvle90bYUKJBbMhDP5mnwWz0nIocw6OS\nDU5FzYbaHcxGEE6nGBI9FY2DpWADRnvYGPapGCWNj+PdYM1FydAokzIZmmWYkDTD84Q0PmI+leJZ\nEjtLHn8F1U2e2XZKaa6xZtJP8+eKreJUJDWzWgstom1hxU8FRhvGEYippIUWWPDU+mn+9SP+P9ly\nSkTUtCaaEsBwv7rGxw2ykQY4gI16tDUboA6Ce9nIpyJBzwz2sMGpqNlQu0ymj40gvGTDEw1kIxjt\nZWMkToU/+Y/CpX3gomRolKFMhmaZhMtC0gxPbC2XjGE+KJ7VYmfJgxuPNMosdM4mluLHSa1X7G4/\nW53iVEg/jTVZP+1DoQKFYdqBgMltSAsNLNpKxIDFXAtN2mh1ytbLWeotmhLAcJPtuippN8iGYA1i\nI3kyG0I9iI18KhL0IHggG9FpZkPtDmYjCCdbnXIwG8FoLxvNqcjnUfvAtyMaZSiToVkm4TJ/j7eK\npzgVSfGsEjurToW/3EkeqZd5yhBei+s2+9jW1L3lqfCnkHV3+JoU49H+JsG/xrBhAkG1ydBCCyx4\nFMOpaF2KAlmSzVMUUm8ldF/Tuw8I3WVukI0EKxD0sFEBzmyAOjrrZSOfioQ/x/SwEXV2sQF5A9hI\nJXBjZtf2YsNu62VjJE5FZ9c4hvYF+2DCd3RolEmZDM0yjKOa28YTe99V0mI+Ui8LDzeTx+7KnnNd\nf5rwbV79oM2FzF589/Gl4rlCamaxJmXz6KlF3zsY7f1AwOQ6nim00LyiPLV+mgM67feVDYE0T1lI\nvZXQ3U22B/078qEOUZWZ+YdPxLWq7AH9VdhIsAawUQEu2AjUg9goTwXabjmmh42os4sNlg9gIxGO\nO6Xciw278IYgomBj2KeCt2Rb1UyG+yen4j7fcV2buYYy2Q9Ds6yFcNlMSJrhiffU13QqngkRNTzc\nrDztpGv22VAvM/OU/MzHXPDpgu+3XT+DOhgialpDNvTTHovnDgy7UwjiHaG00KiofZtifK+ghUa2\nImUIr3VYk6HLTTZMoBtw3SAbaYCxW3vYqDzt0jOYjfpUJOiTVUwfG16nYIPlMzGZPjbiJ2C4i5SD\n2NBQetgY+qlw8CdWBgxlCLdiH4Qo2aNe+87Wun9be29olmE6iJLhmQ6VNE4Fa+ThZvK4AtrnI/r+\nnW6cikiJxpr00yzkovJzxdyyTVxhjbJZ6Ke97/Dhn78Zw7SnkE6DqW+FFpoE0mIrpZjYk3byiB/o\nyJZTxsgl9dbJ0OUm2/XI9+w3wkbsPh9g7NZ177lgI3kqNuQZzEZ9KoQtOPg82frY8DoFGywfzEYo\n3eHOKVcGsaGh9LAx9FPhvz8ZEZU0RnOzi5LNrbhGWVImC3Ump3ctFCmnr+BJUl6xE/2X1OMreLgp\nz9gR/+kRHmmURUo01sy37Rk7vjLjzw3s46jov5yePW2sIYZoL/mc/4+J3QkCmCIFFfXdkRhlO+U+\nshUps9Tb3Io3BUC5yXY98qPuDbAhuTUQgCWzIU9mQ6gHslGfCmHLMX1siDefB9BZPpiNULrDXaQc\nxIaG0sPG0E/FCAl1+T5AlAyNMpMyWX0qJrfs1IY8kvKK+bAGj6TT8Hxhc/Md8qBRJp2zKR+SIWT2\nQHe2U5yKmVAzK7TQiPa1/acCpkihimwloWSvnPBToWw5JSJqrMnQWWNkux75N8qGcgxiA09mA9SD\n2ahPhbDlmD426lNBcpYPZiMIz2wYiQaxoaGQTZ0497bQqKQFDXGFgphEyb581H/IiTKZoVmGQZQM\nD1JeWfHMstgZHhTQiEajTCnjnYghZDZ/9Gv+Xezun/pfskKzLATSCi006afZ+R33h2ENMJA0kxYa\nFfFk/TSJWNeSbEqZpd4kvJb1015NJe2G2SDRQDbwZDbgaSAbarJmw3JMLxviLeZBcqPdgWxAeM2G\nUg5kA0Z72Bj6qWBDNqZhYJQYaE7FKE2jwTIaDDSnYjTm0KAYJQaaUzFK02iwjAYDzakYjTk0KEaJ\ngeZUjNI0GiyjwUCcip2dH48GmAZFw8AIMOA/Dr5kHzp27NdGAEsDoWFgNBh48dixzv8DXrPOf+3n\nhpAAAAAASUVORK5CYII=\n",
+      "text/latex": [
+       "$$\\left[\\begin{matrix}257688760366005665518230564882810636351053761000 & 644221900915014163795576412207026590877634402500 & -1932665702745042491386729236621079772632903207500\\\\0 & 257688760366005665518230564882810636351053761000 & 0\\\\0 & 128844380183002832759115282441405318175526880500 & -128844380183002832759115282441405318175526880500\\end{matrix}\\right]$$"
+      ],
+      "text/plain": [
+       "⎡257688760366005665518230564882810636351053761000  644221900915014163795576412\n",
+       "⎢                                                                             \n",
+       "⎢                       0                          257688760366005665518230564\n",
+       "⎢                                                                             \n",
+       "⎣                       0                          128844380183002832759115282\n",
+       "\n",
+       "207026590877634402500  -1932665702745042491386729236621079772632903207500⎤\n",
+       "                                                                         ⎥\n",
+       "882810636351053761000                          0                         ⎥\n",
+       "                                                                         ⎥\n",
+       "441405318175526880500  -128844380183002832759115282441405318175526880500 ⎦"
+      ]
+     },
+     "execution_count": 31,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "matrix_func_series(M, Lambda(x, 1/(1 - x)), 100)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAIsAAAAaBAMAAAB1DbIqAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAMplmq80idhC7791U\niUQ5geeaAAAB5UlEQVQ4Eb2Tv0oDQRDGvxi9u+gZ8wKCRCxE0PQWBlSwi4gIouApNmITsLNxa5sI\nYicolhbGQlBQMPgC2lhYBPMGFuIfSCTO7F7uNtkohoBDcjfftzO/3b29AxAZRDvhjqruaa8dCrCx\nx/32Z3sU4IQBnbMapr94qCnEhK4ojxSfCqFlJRdLpA7Y0THWAF6ybKpwjkQt9e9riH+E1jrsCqlp\ndnRMbwV950GZM5URgVDJcwHl0JoBbkkZGLcOA+yIsEdm93WYU4FMqQmGSvVNmRjUbWpFYOwHzLyc\ndVceYjNMV5oL/HHalPBXE1MdPEgn8ZiW95x6Qsam0K+m8ccR+aJy+Wy6s7KxdtkuceYoaWJgn2nj\n6OI1TAjAYry1dM1RorRbfxubYJCnpiCGOetYAMYTgUe4BGKvmjYwq8BRKiyw0zLfzMK9DF3kPn/H\nOFVRh7mD5QHRG0LkNHrfLHreNSyvhn5hvNHZeIGMDCDqAff0h35SdgovD+QhPCmnzLoWW4jz2fjj\nm8XiCAnjLcZdcll2qPcimZ9LOXlPOuriJocKnKnx22qVJzExXNIQca/BMOSfMFGjrdH4T0y2cXJD\n/2k1RpdhSEzvseG3aFxwvaO+2RZbtfKOKymik5rXeurut97zU8c395Nyc2G4mDsAAAAASUVORK5C\nYII=\n",
+      "text/latex": [
+       "$$\\begin{Bmatrix}-3 : 1, & 3 : 2\\end{Bmatrix}$$"
+      ],
+      "text/plain": [
+       "{-3: 1, 3: 2}"
+      ]
+     },
+     "execution_count": 32,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "M.eigenvals()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAPQAAABkCAMAAACGl+2PAAAAP1BMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADFBd4eAAAAFHRS\nTlMAMquZdlQQQO0wRLvv3c1mIol8bDogkc4AAAVESURBVHgB7VzbgqMgDMXrzFardpf//9ZNQJRb\nEHHWrpY+zKAhHA4RpEcbVnDxKdkHfJ6SK2MFr2r4NB/AmY3ItORIuvgEvivHUSNdlB3vW7SVPX9W\nayVGW7RKdrF4Phv2eNin/cc0Am3xtyTPBsF10hDzjsuZ3Q5Wi7TFqrgctjWbyr5ejrcKNAJtIdsM\ng1ukx5LLqa3HGZsuSAsJvNNAI9CWnRCquk267eUF7pKmLKqlo/+LkUKgLYmYNmn24B025ZKmLH7g\nVqwNwjb5a9hni5FCoC12G/PxFrhDmlV8BF9JGhb46iVaAmDDQsAp1K7nvXBsq66amwi7wAQyEVKx\nWbsJ7pJmTw6xEaSbJ5bEmoZd0iwbBDq4B9Z8aFk74Oo9yYELO1kIydhsG9xDuuBAU5Ae8Qb+wDEQ\ncYAburKE+1+LK7oB1oPcATTiRNhJkF4RUrFZBLiHNHvxWs3px6t+ia2L6JJuCTGY71M17/H6wE/E\nnctBSMNWUCFwH2m8jEWkp6Fs5/2a7NJikVSov4piJ5aHXaQXhFRsRZoFwL2kp3k/NuB0hk0qrIYz\naWWh6MrzC+lebXDVmYCfhZCKvZKmwb2kYRHC+1YLlzljDS8ehSI9WwJ9R9Mo71f1a5q3tWPsnAbn\ng9gx4CbpRi2zg7hZ97gnhTkN65BlQWqBj5gcNXg/eA/LdyOOA/XRZCEkY8vlKAiuk4Y9Lu/kLnQS\nW/Cpg++c7WuoHcsGgamsqkEsYlPJ+z6Cs4OQjA07/i1wnfQGk13mrU3Rrsb2Vt4C/1ek9/bz1PqZ\n9KnD/UawHOk3Dv6p0DnSpw73G8FypN84+KdCf3ykaVmdtqwRouvQljd5m5GmZXXaonX80KMCGoG2\nJGJbpElJP0Zwp+vQFq3b52HbpI8I7rQoT1t00qdh26SPCO4g+Bx4VHCit0PakPT3Ce6ocqU/KjjR\n2yWtSfo7BXfs9iW8PaSTBXdB+greHtK6pL9LcBekr+CNpL/417yIym6nCu6X8f6tvX4xP7GCB25p\nYv9M+v/39l3eqYL7TDpRrj/R2yR9THC/jLdOGva4B8T+C3nrpNct4c1LmfTNA7zQy5FehuLmhRzp\nmwd4oYeRbuv19b7FcOfCBK+VfPT73ncOrsHt4xcyWpSnLesI0nVoy5u8zUjTsjpt0Tqexf51MFCc\noH4xsNai69CWRG8r0oferqclfdqidzuL/eto4CuaxEOEtRJdx2OxI30RuX5lO5dQbIp+0OCSvoRc\n7yUd3XMP6SvI9X7SsT33kL6CXO8nHdtzJP31/UubGVBMfLMf59UlvP9861845m7//3K9GF39z66e\n+y7vLPbDPIl9sz+L/fBEbM/vAk59VGBe3vosuXE5k75xcA1qOdLGcNz4IEf6xsE1qOVIG8Nx44Mc\n6RsH16CmR5oW5WmL0Zh5EMykY1aFr7c/m0KIBcF10gB9SK43iYQz6Zh18egnseFBbCiHkEWaFOVj\nBHeXyJ4zNAJt2dO+VtcmfURw15pNKNIPBGhLAgy62KQpWR3kmE3BXe/C1u+29bqyTCPQFrcVcWYL\n3CEdL5kTiHh6O5OO64wqV7Rc77qvZ7bBXdLRkvkK45S2M+k4LjK/xg+kEMppfHBs3RxCnkjHSuZu\nsNSZOZVLKJOOqrr+x8sbE4wcTCGkkruEwH2kU8X+hYDKXxPIpLPUXQqS9GFsRTqn8VlGVha8kU58\nN39pOqfxyWl8lovBLhwT+43Wchofb3osc04bI3bfg0z6vrE1meVIm+Nx3yMZ6Q/M5N5idvO6jszE\nfe0LQGRyr2v2F9EolM42ZqoDAAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$$\\left[\\begin{matrix}\\mathrm{NaN} & \\tilde{\\infty} & \\mathrm{NaN} & \\tilde{\\infty}\\\\\\mathrm{NaN} & \\mathrm{NaN} & \\mathrm{NaN} & \\mathrm{NaN}\\\\\\mathrm{NaN} & \\mathrm{NaN} & \\mathrm{NaN} & \\mathrm{NaN}\\\\\\mathrm{NaN} & \\tilde{\\infty} & \\mathrm{NaN} & \\tilde{\\infty}\\end{matrix}\\right]$$"
+      ],
+      "text/plain": [
+       "⎡nan  zoo  nan  zoo⎤\n",
+       "⎢                  ⎥\n",
+       "⎢nan  nan  nan  nan⎥\n",
+       "⎢                  ⎥\n",
+       "⎢nan  nan  nan  nan⎥\n",
+       "⎢                  ⎥\n",
+       "⎣nan  zoo  nan  zoo⎦"
+      ]
+     },
+     "execution_count": 33,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "matrix_func(N, Lambda(x, 1/(1 - x)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAQwAAAAaBAMAAACwWn+SAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAMplmq80idhC7791U\niUQ5geeaAAACdklEQVRIDdVWPW/UQBB994HP95EQ5Q9wgNJAQ0WTJihJDUI0iOZEQUsKJMpYEQ1H\nASU0QAlVrktBEkV0dBFNKqRU1EgIiMTHsTM79s6uzfkiFCxWke3Z92bm7ezO5gDUzqPS8faQ068O\nKlWB6Bnlbx1VqwLo9I2C5jUto5382TLIxv2zE3HgqcYDy0C3F55rArPbpMCTEb9IFMu3CNjFozlH\nyON46NXWt4xjtIT1PRfA4qxAy4hXriaO5Fs03xqh5YqXx/FgRcvwLQrQTND9RB88BM/JANYTofDL\nt4DuEma/KkKIhyctd+46r9D85QJY/NgyTvdR++GiBKIJ8BP7loFPHaE+vYz4tc0VrvbuPmrfCBo+\nYUKIZzIEz8kwXl3aNkmgqtG2ETlsuinxd2uGaUjGT4Iej5gQ4pkMwYtknNk3rpJAyeiscUR5SODE\nmmGaTEZcjGcyBC+ScZNdbQKLN0x9ohtmOrr1hsZhWg1mmkeRDN4UIYR4JkPwAhl1XXzBFwZYnEtz\n8tsP7FsAHdHPih/iU8i4p9zTAx1tobel54P1h2lMw/b+qmHR6+OOSyjVWNwzp+2Smw63gWSYv2yY\n62tmlFmWnSi7qBpyTIQ1D1x2DlYGr6ykU9Kmsb7bGPImuk7x8bTMqlPk0/pHOx/e0zrynaIvc5zb\nvE7FkbYmK94c2Aj83Di4wm97L+Tx+oUv/OvF4mwN9S52x+Mxy+CLSdgFt6hKKZ+zg/ycninD8VGz\ni76nktEo8lRzZTiovBPH/yRjbeJKgDK8VeIvv3i8I1rqchIEVjDz8iRCHyemuRRNc9I/lUrHxYTS\nN5YrFYF3pa30z/T9BlpbuVQBNRoeAAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$$\\begin{Bmatrix}-1 : 1, & 0 : 1, & 1 : 1, & 2 : 1\\end{Bmatrix}$$"
+      ],
+      "text/plain": [
+       "{-1: 1, 0: 1, 1: 1, 2: 1}"
+      ]
+     },
+     "execution_count": 34,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "N.eigenvals()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": []
   }
- ]
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 0
 }

--- a/tutorial_exercises/Advanced-Matrices.ipynb
+++ b/tutorial_exercises/Advanced-Matrices.ipynb
@@ -1,594 +1,611 @@
 {
- "metadata": {
-  "name": "",
-  "signature": "sha256:a1333d18a3d821c9550e4f61e351b1dc780b437cbae06b59216a372c9453e7d4"
- },
- "nbformat": 3,
- "nbformat_minor": 0,
- "worksheets": [
+ "cells": [
   {
-   "cells": [
-    {
-     "cell_type": "heading",
-     "level": 1,
-     "metadata": {},
-     "source": [
-      "Matrices"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "from sympy import *\n",
-      "init_printing()"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Use `row_del` and `row_insert` to go from one Matrix to the other."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def matrix1(M):\n",
-      "    \"\"\"\n",
-      "    >>> M = Matrix([[1, 2, 3], [4, 5, 6], [7, 8, 9]])\n",
-      "    >>> M\n",
-      "    [1, 2, 3]\n",
-      "    [4, 5, 6]\n",
-      "    [7, 8, 9]\n",
-      "    >>> matrix1(M)\n",
-      "    [4, 5, 6]\n",
-      "    [0, 0, 0]\n",
-      "    [7, 8, 9]\n",
-      "    \"\"\"\n"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "M = Matrix([[1, 2, 3], [4, 5, 6], [7, 8, 9]])"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "M"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "matrix1(M)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "heading",
-     "level": 2,
-     "metadata": {},
-     "source": [
-      "Matrix Constructors"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Use the matrix constructors to construct the following matrices.  There may be more than one correct answer."
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "$$\\left[\\begin{array}{ccc}4 & 0 & 0\\\\\\\\ \n",
-      "0 & 4 & 0\\\\\\\\ \n",
-      "0 & 0 & 4\\end{array}\\right]$$"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def matrix2():\n",
-      "    \"\"\"\n",
-      "    >>> matrix2()\n",
-      "    [4, 0, 0]\n",
-      "    [0, 4, 0]\n",
-      "    [0, 0, 4]\n",
-      "    \"\"\"\n"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "matrix2()"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "$$\\left[\\begin{array}{}1 & 1 & 1 & 0\\\\\\\\1 & 1 & 1 & 0\\\\\\\\0 & 0 & 0 & 1\\end{array}\\right]$$"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def matrix3():\n",
-      "    \"\"\"\n",
-      "    >>> matrix3()\n",
-      "    [1, 1, 1, 0]\n",
-      "    [1, 1, 1, 0]\n",
-      "    [0, 0, 0, 1]\n",
-      "    \"\"\"\n"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "matrix3()"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "$$\\left[\\begin{array}{}-1 & -1 & -1 & 0 & 0 & 0\\\\\\\\-1 & -1 & -1 & 0 & 0 & 0\\\\\\\\-1 & -1 & -1 & 0 & 0 & 0\\\\\\\\0 & 0 & 0 & 0 & 0 & 0\\\\\\\\0 & 0 & 0 & 0 & 0 & 0\\\\\\\\0 & 0 & 0 & 0 & 0 & 0\\end{array}\\right]$$"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def matrix4():\n",
-      "    \"\"\"\n",
-      "    >>> matrix4()\n",
-      "    [-1, -1, -1, 0, 0, 0]\n",
-      "    [-1, -1, -1, 0, 0, 0]\n",
-      "    [-1, -1, -1, 0, 0, 0]\n",
-      "    [ 0,  0,  0, 0, 0, 0]\n",
-      "    [ 0,  0,  0, 0, 0, 0]\n",
-      "    [ 0,  0,  0, 0, 0, 0]\n",
-      "    \"\"\"\n"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "matrix4()"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "heading",
-     "level": 2,
-     "metadata": {},
-     "source": [
-      "Advanced Methods"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Recall that if $f$ is an analytic function, then we can define $f(M)$ for any square matrix $M$ by \"plugging\" $M$ into the power series formula for $f(x)$. In other words, if $$f(x) = \\sum_{n=0}^\\infty a_n x^n,$$ then we define $f(M)$ by $$f(M) = \\sum_{n=0}^\\infty a_n M^n,$$ where $M^0$ is $I$, the identity matrix. "
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Furthermore, if $M$ is a diagonalizable matrix, that is, $M=PDP^{-1}$, where $D$ is diagonal, then $M^n = PD^nP^{-1}$ (because $M^n = \\left(PDP^{-1}\\right)\\left(PDP^{-1}\\right)\\cdots\\left(PDP^{-1}\\right)=PD\\left(P^{-1}P\\right)D\\left(P^{-1}P\\right)\\cdots DP^{-1} = PD^nP^{-1}$).\n",
-      "\n",
-      "But if \n",
-      "\n",
-      "$$ D = \\begin{bmatrix}\n",
-      "         d_1 & 0 & \\cdots & 0 \\\\\\\\\n",
-      "         0 & d_2 & \\cdots & 0 \\\\\\\\\n",
-      "         \\vdots & \\vdots & \\ddots & \\vdots \\\\\\\\\n",
-      "         0 & 0 & \\cdots & d_n\n",
-      "      \\end{bmatrix}\n",
-      "$$\n",
-      "\n",
-      "is a diagonal matrix, then \n",
-      "\n",
-      "$$ D^n = \\begin{bmatrix}\n",
-      "         d_1^n & 0 & \\cdots & 0 \\\\\\\\\n",
-      "         0 & d_2^n & \\cdots & 0 \\\\\\\\\n",
-      "         \\vdots & \\vdots & \\ddots & \\vdots \\\\\\\\\n",
-      "         0 & 0 & \\cdots & d_n^n\n",
-      "      \\end{bmatrix}\n",
-      "$$\n",
-      "\n",
-      "so that \n",
-      "\n",
-      "$$\n",
-      "\\sum_{n=0}^\\infty a_n M^n = \\sum_{n=0}^\\infty a_n PD^nP^{-1} = P\\cdot\\begin{bmatrix}\n",
-      "    \\sum_{n=0}^\\infty a_n d_1^n & 0 & \\cdots & 0 \\\\\\\\\n",
-      "         0 & \\sum_{n=0}^\\infty a_n d_2^n & \\cdots & 0 \\\\\\\\\n",
-      "         \\vdots & \\vdots & \\ddots & \\vdots \\\\\\\\\n",
-      "         0 & 0 & \\cdots & \\sum_{n=0}^\\infty a_n d_n^n\n",
-      "\\end{bmatrix}\\cdot P^{-1} = P\\cdot\\begin{bmatrix}\n",
-      "    f(d_1) & 0 & \\cdots & 0 \\\\\\\\\n",
-      "         0 & f(d_2) & \\cdots & 0 \\\\\\\\\n",
-      "         \\vdots & \\vdots & \\ddots & \\vdots \\\\\\\\\n",
-      "         0 & 0 & \\cdots & f(d_n)\n",
-      "\\end{bmatrix}\\cdot P^{-1}\n",
-      "$$"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Let's create some square matrices, which we will use throughout the exercises."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "x = symbols('x')\n",
-      "A = Matrix([[1, 1], [1, 0]])\n",
-      "M = Matrix([[3, 10, -30], [0, 3, 0], [0, 2, -3]])\n",
-      "N = Matrix([[-1, -2, 0, 2], [-1, -1, 2, 1], [0, 0, 2, 0], [-1, -2, 2, 2]])"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "First, verify that these matrices are indeed diagonalizable."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "print(A.is_diagonalizable())\n",
-      "print(M.is_diagonalizable())\n",
-      "print(N.is_diagonalizable())"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Now, we want to write a function that computes $f(M)$, for diagonalizable matrix $M$ and analytic function $f$.\n",
-      "\n",
-      "However, there is one complication. We can use `diagonalize` to get `P` and `D`, but we need to apply the function to the diagonal of `D`. We might think that we could use `eigenvals` to get the eigenvalues of the matrix, since the diagonal values of `D` are just the eigenvalues of `M`, but the issue is that they could be in any order in `D`.\n",
-      "\n",
-      "Instead, we can use matrix slicing to get the diagonal values (or indeed, any value) of a matrix. There is not enough time in this tutorial (or room in this document) to discuss the full details of matrix slicing. For now, we just note that `M[i, j]` returns the element at position `i, j` (which is the `i + 1, j + 1`th element of the matrix, due to Python's 0-indexing). For example"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "M"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "M[0, 1]"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "That should be enough information to write the following function."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def matrix_func(M, func):\n",
-      "    \"\"\"\n",
-      "    Computes M at func. Assumes that M is square diagonalizable.\n",
-      "\n",
-      "    >>> matrix_func(M, exp)\n",
-      "    [exp(3), -5*exp(-3)/3 + 5*exp(3)/3, -5*exp(3) + 5*exp(-3)]\n",
-      "    [     0,                    exp(3),                     0]\n",
-      "    [     0,     -exp(-3)/3 + exp(3)/3,               exp(-3)]\n",
-      "\n",
-      "    Note that for the function exp, we can also just use M.exp()\n",
-      "\n",
-      "    >>> matrix_func(M, exp) == M.exp()\n",
-      "    True\n",
-      "\n",
-      "    But for other functions, we have to do it this way.\n",
-      "\n",
-      "    >>> M.sin()\n",
-      "    Traceback (most recent call last):\n",
-      "    ...\n",
-      "    AttributeError: Matrix has no attribute sin.\n",
-      "    >>> matrix_func(N, sin)\n",
-      "    [-sin(1), -2*sin(1),      0, 2*sin(1)]\n",
-      "    [-sin(1),   -sin(1), sin(2),   sin(1)]\n",
-      "    [      0,         0, sin(2),        0]\n",
-      "    [-sin(1), -2*sin(1), sin(2), 2*sin(1)]\n",
-      "    \n",
-      "    Note that we could also use this to compute the series expansion of a matrix, \n",
-      "    if we know the closed form of that expansion. For example, suppose we wanted to compute\n",
-      "    \n",
-      "    I + M + M**2 + M**3 + \u2026\n",
-      "\n",
-      "    The series\n",
-      "\n",
-      "    1 + x + x**2 + x**3 + \u2026\n",
-      "\n",
-      "    is equal to the function 1/(1 - x).\n",
-      "\n",
-      "    >>> matrix_func(M, Lambda(x, 1/(1 - x))) # Note, Lambda works just like lambda, but is symbolic\n",
-      "    [-1/2, -5/4, 15/4]\n",
-      "    [   0, -1/2,    0]\n",
-      "    [   0, -1/4,  1/4]\n",
-      "    \"\"\"\n"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "matrix_func(M, exp)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "matrix_func(M, Lambda(x, 1/(1 - x)))"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Now lets investigate how this works in relation to the series expansion definition. Write a function that uses `matrix_func` and `series` to compute the approximation of a matrix evaluated at a function up to $O(M^n)$."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def matrix_func_series(M, func, n):\n",
-      "    \"\"\"\n",
-      "    Computes the approximation of the func(M) using the series definition up to O(M**n).\n",
-      "\n",
-      "    >>> matrix_func_series(M, exp, 10)\n",
-      "    [22471/1120,  14953/448, -44859/448]\n",
-      "    [         0, 22471/1120,          0]\n",
-      "    [         0, 14953/2240,    83/2240]\n",
-      "    >>> matrix_func_series(M, exp, 10).evalf()\n",
-      "    [20.0633928571429, 33.3772321428571,  -100.131696428571]\n",
-      "    [               0, 20.0633928571429,                  0]\n",
-      "    [               0, 6.67544642857143, 0.0370535714285714]\n",
-      "    >>> matrix_func(M, exp).evalf()\n",
-      "    [20.0855369231877, 33.3929164246997,  -100.178749274099]\n",
-      "    [               0, 20.0855369231877,                  0]\n",
-      "    [               0, 6.67858328493993, 0.0497870683678639]\n",
-      "\n",
-      "    It's pretty close. Basically what we might expect for those values up to O(x**10).\n",
-      "\n",
-      "    >>> matrix_func_series(N, sin, 3)\n",
-      "    [-1, -2, 0, 2]\n",
-      "    [-1, -1, 2, 1]\n",
-      "    [ 0,  0, 2, 0]\n",
-      "    [-1, -2, 2, 2]\n",
-      "    >>> matrix_func(N, sin).evalf()\n",
-      "    [-0.841470984807897,  -1.68294196961579,                 0,  1.68294196961579]\n",
-      "    [-0.841470984807897, -0.841470984807897, 0.909297426825682, 0.841470984807897]\n",
-      "    [                 0,                  0, 0.909297426825682,                 0]\n",
-      "    [-0.841470984807897,  -1.68294196961579, 0.909297426825682,  1.68294196961579]\n",
-      "\n",
-      "    It's not as close, because we used O(x**3), but clearly still the same thing.\n",
-      "\n",
-      "    >>> matrix_func_series(M, Lambda(x, 1/(1 - x)), 10)\n",
-      "    [29524, 73810, -221430]\n",
-      "    [    0, 29524,       0]\n",
-      "    [    0, 14762,  -14762]\n",
-      "    >>> matrix_func(M, Lambda(x, 1/(1 - x)))\n",
-      "    [-1/2, -5/4, 15/4]\n",
-      "    [   0, -1/2,    0]\n",
-      "    [   0, -1/4,  1/4]\n",
-      "\n",
-      "    Woah! That one's not close at all. What is happening here?  Let's try more terms\n",
-      "\n",
-      "    >>> matrix_func_series(M, Lambda(x, 1/(1 - x)), 100)\n",
-      "    [257688760366005665518230564882810636351053761000, 644221900915014163795576412207026590877634402500, -1932665702745042491386729236621079772632903207500]\n",
-      "    [                                               0, 257688760366005665518230564882810636351053761000,                                                  0]\n",
-      "    [                                               0, 128844380183002832759115282441405318175526880500,  -128844380183002832759115282441405318175526880500]\n",
-      "    \n",
-      "    It just keeps getting bigger. In fact, the series diverges. Recall that \n",
-      "    1/(1 - x) = 1 + x + x**2 + x**3 + \u2026 *only if* |x| < 1.  But the eigenvalues \n",
-      "    of M are bigger than 1 in absolute value.\n",
-      "    \n",
-      "    >>> M.eigenvals()\n",
-      "    {3: 2, -3: 1}\n",
-      "\n",
-      "    In fact, 1/(1 - M) is mathematically defined via the analytic continuation \n",
-      "    of the series expansion 1 + x + x**2 + \u2026, which is just 1/(1 - x).  This is\n",
-      "    well-defined as long as none of the eigenvalues of M are equal to 1.  Let's\n",
-      "    try it on N.\n",
-      "\n",
-      "    >>> matrix_func(N, Lambda(x, 1/(1 - x)))\n",
-      "    [nan, -oo, nan,  oo]\n",
-      "    [nan, nan, nan, nan]\n",
-      "    [nan, nan, nan, nan]\n",
-      "    [nan, -oo, nan,  oo]\n",
-      "    \n",
-      "    That didn't work. What are the eigenvalues of N?\n",
-      "\n",
-      "    >>> N.eigenvals()\n",
-      "    {1: 1, 2: 1, -1: 1, 0: 1}\n",
-      "\n",
-      "    Ah, the first one is 1, so we cannot define 1/(1 - N). \n",
-      "    \"\"\"\n"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "matrix_func_series(M, exp, 10)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "matrix_func_series(M, exp, 10).evalf()"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "matrix_func(M, exp).evalf()"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "matrix_func_series(N, sin, 3)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "matrix_func_series(M, Lambda(x, 1/(1 - x)), 100)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "M.eigenvals()"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "matrix_func(N, Lambda(x, 1/(1 - x)))"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "N.eigenvals()"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    }
-   ],
-   "metadata": {}
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Matrices"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from sympy import *\n",
+    "init_printing()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Use `row_del` and `row_insert` to go from one Matrix to the other."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def matrix1(M):\n",
+    "    \"\"\"\n",
+    "    >>> M = Matrix([[1, 2, 3], [4, 5, 6], [7, 8, 9]])\n",
+    "    >>> M\n",
+    "    [1, 2, 3]\n",
+    "    [4, 5, 6]\n",
+    "    [7, 8, 9]\n",
+    "    >>> matrix1(M)\n",
+    "    [4, 5, 6]\n",
+    "    [0, 0, 0]\n",
+    "    [7, 8, 9]\n",
+    "    \"\"\"\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "M = Matrix([[1, 2, 3], [4, 5, 6], [7, 8, 9]])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "M"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "matrix1(M)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Matrix Constructors"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Use the matrix constructors to construct the following matrices.  There may be more than one correct answer."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "$$\\left[\\begin{array}{ccc}4 & 0 & 0\\\\\\\\ \n",
+    "0 & 4 & 0\\\\\\\\ \n",
+    "0 & 0 & 4\\end{array}\\right]$$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def matrix2():\n",
+    "    \"\"\"\n",
+    "    >>> matrix2()\n",
+    "    [4, 0, 0]\n",
+    "    [0, 4, 0]\n",
+    "    [0, 0, 4]\n",
+    "    \"\"\"\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "matrix2()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "$$\\left[\\begin{array}{}1 & 1 & 1 & 0\\\\\\\\1 & 1 & 1 & 0\\\\\\\\0 & 0 & 0 & 1\\end{array}\\right]$$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def matrix3():\n",
+    "    \"\"\"\n",
+    "    >>> matrix3()\n",
+    "    [1, 1, 1, 0]\n",
+    "    [1, 1, 1, 0]\n",
+    "    [0, 0, 0, 1]\n",
+    "    \"\"\"\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "matrix3()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "$$\\left[\\begin{array}{}-1 & -1 & -1 & 0 & 0 & 0\\\\\\\\-1 & -1 & -1 & 0 & 0 & 0\\\\\\\\-1 & -1 & -1 & 0 & 0 & 0\\\\\\\\0 & 0 & 0 & 0 & 0 & 0\\\\\\\\0 & 0 & 0 & 0 & 0 & 0\\\\\\\\0 & 0 & 0 & 0 & 0 & 0\\end{array}\\right]$$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def matrix4():\n",
+    "    \"\"\"\n",
+    "    >>> matrix4()\n",
+    "    [-1, -1, -1, 0, 0, 0]\n",
+    "    [-1, -1, -1, 0, 0, 0]\n",
+    "    [-1, -1, -1, 0, 0, 0]\n",
+    "    [ 0,  0,  0, 0, 0, 0]\n",
+    "    [ 0,  0,  0, 0, 0, 0]\n",
+    "    [ 0,  0,  0, 0, 0, 0]\n",
+    "    \"\"\"\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "matrix4()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Advanced Methods"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Recall that if $f$ is an analytic function, then we can define $f(M)$ for any square matrix $M$ by \"plugging\" $M$ into the power series formula for $f(x)$. In other words, if $$f(x) = \\sum_{n=0}^\\infty a_n x^n,$$ then we define $f(M)$ by $$f(M) = \\sum_{n=0}^\\infty a_n M^n,$$ where $M^0$ is $I$, the identity matrix. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Furthermore, if $M$ is a diagonalizable matrix, that is, $M=PDP^{-1}$, where $D$ is diagonal, then $M^n = PD^nP^{-1}$ (because $M^n = \\left(PDP^{-1}\\right)\\left(PDP^{-1}\\right)\\cdots\\left(PDP^{-1}\\right)=PD\\left(P^{-1}P\\right)D\\left(P^{-1}P\\right)\\cdots DP^{-1} = PD^nP^{-1}$).\n",
+    "\n",
+    "But if \n",
+    "\n",
+    "$$ D = \\begin{bmatrix}\n",
+    "         d_1 & 0 & \\cdots & 0 \\\\\\\\\n",
+    "         0 & d_2 & \\cdots & 0 \\\\\\\\\n",
+    "         \\vdots & \\vdots & \\ddots & \\vdots \\\\\\\\\n",
+    "         0 & 0 & \\cdots & d_n\n",
+    "      \\end{bmatrix}\n",
+    "$$\n",
+    "\n",
+    "is a diagonal matrix, then \n",
+    "\n",
+    "$$ D^n = \\begin{bmatrix}\n",
+    "         d_1^n & 0 & \\cdots & 0 \\\\\\\\\n",
+    "         0 & d_2^n & \\cdots & 0 \\\\\\\\\n",
+    "         \\vdots & \\vdots & \\ddots & \\vdots \\\\\\\\\n",
+    "         0 & 0 & \\cdots & d_n^n\n",
+    "      \\end{bmatrix}\n",
+    "$$\n",
+    "\n",
+    "so that \n",
+    "\n",
+    "$$\n",
+    "\\sum_{n=0}^\\infty a_n M^n = \\sum_{n=0}^\\infty a_n PD^nP^{-1} = P\\cdot\\begin{bmatrix}\n",
+    "    \\sum_{n=0}^\\infty a_n d_1^n & 0 & \\cdots & 0 \\\\\\\\\n",
+    "         0 & \\sum_{n=0}^\\infty a_n d_2^n & \\cdots & 0 \\\\\\\\\n",
+    "         \\vdots & \\vdots & \\ddots & \\vdots \\\\\\\\\n",
+    "         0 & 0 & \\cdots & \\sum_{n=0}^\\infty a_n d_n^n\n",
+    "\\end{bmatrix}\\cdot P^{-1} = P\\cdot\\begin{bmatrix}\n",
+    "    f(d_1) & 0 & \\cdots & 0 \\\\\\\\\n",
+    "         0 & f(d_2) & \\cdots & 0 \\\\\\\\\n",
+    "         \\vdots & \\vdots & \\ddots & \\vdots \\\\\\\\\n",
+    "         0 & 0 & \\cdots & f(d_n)\n",
+    "\\end{bmatrix}\\cdot P^{-1}\n",
+    "$$"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's create some square matrices, which we will use throughout the exercises."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "x = symbols('x')\n",
+    "A = Matrix([[1, 1], [1, 0]])\n",
+    "M = Matrix([[3, 10, -30], [0, 3, 0], [0, 2, -3]])\n",
+    "N = Matrix([[-1, -2, 0, 2], [-1, -1, 2, 1], [0, 0, 2, 0], [-1, -2, 2, 2]])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "First, verify that these matrices are indeed diagonalizable."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print(A.is_diagonalizable())\n",
+    "print(M.is_diagonalizable())\n",
+    "print(N.is_diagonalizable())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now, we want to write a function that computes $f(M)$, for diagonalizable matrix $M$ and analytic function $f$.\n",
+    "\n",
+    "However, there is one complication. We can use `diagonalize` to get `P` and `D`, but we need to apply the function to the diagonal of `D`. We might think that we could use `eigenvals` to get the eigenvalues of the matrix, since the diagonal values of `D` are just the eigenvalues of `M`, but the issue is that they could be in any order in `D`.\n",
+    "\n",
+    "Instead, we can use matrix slicing to get the diagonal values (or indeed, any value) of a matrix. There is not enough time in this tutorial (or room in this document) to discuss the full details of matrix slicing. For now, we just note that `M[i, j]` returns the element at position `i, j` (which is the `i + 1, j + 1`th element of the matrix, due to Python's 0-indexing). For example"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "M"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "M[0, 1]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "That should be enough information to write the following function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def matrix_func(M, func):\n",
+    "    \"\"\"\n",
+    "    Computes M at func. Assumes that M is square diagonalizable.\n",
+    "\n",
+    "    >>> matrix_func(M, exp)\n",
+    "    [exp(3), -5*exp(-3)/3 + 5*exp(3)/3, -5*exp(3) + 5*exp(-3)]\n",
+    "    [     0,                    exp(3),                     0]\n",
+    "    [     0,     -exp(-3)/3 + exp(3)/3,               exp(-3)]\n",
+    "\n",
+    "    Note that for the function exp, we can also just use M.exp()\n",
+    "\n",
+    "    >>> matrix_func(M, exp) == M.exp()\n",
+    "    True\n",
+    "\n",
+    "    But for other functions, we have to do it this way.\n",
+    "\n",
+    "    >>> M.sin()\n",
+    "    Traceback (most recent call last):\n",
+    "    ...\n",
+    "    AttributeError: Matrix has no attribute sin.\n",
+    "    >>> matrix_func(N, sin)\n",
+    "    [-sin(1), -2*sin(1),      0, 2*sin(1)]\n",
+    "    [-sin(1),   -sin(1), sin(2),   sin(1)]\n",
+    "    [      0,         0, sin(2),        0]\n",
+    "    [-sin(1), -2*sin(1), sin(2), 2*sin(1)]\n",
+    "    \n",
+    "    Note that we could also use this to compute the series expansion of a matrix, \n",
+    "    if we know the closed form of that expansion. For example, suppose we wanted to compute\n",
+    "    \n",
+    "    I + M + M**2 + M**3 + …\n",
+    "\n",
+    "    The series\n",
+    "\n",
+    "    1 + x + x**2 + x**3 + …\n",
+    "\n",
+    "    is equal to the function 1/(1 - x).\n",
+    "\n",
+    "    >>> matrix_func(M, Lambda(x, 1/(1 - x))) # Note, Lambda works just like lambda, but is symbolic\n",
+    "    [-1/2, -5/4, 15/4]\n",
+    "    [   0, -1/2,    0]\n",
+    "    [   0, -1/4,  1/4]\n",
+    "    \"\"\"\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "matrix_func(M, exp)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "matrix_func(M, Lambda(x, 1/(1 - x)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now lets investigate how this works in relation to the series expansion definition. Write a function that uses `matrix_func` and `series` to compute the approximation of a matrix evaluated at a function up to $O(M^n)$."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def matrix_func_series(M, func, n):\n",
+    "    \"\"\"\n",
+    "    Computes the approximation of the func(M) using the series definition up to O(M**n).\n",
+    "\n",
+    "    >>> matrix_func_series(M, exp, 10)\n",
+    "    [22471/1120,  14953/448, -44859/448]\n",
+    "    [         0, 22471/1120,          0]\n",
+    "    [         0, 14953/2240,    83/2240]\n",
+    "    >>> matrix_func_series(M, exp, 10).evalf()\n",
+    "    [20.0633928571429, 33.3772321428571,  -100.131696428571]\n",
+    "    [               0, 20.0633928571429,                  0]\n",
+    "    [               0, 6.67544642857143, 0.0370535714285714]\n",
+    "    >>> matrix_func(M, exp).evalf()\n",
+    "    [20.0855369231877, 33.3929164246997,  -100.178749274099]\n",
+    "    [               0, 20.0855369231877,                  0]\n",
+    "    [               0, 6.67858328493993, 0.0497870683678639]\n",
+    "\n",
+    "    It's pretty close. Basically what we might expect for those values up to O(x**10).\n",
+    "\n",
+    "    >>> matrix_func_series(N, sin, 3)\n",
+    "    [-1, -2, 0, 2]\n",
+    "    [-1, -1, 2, 1]\n",
+    "    [ 0,  0, 2, 0]\n",
+    "    [-1, -2, 2, 2]\n",
+    "    >>> matrix_func(N, sin).evalf()\n",
+    "    [-0.841470984807897,  -1.68294196961579,                 0,  1.68294196961579]\n",
+    "    [-0.841470984807897, -0.841470984807897, 0.909297426825682, 0.841470984807897]\n",
+    "    [                 0,                  0, 0.909297426825682,                 0]\n",
+    "    [-0.841470984807897,  -1.68294196961579, 0.909297426825682,  1.68294196961579]\n",
+    "\n",
+    "    It's not as close, because we used O(x**3), but clearly still the same thing.\n",
+    "\n",
+    "    >>> matrix_func_series(M, Lambda(x, 1/(1 - x)), 10)\n",
+    "    [29524, 73810, -221430]\n",
+    "    [    0, 29524,       0]\n",
+    "    [    0, 14762,  -14762]\n",
+    "    >>> matrix_func(M, Lambda(x, 1/(1 - x)))\n",
+    "    [-1/2, -5/4, 15/4]\n",
+    "    [   0, -1/2,    0]\n",
+    "    [   0, -1/4,  1/4]\n",
+    "\n",
+    "    Woah! That one's not close at all. What is happening here?  Let's try more terms\n",
+    "\n",
+    "    >>> matrix_func_series(M, Lambda(x, 1/(1 - x)), 100)\n",
+    "    [257688760366005665518230564882810636351053761000, 644221900915014163795576412207026590877634402500, -1932665702745042491386729236621079772632903207500]\n",
+    "    [                                               0, 257688760366005665518230564882810636351053761000,                                                  0]\n",
+    "    [                                               0, 128844380183002832759115282441405318175526880500,  -128844380183002832759115282441405318175526880500]\n",
+    "    \n",
+    "    It just keeps getting bigger. In fact, the series diverges. Recall that \n",
+    "    1/(1 - x) = 1 + x + x**2 + x**3 + … *only if* |x| < 1.  But the eigenvalues \n",
+    "    of M are bigger than 1 in absolute value.\n",
+    "    \n",
+    "    >>> M.eigenvals()\n",
+    "    {3: 2, -3: 1}\n",
+    "\n",
+    "    In fact, 1/(1 - M) is mathematically defined via the analytic continuation \n",
+    "    of the series expansion 1 + x + x**2 + …, which is just 1/(1 - x).  This is\n",
+    "    well-defined as long as none of the eigenvalues of M are equal to 1.  Let's\n",
+    "    try it on N.\n",
+    "\n",
+    "    >>> matrix_func(N, Lambda(x, 1/(1 - x)))\n",
+    "    [nan, -oo, nan,  oo]\n",
+    "    [nan, nan, nan, nan]\n",
+    "    [nan, nan, nan, nan]\n",
+    "    [nan, -oo, nan,  oo]\n",
+    "    \n",
+    "    That didn't work. What are the eigenvalues of N?\n",
+    "\n",
+    "    >>> N.eigenvals()\n",
+    "    {1: 1, 2: 1, -1: 1, 0: 1}\n",
+    "\n",
+    "    Ah, the first one is 1, so we cannot define 1/(1 - N). \n",
+    "    \"\"\"\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "matrix_func_series(M, exp, 10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "matrix_func_series(M, exp, 10).evalf()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "matrix_func(M, exp).evalf()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "matrix_func_series(N, sin, 3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "matrix_func_series(M, Lambda(x, 1/(1 - x)), 100)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "M.eigenvals()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "matrix_func(N, Lambda(x, 1/(1 - x)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "N.eigenvals()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": []
   }
- ]
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 0
 }

--- a/tutorial_exercises/Advanced-Simplification Solutions.ipynb
+++ b/tutorial_exercises/Advanced-Simplification Solutions.ipynb
@@ -1,721 +1,738 @@
 {
- "metadata": {
-  "name": "",
-  "signature": "sha256:346ed1d88073bd614dfe4f9a62f9352b0e4f11cd6775964c5304a5ed6d7b8f98"
- },
- "nbformat": 3,
- "nbformat_minor": 0,
- "worksheets": [
+ "cells": [
   {
-   "cells": [
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Simplification Solutions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from sympy import *\n",
+    "x, y, z = symbols('x y z')\n",
+    "init_printing()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For each exercise, fill in the function according to its docstring. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Polynomial/Rational Function Simplification"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In each exercise, apply specific simplification functions to get the desired result."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def polysimp1(expr):\n",
+    "    \"\"\"\n",
+    "    >>> polysimp1(cos(x)*sin(x) + cos(x))\n",
+    "    (sin(x) + 1)*cos(x)\n",
+    "    >>> polysimp1(cos(x)*sin(x) + cos(x) + 1)\n",
+    "    (sin(x) + 1)*cos(x) + 1\n",
+    "    \"\"\"\n",
+    "    return collect(expr, cos(x))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
     {
-     "cell_type": "heading",
-     "level": 1,
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAKgAAAAVBAMAAAAgMbgsAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMARHYyq80Q75mJZlS7\n3SINk/qdAAAC3UlEQVQ4EbVUT2jTcBh9bde0a7uuDGSIDMP8wzaEVR14UVucCAOZ9VARUchlyGCH\nKTgU0Y16cbdaRSYiRGGHCboxGV4EhwgTFe3JgxeD9CIetunAPzvM9yVp0jTVm98hv+9773svvy+/\nJMB/iYDqs22zkfs+hkAs1QgFqiKT7zN7Qr/c1lDWzqNpF7SyhAZcqwfN2hGZ/AkTC/x0W8NaNc9V\nE3tV3pMK14FW6YrIB1UL1KxFrp1OOmNnimEmyuFjGucv2qhncUXkI2yrizGnPmtncdVOejVAGbUL\nz+KKyG+yqORepyXgDp2Ys1CPKd44rW5SIyI/CQR6HuQqa9h/cc8ulW1RjpcsDc4XgOYJS+Y1nRKw\nMnkXyULXHNoe7mApInzZ/rVLBaZwChgByngJnNaVVVJhHRjGI/0KELc37TVdYFNoFfvSBzQMKIto\nYR3W+VyKsY+RMrCAc0CHhqKYLgHfyEdSYN2LJ5xhlDXDa9pOJLyI2fQlYHn3BzSzFlEzgivxNNAO\n7i2ytg1i+tYybSWv4aiYhVbkWm+aIbJc5C3XgdaJ8UP0gYgUNC0yRUZMlXsb2TpT4LzQpmk0nz9z\nIZ/PCiCnTxGwVee7RW1rbvjTGmsx5fZUuWZwGTiI2HqNaWSORPI7b/yP8TNF7l922m9glgJThOU0\nZ+T4r4F5oFBjmtCBx8EV7ORecvRneJ/pNJEWMjqfaWaLiqgKiChm9CKoAdM8fzzV8K7GlO9R/Hdi\nNMnWv79SoXUEjXYDr+JjSBhW53N9CZ8hr1QHsLmzO9W3caRvo//ZjwnOXIby4vadHtLhFC+M6k6v\nj5/UgeMCVQo3ERq4pQdKnTdYUoSR7uESafIRg4s3rjql7zMVpvFn6orIN/g9zDimJTsLqA7ESWsL\nB3dFwlu/Podk4vzFFJ6GP4b8EBFHBOErvp5k1oaaDB9HYLARCEdk8nLKdSFHKMEPzR/BtB8TpCoi\n/wd7T6t3rXsFAgAAAABJRU5ErkJggg==\n",
+      "text/latex": [
+       "$$\\left(\\sin{\\left (x \\right )} + 1\\right) \\cos{\\left (x \\right )}$$"
+      ],
+      "text/plain": [
+       "(sin(x) + 1)⋅cos(x)"
+      ]
+     },
+     "execution_count": 3,
      "metadata": {},
-     "source": [
-      "Simplification Solutions"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "from sympy import *\n",
-      "x, y, z = symbols('x y z')\n",
-      "init_printing()"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 1
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "For each exercise, fill in the function according to its docstring. "
-     ]
-    },
-    {
-     "cell_type": "heading",
-     "level": 2,
-     "metadata": {},
-     "source": [
-      "Polynomial/Rational Function Simplification"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "In each exercise, apply specific simplification functions to get the desired result."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def polysimp1(expr):\n",
-      "    \"\"\"\n",
-      "    >>> polysimp1(cos(x)*sin(x) + cos(x))\n",
-      "    (sin(x) + 1)*cos(x)\n",
-      "    >>> polysimp1(cos(x)*sin(x) + cos(x) + 1)\n",
-      "    (sin(x) + 1)*cos(x) + 1\n",
-      "    \"\"\"\n",
-      "    return collect(expr, cos(x))"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 2
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "polysimp1(cos(x)*sin(x) + cos(x))"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\left(\\sin{\\left (x \\right )} + 1\\right) \\cos{\\left (x \\right )}$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAKgAAAAVBAMAAAAgMbgsAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMARHYyq80Q75mJZlS7\n3SINk/qdAAAC3UlEQVQ4EbVUT2jTcBh9bde0a7uuDGSIDMP8wzaEVR14UVucCAOZ9VARUchlyGCH\nKTgU0Y16cbdaRSYiRGGHCboxGV4EhwgTFe3JgxeD9CIetunAPzvM9yVp0jTVm98hv+9773svvy+/\nJMB/iYDqs22zkfs+hkAs1QgFqiKT7zN7Qr/c1lDWzqNpF7SyhAZcqwfN2hGZ/AkTC/x0W8NaNc9V\nE3tV3pMK14FW6YrIB1UL1KxFrp1OOmNnimEmyuFjGucv2qhncUXkI2yrizGnPmtncdVOejVAGbUL\nz+KKyG+yqORepyXgDp2Ys1CPKd44rW5SIyI/CQR6HuQqa9h/cc8ulW1RjpcsDc4XgOYJS+Y1nRKw\nMnkXyULXHNoe7mApInzZ/rVLBaZwChgByngJnNaVVVJhHRjGI/0KELc37TVdYFNoFfvSBzQMKIto\nYR3W+VyKsY+RMrCAc0CHhqKYLgHfyEdSYN2LJ5xhlDXDa9pOJLyI2fQlYHn3BzSzFlEzgivxNNAO\n7i2ytg1i+tYybSWv4aiYhVbkWm+aIbJc5C3XgdaJ8UP0gYgUNC0yRUZMlXsb2TpT4LzQpmk0nz9z\nIZ/PCiCnTxGwVee7RW1rbvjTGmsx5fZUuWZwGTiI2HqNaWSORPI7b/yP8TNF7l922m9glgJThOU0\nZ+T4r4F5oFBjmtCBx8EV7ORecvRneJ/pNJEWMjqfaWaLiqgKiChm9CKoAdM8fzzV8K7GlO9R/Hdi\nNMnWv79SoXUEjXYDr+JjSBhW53N9CZ8hr1QHsLmzO9W3caRvo//ZjwnOXIby4vadHtLhFC+M6k6v\nj5/UgeMCVQo3ERq4pQdKnTdYUoSR7uESafIRg4s3rjql7zMVpvFn6orIN/g9zDimJTsLqA7ESWsL\nB3dFwlu/Podk4vzFFJ6GP4b8EBFHBOErvp5k1oaaDB9HYLARCEdk8nLKdSFHKMEPzR/BtB8TpCoi\n/wd7T6t3rXsFAgAAAABJRU5ErkJggg==\n",
-       "prompt_number": 3,
-       "text": [
-        "(sin(x) + 1)\u22c5cos(x)"
-       ]
-      }
-     ],
-     "prompt_number": 3
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "polysimp1(cos(x)*sin(x) + cos(x) + 1)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\left(\\sin{\\left (x \\right )} + 1\\right) \\cos{\\left (x \\right )} + 1$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAMwAAAAVBAMAAAD4PRwmAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMARHYyq80Q75mJZlS7\n3SINk/qdAAADMUlEQVRIDb1VTUgUYRh+dtedXd11FSEkQhrsh5TArYQulZISCGF2UCIK5lCE4MGC\npIhStkPZySyiiGAKOhiUYkSXIInIqChPHbo0hJfooJb9erDnnfnm25ndzWPvYb7nfZ73fZ/5vv2Y\nBf5TRMwioxrF3C5SSFRUl2KBiOnx/9CbXTX22yuSZ6xV4WRWAb2kLeC8zkLAm0OqWH9BtsctjvzK\n98QtH3f5QK3GO0rxAlKl3hwmRXrfDyBqemWWt8izXsMxhQzHBUb7PounNqLY0OLPyeuqCUfaaZNg\nY0EM6PyYQilTgSYLMPpVElryc3xdN0Vps8orzmzTTZH8UaUnPFZ3iA1e69IAUHOEUbpuEpth3pHG\nO12zi9hxautmk1VJHkpmtHMyB5QPMWfoDtfmulCzwzeRyW2aQM29DZJzDj6v/7LJBFw90CQ2B4E+\nYAbPgUO2scDiuA304r59lpVqY2GbRyyKLWB7dqeFDmMKlcxljjFS8SExA4jO0E1icxyoszAiNtPA\nV8qJajBvwkPus99tyHe4u6klGZ/CePY0MLflPcqliHPKEZ1PZQHRGSEbvn9icR3E5o1nU0UbC3ul\nMjYvz0CHa9NCZm6EL7EEVA0N7uZkgHMMlE0JFJ1RaGPcWm4tsAFOSKVrk+zuPnyyu7tVCG2z1ubN\n5eiqrt6Pi6IQ84VNeYpNsEkO7QywCxVLAZvEBMsy3/hyKxxaC3eTkt20ORiXBs7hHrM8h5KH9gqY\nBHIBm7QNPIjOYyPft0uaA/t3d3OXTCUVm79NyxoTSZME51Q4TYhagOiM0KHx9j228DZgw1uc+pPu\nz5grXejYEqJOrYOXqQGkHQ7lnKf2ND55kM+wTR2wur6hunl5T/Ny25OfQzypGRjPrt1oZGW8Wurz\nHRcHD9jAfqFmc1cQ67hqR0brL0vOOX0NvaM2oavnm5IXvl9CwqEQjnM6LfrYiOJ/THSVCxKOn/u6\nPjQRSnwIx/wGjCoUMTXFkwwmms/P8fVIqK5HV/pA/xEY6gb4grceDad+pueU1mf9Or1mWhUsczQX\nAJ0BHIB6TmldblRByHWR4MehOKLZYk4Yf05J/S/KOcD9xTt91AAAAABJRU5ErkJggg==\n",
-       "prompt_number": 4,
-       "text": [
-        "(sin(x) + 1)\u22c5cos(x) + 1"
-       ]
-      }
-     ],
-     "prompt_number": 4
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def polysimp2(expr):\n",
-      "    \"\"\"\n",
-      "    >>> polysimp2((2*x + 1)/(x**2 + x))\n",
-      "    1/(x + 1) + 1/x\n",
-      "    >>> polysimp2((x**2 + 3*x + 1)/(x**3 + 2*x**2 + x))\n",
-      "    1/(x**2 + 2*x + 1) + 1/x\n",
-      "    \"\"\"\n",
-      "    return expand(apart(expr))"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 5
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "polysimp2((2*x + 1)/(x**2 + x))"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\frac{1}{x + 1} + \\frac{1}{x}$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAFoAAAAsBAMAAAAX/bLtAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAuxCrdpnvzWYiiVTd\nMkSRVyLjAAABG0lEQVQ4EWNgQABGBQQbk4UmyySPTzWaLJOxPR7VmLL+eFQzMKDLovMZUAC6LDof\nRfGo2ajBAeahhxg6H1ULmmxofmkDqgJkHn5ZZJU0YmuSZO6W4aH6Pw4A9R3MlxBVeL0cXl5+rLy8\nGK8aFEmY2SiCODkDrVoI7jIiXKL4Ca76CZyFzmCaABFRNkaoRleD4HM7QNks1FI9y3m2K8RQvGZD\nlDEt4DjBdgDsBHyqocq4GFg+cF8gqBqqjImBWQCsloEBr9kwZWwOINWs5eU16eXlBiA21jCBKGOY\nf4FBAaQGr9kMEGUcE/wZWAirhirb3yDGMAVsNF6zocoUvbSWNKCqZg37HgERQZBIyqCC8DBBKMLD\n4nPAIwmWAgAViGYs3A8cDwAAAABJRU5ErkJggg==\n",
-       "prompt_number": 6,
-       "text": [
-        "  1     1\n",
-        "\u2500\u2500\u2500\u2500\u2500 + \u2500\n",
-        "x + 1   x"
-       ]
-      }
-     ],
-     "prompt_number": 6
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "polysimp2((x**2 + 3*x + 1)/(x**3 + 2*x**2 + x))"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\frac{1}{x^{2} + 2 x + 1} + \\frac{1}{x}$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAJMAAAAsBAMAAACTV5eGAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAuxCrdpnvzWYiiVTd\nMkSRVyLjAAACDElEQVRIDWNgwAmEcMpgSjAqYIohRBQ/IdiEWEzyCniUKBsTbxSTsT0+oxhYiDeK\ngcF/1Cg80YIqNRpWqOGBj0evsGIN+x6Bzx0ocqH5pQ0oAsODwzSBav7gdhg1itgQQA+r/2SADxDL\nYEbxg42AChLrDiR1rOXlNenl5QZIQhQwYa5CM2KpsAKaCGEudqNYFVgLCOtFU4HdKJ4JnH/RFBLm\nYjeKbQPTP1S9nKGFD1BFoDxGBZgwdqMYGLjRKuPJDCy/YXqQaaTmAZ8DsgSCzb4AwoZldyMGhvMI\nWQYGqDih5gFIy2KoPpir0xQY7B9AxUAUTJxA8wCokmMBSD0QwLTUKzDEPwCLQAiYOD6jZjnPdnVg\neMVwF00L0IMKnEsst4SgiWOpXKDKmBZwnGA7wCu9Gxg4IAC3nYH3F4MWQ09DDpo4FqOgyrgYWD5w\nX2D7/x8tjzIwsAswLGDwZ9hL2CioMiYGZgGIYjQtDIEMDAoMhjA5uGuxuAqujM0BppwBObuzgDN9\nClgOWRyLUQwMEGUM8y8AbYcDuO1bGTgnMACzExNECi6OzSiIMo4J/gwsWIziDWDgmNDJ8oHBibBR\nUGX7G8QYpsDdhIjBOatWxXD/YEzgdCBoFEyZopfWkgaIajAJ88j5////MIksWuUBlYOJY2keICtD\nMgkpXSGLIlyLKoqXhyu74xJHGAYAbUWwlhzKdrAAAAAASUVORK5CYII=\n",
-       "prompt_number": 7,
-       "text": [
-        "     1         1\n",
-        "\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500 + \u2500\n",
-        " 2             x\n",
-        "x  + 2\u22c5x + 1    "
-       ]
-      }
-     ],
-     "prompt_number": 7
-    },
-    {
-     "cell_type": "heading",
-     "level": 2,
-     "metadata": {},
-     "source": [
-      "Powers"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "In each exercise, apply specific simplification functions to get the desired result. "
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def powersimp1(expr):\n",
-      "    \"\"\"\n",
-      "    >>> powersimp1(exp(x)*(exp(y) + 1))\n",
-      "    exp(x) + exp(x + y)\n",
-      "    \"\"\"\n",
-      "    return powsimp(expand(expr))"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 8
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "powersimp1(exp(x)*(exp(y) + 1))"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$e^{x} + e^{x + y}$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAFcAAAAVBAMAAADBdm84AAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIpmJdlTdRDKr72bN\nELv8JKevAAABJklEQVQoFWNgIAxYCStBqOBDMAmz0BWbTPdswKILIgxSzO7HwHUBooL5wjyuAEzF\nUGGQ4iv8Al1QBewMpzGVAo2DCIMUy5Yx+MGVfISzUBhA4TlnTp0548AwmWEKTIZjAQeUeREmBKIh\nwiCTGZYzrABRQNDPfIAZwmIIgdJIwmDFK9g/QGXuuarYYlEMFQYrjvQ7AFTBqOwkAFUIomAmIwmD\nFDMKcDoAqTABRgUgBQMwxUjCnEA5PoMaIMn4nYGpAaYSSEMVowuzuhgAJTlXb3FEUgtTjC4MUcKv\ngKRU58yZrDNnTgJFUIThKvgd4EwwA+oMdGGIIi6gYiCCA6hidGGIPMsBhktYgg5dGGqYkYsD3Fgg\nAxZ0aMLIShBsmGKECB5WCR45AAOfOPuPJEVeAAAAAElFTkSuQmCC\n",
-       "prompt_number": 9,
-       "text": [
-        " x    x + y\n",
-        "\u212f  + \u212f     "
-       ]
-      }
-     ],
-     "prompt_number": 9
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def powersimp2(expr):\n",
-      "    \"\"\"\n",
-      "    >>> powersimp2(2**x*x**x)\n",
-      "    (2*x)**x\n",
-      "    >>> powersimp2(x**x*x**x)\n",
-      "    (x**2)**x\n",
-      "    \"\"\"\n",
-      "    return powsimp(expr, force=True)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 10
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "powersimp2(2**x*x**x)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\left(2 x\\right)^{x}$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAC4AAAAXBAMAAACG4mBhAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMARHYyq80Q75mJZlS7\n3SINk/qdAAABK0lEQVQoFW2QIUjEUBzGP+duu+3YPAQxCS8seOkWBG0n2AXLBTGsGASDFotFEINt\nCMrZVqxiEWxOi6BlVdMQgyLoLFfn///23jw4Px7/7/t+sLfHHxiXE0yvjFPgzEz3/+PtRkJ4QtDQ\nctucpnIaC8D70R1X1iGPRYRAH/4yulfcSQ1gsjhFDEPAjOAVFYYbw7q/6USw6ezB/FHc2lFhhr4d\noqk5nhQ/lu4N8RF8zgtgoPi69F5sxe6LnQHXiu9K34ADo2iFwKzi8uJmCgtmyqg3ygMutuCpOW+o\ndYAv4DtE9HfPI/El4NLNuzCIX1Bn0bv85/NBdps84LXqks8BXlmW2XZn6yQhsiYp/S1XobJ6D7So\nUTlCt74O0jfr9lYnDqt180UdAYM2IfULDYE8tfjIEh8AAAAASUVORK5CYII=\n",
-       "prompt_number": 11,
-       "text": [
-        "     x\n",
-        "(2\u22c5x) "
-       ]
-      }
-     ],
-     "prompt_number": 11
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "powersimp2(x**x*x**x)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\left(x^{2}\\right)^{x}$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAC8AAAAcBAMAAAAD5/ucAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMARDKrEM1mIu+Zdrvd\niVTWGHL+AAABSklEQVQoFW2RPUsDQRCG35zBS2Iuxl9w21tEwY8izTZWIhEEQUGwE8GPNNaXWkQt\ntEkaQZEgooKdhVgpdlfEJiAE7SxURLSMs5uZTQoXbuZ53rnb+wLcCmpjzM3RY+Vi4ACHHQt0MdUi\nHOLhAyIVGE5g3jRvxFRauyjlWX6NT2lT7frQODPgVTyqEzazZQnIloFCMEtb+hU3CGjTDB3TF9UG\nkN53g3Wi5LdoKi+UiD0F3IsWBDD8/qqBmnhdAHvtNvGm+DiB35x8q3IQaoZr6jNYW95hLyiGBeox\nLvHCHsnDPFKgUeQYKLUYzQDYZgPcFXMm8r+Q5FGkGMwmK5lPnLCHZYZzIPczUPGP2N17hPR9bhrP\np5zjSWBQCXX6omhfLGR70v48g96dDaT0Xwnh1pGBrHK65cjAatdyvTfxuzsBG92TkNY98j/+ASBj\nPT/dHxZRAAAAAElFTkSuQmCC\n",
-       "prompt_number": 12,
-       "text": [
-        "    x\n",
-        "\u239b 2\u239e \n",
-        "\u239dx \u23a0 "
-       ]
-      }
-     ],
-     "prompt_number": 12
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def powersimp3(expr):\n",
-      "    \"\"\"\n",
-      "    >>> a, b, c = symbols('a b c')\n",
-      "    >>> powersimp3((a**b)**c)\n",
-      "    a**(b*c)\n",
-      "    >>> powersimp3((a**b)**(c + 1))\n",
-      "    a**(b*c + b)\n",
-      "    \"\"\"\n",
-      "    return powdenest(expand_power_exp(expr), force=True)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 13
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "a, b, c = symbols('a b c')"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 14
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "powersimp3((a**b)**c)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$a^{b c}$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAUBAMAAABhbjCNAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIqt2iUTvu2aZ3RAy\nVM0ud2cfAAAAmElEQVQYGWNgAIO4BxAaQrJMQObxXUDm8Qsg8+KNtRl2OhtAhawYmrjXsH6A8ooZ\nupgUuA9AeTkM0/kDoGwGhg8MK/YjDFrA+4DrAIM3VDbShIFR2WQDA5B0TYTrYAgTYIeZDJT6wcBZ\nAJdj+sDAZQDn8Rcw7D8A58kbMNxnABoGAfsvMOjxHoDx+Bp4V7LAOEDrTI+bwngAu6ce02hGmyoA\nAAAASUVORK5CYII=\n",
-       "prompt_number": 15,
-       "text": [
-        " b\u22c5c\n",
-        "a   "
-       ]
-      }
-     ],
-     "prompt_number": 15
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "powersimp3((a**b)**(c + 1))"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$a^{b c + b}$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAC0AAAAUBAMAAADrQanMAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIqt2iUTvu2aZ3RAy\nVM0ud2cfAAAA7UlEQVQYGWNgAIO4BxAaTLK+g3NYJkCZvCDaEy7OdwHKZAfRb+Hi/ALI4h/h4vHG\n2gw7nQ0YGEDqWT8bbYDKWDE0ca9h/QARZ17AoQAVL2boYlLgPgARZzfgWAAVz2GYzh/AwKD37tm7\ndwZsBzgLoOIfGFbsFwCxQebzM3A1gNhAsID3AdcBBm+IOBfDPYgoA0OkCQOjsskGiDjrZAegOKOy\nayJMGiIO4YUJsH9AiDPBmIw/GOC2w8RANNMHBi4DZAEom7+AYf8BLOLyBgz3GYAOQQf7LzDo8R5A\nF2Vg4GvgXcmCKQx0vulxU0xxABOjLWXanlaIAAAAAElFTkSuQmCC\n",
-       "prompt_number": 16,
-       "text": [
-        " b\u22c5c + b\n",
-        "a       "
-       ]
-      }
-     ],
-     "prompt_number": 16
-    },
-    {
-     "cell_type": "heading",
-     "level": 2,
-     "metadata": {},
-     "source": [
-      "Logs"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def logsimp1(expr):\n",
-      "    \"\"\"\n",
-      "    >>> a, b = symbols('a b', positive=True)\n",
-      "    >>> logsimp1(log(x**y*a**b))\n",
-      "    y*log(x) + log(a**b)\n",
-      "    >>> logsimp1(log(x*y*a*b))\n",
-      "    log(x) + log(y) + log(a*b)\n",
-      "    \"\"\"\n",
-      "    return logcombine(expand_log(expr, force=True))"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 17
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "a, b = symbols('a b', positive=True)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 18
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "logsimp1(log(x**y*a**b))"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$y \\log{\\left (x \\right )} + \\log{\\left (a^{b} \\right )}$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAKUAAAAcBAMAAADywGJUAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAEImZIkR2MlTdu+/N\nq2Z6CBlbAAADWklEQVRIDa1UWWgTURQ908x0kmnSDII/VuhYsSIo5McqLjggFAShAVFwgcSKERE0\nH4ILlOZLQZBGC/qlFgQ3UKqIC/gRFAWhQhQRlKLBBVQQU1zqhzWe9+ZNZxqXD82FuXPuufedee/O\nnQEaZ5tKjdPylZpSPmrAfa2nES8ATQ2QExJm2RNKugH2mH/3M21vbSb3EMj9TWedSr75W5HMPVcV\n2/EBiLmT9eaoM4kl8A+ESH5qou/21Bj6sCLO4B3QrBohuFgIizhuCy+sJH3gTgRQokhKEdexBNDG\ngrRVpxn05aUq0lwPXAwWSdSSVkQVJ4nEpaxe87KfQJtC0awH6jX7/cpitETIvfpWp2mU/ASsggf/\npLnDr1zTK9BHnn+2gx72jpp615YCok+6ckUg4gB65+MDXRzjlLcopLkytxg4vCW3XWRGeelP5lz1\nqpCx0WRUsYshNffZeEQqlnX4iirANLyr3ATkiVgRaJpHkHCMMRxrIg3Ri42uVRWY1p/H3kgRFwip\neQXoyZ9HZJihaLzDhx0EDBHTAs0WB/q4VcRSyd/hNn8gMiQDSqRht2TxlaFVNr4BydRTJIoMk9S0\n8UzUmVXhw5qZAvCJZU8lPwgkqohlZQC0Mzlgm+MMrXLrF0qV+vNtJKUmcI3I04yMjNy/NTJSZnwR\nH/nA7+a4dkOkQc3kENrzMpD7xDI0DzO0ylGxz3J351yRbCnQ6ePQfnf2ASYn9N5eT+YBdbIY4LGk\n9ZC9I1rp97M/rT5vqwK8bq5iM9BakrVT+2l+aU17tGgQzzsapZawjAssR6ZCSOGNLk5jw57djMQA\nRX9Yw3r2d7NkXIWVMs7ucUUlOFDxSnRQzgBDzidm5Fa4bNqLCdd8tKCCWK32iaxRhHZmVsdOwrja\nkHrvfbXH6Ovgv+hUrZZiGhkxnlv3bxWYNl/6edJ7TrsLbb1D7I8wfvk2VfXMNKYfFTipDq34exyD\nonp9HtU6xKHhhZdeTN+pkJGdpAR4z+uQAAlHeN+0z/zHOZbjx7zrx9naCkHcVqxWUqDutorbuyQ4\nsxjOyE3lFoYpTOvsXSQIvazohKtA3U3ryM2mLO1cOBPzuDAV4G4FtwXUH9DqMP8qHPw7jjrBWn0o\nwP+F3garI3aAG4l+AqYQyYpQSHZMAAAAAElFTkSuQmCC\n",
-       "prompt_number": 19,
-       "text": [
-        "              \u239b b\u239e\n",
-        "y\u22c5log(x) + log\u239da \u23a0"
-       ]
-      }
-     ],
-     "prompt_number": 19
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "logsimp1(log(x*y*a*b))"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\log{\\left (x \\right )} + \\log{\\left (y \\right )} + \\log{\\left (a b \\right )}$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAOcAAAAVBAMAAABPgOQBAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAMqvNid27Ipl2VBDv\nRGYoM0XMAAADmUlEQVRIDc2VTWgTQRTH/5vmq9lsEgsieHHBj1IQDY2CUJRVKjR4ieKlKKgBRS8a\nCoI9NX4gVPyIEMFF0CgoeDKg6EWhoFJUhIgoCEJzqHoSUwWxFo3v7c7sV429OtCZN+/95v+fncxu\ngf+jvRPb+LzQdrSKTSwIQkoyz3TPOnul0yu6COMZJ2cF88ieDqCy3PCvVHR7rq4uAJbsDj+ArrpM\nZGUgxiA5IOtBMKLLij06kl1cYLpoF5zedKJpET0QY4DsrkhSgmrJzkR1WbFHRzJdowTTASm8sEHq\nH4rothgDZLIuSQkmxDaCpo7kFC9hOiClZaUUojU77GD6eh7YwdSV3MpLWJZMj5lngBuXzUuUihtA\nLN97exwIl2E1j6mXPAWoQwbG6giXLQ4e09j45RoSfeNmwZbESPV9Cf3mGlu2CGUXQoY2h+Ewre1q\nAvfwofkUSIiHdk195CZar7VwzQU9povrWIGpeqRi2JLaJI5A/Y50xpItImkgNhMt4Cx5ItkADFK6\nDmgTnABcUx/5ElgaL+CAC3pMnwBjmf2IT9B6lhxr4jQSc+zFskVM1YAfoQJWEoA0EXWs4lBpce81\n9ZG/CExWMOuCrqn2k5TKK0GqtuRaYBjxLCUt2SK+kM83ZUZ9zg5sCjzjzjI9mcvtzuX6eR4gyRR3\n6sqMAOO53PrHuZxO2aieomI6uyzzsEZTlvwOdQaRMqaawvQOVb7GqtUMAUjShE4bqntq7vH6SN7j\nSXRPuKD7pAl+Un00v5kYlozNItFS0zVcqIvjpXNWfqWsJ6RdNoFP3S1cAVJZXuI9Xh95mEob6Klc\n0DUF/abLGuKjTJLqT4Sy1+kWUZ5li6CbFS1r+xaV2CFcRuJ3dCJW+dsr4yOHiD7B58VrrOYxpffj\nIN4uWsL5cBnYhJtlI1SL69a0p92LnsE1wJ52m4rQClAPbRu8SmFXgzpq4niD5Bsq3Tcv0FYlKEyV\ntV9LyootTUTa7R8EkSRGzFeHGmrfeZpKmsK7DTzaSSMmubOa/LrJ31SkJZkkO4A/MhKUTypAdSPU\nNwZNXEmuSJrCj/R3i3PT3FktL8Z3YhSDJFMGvRHWlZegVvGRqb303aA/jyTXJU3h0QzAVwPO/yE1\ny9P5zSEHEDGiBn0MO4Cx7fa9dCVZzEurg+YQ+dLronNPLVSyx2DvkCNImOf+AeJevnqcVzuSPPm7\n7CiXqF20h84933BuC4KQkoL+A6HuDQCGeipPAAAAAElFTkSuQmCC\n",
-       "prompt_number": 20,
-       "text": [
-        "log(x) + log(y) + log(a\u22c5b)"
-       ]
-      }
-     ],
-     "prompt_number": 20
-    },
-    {
-     "cell_type": "heading",
-     "level": 2,
-     "metadata": {},
-     "source": [
-      "Miscellaneous  "
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def miscsimp1(expr):\n",
-      "    \"\"\"\n",
-      "    >>> miscsimp1(sin(x + y))\n",
-      "    2*(-tan(x/2)**2 + 1)*tan(y/2)/((tan(x/2)**2 + 1)*(tan(y/2)**2 + 1)) + 2*(-tan(y/2)**2 + 1)*tan(x/2)/((tan(x/2)**2 + 1)*(tan(y/2)**2 + 1))\n",
-      "    \"\"\"\n",
-      "    return expand_trig(expr).rewrite(tan)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 21
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "miscsimp1(sin(x + y))"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\frac{2 \\left(- \\tan^{2}{\\left (\\frac{x}{2} \\right )} + 1\\right) \\tan{\\left (\\frac{y}{2} \\right )}}{\\left(\\tan^{2}{\\left (\\frac{x}{2} \\right )} + 1\\right) \\left(\\tan^{2}{\\left (\\frac{y}{2} \\right )} + 1\\right)} + \\frac{2 \\left(- \\tan^{2}{\\left (\\frac{y}{2} \\right )} + 1\\right) \\tan{\\left (\\frac{x}{2} \\right )}}{\\left(\\tan^{2}{\\left (\\frac{x}{2} \\right )} + 1\\right) \\left(\\tan^{2}{\\left (\\frac{y}{2} \\right )} + 1\\right)}$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAjAAAAA5BAMAAADaTwy9AAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIpnNu0SrdlQQ3e8y\niWbzIQYJAAAMg0lEQVRoBeVabYicVxU+87Wfs7OrLYL2R4YkUOLn0g0pFtRBNG0p2AUpAbVkoDFa\naJpFQlatJWORtgglUyyKP2ST/PCH1iZUIi0WMkiN1Qq7NtDSH6FrKOqfkBXR2rqyno977nvvez9m\nC0uz4IXcj3Oe85x77rw7ed93HoB3017Z33838PcCO7X7/vciDeW4J5mo2q/OitNiVqLguJWgjXkT\nMBUNTBhtVOjfA7vEaDHx5Jl8Q4rRnM2uzoJxYqayzsYCczEAkSFuNZ7GMZjsQ0ERZfCNaT44DTsG\nDEaMMMfB6XyFJx6pW/lBX2fBONkb/ycbCTN1/MADAKMLAQoNcSs6xj8J8KPpmZdxuhgLjNsoKtWe\ng6V58hXMieTJfEOKqezcywngwdQWyD72NnsJ8/pI5zkcTrPB7e6MWgUxsgrwwS/BMVxNzIgp079/\n1+fZS1HpdrJPPoc53FIdIcl82WIAPgCj/6YElXPUa2voxIy1FZowZr62SvPj1LntKTo7Y513HTS/\niboj8DXsR7s0z7VKF070CMBRFlkm/RR7HOZgS+N3922+ckX5YpAav9vPUoZqm3ptVZ2Y8VUeBTM9\nQ4slzMntSRl+eJgOxljbYiv6nTQ9Dy9gPy4XX+ELZiN9mFgjK0dZd9vOeDLV5cFhLm9p/PBR3KTJ\nV67IFFwqxknx6z4cncf1JHW2XbEznrRWeBDMyzDA1cQqmwAeM+MoFSzWVtvY7HCeZi801mh4hrpc\nm3weRvg7jaMUWSa9Kg6HOdgSnOgjSPKVKtKCS8VoMhw/04dP0JksOzZoPOuuAO6FP5KBMM21S0DH\nVO1gR807mGqHTF9uU++0Jp/Io8dmybbbcUSntbehSgcjUQopkTZWmgOLEeZqBw3UdEtyMJyvXFGi\nGInX/mwfZw/pisa/vHO4B3/9xgq8+Ozvji1A847H+W6KMOO3P/Iw4VtcK050F3zFsLV19Kdfh9bi\nx6B510cXb0cIjJ7DrjIzskCLa9QNaRN0+XGUAsukLz7+KG3DZQ62JAfD+UoVYWS0GM3GY/O/NNzn\n2c7gf0Sn6RZq7yr+Tz25scHH4GIa+lXhHYxYJ9oA35/Bm8LaF+Q/1ZFZZK+vfJFzHKSChrTlFQRw\nlAWWSC9sbJDLZQ62JAcj+fyKMDJajM1Gk1qH+v3U2YY0rXU4OAN3AbxlrS6mKbd8pStGrFTDtUHj\n71A/B9MLGF7vYje2SNXiNTzgIdvtJS9HWVhAyh6XOdiSHIzkCyqKFmOz0UT+5m/Ba/22n1GbRxvS\nQOO1NwbwOfdgEGNbhb8eceldMWKlGuDeh9eh3pGDqZFB2w5KkG/VDvkpqthTQEoQxvAEu2BLcjCS\nL6goWoxS0Tja5RUFFg1XlX19PGvvYAgzvYFtDb9r+O5n19zcz+fm9lEgf8eIlWq44X78APVguCgT\nCEs9gmeb3JFwlMUFpOxxmYMtycFIvqCisBibSiaP4LcizghXtDOwUJuF5d/3g4NRTPDx8MHoFTMK\nc9Bc/7F3MBo5/IoZa8P7EF0+mBIp87mYYEv+FVOqyC3YRuoecWy2oUUHw5+6tZ+BlaUFOPnbgXcw\njDHP++axsvynxN88E+2p8bdgbP0rejC1LjGbyB0DWuTabwD+jP5aFzvbAlL21Lo0yGuRYEvmYAYE\nCSqSgkuRhDTtQ5cvf5imh9TA4y5YmezCGy/NeAfDGPO8j1+t0rzvGLFWZ6fgVzC1/l09mJEOYU0k\nfqXnW+UXl185hRCJUmxAyg7GmNciwZbkYCRfUBEXU47UZDie3dh4h5bfdmwATx2ZqXx28Se3Xtx4\n4Hv/aauLMeZ5v3zTUP3IPz6udzfj+/8EN978rUvfOfqvl+6me8XRU0RhIofex0zgtxEFSBRFUgtI\n2coY81qkvCXYeeGWVb1vCiriYsqRzOl3B/1ldMUY87w/NWsgesXw0lr9+MYarU3kJd+XXklU2k8e\nxpjXIja5tyVI5ONiypGRZNODiLFkMpiTfbTXFozzgAuyVteIc3PTw5G3lnzppd4qpRHKzK9FbHJv\nS5DIZ4rxIyOZRlYixpLJYPh5f2mm5ORl3EpvHLhR5Lh+OYkp15uoHMQw82uRePJUPlNMJlLyNk9l\n87NTMPK8/2YUHrcC/IHRHNnqRCNjRomKeQqbYF4lQzx5Kp8pOBNpktxRJEvOGHOV3U9HQXEr3t33\nCM6REwOaum08evEhot7Dbkir9xAgr0XiycN8hpGLyUUa3A1mzA2Ekef9VjuGi1sRWZm1kVeCwLGF\nwCQGjkr41MwYfi2SSB7mM6FccC7S4MZWNFd6JIw8798YBcWtBH0C/3FkpUNLryUPhqM8aGSBzPJa\nJJ48ks+QUDG5SJvrb3aWniDmAj/v74li4laCtnomstoPItMHQ1HDGmLktUg8eSSfMmIxuUiFXb8x\nfTDXb0/bIvP2Ohh6CXC925p8Lnow/Ebjeu9pW1wqtInq3Nxtv5yb626bDW2jjegVs222ZHUCuiMr\nrbCeKXX5I/5HJ80C1WBejeDtzrwxDaPAl8ELNjqUXMgLEwTcoyCbXA08FmksUP1hWUMoLmqkjlZa\nYT3Nrvq80frtRN1WMWI9wyi8gwnAlq/wWGbNyaP124l1h2XlKUItgUorHM+ipXcnKixwgMatihHy\niDojIW9QCoxzrphAcqF8UHicSHdPutMCqF63LNlTnoJ0An5TaQV7Xvvq8UFSK3BaAkMKVYyQx+g+\nEnIDQ4FEzsE8KLxFr3wsxhAFSkRoQXhNE1DoeyAWRpg9FcmLVJbiJtdm5if7NCHPVP/QZM/+hkBW\nbXfi5LgsYhSiGCGP0X2MdgXs9A4FWhsL6qqc01kxCh97jALFJC8gUMdtmzQxCijKMnvKUuxE5nmH\nnaYirSBPAz5NhlCbwHKPJdwJNgHy1HaiGCGP0X3kKWwcTaptSuw34SMPGAWKSV7AWO6hqgYGFj6e\nFWWZPWUpzmMMsThNXrWgXoOavFB6xrj13YDIPSZW2UzAqgHowC84hEJ0H1beEKXQMB4n8YOK85EH\nf9Saod4kB3iSVvjhsdzDpGFgm+22c8uSPeUommv4aFdiuMpc5MEHz3NNGnZTh21sQUb5Ya3aoRUD\nr9CsaPKCQyiM7iNHUQTSbBn/RfmMGENEG9UOwqjZd7sn+riSNESRK0v2VO0gjFqEYvRcoNcw0gry\nwPIU/gaC7Rp12PyDaa2RjYBlfYUoRpgCjO4jR0E0RXsoxcfaBFWgSHKM8quSNEhRlqG4ZZk95ShG\nZiEhrUAP/oDyzZtfpx0f7FNfPhgRFhCwpK8wihGmUN1HjkLItb8vxcfaBFWgZFUNSJEry+wpR1Hv\n4l9r29NrXBBpBXlsWx7I1L9iRFjAwDN4aIFihD2q+8hR2Dw82Y99lM8TY2RVDUSRKcvsKUdRawuD\np9fg7ZHHNv2l2T8Y+bGXgVhIqBhhj+o+chQ2D09IgRDlg6g24TGN5u8YSUNAOphEWWZP9sfqCAVF\n0z9Pr4FLY+XHf1ws9chU/lMqVA2sBggUI0xMFGsYmqNgbtvhocT52OoLLRDqVyVpiGJIWbgn2X+c\nQg/G02sg1PDyDDv+HNx3A56qAQG4k1AxwlvbDIViZDQHE/LxwShWPm5HgeKrGqSAfFk5ilqXGGLS\nCvIE2oTSnxL/SMjAqGKEPWV5Q4yCMhVtH06jfEaMUdIm+FeMqCiIIlfWcIqRDjGU9Bq8R/IE2gS/\nKhEWMDDQV1DwpikIXLRDOI3yiRijrE3wD0ZUDUSRKWsTFKOn8C6zrNfgPZIn0Cb4B2PuYwgY6Cso\neNMUBC4aKRCifCLGKGsT/IOR+xiiyJS1CYoGfQeV9Rq8R/IE2gQ9GJF7iLCAgYG+goI3TUHgopEC\nIcoHUW2CHozIPUTVQMBMWWV5Q4wirSWIaRP0YKSK2gKPW0AhfKafHnhLZ2E8vjZBqxKcqBrSFEZy\nMZziiJPXnxqPp00o3g0Q1ggLtoDCyzyy4i2dhfH42oQDDkBVFGmKqDAiRiE6AZdb5+LhZ9JWR43e\n+KastoDCo22e8pbOwnj40d0kd7w0NTtNUxjJxXCKeo/4Yq3eI+tV6hJagafJl5Mj1Hvk3wQFwYrG\nCoRi6czYk9Mm6E7TFPUe8m2CojLr5PWm7JFn0iueQxettsy2gEIpZUxLLoZqE3SnaQrebU7eoBRP\n+JtyVuRJaRMIZoUFW0DhpMUHj+SXzDBtQqVjiNIUJJ7IyRssBeoEEo08/Kid0Ars0bgtoFAqGVGB\nkGjoyWkTip2mKXC3m6NIbOH/2vw/cfPaKSRDNwMAAAAASUVORK5CYII=\n",
-       "prompt_number": 22,
-       "text": [
-        "    \u239b     2\u239bx\u239e    \u239e    \u239by\u239e        \u239b     2\u239by\u239e    \u239e    \u239bx\u239e \n",
-        "  2\u22c5\u239c- tan \u239c\u2500\u239f + 1\u239f\u22c5tan\u239c\u2500\u239f      2\u22c5\u239c- tan \u239c\u2500\u239f + 1\u239f\u22c5tan\u239c\u2500\u239f \n",
-        "    \u239d      \u239d2\u23a0    \u23a0    \u239d2\u23a0        \u239d      \u239d2\u23a0    \u23a0    \u239d2\u23a0 \n",
-        "\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500 + \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n",
-        "\u239b   2\u239bx\u239e    \u239e \u239b   2\u239by\u239e    \u239e   \u239b   2\u239bx\u239e    \u239e \u239b   2\u239by\u239e    \u239e\n",
-        "\u239ctan \u239c\u2500\u239f + 1\u239f\u22c5\u239ctan \u239c\u2500\u239f + 1\u239f   \u239ctan \u239c\u2500\u239f + 1\u239f\u22c5\u239ctan \u239c\u2500\u239f + 1\u239f\n",
-        "\u239d    \u239d2\u23a0    \u23a0 \u239d    \u239d2\u23a0    \u23a0   \u239d    \u239d2\u23a0    \u23a0 \u239d    \u239d2\u23a0    \u23a0"
-       ]
-      }
-     ],
-     "prompt_number": 22
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def miscsimp2(expr):\n",
-      "    \"\"\"\n",
-      "    >>> miscsimp2(gamma(x + 4))\n",
-      "    x**4*gamma(x) + 6*x**3*gamma(x) + 11*x**2*gamma(x) + 6*x*gamma(x)\n",
-      "    \"\"\"\n",
-      "    return expand(expand_func(expr))"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 23
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "miscsimp2(gamma(x + 4))"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$x^{4} \\Gamma{\\left(x \\right)} + 6 x^{3} \\Gamma{\\left(x \\right)} + 11 x^{2} \\Gamma{\\left(x \\right)} + 6 x \\Gamma{\\left(x \\right)}$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAWMAAAAZBAMAAAAWIlLBAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIol2q1SZEGbd7zK7\nzUTvhYErAAAEGklEQVRYCZ1WTYgcRRT+5rc787M7+Aeedsgu69HBDSp42A2skYCYhaAXkUTFEJDg\nmJxclG1z86AsnoKXjKgELzoHPXlIiAbEi3MQFWR10JOCMGhCgoLrq6r3qqq7p6ent2GqXr/3fd/7\nuru6pgE+2hLMNwfLK/35kDHU6lcHYcUk3MmpYlr1qD5y5Hmjev8grAz14MFilqunw0mG1Iz0oU7p\n3xnlYqXKTjHLQPkAd7mxFfxXzNcM9OeFLW+PZ8hllmq3M0tFC13P8kLPsMPxDJUL111xLoKBt7uO\n9huH77hUZpTGhp2dfvP4P5ubl7vAZ0J8WQKZg9XDQ4nr1+YgoKXWmx4Mb4XkL3+4efwvoLnBUnWr\nyQnXZgb2AuguN28CFdL5gZlIbXz3D6u7UizdmoMQfEuW9WBoYZfmqxvAEaCtrkYfIwl49tpkY585\n88pZ7QAbqPREQTdQJ69y5l20WX5pXLqTTwg2T/ShBxb4FV8Yy1VgjXPARY7SbfTlTcUSZcncZXTR\nsFcfDFjrpJlD9+681gmvGMuzCMC6EtODkmjeePoJY7kMXDGiNG5zlG6jLU/FAuGJx42DLfxppXAj\nrtUe2FJzbaWTT0habuzvT4zlGhb4eZFka8vosmWvjbacwt515N6He5qi1jIdL9CPk6s6AbDW4k9r\nL9kalXIJnmXXRtsA6l2gtHz05Iu0xZ82faa0UWs5iQ264aXGrqawgx/pheHkczpvLe9cwqFIalTK\nJTjLHosttyPgPN6KPgZqfMPZst/GWI5jy6hMakPf8id02Zz8I2F5gvJtqTnL2QRn2WOx5cYY9OKs\n41lgYWD6iGWvjbEcxwaoXjMEuWn0lyrJq1wRrV2Et6RGJb7L2QRn2WOx5cUx0MeTqkNzokb3ML02\nxnIS2+gZgucAMElt+dze3nt7e98RaHGE8G+p0bmzLMkEwVkWgGrlbAAfqIS2PL3NdOzSkK5WM83r\n95GKTTKxMFrq8qVGILacTfAt2zayMLZIgT7sgtTC8Nvwwohhw846KjHLX9OWx8m3lXs6eGHU1CKT\nGqXZcjbBWfZYbLkVAW9WJniE2o1Uk6ltjOU49lT0De42DHZAO5skE5scrmM7khpx8gn2r8RjsWXa\n2Wp3WoNSL7XJ+W2M5Tj29YfOL0facunc/rEORb8DkvxZF+zlo37sKVujp5pPOPPp9xHUIIokeN8v\nN5+naWEXwZcPHH6UwvaYBjr4YXptsrGGwWND+dZHMOBAtPg0MRUmGP77Vibxh23zLkhjXY2isCun\nZXpo+pCvVSnE58IEQ79oVZY5ym6TxlqyDuzH5xvxfOZZYYJWsh+fwShTWQp52HsEeFSCnLkwQeuV\nNli2aldiZp88rHqJ1VEZmjl3LEwwirxR4bHcBpBNTWH/B7wNdun71wGRAAAAAElFTkSuQmCC\n",
-       "prompt_number": 24,
-       "text": [
-        " 4           3            2                \n",
-        "x \u22c5\u0393(x) + 6\u22c5x \u22c5\u0393(x) + 11\u22c5x \u22c5\u0393(x) + 6\u22c5x\u22c5\u0393(x)"
-       ]
-      }
-     ],
-     "prompt_number": 24
-    },
-    {
-     "cell_type": "heading",
-     "level": 2,
-     "metadata": {},
-     "source": [
-      "Continued Fractions"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "If we do not cover this, see http://asmeurer.github.io/scipy-2014-tutorial/html/tutorial/simplification.html#example-continued-fractions."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def list_to_frac(l):\n",
-      "    expr = Integer(0)\n",
-      "    for i in reversed(l[1:]):\n",
-      "        expr += i\n",
-      "        expr = 1/expr\n",
-      "    return l[0] + expr"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 25
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "a0, a1, a2, a3, a4 = symbols('a0:5')"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 26
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Determine the list used to create the continued fraction $$\\frac{a_{0} a_{1} a_{2} a_{3} a_{4} + a_{0} a_{1} a_{2} + a_{0} a_{3} a_{4} + a_{0} + a_{1} a_{2} a_{3} + a_{1} a_{3} a_{4} + a_{1} + a_{3}}{a_{0} a_{1} a_{2} a_{4} + a_{0} a_{4} + a_{1} a_{2} + a_{1} a_{4} + 1}.$$"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def continued_frac():\n",
-      "    \"\"\"\n",
-      "    Determine the original list used to create the fraction.  \n",
-      "\n",
-      "    Return the original list from this function.\n",
-      "\n",
-      "    >>> orig_frac = (a0*a1*a2*a3*a4 + a0*a1*a2 + a0*a3*a4 + a0 + a1*a2*a3 + a1*a3*a4 + a1 + a3)/(a0*a1*a2*a4 + a0*a4 + a1*a2 + a1*a4 + 1)\n",
-      "    >>> pprint(orig_frac)\n",
-      "    a\u2080\u22c5a\u2081\u22c5a\u2082\u22c5a\u2083\u22c5a\u2084 + a\u2080\u22c5a\u2081\u22c5a\u2082 + a\u2080\u22c5a\u2083\u22c5a\u2084 + a\u2080 + a\u2081\u22c5a\u2082\u22c5a\u2083 + a\u2081\u22c5a\u2083\u22c5a\u2084 + a\u2081 + a\u2083\n",
-      "    \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n",
-      "                     a\u2080\u22c5a\u2081\u22c5a\u2082\u22c5a\u2084 + a\u2080\u22c5a\u2084 + a\u2081\u22c5a\u2082 + a\u2081\u22c5a\u2084 + 1\n",
-      "    >>> cancel(list_to_frac(continued_frac())) == orig_frac\n",
-      "    True\n",
-      "    \"\"\"\n",
-      "    return [a3, a4, a0, a2, a1]"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 28
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "orig_frac = (a0*a1*a2*a3*a4 + a0*a1*a2 + a0*a3*a4 + a0 + a1*a2*a3 + a1*a3*a4 + a1 + a3)/(a0*a1*a2*a4 + a0*a4 + a1*a2 + a1*a4 + 1)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 29
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "orig_frac"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\frac{a_{0} a_{1} a_{2} a_{3} a_{4} + a_{0} a_{1} a_{2} + a_{0} a_{3} a_{4} + a_{0} + a_{1} a_{2} a_{3} + a_{1} a_{3} a_{4} + a_{1} + a_{3}}{a_{0} a_{1} a_{2} a_{4} + a_{0} a_{4} + a_{1} a_{2} + a_{1} a_{4} + 1}$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAkgAAAArBAMAAABxz2pBAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIqt2iUTvu2aZ3RAy\nVM0ud2cfAAAFqklEQVRoBe1aTYhbVRQ+mT+TeUknFPepdqWiDcwUKW7CVBdu6qBSN4J04cofBnVX\nxNGFWwcF7SDUSkEQFKItFUSYgEgRFAOurEoHV+IiTpWiZVrHe885753793L7Zqo+6XuL5Lyb73zf\nuV9ekkfOAdjhkbSvO7EAFD4KshZgKADdvViwWGOx1TVOxocFoPBtkKoAQwHo7sWCxRqLBYopAN19\n3f+MWG3/A8do8xLB3oWj/HEKRRqeFRMCyFoUaohqbHol7ZhhbF07FYOj7Vs2YerwKlAE51Wp08fg\nJYAHn+tTlBxe5Ahgj96KOtJiCHr/oTSpuZxGOn0cFFlZFDYImpokrAEGRwI3cHbhLmKw68qgcTEN\n9cUor/YnNJZhAR4Gir68UyE7K/AWNPqNDY5W0gjgorNzhE72pvcRtPn6KTPdUnWgDc1KotDaQmR2\nJQnUZ3AkiOEEnCSG1CRkMKAxMYT6YlgkTGzCbBc+gLk+RXBBIQ8AnIbZdu0qRROr9U2KIHnIMYmg\nA9hiQOuUmW6pOlBkZdGzjkkC9RnAliCGO+A1RGZXODIINCqGUF8M82BuGdYHyRbMDjECNOkPSK7C\nzDC5DBgBTG1wNLmuTWqMRr88OxrtUyEC1OKHDNA7kPSxUM3KovehSSdHo/dGo58sVp8BtyMSzABH\nVJpbl0BxC+PE2CSPQRcJnS5chM+USV2M+tqk2u/Q2kzU985WGp1b4uhrNEnV0+qqhxT6TR9OM0CZ\nlCaln6E8KJxbIvl+83v7SiIGzYoitpjejiHBZSdPRqARMTZJkVjlgi4S1odwT+sLbRJGA21Scg0m\nNn5QX9I9js68kK71HJMI8ITaDkPVDiTdqtuDKlaSH0ypS5kO+nUTaIBBb8eQoLKTe3vjoTExzySW\n0HmwZ6X1/lRTm4QRfdx+hgurSnQRgCP13Y5Rve2YRMv4nhNU7SBNUul48FvjQfUvBom+7JhkQH0G\n3I5UyGWrX5rx0IiYZ1K6C5UHtf0Hzx9MLqlvIIzIpL3zjz+/BPUeAEVQu0bRGXBNQsB6G55hqDZJ\n0q26XahmJfmua5JAfQbcjkhw2dAZjoXGxHyTSELn8fE0zLU51L9udDwKX1HQWVK/s3h8t/bOCYrS\nywPPZgZwiZZFC7L0HKiwttbWrqxQfnozqc9mMlaLISRRu6zvQPSRA42KCavFIHmg7pMeQwn1kJnU\nfPFHvkH7tF1/Kn2506doupuuqGd1n7TMp/pKwkPSc6Amay39TnqEs/WTsFoMsh2RSN6FV6mwHGhU\nTFgtBjNvcv5tru7WX9/gaGZ7e5PC5vximxfrB+7myHqaP0QlQu3IlS69IukWEjKowQqv/Da0UXiW\nQa3XghKfL9xmgehEoFExgVo8Zp71QnVSOVA5UDlQOVBmB7arI+pAmd+/qrbKgcqByoHKgZvPgeM3\n35YL7/iT9M+Fwpn/cUK0WX/jAB/f/n81yfpPK/SG3UDAZGVSyGFcy2wuk0lGi116+KFIbyHbwb8A\nKJNJMk5APfysAy/jBPEhgpwpA5vLulBcMY8BSmQSdeP1OEFwHqCjBwuiQwQ5AKObr0cTLJOQWAA+\nQ5lMknGC4DwAdeWjQwRhAP4/jww4mmCZ5LT7/TmFMpk0l40TBOcBaJwgOkQQBqBJ0vgf2+73GMpk\nkowThOYBeC06RBAGaJOMxr95JXliLoNqSpXnFkDGCbh/rjYmzXqOokMEYYA2Sbis7yRPzGUolUky\nTsD9c92glGb99Q0R5EwZ4MdNuMwryRXzGcp0Jck4QXAeAHvq0SGCHACaJI1/yyRa1u9IjkTjzb+4\nKY95JXgwxgl03XRk8wDRIYIcAJrkcGW3o7ieieUxcCmleDLGCbK6pVmvbqG4EW612qXdnwMQk4TL\nYhBAHkMp3OEiZJxA2urGPEBsiADCgCCXuW0B5DCY4B3GfwPGFsAHW/8rGAAAAABJRU5ErkJggg==\n",
-       "prompt_number": 30,
-       "text": [
-        "a\u2080\u22c5a\u2081\u22c5a\u2082\u22c5a\u2083\u22c5a\u2084 + a\u2080\u22c5a\u2081\u22c5a\u2082 + a\u2080\u22c5a\u2083\u22c5a\u2084 + a\u2080 + a\u2081\u22c5a\u2082\u22c5a\u2083 + a\u2081\u22c5a\u2083\u22c5a\u2084 + a\u2081 + a\u2083\n",
-        "\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n",
-        "                 a\u2080\u22c5a\u2081\u22c5a\u2082\u22c5a\u2084 + a\u2080\u22c5a\u2084 + a\u2081\u22c5a\u2082 + a\u2081\u22c5a\u2084 + 1                 "
-       ]
-      }
-     ],
-     "prompt_number": 30
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "cancel(list_to_frac(continued_frac())) == orig_frac"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 31,
-       "text": [
-        "True"
-       ]
-      }
-     ],
-     "prompt_number": 31
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
+     "output_type": "execute_result"
     }
    ],
-   "metadata": {}
+   "source": [
+    "polysimp1(cos(x)*sin(x) + cos(x))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAMwAAAAVBAMAAAD4PRwmAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMARHYyq80Q75mJZlS7\n3SINk/qdAAADMUlEQVRIDb1VTUgUYRh+dtedXd11FSEkQhrsh5TArYQulZISCGF2UCIK5lCE4MGC\npIhStkPZySyiiGAKOhiUYkSXIInIqChPHbo0hJfooJb9erDnnfnm25ndzWPvYb7nfZ73fZ/5vv2Y\nBf5TRMwioxrF3C5SSFRUl2KBiOnx/9CbXTX22yuSZ6xV4WRWAb2kLeC8zkLAm0OqWH9BtsctjvzK\n98QtH3f5QK3GO0rxAlKl3hwmRXrfDyBqemWWt8izXsMxhQzHBUb7PounNqLY0OLPyeuqCUfaaZNg\nY0EM6PyYQilTgSYLMPpVElryc3xdN0Vps8orzmzTTZH8UaUnPFZ3iA1e69IAUHOEUbpuEpth3pHG\nO12zi9hxautmk1VJHkpmtHMyB5QPMWfoDtfmulCzwzeRyW2aQM29DZJzDj6v/7LJBFw90CQ2B4E+\nYAbPgUO2scDiuA304r59lpVqY2GbRyyKLWB7dqeFDmMKlcxljjFS8SExA4jO0E1icxyoszAiNtPA\nV8qJajBvwkPus99tyHe4u6klGZ/CePY0MLflPcqliHPKEZ1PZQHRGSEbvn9icR3E5o1nU0UbC3ul\nMjYvz0CHa9NCZm6EL7EEVA0N7uZkgHMMlE0JFJ1RaGPcWm4tsAFOSKVrk+zuPnyyu7tVCG2z1ubN\n5eiqrt6Pi6IQ84VNeYpNsEkO7QywCxVLAZvEBMsy3/hyKxxaC3eTkt20ORiXBs7hHrM8h5KH9gqY\nBHIBm7QNPIjOYyPft0uaA/t3d3OXTCUVm79NyxoTSZME51Q4TYhagOiM0KHx9j228DZgw1uc+pPu\nz5grXejYEqJOrYOXqQGkHQ7lnKf2ND55kM+wTR2wur6hunl5T/Ny25OfQzypGRjPrt1oZGW8Wurz\nHRcHD9jAfqFmc1cQ67hqR0brL0vOOX0NvaM2oavnm5IXvl9CwqEQjnM6LfrYiOJ/THSVCxKOn/u6\nPjQRSnwIx/wGjCoUMTXFkwwmms/P8fVIqK5HV/pA/xEY6gb4grceDad+pueU1mf9Or1mWhUsczQX\nAJ0BHIB6TmldblRByHWR4MehOKLZYk4Yf05J/S/KOcD9xTt91AAAAABJRU5ErkJggg==\n",
+      "text/latex": [
+       "$$\\left(\\sin{\\left (x \\right )} + 1\\right) \\cos{\\left (x \\right )} + 1$$"
+      ],
+      "text/plain": [
+       "(sin(x) + 1)⋅cos(x) + 1"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "polysimp1(cos(x)*sin(x) + cos(x) + 1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def polysimp2(expr):\n",
+    "    \"\"\"\n",
+    "    >>> polysimp2((2*x + 1)/(x**2 + x))\n",
+    "    1/(x + 1) + 1/x\n",
+    "    >>> polysimp2((x**2 + 3*x + 1)/(x**3 + 2*x**2 + x))\n",
+    "    1/(x**2 + 2*x + 1) + 1/x\n",
+    "    \"\"\"\n",
+    "    return expand(apart(expr))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAFoAAAAsBAMAAAAX/bLtAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAuxCrdpnvzWYiiVTd\nMkSRVyLjAAABG0lEQVQ4EWNgQABGBQQbk4UmyySPTzWaLJOxPR7VmLL+eFQzMKDLovMZUAC6LDof\nRfGo2ajBAeahhxg6H1ULmmxofmkDqgJkHn5ZZJU0YmuSZO6W4aH6Pw4A9R3MlxBVeL0cXl5+rLy8\nGK8aFEmY2SiCODkDrVoI7jIiXKL4Ca76CZyFzmCaABFRNkaoRleD4HM7QNks1FI9y3m2K8RQvGZD\nlDEt4DjBdgDsBHyqocq4GFg+cF8gqBqqjImBWQCsloEBr9kwZWwOINWs5eU16eXlBiA21jCBKGOY\nf4FBAaQGr9kMEGUcE/wZWAirhirb3yDGMAVsNF6zocoUvbSWNKCqZg37HgERQZBIyqCC8DBBKMLD\n4nPAIwmWAgAViGYs3A8cDwAAAABJRU5ErkJggg==\n",
+      "text/latex": [
+       "$$\\frac{1}{x + 1} + \\frac{1}{x}$$"
+      ],
+      "text/plain": [
+       "  1     1\n",
+       "───── + ─\n",
+       "x + 1   x"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "polysimp2((2*x + 1)/(x**2 + x))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAJMAAAAsBAMAAACTV5eGAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAuxCrdpnvzWYiiVTd\nMkSRVyLjAAACDElEQVRIDWNgwAmEcMpgSjAqYIohRBQ/IdiEWEzyCniUKBsTbxSTsT0+oxhYiDeK\ngcF/1Cg80YIqNRpWqOGBj0evsGIN+x6Bzx0ocqH5pQ0oAsODwzSBav7gdhg1itgQQA+r/2SADxDL\nYEbxg42AChLrDiR1rOXlNenl5QZIQhQwYa5CM2KpsAKaCGEudqNYFVgLCOtFU4HdKJ4JnH/RFBLm\nYjeKbQPTP1S9nKGFD1BFoDxGBZgwdqMYGLjRKuPJDCy/YXqQaaTmAZ8DsgSCzb4AwoZldyMGhvMI\nWQYGqDih5gFIy2KoPpir0xQY7B9AxUAUTJxA8wCokmMBSD0QwLTUKzDEPwCLQAiYOD6jZjnPdnVg\neMVwF00L0IMKnEsst4SgiWOpXKDKmBZwnGA7wCu9Gxg4IAC3nYH3F4MWQ09DDpo4FqOgyrgYWD5w\nX2D7/x8tjzIwsAswLGDwZ9hL2CioMiYGZgGIYjQtDIEMDAoMhjA5uGuxuAqujM0BppwBObuzgDN9\nClgOWRyLUQwMEGUM8y8AbYcDuO1bGTgnMACzExNECi6OzSiIMo4J/gwsWIziDWDgmNDJ8oHBibBR\nUGX7G8QYpsDdhIjBOatWxXD/YEzgdCBoFEyZopfWkgaIajAJ88j5////MIksWuUBlYOJY2keICtD\nMgkpXSGLIlyLKoqXhyu74xJHGAYAbUWwlhzKdrAAAAAASUVORK5CYII=\n",
+      "text/latex": [
+       "$$\\frac{1}{x^{2} + 2 x + 1} + \\frac{1}{x}$$"
+      ],
+      "text/plain": [
+       "     1         1\n",
+       "──────────── + ─\n",
+       " 2             x\n",
+       "x  + 2⋅x + 1    "
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "polysimp2((x**2 + 3*x + 1)/(x**3 + 2*x**2 + x))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Powers"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In each exercise, apply specific simplification functions to get the desired result. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def powersimp1(expr):\n",
+    "    \"\"\"\n",
+    "    >>> powersimp1(exp(x)*(exp(y) + 1))\n",
+    "    exp(x) + exp(x + y)\n",
+    "    \"\"\"\n",
+    "    return powsimp(expand(expr))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAFcAAAAVBAMAAADBdm84AAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIpmJdlTdRDKr72bN\nELv8JKevAAABJklEQVQoFWNgIAxYCStBqOBDMAmz0BWbTPdswKILIgxSzO7HwHUBooL5wjyuAEzF\nUGGQ4iv8Al1QBewMpzGVAo2DCIMUy5Yx+MGVfISzUBhA4TlnTp0548AwmWEKTIZjAQeUeREmBKIh\nwiCTGZYzrABRQNDPfIAZwmIIgdJIwmDFK9g/QGXuuarYYlEMFQYrjvQ7AFTBqOwkAFUIomAmIwmD\nFDMKcDoAqTABRgUgBQMwxUjCnEA5PoMaIMn4nYGpAaYSSEMVowuzuhgAJTlXb3FEUgtTjC4MUcKv\ngKRU58yZrDNnTgJFUIThKvgd4EwwA+oMdGGIIi6gYiCCA6hidGGIPMsBhktYgg5dGGqYkYsD3Fgg\nAxZ0aMLIShBsmGKECB5WCR45AAOfOPuPJEVeAAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$$e^{x} + e^{x + y}$$"
+      ],
+      "text/plain": [
+       " x    x + y\n",
+       "ℯ  + ℯ     "
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "powersimp1(exp(x)*(exp(y) + 1))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def powersimp2(expr):\n",
+    "    \"\"\"\n",
+    "    >>> powersimp2(2**x*x**x)\n",
+    "    (2*x)**x\n",
+    "    >>> powersimp2(x**x*x**x)\n",
+    "    (x**2)**x\n",
+    "    \"\"\"\n",
+    "    return powsimp(expr, force=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAC4AAAAXBAMAAACG4mBhAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMARHYyq80Q75mJZlS7\n3SINk/qdAAABK0lEQVQoFW2QIUjEUBzGP+duu+3YPAQxCS8seOkWBG0n2AXLBTGsGASDFotFEINt\nCMrZVqxiEWxOi6BlVdMQgyLoLFfn///23jw4Px7/7/t+sLfHHxiXE0yvjFPgzEz3/+PtRkJ4QtDQ\nctucpnIaC8D70R1X1iGPRYRAH/4yulfcSQ1gsjhFDEPAjOAVFYYbw7q/6USw6ezB/FHc2lFhhr4d\noqk5nhQ/lu4N8RF8zgtgoPi69F5sxe6LnQHXiu9K34ADo2iFwKzi8uJmCgtmyqg3ygMutuCpOW+o\ndYAv4DtE9HfPI/El4NLNuzCIX1Bn0bv85/NBdps84LXqks8BXlmW2XZn6yQhsiYp/S1XobJ6D7So\nUTlCt74O0jfr9lYnDqt180UdAYM2IfULDYE8tfjIEh8AAAAASUVORK5CYII=\n",
+      "text/latex": [
+       "$$\\left(2 x\\right)^{x}$$"
+      ],
+      "text/plain": [
+       "     x\n",
+       "(2⋅x) "
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "powersimp2(2**x*x**x)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAC8AAAAcBAMAAAAD5/ucAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMARDKrEM1mIu+Zdrvd\niVTWGHL+AAABSklEQVQoFW2RPUsDQRCG35zBS2Iuxl9w21tEwY8izTZWIhEEQUGwE8GPNNaXWkQt\ntEkaQZEgooKdhVgpdlfEJiAE7SxURLSMs5uZTQoXbuZ53rnb+wLcCmpjzM3RY+Vi4ACHHQt0MdUi\nHOLhAyIVGE5g3jRvxFRauyjlWX6NT2lT7frQODPgVTyqEzazZQnIloFCMEtb+hU3CGjTDB3TF9UG\nkN53g3Wi5LdoKi+UiD0F3IsWBDD8/qqBmnhdAHvtNvGm+DiB35x8q3IQaoZr6jNYW95hLyiGBeox\nLvHCHsnDPFKgUeQYKLUYzQDYZgPcFXMm8r+Q5FGkGMwmK5lPnLCHZYZzIPczUPGP2N17hPR9bhrP\np5zjSWBQCXX6omhfLGR70v48g96dDaT0Xwnh1pGBrHK65cjAatdyvTfxuzsBG92TkNY98j/+ASBj\nPT/dHxZRAAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$$\\left(x^{2}\\right)^{x}$$"
+      ],
+      "text/plain": [
+       "    x\n",
+       "⎛ 2⎞ \n",
+       "⎝x ⎠ "
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "powersimp2(x**x*x**x)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def powersimp3(expr):\n",
+    "    \"\"\"\n",
+    "    >>> a, b, c = symbols('a b c')\n",
+    "    >>> powersimp3((a**b)**c)\n",
+    "    a**(b*c)\n",
+    "    >>> powersimp3((a**b)**(c + 1))\n",
+    "    a**(b*c + b)\n",
+    "    \"\"\"\n",
+    "    return powdenest(expand_power_exp(expr), force=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "a, b, c = symbols('a b c')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAUBAMAAABhbjCNAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIqt2iUTvu2aZ3RAy\nVM0ud2cfAAAAmElEQVQYGWNgAIO4BxAaQrJMQObxXUDm8Qsg8+KNtRl2OhtAhawYmrjXsH6A8ooZ\nupgUuA9AeTkM0/kDoGwGhg8MK/YjDFrA+4DrAIM3VDbShIFR2WQDA5B0TYTrYAgTYIeZDJT6wcBZ\nAJdj+sDAZQDn8Rcw7D8A58kbMNxnABoGAfsvMOjxHoDx+Bp4V7LAOEDrTI+bwngAu6ce02hGmyoA\nAAAASUVORK5CYII=\n",
+      "text/latex": [
+       "$$a^{b c}$$"
+      ],
+      "text/plain": [
+       " b⋅c\n",
+       "a   "
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "powersimp3((a**b)**c)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAC0AAAAUBAMAAADrQanMAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIqt2iUTvu2aZ3RAy\nVM0ud2cfAAAA7UlEQVQYGWNgAIO4BxAaTLK+g3NYJkCZvCDaEy7OdwHKZAfRb+Hi/ALI4h/h4vHG\n2gw7nQ0YGEDqWT8bbYDKWDE0ca9h/QARZ17AoQAVL2boYlLgPgARZzfgWAAVz2GYzh/AwKD37tm7\ndwZsBzgLoOIfGFbsFwCxQebzM3A1gNhAsID3AdcBBm+IOBfDPYgoA0OkCQOjsskGiDjrZAegOKOy\nayJMGiIO4YUJsH9AiDPBmIw/GOC2w8RANNMHBi4DZAEom7+AYf8BLOLyBgz3GYAOQQf7LzDo8R5A\nF2Vg4GvgXcmCKQx0vulxU0xxABOjLWXanlaIAAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$$a^{b c + b}$$"
+      ],
+      "text/plain": [
+       " b⋅c + b\n",
+       "a       "
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "powersimp3((a**b)**(c + 1))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Logs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def logsimp1(expr):\n",
+    "    \"\"\"\n",
+    "    >>> a, b = symbols('a b', positive=True)\n",
+    "    >>> logsimp1(log(x**y*a**b))\n",
+    "    y*log(x) + log(a**b)\n",
+    "    >>> logsimp1(log(x*y*a*b))\n",
+    "    log(x) + log(y) + log(a*b)\n",
+    "    \"\"\"\n",
+    "    return logcombine(expand_log(expr, force=True))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "a, b = symbols('a b', positive=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAKUAAAAcBAMAAADywGJUAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAEImZIkR2MlTdu+/N\nq2Z6CBlbAAADWklEQVRIDa1UWWgTURQ908x0kmnSDII/VuhYsSIo5McqLjggFAShAVFwgcSKERE0\nH4ILlOZLQZBGC/qlFgQ3UKqIC/gRFAWhQhQRlKLBBVQQU1zqhzWe9+ZNZxqXD82FuXPuufedee/O\nnQEaZ5tKjdPylZpSPmrAfa2nES8ATQ2QExJm2RNKugH2mH/3M21vbSb3EMj9TWedSr75W5HMPVcV\n2/EBiLmT9eaoM4kl8A+ESH5qou/21Bj6sCLO4B3QrBohuFgIizhuCy+sJH3gTgRQokhKEdexBNDG\ngrRVpxn05aUq0lwPXAwWSdSSVkQVJ4nEpaxe87KfQJtC0awH6jX7/cpitETIvfpWp2mU/ASsggf/\npLnDr1zTK9BHnn+2gx72jpp615YCok+6ckUg4gB65+MDXRzjlLcopLkytxg4vCW3XWRGeelP5lz1\nqpCx0WRUsYshNffZeEQqlnX4iirANLyr3ATkiVgRaJpHkHCMMRxrIg3Ri42uVRWY1p/H3kgRFwip\neQXoyZ9HZJihaLzDhx0EDBHTAs0WB/q4VcRSyd/hNn8gMiQDSqRht2TxlaFVNr4BydRTJIoMk9S0\n8UzUmVXhw5qZAvCJZU8lPwgkqohlZQC0Mzlgm+MMrXLrF0qV+vNtJKUmcI3I04yMjNy/NTJSZnwR\nH/nA7+a4dkOkQc3kENrzMpD7xDI0DzO0ylGxz3J351yRbCnQ6ePQfnf2ASYn9N5eT+YBdbIY4LGk\n9ZC9I1rp97M/rT5vqwK8bq5iM9BakrVT+2l+aU17tGgQzzsapZawjAssR6ZCSOGNLk5jw57djMQA\nRX9Yw3r2d7NkXIWVMs7ucUUlOFDxSnRQzgBDzidm5Fa4bNqLCdd8tKCCWK32iaxRhHZmVsdOwrja\nkHrvfbXH6Ovgv+hUrZZiGhkxnlv3bxWYNl/6edJ7TrsLbb1D7I8wfvk2VfXMNKYfFTipDq34exyD\nonp9HtU6xKHhhZdeTN+pkJGdpAR4z+uQAAlHeN+0z/zHOZbjx7zrx9naCkHcVqxWUqDutorbuyQ4\nsxjOyE3lFoYpTOvsXSQIvazohKtA3U3ryM2mLO1cOBPzuDAV4G4FtwXUH9DqMP8qHPw7jjrBWn0o\nwP+F3garI3aAG4l+AqYQyYpQSHZMAAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$$y \\log{\\left (x \\right )} + \\log{\\left (a^{b} \\right )}$$"
+      ],
+      "text/plain": [
+       "              ⎛ b⎞\n",
+       "y⋅log(x) + log⎝a ⎠"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "logsimp1(log(x**y*a**b))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAOcAAAAVBAMAAABPgOQBAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAMqvNid27Ipl2VBDv\nRGYoM0XMAAADmUlEQVRIDc2VTWgTQRTH/5vmq9lsEgsieHHBj1IQDY2CUJRVKjR4ieKlKKgBRS8a\nCoI9NX4gVPyIEMFF0CgoeDKg6EWhoFJUhIgoCEJzqHoSUwWxFo3v7c7sV429OtCZN+/95v+fncxu\ngf+jvRPb+LzQdrSKTSwIQkoyz3TPOnul0yu6COMZJ2cF88ieDqCy3PCvVHR7rq4uAJbsDj+ArrpM\nZGUgxiA5IOtBMKLLij06kl1cYLpoF5zedKJpET0QY4DsrkhSgmrJzkR1WbFHRzJdowTTASm8sEHq\nH4rothgDZLIuSQkmxDaCpo7kFC9hOiClZaUUojU77GD6eh7YwdSV3MpLWJZMj5lngBuXzUuUihtA\nLN97exwIl2E1j6mXPAWoQwbG6giXLQ4e09j45RoSfeNmwZbESPV9Cf3mGlu2CGUXQoY2h+Ewre1q\nAvfwofkUSIiHdk195CZar7VwzQU9povrWIGpeqRi2JLaJI5A/Y50xpItImkgNhMt4Cx5ItkADFK6\nDmgTnABcUx/5ElgaL+CAC3pMnwBjmf2IT9B6lhxr4jQSc+zFskVM1YAfoQJWEoA0EXWs4lBpce81\n9ZG/CExWMOuCrqn2k5TKK0GqtuRaYBjxLCUt2SK+kM83ZUZ9zg5sCjzjzjI9mcvtzuX6eR4gyRR3\n6sqMAOO53PrHuZxO2aieomI6uyzzsEZTlvwOdQaRMqaawvQOVb7GqtUMAUjShE4bqntq7vH6SN7j\nSXRPuKD7pAl+Un00v5kYlozNItFS0zVcqIvjpXNWfqWsJ6RdNoFP3S1cAVJZXuI9Xh95mEob6Klc\n0DUF/abLGuKjTJLqT4Sy1+kWUZ5li6CbFS1r+xaV2CFcRuJ3dCJW+dsr4yOHiD7B58VrrOYxpffj\nIN4uWsL5cBnYhJtlI1SL69a0p92LnsE1wJ52m4rQClAPbRu8SmFXgzpq4niD5Bsq3Tcv0FYlKEyV\ntV9LyootTUTa7R8EkSRGzFeHGmrfeZpKmsK7DTzaSSMmubOa/LrJ31SkJZkkO4A/MhKUTypAdSPU\nNwZNXEmuSJrCj/R3i3PT3FktL8Z3YhSDJFMGvRHWlZegVvGRqb303aA/jyTXJU3h0QzAVwPO/yE1\ny9P5zSEHEDGiBn0MO4Cx7fa9dCVZzEurg+YQ+dLronNPLVSyx2DvkCNImOf+AeJevnqcVzuSPPm7\n7CiXqF20h84933BuC4KQkoL+A6HuDQCGeipPAAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$$\\log{\\left (x \\right )} + \\log{\\left (y \\right )} + \\log{\\left (a b \\right )}$$"
+      ],
+      "text/plain": [
+       "log(x) + log(y) + log(a⋅b)"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "logsimp1(log(x*y*a*b))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Miscellaneous  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def miscsimp1(expr):\n",
+    "    \"\"\"\n",
+    "    >>> miscsimp1(sin(x + y))\n",
+    "    2*(-tan(x/2)**2 + 1)*tan(y/2)/((tan(x/2)**2 + 1)*(tan(y/2)**2 + 1)) + 2*(-tan(y/2)**2 + 1)*tan(x/2)/((tan(x/2)**2 + 1)*(tan(y/2)**2 + 1))\n",
+    "    \"\"\"\n",
+    "    return expand_trig(expr).rewrite(tan)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAjAAAAA5BAMAAADaTwy9AAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIpnNu0SrdlQQ3e8y\niWbzIQYJAAAMg0lEQVRoBeVabYicVxU+87Wfs7OrLYL2R4YkUOLn0g0pFtRBNG0p2AUpAbVkoDFa\naJpFQlatJWORtgglUyyKP2ST/PCH1iZUIi0WMkiN1Qq7NtDSH6FrKOqfkBXR2rqyno977nvvez9m\nC0uz4IXcj3Oe85x77rw7ed93HoB3017Z33838PcCO7X7/vciDeW4J5mo2q/OitNiVqLguJWgjXkT\nMBUNTBhtVOjfA7vEaDHx5Jl8Q4rRnM2uzoJxYqayzsYCczEAkSFuNZ7GMZjsQ0ERZfCNaT44DTsG\nDEaMMMfB6XyFJx6pW/lBX2fBONkb/ycbCTN1/MADAKMLAQoNcSs6xj8J8KPpmZdxuhgLjNsoKtWe\ng6V58hXMieTJfEOKqezcywngwdQWyD72NnsJ8/pI5zkcTrPB7e6MWgUxsgrwwS/BMVxNzIgp079/\n1+fZS1HpdrJPPoc53FIdIcl82WIAPgCj/6YElXPUa2voxIy1FZowZr62SvPj1LntKTo7Y513HTS/\niboj8DXsR7s0z7VKF070CMBRFlkm/RR7HOZgS+N3922+ckX5YpAav9vPUoZqm3ptVZ2Y8VUeBTM9\nQ4slzMntSRl+eJgOxljbYiv6nTQ9Dy9gPy4XX+ELZiN9mFgjK0dZd9vOeDLV5cFhLm9p/PBR3KTJ\nV67IFFwqxknx6z4cncf1JHW2XbEznrRWeBDMyzDA1cQqmwAeM+MoFSzWVtvY7HCeZi801mh4hrpc\nm3weRvg7jaMUWSa9Kg6HOdgSnOgjSPKVKtKCS8VoMhw/04dP0JksOzZoPOuuAO6FP5KBMM21S0DH\nVO1gR807mGqHTF9uU++0Jp/Io8dmybbbcUSntbehSgcjUQopkTZWmgOLEeZqBw3UdEtyMJyvXFGi\nGInX/mwfZw/pisa/vHO4B3/9xgq8+Ozvji1A847H+W6KMOO3P/Iw4VtcK050F3zFsLV19Kdfh9bi\nx6B510cXb0cIjJ7DrjIzskCLa9QNaRN0+XGUAsukLz7+KG3DZQ62JAfD+UoVYWS0GM3GY/O/NNzn\n2c7gf0Sn6RZq7yr+Tz25scHH4GIa+lXhHYxYJ9oA35/Bm8LaF+Q/1ZFZZK+vfJFzHKSChrTlFQRw\nlAWWSC9sbJDLZQ62JAcj+fyKMDJajM1Gk1qH+v3U2YY0rXU4OAN3AbxlrS6mKbd8pStGrFTDtUHj\n71A/B9MLGF7vYje2SNXiNTzgIdvtJS9HWVhAyh6XOdiSHIzkCyqKFmOz0UT+5m/Ba/22n1GbRxvS\nQOO1NwbwOfdgEGNbhb8eceldMWKlGuDeh9eh3pGDqZFB2w5KkG/VDvkpqthTQEoQxvAEu2BLcjCS\nL6goWoxS0Tja5RUFFg1XlX19PGvvYAgzvYFtDb9r+O5n19zcz+fm9lEgf8eIlWq44X78APVguCgT\nCEs9gmeb3JFwlMUFpOxxmYMtycFIvqCisBibSiaP4LcizghXtDOwUJuF5d/3g4NRTPDx8MHoFTMK\nc9Bc/7F3MBo5/IoZa8P7EF0+mBIp87mYYEv+FVOqyC3YRuoecWy2oUUHw5+6tZ+BlaUFOPnbgXcw\njDHP++axsvynxN88E+2p8bdgbP0rejC1LjGbyB0DWuTabwD+jP5aFzvbAlL21Lo0yGuRYEvmYAYE\nCSqSgkuRhDTtQ5cvf5imh9TA4y5YmezCGy/NeAfDGPO8j1+t0rzvGLFWZ6fgVzC1/l09mJEOYU0k\nfqXnW+UXl185hRCJUmxAyg7GmNciwZbkYCRfUBEXU47UZDie3dh4h5bfdmwATx2ZqXx28Se3Xtx4\n4Hv/aauLMeZ5v3zTUP3IPz6udzfj+/8EN978rUvfOfqvl+6me8XRU0RhIofex0zgtxEFSBRFUgtI\n2coY81qkvCXYeeGWVb1vCiriYsqRzOl3B/1ldMUY87w/NWsgesXw0lr9+MYarU3kJd+XXklU2k8e\nxpjXIja5tyVI5ONiypGRZNODiLFkMpiTfbTXFozzgAuyVteIc3PTw5G3lnzppd4qpRHKzK9FbHJv\nS5DIZ4rxIyOZRlYixpLJYPh5f2mm5ORl3EpvHLhR5Lh+OYkp15uoHMQw82uRePJUPlNMJlLyNk9l\n87NTMPK8/2YUHrcC/IHRHNnqRCNjRomKeQqbYF4lQzx5Kp8pOBNpktxRJEvOGHOV3U9HQXEr3t33\nCM6REwOaum08evEhot7Dbkir9xAgr0XiycN8hpGLyUUa3A1mzA2Ekef9VjuGi1sRWZm1kVeCwLGF\nwCQGjkr41MwYfi2SSB7mM6FccC7S4MZWNFd6JIw8798YBcWtBH0C/3FkpUNLryUPhqM8aGSBzPJa\nJJ48ks+QUDG5SJvrb3aWniDmAj/v74li4laCtnomstoPItMHQ1HDGmLktUg8eSSfMmIxuUiFXb8x\nfTDXb0/bIvP2Ohh6CXC925p8Lnow/Ebjeu9pW1wqtInq3Nxtv5yb626bDW2jjegVs222ZHUCuiMr\nrbCeKXX5I/5HJ80C1WBejeDtzrwxDaPAl8ELNjqUXMgLEwTcoyCbXA08FmksUP1hWUMoLmqkjlZa\nYT3Nrvq80frtRN1WMWI9wyi8gwnAlq/wWGbNyaP124l1h2XlKUItgUorHM+ipXcnKixwgMatihHy\niDojIW9QCoxzrphAcqF8UHicSHdPutMCqF63LNlTnoJ0An5TaQV7Xvvq8UFSK3BaAkMKVYyQx+g+\nEnIDQ4FEzsE8KLxFr3wsxhAFSkRoQXhNE1DoeyAWRpg9FcmLVJbiJtdm5if7NCHPVP/QZM/+hkBW\nbXfi5LgsYhSiGCGP0X2MdgXs9A4FWhsL6qqc01kxCh97jALFJC8gUMdtmzQxCijKMnvKUuxE5nmH\nnaYirSBPAz5NhlCbwHKPJdwJNgHy1HaiGCGP0X3kKWwcTaptSuw34SMPGAWKSV7AWO6hqgYGFj6e\nFWWZPWUpzmMMsThNXrWgXoOavFB6xrj13YDIPSZW2UzAqgHowC84hEJ0H1beEKXQMB4n8YOK85EH\nf9Saod4kB3iSVvjhsdzDpGFgm+22c8uSPeUommv4aFdiuMpc5MEHz3NNGnZTh21sQUb5Ya3aoRUD\nr9CsaPKCQyiM7iNHUQTSbBn/RfmMGENEG9UOwqjZd7sn+riSNESRK0v2VO0gjFqEYvRcoNcw0gry\nwPIU/gaC7Rp12PyDaa2RjYBlfYUoRpgCjO4jR0E0RXsoxcfaBFWgSHKM8quSNEhRlqG4ZZk95ShG\nZiEhrUAP/oDyzZtfpx0f7FNfPhgRFhCwpK8wihGmUN1HjkLItb8vxcfaBFWgZFUNSJEry+wpR1Hv\n4l9r29NrXBBpBXlsWx7I1L9iRFjAwDN4aIFihD2q+8hR2Dw82Y99lM8TY2RVDUSRKcvsKUdRawuD\np9fg7ZHHNv2l2T8Y+bGXgVhIqBhhj+o+chQ2D09IgRDlg6g24TGN5u8YSUNAOphEWWZP9sfqCAVF\n0z9Pr4FLY+XHf1ws9chU/lMqVA2sBggUI0xMFGsYmqNgbtvhocT52OoLLRDqVyVpiGJIWbgn2X+c\nQg/G02sg1PDyDDv+HNx3A56qAQG4k1AxwlvbDIViZDQHE/LxwShWPm5HgeKrGqSAfFk5ilqXGGLS\nCvIE2oTSnxL/SMjAqGKEPWV5Q4yCMhVtH06jfEaMUdIm+FeMqCiIIlfWcIqRDjGU9Bq8R/IE2gS/\nKhEWMDDQV1DwpikIXLRDOI3yiRijrE3wD0ZUDUSRKWsTFKOn8C6zrNfgPZIn0Cb4B2PuYwgY6Cso\neNMUBC4aKRCifCLGKGsT/IOR+xiiyJS1CYoGfQeV9Rq8R/IE2gQ9GJF7iLCAgYG+goI3TUHgopEC\nIcoHUW2CHozIPUTVQMBMWWV5Q4wirSWIaRP0YKSK2gKPW0AhfKafHnhLZ2E8vjZBqxKcqBrSFEZy\nMZziiJPXnxqPp00o3g0Q1ggLtoDCyzyy4i2dhfH42oQDDkBVFGmKqDAiRiE6AZdb5+LhZ9JWR43e\n+KastoDCo22e8pbOwnj40d0kd7w0NTtNUxjJxXCKeo/4Yq3eI+tV6hJagafJl5Mj1Hvk3wQFwYrG\nCoRi6czYk9Mm6E7TFPUe8m2CojLr5PWm7JFn0iueQxettsy2gEIpZUxLLoZqE3SnaQrebU7eoBRP\n+JtyVuRJaRMIZoUFW0DhpMUHj+SXzDBtQqVjiNIUJJ7IyRssBeoEEo08/Kid0Ars0bgtoFAqGVGB\nkGjoyWkTip2mKXC3m6NIbOH/2vw/cfPaKSRDNwMAAAAASUVORK5CYII=\n",
+      "text/latex": [
+       "$$\\frac{2 \\left(- \\tan^{2}{\\left (\\frac{x}{2} \\right )} + 1\\right) \\tan{\\left (\\frac{y}{2} \\right )}}{\\left(\\tan^{2}{\\left (\\frac{x}{2} \\right )} + 1\\right) \\left(\\tan^{2}{\\left (\\frac{y}{2} \\right )} + 1\\right)} + \\frac{2 \\left(- \\tan^{2}{\\left (\\frac{y}{2} \\right )} + 1\\right) \\tan{\\left (\\frac{x}{2} \\right )}}{\\left(\\tan^{2}{\\left (\\frac{x}{2} \\right )} + 1\\right) \\left(\\tan^{2}{\\left (\\frac{y}{2} \\right )} + 1\\right)}$$"
+      ],
+      "text/plain": [
+       "    ⎛     2⎛x⎞    ⎞    ⎛y⎞        ⎛     2⎛y⎞    ⎞    ⎛x⎞ \n",
+       "  2⋅⎜- tan ⎜─⎟ + 1⎟⋅tan⎜─⎟      2⋅⎜- tan ⎜─⎟ + 1⎟⋅tan⎜─⎟ \n",
+       "    ⎝      ⎝2⎠    ⎠    ⎝2⎠        ⎝      ⎝2⎠    ⎠    ⎝2⎠ \n",
+       "─────────────────────────── + ───────────────────────────\n",
+       "⎛   2⎛x⎞    ⎞ ⎛   2⎛y⎞    ⎞   ⎛   2⎛x⎞    ⎞ ⎛   2⎛y⎞    ⎞\n",
+       "⎜tan ⎜─⎟ + 1⎟⋅⎜tan ⎜─⎟ + 1⎟   ⎜tan ⎜─⎟ + 1⎟⋅⎜tan ⎜─⎟ + 1⎟\n",
+       "⎝    ⎝2⎠    ⎠ ⎝    ⎝2⎠    ⎠   ⎝    ⎝2⎠    ⎠ ⎝    ⎝2⎠    ⎠"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "miscsimp1(sin(x + y))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def miscsimp2(expr):\n",
+    "    \"\"\"\n",
+    "    >>> miscsimp2(gamma(x + 4))\n",
+    "    x**4*gamma(x) + 6*x**3*gamma(x) + 11*x**2*gamma(x) + 6*x*gamma(x)\n",
+    "    \"\"\"\n",
+    "    return expand(expand_func(expr))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAWMAAAAZBAMAAAAWIlLBAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIol2q1SZEGbd7zK7\nzUTvhYErAAAEGklEQVRYCZ1WTYgcRRT+5rc787M7+Aeedsgu69HBDSp42A2skYCYhaAXkUTFEJDg\nmJxclG1z86AsnoKXjKgELzoHPXlIiAbEi3MQFWR10JOCMGhCgoLrq6r3qqq7p6ent2GqXr/3fd/7\nuru6pgE+2hLMNwfLK/35kDHU6lcHYcUk3MmpYlr1qD5y5Hmjev8grAz14MFilqunw0mG1Iz0oU7p\n3xnlYqXKTjHLQPkAd7mxFfxXzNcM9OeFLW+PZ8hllmq3M0tFC13P8kLPsMPxDJUL111xLoKBt7uO\n9huH77hUZpTGhp2dfvP4P5ubl7vAZ0J8WQKZg9XDQ4nr1+YgoKXWmx4Mb4XkL3+4efwvoLnBUnWr\nyQnXZgb2AuguN28CFdL5gZlIbXz3D6u7UizdmoMQfEuW9WBoYZfmqxvAEaCtrkYfIwl49tpkY585\n88pZ7QAbqPREQTdQJ69y5l20WX5pXLqTTwg2T/ShBxb4FV8Yy1VgjXPARY7SbfTlTcUSZcncZXTR\nsFcfDFjrpJlD9+681gmvGMuzCMC6EtODkmjeePoJY7kMXDGiNG5zlG6jLU/FAuGJx42DLfxppXAj\nrtUe2FJzbaWTT0habuzvT4zlGhb4eZFka8vosmWvjbacwt515N6He5qi1jIdL9CPk6s6AbDW4k9r\nL9kalXIJnmXXRtsA6l2gtHz05Iu0xZ82faa0UWs5iQ264aXGrqawgx/pheHkczpvLe9cwqFIalTK\nJTjLHosttyPgPN6KPgZqfMPZst/GWI5jy6hMakPf8id02Zz8I2F5gvJtqTnL2QRn2WOx5cYY9OKs\n41lgYWD6iGWvjbEcxwaoXjMEuWn0lyrJq1wRrV2Et6RGJb7L2QRn2WOx5cUx0MeTqkNzokb3ML02\nxnIS2+gZgucAMElt+dze3nt7e98RaHGE8G+p0bmzLMkEwVkWgGrlbAAfqIS2PL3NdOzSkK5WM83r\n95GKTTKxMFrq8qVGILacTfAt2zayMLZIgT7sgtTC8Nvwwohhw846KjHLX9OWx8m3lXs6eGHU1CKT\nGqXZcjbBWfZYbLkVAW9WJniE2o1Uk6ltjOU49lT0De42DHZAO5skE5scrmM7khpx8gn2r8RjsWXa\n2Wp3WoNSL7XJ+W2M5Tj29YfOL0facunc/rEORb8DkvxZF+zlo37sKVujp5pPOPPp9xHUIIokeN8v\nN5+naWEXwZcPHH6UwvaYBjr4YXptsrGGwWND+dZHMOBAtPg0MRUmGP77Vibxh23zLkhjXY2isCun\nZXpo+pCvVSnE58IEQ79oVZY5ym6TxlqyDuzH5xvxfOZZYYJWsh+fwShTWQp52HsEeFSCnLkwQeuV\nNli2aldiZp88rHqJ1VEZmjl3LEwwirxR4bHcBpBNTWH/B7wNdun71wGRAAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$$x^{4} \\Gamma{\\left(x \\right)} + 6 x^{3} \\Gamma{\\left(x \\right)} + 11 x^{2} \\Gamma{\\left(x \\right)} + 6 x \\Gamma{\\left(x \\right)}$$"
+      ],
+      "text/plain": [
+       " 4           3            2                \n",
+       "x ⋅Γ(x) + 6⋅x ⋅Γ(x) + 11⋅x ⋅Γ(x) + 6⋅x⋅Γ(x)"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "miscsimp2(gamma(x + 4))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Continued Fractions"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If we do not cover this, see http://asmeurer.github.io/scipy-2014-tutorial/html/tutorial/simplification.html#example-continued-fractions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def list_to_frac(l):\n",
+    "    expr = Integer(0)\n",
+    "    for i in reversed(l[1:]):\n",
+    "        expr += i\n",
+    "        expr = 1/expr\n",
+    "    return l[0] + expr"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "a0, a1, a2, a3, a4 = symbols('a0:5')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Determine the list used to create the continued fraction $$\\frac{a_{0} a_{1} a_{2} a_{3} a_{4} + a_{0} a_{1} a_{2} + a_{0} a_{3} a_{4} + a_{0} + a_{1} a_{2} a_{3} + a_{1} a_{3} a_{4} + a_{1} + a_{3}}{a_{0} a_{1} a_{2} a_{4} + a_{0} a_{4} + a_{1} a_{2} + a_{1} a_{4} + 1}.$$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def continued_frac():\n",
+    "    \"\"\"\n",
+    "    Determine the original list used to create the fraction.  \n",
+    "\n",
+    "    Return the original list from this function.\n",
+    "\n",
+    "    >>> orig_frac = (a0*a1*a2*a3*a4 + a0*a1*a2 + a0*a3*a4 + a0 + a1*a2*a3 + a1*a3*a4 + a1 + a3)/(a0*a1*a2*a4 + a0*a4 + a1*a2 + a1*a4 + 1)\n",
+    "    >>> pprint(orig_frac)\n",
+    "    a₀⋅a₁⋅a₂⋅a₃⋅a₄ + a₀⋅a₁⋅a₂ + a₀⋅a₃⋅a₄ + a₀ + a₁⋅a₂⋅a₃ + a₁⋅a₃⋅a₄ + a₁ + a₃\n",
+    "    ─────────────────────────────────────────────────────────────────────────\n",
+    "                     a₀⋅a₁⋅a₂⋅a₄ + a₀⋅a₄ + a₁⋅a₂ + a₁⋅a₄ + 1\n",
+    "    >>> cancel(list_to_frac(continued_frac())) == orig_frac\n",
+    "    True\n",
+    "    \"\"\"\n",
+    "    return [a3, a4, a0, a2, a1]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "orig_frac = (a0*a1*a2*a3*a4 + a0*a1*a2 + a0*a3*a4 + a0 + a1*a2*a3 + a1*a3*a4 + a1 + a3)/(a0*a1*a2*a4 + a0*a4 + a1*a2 + a1*a4 + 1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAkgAAAArBAMAAABxz2pBAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIqt2iUTvu2aZ3RAy\nVM0ud2cfAAAFqklEQVRoBe1aTYhbVRQ+mT+TeUknFPepdqWiDcwUKW7CVBdu6qBSN4J04cofBnVX\nxNGFWwcF7SDUSkEQFKItFUSYgEgRFAOurEoHV+IiTpWiZVrHe885753793L7Zqo+6XuL5Lyb73zf\nuV9ekkfOAdjhkbSvO7EAFD4KshZgKADdvViwWGOx1TVOxocFoPBtkKoAQwHo7sWCxRqLBYopAN19\n3f+MWG3/A8do8xLB3oWj/HEKRRqeFRMCyFoUaohqbHol7ZhhbF07FYOj7Vs2YerwKlAE51Wp08fg\nJYAHn+tTlBxe5Ahgj96KOtJiCHr/oTSpuZxGOn0cFFlZFDYImpokrAEGRwI3cHbhLmKw68qgcTEN\n9cUor/YnNJZhAR4Gir68UyE7K/AWNPqNDY5W0gjgorNzhE72pvcRtPn6KTPdUnWgDc1KotDaQmR2\nJQnUZ3AkiOEEnCSG1CRkMKAxMYT6YlgkTGzCbBc+gLk+RXBBIQ8AnIbZdu0qRROr9U2KIHnIMYmg\nA9hiQOuUmW6pOlBkZdGzjkkC9RnAliCGO+A1RGZXODIINCqGUF8M82BuGdYHyRbMDjECNOkPSK7C\nzDC5DBgBTG1wNLmuTWqMRr88OxrtUyEC1OKHDNA7kPSxUM3KovehSSdHo/dGo58sVp8BtyMSzABH\nVJpbl0BxC+PE2CSPQRcJnS5chM+USV2M+tqk2u/Q2kzU985WGp1b4uhrNEnV0+qqhxT6TR9OM0CZ\nlCaln6E8KJxbIvl+83v7SiIGzYoitpjejiHBZSdPRqARMTZJkVjlgi4S1odwT+sLbRJGA21Scg0m\nNn5QX9I9js68kK71HJMI8ITaDkPVDiTdqtuDKlaSH0ypS5kO+nUTaIBBb8eQoLKTe3vjoTExzySW\n0HmwZ6X1/lRTm4QRfdx+hgurSnQRgCP13Y5Rve2YRMv4nhNU7SBNUul48FvjQfUvBom+7JhkQH0G\n3I5UyGWrX5rx0IiYZ1K6C5UHtf0Hzx9MLqlvIIzIpL3zjz+/BPUeAEVQu0bRGXBNQsB6G55hqDZJ\n0q26XahmJfmua5JAfQbcjkhw2dAZjoXGxHyTSELn8fE0zLU51L9udDwKX1HQWVK/s3h8t/bOCYrS\nywPPZgZwiZZFC7L0HKiwttbWrqxQfnozqc9mMlaLISRRu6zvQPSRA42KCavFIHmg7pMeQwn1kJnU\nfPFHvkH7tF1/Kn2506doupuuqGd1n7TMp/pKwkPSc6Amay39TnqEs/WTsFoMsh2RSN6FV6mwHGhU\nTFgtBjNvcv5tru7WX9/gaGZ7e5PC5vximxfrB+7myHqaP0QlQu3IlS69IukWEjKowQqv/Da0UXiW\nQa3XghKfL9xmgehEoFExgVo8Zp71QnVSOVA5UDlQOVBmB7arI+pAmd+/qrbKgcqByoHKgZvPgeM3\n35YL7/iT9M+Fwpn/cUK0WX/jAB/f/n81yfpPK/SG3UDAZGVSyGFcy2wuk0lGi116+KFIbyHbwb8A\nKJNJMk5APfysAy/jBPEhgpwpA5vLulBcMY8BSmQSdeP1OEFwHqCjBwuiQwQ5AKObr0cTLJOQWAA+\nQ5lMknGC4DwAdeWjQwRhAP4/jww4mmCZ5LT7/TmFMpk0l40TBOcBaJwgOkQQBqBJ0vgf2+73GMpk\nkowThOYBeC06RBAGaJOMxr95JXliLoNqSpXnFkDGCbh/rjYmzXqOokMEYYA2Sbis7yRPzGUolUky\nTsD9c92glGb99Q0R5EwZ4MdNuMwryRXzGcp0Jck4QXAeAHvq0SGCHACaJI1/yyRa1u9IjkTjzb+4\nKY95JXgwxgl03XRk8wDRIYIcAJrkcGW3o7ieieUxcCmleDLGCbK6pVmvbqG4EW612qXdnwMQk4TL\nYhBAHkMp3OEiZJxA2urGPEBsiADCgCCXuW0B5DCY4B3GfwPGFsAHW/8rGAAAAABJRU5ErkJggg==\n",
+      "text/latex": [
+       "$$\\frac{a_{0} a_{1} a_{2} a_{3} a_{4} + a_{0} a_{1} a_{2} + a_{0} a_{3} a_{4} + a_{0} + a_{1} a_{2} a_{3} + a_{1} a_{3} a_{4} + a_{1} + a_{3}}{a_{0} a_{1} a_{2} a_{4} + a_{0} a_{4} + a_{1} a_{2} + a_{1} a_{4} + 1}$$"
+      ],
+      "text/plain": [
+       "a₀⋅a₁⋅a₂⋅a₃⋅a₄ + a₀⋅a₁⋅a₂ + a₀⋅a₃⋅a₄ + a₀ + a₁⋅a₂⋅a₃ + a₁⋅a₃⋅a₄ + a₁ + a₃\n",
+       "─────────────────────────────────────────────────────────────────────────\n",
+       "                 a₀⋅a₁⋅a₂⋅a₄ + a₀⋅a₄ + a₁⋅a₂ + a₁⋅a₄ + 1                 "
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "orig_frac"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 31,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "cancel(list_to_frac(continued_frac())) == orig_frac"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": []
   }
- ]
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 0
 }

--- a/tutorial_exercises/Advanced-Simplification.ipynb
+++ b/tutorial_exercises/Advanced-Simplification.ipynb
@@ -1,524 +1,515 @@
 {
- "metadata": {
-  "name": "",
-  "signature": "sha256:1ea7eb5baa9b54b9c8bb4ec97fe085e1ae285d5775adecea239fa6b380a18a68"
- },
- "nbformat": 3,
- "nbformat_minor": 0,
- "worksheets": [
+ "cells": [
   {
-   "cells": [
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Simplification"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from sympy import *\n",
+    "x, y, z = symbols('x y z')\n",
+    "init_printing()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For each exercise, fill in the function according to its docstring."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Polynomial/Rational Function Simplification"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In each exercise, apply specific simplification functions to get the desired result."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def polysimp1(expr):\n",
+    "    \"\"\"\n",
+    "    >>> polysimp1(cos(x)*sin(x) + cos(x))\n",
+    "    (sin(x) + 1)*cos(x)\n",
+    "    >>> polysimp1(cos(x)*sin(x) + cos(x) + 1)\n",
+    "    (sin(x) + 1)*cos(x) + 1\n",
+    "    \"\"\"\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "polysimp1(cos(x)*sin(x) + cos(x))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "polysimp1(cos(x)*sin(x) + cos(x) + 1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def polysimp2(expr):\n",
+    "    \"\"\"\n",
+    "    >>> polysimp2((2*x + 1)/(x**2 + x))\n",
+    "    1/(x + 1) + 1/x\n",
+    "    >>> polysimp2((x**2 + 3*x + 1)/(x**3 + 2*x**2 + x))\n",
+    "    1/(x**2 + 2*x + 1) + 1/x\n",
+    "    \"\"\"\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "polysimp2((2*x + 1)/(x**2 + x))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "polysimp2((x**2 + 3*x + 1)/(x**3 + 2*x**2 + x))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Powers"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In each exercise, apply specific simplification functions to get the desired result. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def powersimp1(expr):\n",
+    "    \"\"\"\n",
+    "    >>> powersimp1(exp(x)*(exp(y) + 1))\n",
+    "    exp(x) + exp(x + y)\n",
+    "    \"\"\"\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "powersimp1(exp(x)*(exp(y) + 1))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def powersimp2(expr):\n",
+    "    \"\"\"\n",
+    "    >>> powersimp2(2**x*x**x)\n",
+    "    (2*x)**x\n",
+    "    >>> powersimp2(x**x*x**x)\n",
+    "    (x**2)**x\n",
+    "    \"\"\"\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "powersimp2(2**x*x**x)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "powersimp2(x**x*x**x)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def powersimp3(expr):\n",
+    "    \"\"\"\n",
+    "    >>> a, b, c = symbols('a b c')\n",
+    "    >>> powersimp3((a**b)**c)\n",
+    "    a**(b*c)\n",
+    "    >>> powersimp3((a**b)**(c + 1))\n",
+    "    a**(b*c + b)\n",
+    "    \"\"\"\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "a, b, c = symbols('a b c')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "powersimp3((a**b)**c)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "powersimp3((a**b)**(c + 1))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Logs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def logsimp1(expr):\n",
+    "    \"\"\"\n",
+    "    >>> a, b = symbols('a b', positive=True)\n",
+    "    >>> logsimp1(log(x**y*a**b))\n",
+    "    y*log(x) + log(a**b)\n",
+    "    >>> logsimp1(log(x*y*a*b))\n",
+    "    log(x) + log(y) + log(a*b)\n",
+    "    \"\"\"\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "a, b = symbols('a b', positive=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "logsimp1(log(x**y*a**b))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "logsimp1(log(x*y*a*b))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Miscellaneous  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def miscsimp1(expr):\n",
+    "    \"\"\"\n",
+    "    >>> miscsimp1(sin(x + y))\n",
+    "    2*(-tan(x/2)**2 + 1)*tan(y/2)/((tan(x/2)**2 + 1)*(tan(y/2)**2 + 1)) + 2*(-tan(y/2)**2 + 1)*tan(x/2)/((tan(x/2)**2 + 1)*(tan(y/2)**2 + 1))\n",
+    "    \"\"\"\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "miscsimp1(sin(x + y))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def miscsimp2(expr):\n",
+    "    \"\"\"\n",
+    "    >>> miscsimp2(gamma(x + 4))\n",
+    "    x**4*gamma(x) + 6*x**3*gamma(x) + 11*x**2*gamma(x) + 6*x*gamma(x)\n",
+    "    \"\"\"\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "miscsimp2(gamma(x + 4))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Continued Fractions"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If we do not cover this, see http://asmeurer.github.io/scipy-2014-tutorial/html/tutorial/simplification.html#example-continued-fractions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def list_to_frac(l):\n",
+    "    expr = Integer(0)\n",
+    "    for i in reversed(l[1:]):\n",
+    "        expr += i\n",
+    "        expr = 1/expr\n",
+    "    return l[0] + expr"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "a0, a1, a2, a3, a4 = symbols('a0:5')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Determine the list used to create the continued fraction $$\\frac{a_{0} a_{1} a_{2} a_{3} a_{4} + a_{0} a_{1} a_{2} + a_{0} a_{3} a_{4} + a_{0} + a_{1} a_{2} a_{3} + a_{1} a_{3} a_{4} + a_{1} + a_{3}}{a_{0} a_{1} a_{2} a_{4} + a_{0} a_{4} + a_{1} a_{2} + a_{1} a_{4} + 1}.$$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def continued_frac():\n",
+    "    \"\"\"\n",
+    "    Determine the original list used to create the fraction.  \n",
+    "\n",
+    "    Return the original list from this function.\n",
+    "\n",
+    "    >>> orig_frac = (a0*a1*a2*a3*a4 + a0*a1*a2 + a0*a3*a4 + a0 + a1*a2*a3 + a1*a3*a4 + a1 + a3)/(a0*a1*a2*a4 + a0*a4 + a1*a2 + a1*a4 + 1)\n",
+    "    >>> pprint(orig_frac)\n",
+    "    a₀⋅a₁⋅a₂⋅a₃⋅a₄ + a₀⋅a₁⋅a₂ + a₀⋅a₃⋅a₄ + a₀ + a₁⋅a₂⋅a₃ + a₁⋅a₃⋅a₄ + a₁ + a₃\n",
+    "    ─────────────────────────────────────────────────────────────────────────\n",
+    "                     a₀⋅a₁⋅a₂⋅a₄ + a₀⋅a₄ + a₁⋅a₂ + a₁⋅a₄ + 1\n",
+    "    >>> cancel(list_to_frac(continued_frac())) == orig_frac\n",
+    "    True\n",
+    "    \"\"\"\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "orig_frac = (a0*a1*a2*a3*a4 + a0*a1*a2 + a0*a3*a4 + a0 + a1*a2*a3 + a1*a3*a4 + a1 + a3)/(a0*a1*a2*a4 + a0*a4 + a1*a2 + a1*a4 + 1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
     {
-     "cell_type": "heading",
-     "level": 1,
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAkgAAAArBAMAAABxz2pBAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIqt2iUTvu2aZ3RAy\nVM0ud2cfAAAFqklEQVRoBe1aTYhbVRQ+mT+TeUknFPepdqWiDcwUKW7CVBdu6qBSN4J04cofBnVX\nxNGFWwcF7SDUSkEQFKItFUSYgEgRFAOurEoHV+IiTpWiZVrHe885753793L7Zqo+6XuL5Lyb73zf\nuV9ekkfOAdjhkbSvO7EAFD4KshZgKADdvViwWGOx1TVOxocFoPBtkKoAQwHo7sWCxRqLBYopAN19\n3f+MWG3/A8do8xLB3oWj/HEKRRqeFRMCyFoUaohqbHol7ZhhbF07FYOj7Vs2YerwKlAE51Wp08fg\nJYAHn+tTlBxe5Ahgj96KOtJiCHr/oTSpuZxGOn0cFFlZFDYImpokrAEGRwI3cHbhLmKw68qgcTEN\n9cUor/YnNJZhAR4Gir68UyE7K/AWNPqNDY5W0gjgorNzhE72pvcRtPn6KTPdUnWgDc1KotDaQmR2\nJQnUZ3AkiOEEnCSG1CRkMKAxMYT6YlgkTGzCbBc+gLk+RXBBIQ8AnIbZdu0qRROr9U2KIHnIMYmg\nA9hiQOuUmW6pOlBkZdGzjkkC9RnAliCGO+A1RGZXODIINCqGUF8M82BuGdYHyRbMDjECNOkPSK7C\nzDC5DBgBTG1wNLmuTWqMRr88OxrtUyEC1OKHDNA7kPSxUM3KovehSSdHo/dGo58sVp8BtyMSzABH\nVJpbl0BxC+PE2CSPQRcJnS5chM+USV2M+tqk2u/Q2kzU985WGp1b4uhrNEnV0+qqhxT6TR9OM0CZ\nlCaln6E8KJxbIvl+83v7SiIGzYoitpjejiHBZSdPRqARMTZJkVjlgi4S1odwT+sLbRJGA21Scg0m\nNn5QX9I9js68kK71HJMI8ITaDkPVDiTdqtuDKlaSH0ypS5kO+nUTaIBBb8eQoLKTe3vjoTExzySW\n0HmwZ6X1/lRTm4QRfdx+hgurSnQRgCP13Y5Rve2YRMv4nhNU7SBNUul48FvjQfUvBom+7JhkQH0G\n3I5UyGWrX5rx0IiYZ1K6C5UHtf0Hzx9MLqlvIIzIpL3zjz+/BPUeAEVQu0bRGXBNQsB6G55hqDZJ\n0q26XahmJfmua5JAfQbcjkhw2dAZjoXGxHyTSELn8fE0zLU51L9udDwKX1HQWVK/s3h8t/bOCYrS\nywPPZgZwiZZFC7L0HKiwttbWrqxQfnozqc9mMlaLISRRu6zvQPSRA42KCavFIHmg7pMeQwn1kJnU\nfPFHvkH7tF1/Kn2506doupuuqGd1n7TMp/pKwkPSc6Amay39TnqEs/WTsFoMsh2RSN6FV6mwHGhU\nTFgtBjNvcv5tru7WX9/gaGZ7e5PC5vximxfrB+7myHqaP0QlQu3IlS69IukWEjKowQqv/Da0UXiW\nQa3XghKfL9xmgehEoFExgVo8Zp71QnVSOVA5UDlQOVBmB7arI+pAmd+/qrbKgcqByoHKgZvPgeM3\n35YL7/iT9M+Fwpn/cUK0WX/jAB/f/n81yfpPK/SG3UDAZGVSyGFcy2wuk0lGi116+KFIbyHbwb8A\nKJNJMk5APfysAy/jBPEhgpwpA5vLulBcMY8BSmQSdeP1OEFwHqCjBwuiQwQ5AKObr0cTLJOQWAA+\nQ5lMknGC4DwAdeWjQwRhAP4/jww4mmCZ5LT7/TmFMpk0l40TBOcBaJwgOkQQBqBJ0vgf2+73GMpk\nkowThOYBeC06RBAGaJOMxr95JXliLoNqSpXnFkDGCbh/rjYmzXqOokMEYYA2Sbis7yRPzGUolUky\nTsD9c92glGb99Q0R5EwZ4MdNuMwryRXzGcp0Jck4QXAeAHvq0SGCHACaJI1/yyRa1u9IjkTjzb+4\nKY95JXgwxgl03XRk8wDRIYIcAJrkcGW3o7ieieUxcCmleDLGCbK6pVmvbqG4EW612qXdnwMQk4TL\nYhBAHkMp3OEiZJxA2urGPEBsiADCgCCXuW0B5DCY4B3GfwPGFsAHW/8rGAAAAABJRU5ErkJggg==\n",
+      "text/latex": [
+       "$$\\frac{a_{0} a_{1} a_{2} a_{3} a_{4} + a_{0} a_{1} a_{2} + a_{0} a_{3} a_{4} + a_{0} + a_{1} a_{2} a_{3} + a_{1} a_{3} a_{4} + a_{1} + a_{3}}{a_{0} a_{1} a_{2} a_{4} + a_{0} a_{4} + a_{1} a_{2} + a_{1} a_{4} + 1}$$"
+      ],
+      "text/plain": [
+       "a₀⋅a₁⋅a₂⋅a₃⋅a₄ + a₀⋅a₁⋅a₂ + a₀⋅a₃⋅a₄ + a₀ + a₁⋅a₂⋅a₃ + a₁⋅a₃⋅a₄ + a₁ + a₃\n",
+       "─────────────────────────────────────────────────────────────────────────\n",
+       "                 a₀⋅a₁⋅a₂⋅a₄ + a₀⋅a₄ + a₁⋅a₂ + a₁⋅a₄ + 1                 "
+      ]
+     },
+     "execution_count": 30,
      "metadata": {},
-     "source": [
-      "Simplification"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "from sympy import *\n",
-      "x, y, z = symbols('x y z')\n",
-      "init_printing()"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 1
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "For each exercise, fill in the function according to its docstring."
-     ]
-    },
-    {
-     "cell_type": "heading",
-     "level": 2,
-     "metadata": {},
-     "source": [
-      "Polynomial/Rational Function Simplification"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "In each exercise, apply specific simplification functions to get the desired result."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def polysimp1(expr):\n",
-      "    \"\"\"\n",
-      "    >>> polysimp1(cos(x)*sin(x) + cos(x))\n",
-      "    (sin(x) + 1)*cos(x)\n",
-      "    >>> polysimp1(cos(x)*sin(x) + cos(x) + 1)\n",
-      "    (sin(x) + 1)*cos(x) + 1\n",
-      "    \"\"\"\n"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 2
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "polysimp1(cos(x)*sin(x) + cos(x))"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 3
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "polysimp1(cos(x)*sin(x) + cos(x) + 1)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 4
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def polysimp2(expr):\n",
-      "    \"\"\"\n",
-      "    >>> polysimp2((2*x + 1)/(x**2 + x))\n",
-      "    1/(x + 1) + 1/x\n",
-      "    >>> polysimp2((x**2 + 3*x + 1)/(x**3 + 2*x**2 + x))\n",
-      "    1/(x**2 + 2*x + 1) + 1/x\n",
-      "    \"\"\"\n"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 5
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "polysimp2((2*x + 1)/(x**2 + x))"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 6
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "polysimp2((x**2 + 3*x + 1)/(x**3 + 2*x**2 + x))"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 7
-    },
-    {
-     "cell_type": "heading",
-     "level": 2,
-     "metadata": {},
-     "source": [
-      "Powers"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "In each exercise, apply specific simplification functions to get the desired result. "
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def powersimp1(expr):\n",
-      "    \"\"\"\n",
-      "    >>> powersimp1(exp(x)*(exp(y) + 1))\n",
-      "    exp(x) + exp(x + y)\n",
-      "    \"\"\"\n"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 8
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "powersimp1(exp(x)*(exp(y) + 1))"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 9
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def powersimp2(expr):\n",
-      "    \"\"\"\n",
-      "    >>> powersimp2(2**x*x**x)\n",
-      "    (2*x)**x\n",
-      "    >>> powersimp2(x**x*x**x)\n",
-      "    (x**2)**x\n",
-      "    \"\"\"\n"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 10
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "powersimp2(2**x*x**x)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 11
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "powersimp2(x**x*x**x)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 12
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def powersimp3(expr):\n",
-      "    \"\"\"\n",
-      "    >>> a, b, c = symbols('a b c')\n",
-      "    >>> powersimp3((a**b)**c)\n",
-      "    a**(b*c)\n",
-      "    >>> powersimp3((a**b)**(c + 1))\n",
-      "    a**(b*c + b)\n",
-      "    \"\"\"\n"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 13
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "a, b, c = symbols('a b c')"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 14
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "powersimp3((a**b)**c)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 15
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "powersimp3((a**b)**(c + 1))"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 16
-    },
-    {
-     "cell_type": "heading",
-     "level": 2,
-     "metadata": {},
-     "source": [
-      "Logs"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def logsimp1(expr):\n",
-      "    \"\"\"\n",
-      "    >>> a, b = symbols('a b', positive=True)\n",
-      "    >>> logsimp1(log(x**y*a**b))\n",
-      "    y*log(x) + log(a**b)\n",
-      "    >>> logsimp1(log(x*y*a*b))\n",
-      "    log(x) + log(y) + log(a*b)\n",
-      "    \"\"\"\n"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 17
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "a, b = symbols('a b', positive=True)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 18
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "logsimp1(log(x**y*a**b))"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 19
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "logsimp1(log(x*y*a*b))"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 20
-    },
-    {
-     "cell_type": "heading",
-     "level": 2,
-     "metadata": {},
-     "source": [
-      "Miscellaneous  "
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def miscsimp1(expr):\n",
-      "    \"\"\"\n",
-      "    >>> miscsimp1(sin(x + y))\n",
-      "    2*(-tan(x/2)**2 + 1)*tan(y/2)/((tan(x/2)**2 + 1)*(tan(y/2)**2 + 1)) + 2*(-tan(y/2)**2 + 1)*tan(x/2)/((tan(x/2)**2 + 1)*(tan(y/2)**2 + 1))\n",
-      "    \"\"\"\n"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 21
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "miscsimp1(sin(x + y))"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 22
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def miscsimp2(expr):\n",
-      "    \"\"\"\n",
-      "    >>> miscsimp2(gamma(x + 4))\n",
-      "    x**4*gamma(x) + 6*x**3*gamma(x) + 11*x**2*gamma(x) + 6*x*gamma(x)\n",
-      "    \"\"\"\n"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 23
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "miscsimp2(gamma(x + 4))"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 24
-    },
-    {
-     "cell_type": "heading",
-     "level": 2,
-     "metadata": {},
-     "source": [
-      "Continued Fractions"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "If we do not cover this, see http://asmeurer.github.io/scipy-2014-tutorial/html/tutorial/simplification.html#example-continued-fractions."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def list_to_frac(l):\n",
-      "    expr = Integer(0)\n",
-      "    for i in reversed(l[1:]):\n",
-      "        expr += i\n",
-      "        expr = 1/expr\n",
-      "    return l[0] + expr"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 25
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "a0, a1, a2, a3, a4 = symbols('a0:5')"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 27
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Determine the list used to create the continued fraction $$\\frac{a_{0} a_{1} a_{2} a_{3} a_{4} + a_{0} a_{1} a_{2} + a_{0} a_{3} a_{4} + a_{0} + a_{1} a_{2} a_{3} + a_{1} a_{3} a_{4} + a_{1} + a_{3}}{a_{0} a_{1} a_{2} a_{4} + a_{0} a_{4} + a_{1} a_{2} + a_{1} a_{4} + 1}.$$"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def continued_frac():\n",
-      "    \"\"\"\n",
-      "    Determine the original list used to create the fraction.  \n",
-      "\n",
-      "    Return the original list from this function.\n",
-      "\n",
-      "    >>> orig_frac = (a0*a1*a2*a3*a4 + a0*a1*a2 + a0*a3*a4 + a0 + a1*a2*a3 + a1*a3*a4 + a1 + a3)/(a0*a1*a2*a4 + a0*a4 + a1*a2 + a1*a4 + 1)\n",
-      "    >>> pprint(orig_frac)\n",
-      "    a\u2080\u22c5a\u2081\u22c5a\u2082\u22c5a\u2083\u22c5a\u2084 + a\u2080\u22c5a\u2081\u22c5a\u2082 + a\u2080\u22c5a\u2083\u22c5a\u2084 + a\u2080 + a\u2081\u22c5a\u2082\u22c5a\u2083 + a\u2081\u22c5a\u2083\u22c5a\u2084 + a\u2081 + a\u2083\n",
-      "    \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n",
-      "                     a\u2080\u22c5a\u2081\u22c5a\u2082\u22c5a\u2084 + a\u2080\u22c5a\u2084 + a\u2081\u22c5a\u2082 + a\u2081\u22c5a\u2084 + 1\n",
-      "    >>> cancel(list_to_frac(continued_frac())) == orig_frac\n",
-      "    True\n",
-      "    \"\"\"\n"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 28
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "orig_frac = (a0*a1*a2*a3*a4 + a0*a1*a2 + a0*a3*a4 + a0 + a1*a2*a3 + a1*a3*a4 + a1 + a3)/(a0*a1*a2*a4 + a0*a4 + a1*a2 + a1*a4 + 1)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 29
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "orig_frac"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\frac{a_{0} a_{1} a_{2} a_{3} a_{4} + a_{0} a_{1} a_{2} + a_{0} a_{3} a_{4} + a_{0} + a_{1} a_{2} a_{3} + a_{1} a_{3} a_{4} + a_{1} + a_{3}}{a_{0} a_{1} a_{2} a_{4} + a_{0} a_{4} + a_{1} a_{2} + a_{1} a_{4} + 1}$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAkgAAAArBAMAAABxz2pBAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAIqt2iUTvu2aZ3RAy\nVM0ud2cfAAAFqklEQVRoBe1aTYhbVRQ+mT+TeUknFPepdqWiDcwUKW7CVBdu6qBSN4J04cofBnVX\nxNGFWwcF7SDUSkEQFKItFUSYgEgRFAOurEoHV+IiTpWiZVrHe885753793L7Zqo+6XuL5Lyb73zf\nuV9ekkfOAdjhkbSvO7EAFD4KshZgKADdvViwWGOx1TVOxocFoPBtkKoAQwHo7sWCxRqLBYopAN19\n3f+MWG3/A8do8xLB3oWj/HEKRRqeFRMCyFoUaohqbHol7ZhhbF07FYOj7Vs2YerwKlAE51Wp08fg\nJYAHn+tTlBxe5Ahgj96KOtJiCHr/oTSpuZxGOn0cFFlZFDYImpokrAEGRwI3cHbhLmKw68qgcTEN\n9cUor/YnNJZhAR4Gir68UyE7K/AWNPqNDY5W0gjgorNzhE72pvcRtPn6KTPdUnWgDc1KotDaQmR2\nJQnUZ3AkiOEEnCSG1CRkMKAxMYT6YlgkTGzCbBc+gLk+RXBBIQ8AnIbZdu0qRROr9U2KIHnIMYmg\nA9hiQOuUmW6pOlBkZdGzjkkC9RnAliCGO+A1RGZXODIINCqGUF8M82BuGdYHyRbMDjECNOkPSK7C\nzDC5DBgBTG1wNLmuTWqMRr88OxrtUyEC1OKHDNA7kPSxUM3KovehSSdHo/dGo58sVp8BtyMSzABH\nVJpbl0BxC+PE2CSPQRcJnS5chM+USV2M+tqk2u/Q2kzU985WGp1b4uhrNEnV0+qqhxT6TR9OM0CZ\nlCaln6E8KJxbIvl+83v7SiIGzYoitpjejiHBZSdPRqARMTZJkVjlgi4S1odwT+sLbRJGA21Scg0m\nNn5QX9I9js68kK71HJMI8ITaDkPVDiTdqtuDKlaSH0ypS5kO+nUTaIBBb8eQoLKTe3vjoTExzySW\n0HmwZ6X1/lRTm4QRfdx+hgurSnQRgCP13Y5Rve2YRMv4nhNU7SBNUul48FvjQfUvBom+7JhkQH0G\n3I5UyGWrX5rx0IiYZ1K6C5UHtf0Hzx9MLqlvIIzIpL3zjz+/BPUeAEVQu0bRGXBNQsB6G55hqDZJ\n0q26XahmJfmua5JAfQbcjkhw2dAZjoXGxHyTSELn8fE0zLU51L9udDwKX1HQWVK/s3h8t/bOCYrS\nywPPZgZwiZZFC7L0HKiwttbWrqxQfnozqc9mMlaLISRRu6zvQPSRA42KCavFIHmg7pMeQwn1kJnU\nfPFHvkH7tF1/Kn2506doupuuqGd1n7TMp/pKwkPSc6Amay39TnqEs/WTsFoMsh2RSN6FV6mwHGhU\nTFgtBjNvcv5tru7WX9/gaGZ7e5PC5vximxfrB+7myHqaP0QlQu3IlS69IukWEjKowQqv/Da0UXiW\nQa3XghKfL9xmgehEoFExgVo8Zp71QnVSOVA5UDlQOVBmB7arI+pAmd+/qrbKgcqByoHKgZvPgeM3\n35YL7/iT9M+Fwpn/cUK0WX/jAB/f/n81yfpPK/SG3UDAZGVSyGFcy2wuk0lGi116+KFIbyHbwb8A\nKJNJMk5APfysAy/jBPEhgpwpA5vLulBcMY8BSmQSdeP1OEFwHqCjBwuiQwQ5AKObr0cTLJOQWAA+\nQ5lMknGC4DwAdeWjQwRhAP4/jww4mmCZ5LT7/TmFMpk0l40TBOcBaJwgOkQQBqBJ0vgf2+73GMpk\nkowThOYBeC06RBAGaJOMxr95JXliLoNqSpXnFkDGCbh/rjYmzXqOokMEYYA2Sbis7yRPzGUolUky\nTsD9c92glGb99Q0R5EwZ4MdNuMwryRXzGcp0Jck4QXAeAHvq0SGCHACaJI1/yyRa1u9IjkTjzb+4\nKY95JXgwxgl03XRk8wDRIYIcAJrkcGW3o7ieieUxcCmleDLGCbK6pVmvbqG4EW612qXdnwMQk4TL\nYhBAHkMp3OEiZJxA2urGPEBsiADCgCCXuW0B5DCY4B3GfwPGFsAHW/8rGAAAAABJRU5ErkJggg==\n",
-       "prompt_number": 30,
-       "text": [
-        "a\u2080\u22c5a\u2081\u22c5a\u2082\u22c5a\u2083\u22c5a\u2084 + a\u2080\u22c5a\u2081\u22c5a\u2082 + a\u2080\u22c5a\u2083\u22c5a\u2084 + a\u2080 + a\u2081\u22c5a\u2082\u22c5a\u2083 + a\u2081\u22c5a\u2083\u22c5a\u2084 + a\u2081 + a\u2083\n",
-        "\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n",
-        "                 a\u2080\u22c5a\u2081\u22c5a\u2082\u22c5a\u2084 + a\u2080\u22c5a\u2084 + a\u2081\u22c5a\u2082 + a\u2081\u22c5a\u2084 + 1                 "
-       ]
-      }
-     ],
-     "prompt_number": 30
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "cancel(list_to_frac(continued_frac())) == orig_frac"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 31,
-       "text": [
-        "True"
-       ]
-      }
-     ],
-     "prompt_number": 31
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
+     "output_type": "execute_result"
     }
    ],
-   "metadata": {}
+   "source": [
+    "orig_frac"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 31,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "cancel(list_to_frac(continued_frac())) == orig_frac"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": []
   }
- ]
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 0
 }

--- a/tutorial_exercises/Advanced-Solvers Solutions.ipynb
+++ b/tutorial_exercises/Advanced-Solvers Solutions.ipynb
@@ -1,332 +1,330 @@
 {
- "metadata": {
-  "name": ""
- },
- "nbformat": 3,
- "nbformat_minor": 0,
- "worksheets": [
+ "cells": [
   {
-   "cells": [
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Solvers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from sympy import *\n",
+    "init_printing()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For each exercise, fill in the function according to its docstring. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "a, b, c, d, x, y, z, t = symbols('a b c d x y z t')\n",
+    "f, g, h = symbols('f g h', cls=Function)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Algebraic Equations"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Write a function that computes the [quadratic equation](http://en.wikipedia.org/wiki/Quadratic_equation)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
     {
-     "cell_type": "heading",
-     "level": 1,
+     "data": {
+      "text/latex": [
+       "$$\\begin{bmatrix}\\frac{- b + \\sqrt{- 4 a c + b^{2}}}{2 a}, & - \\frac{b + \\sqrt{- 4 a c + b^{2}}}{2 a}\\end{bmatrix}$$"
+      ],
+      "text/plain": [
+       "⎡        _____________   ⎛       _____________⎞⎤\n",
+       "⎢       ╱           2    ⎜      ╱           2 ⎟⎥\n",
+       "⎢-b + ╲╱  -4⋅a⋅c + b    -⎝b + ╲╱  -4⋅a⋅c + b  ⎠⎥\n",
+       "⎢─────────────────────, ───────────────────────⎥\n",
+       "⎣         2⋅a                     2⋅a          ⎦"
+      ]
+     },
+     "execution_count": 5,
      "metadata": {},
-     "source": [
-      "Solvers"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "from sympy import *\n",
-      "init_printing()"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 2
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "For each exercise, fill in the function according to its docstring. "
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "a, b, c, d, x, y, z, t = symbols('a b c d x y z t')\n",
-      "f, g, h = symbols('f g h', cls=Function)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 3
-    },
-    {
-     "cell_type": "heading",
-     "level": 2,
-     "metadata": {},
-     "source": [
-      "Algebraic Equations"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Write a function that computes the [quadratic equation](http://en.wikipedia.org/wiki/Quadratic_equation)."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def quadratic():\n",
-      "    return solve(a*x**2 + b*x + c, x)\n",
-      "quadratic()"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\begin{bmatrix}\\frac{- b + \\sqrt{- 4 a c + b^{2}}}{2 a}, & - \\frac{b + \\sqrt{- 4 a c + b^{2}}}{2 a}\\end{bmatrix}$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 5,
-       "text": [
-        "\u23a1        _____________   \u239b       _____________\u239e\u23a4\n",
-        "\u23a2       \u2571           2    \u239c      \u2571           2 \u239f\u23a5\n",
-        "\u23a2-b + \u2572\u2571  -4\u22c5a\u22c5c + b    -\u239db + \u2572\u2571  -4\u22c5a\u22c5c + b  \u23a0\u23a5\n",
-        "\u23a2\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500, \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u23a5\n",
-        "\u23a3         2\u22c5a                     2\u22c5a          \u23a6"
-       ]
-      }
-     ],
-     "prompt_number": 5
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Write a function that computes the general solution to the cubic $x^3 + ax^2 + bx + c$."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def cubic():\n",
-      "    return solve(x**3 + a*x**2 + b*x + c, x)\n",
-      "cubic()"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\begin{bmatrix}- \\frac{1}{3} a + \\frac{- \\frac{1}{9} a^{2} + \\frac{1}{3} b}{\\sqrt[3]{\\frac{1}{27} a^{3} - \\frac{1}{6} a b + \\frac{1}{2} c + \\sqrt{\\left(- \\frac{1}{9} a^{2} + \\frac{1}{3} b\\right)^{3} + \\frac{1}{4} \\left(\\frac{2}{27} a^{3} - \\frac{1}{3} a b + c\\right)^{2}}}} - \\sqrt[3]{\\frac{1}{27} a^{3} - \\frac{1}{6} a b + \\frac{1}{2} c + \\sqrt{\\left(- \\frac{1}{9} a^{2} + \\frac{1}{3} b\\right)^{3} + \\frac{1}{4} \\left(\\frac{2}{27} a^{3} - \\frac{1}{3} a b + c\\right)^{2}}}, & - \\frac{1}{3} a + \\frac{- \\frac{1}{9} a^{2} + \\frac{1}{3} b}{\\left(- \\frac{1}{2} - \\frac{1}{2} \\sqrt{3} \\mathbf{\\imath}\\right) \\sqrt[3]{\\frac{1}{27} a^{3} - \\frac{1}{6} a b + \\frac{1}{2} c + \\sqrt{\\left(- \\frac{1}{9} a^{2} + \\frac{1}{3} b\\right)^{3} + \\frac{1}{4} \\left(\\frac{2}{27} a^{3} - \\frac{1}{3} a b + c\\right)^{2}}}} - \\left(- \\frac{1}{2} - \\frac{1}{2} \\sqrt{3} \\mathbf{\\imath}\\right) \\sqrt[3]{\\frac{1}{27} a^{3} - \\frac{1}{6} a b + \\frac{1}{2} c + \\sqrt{\\left(- \\frac{1}{9} a^{2} + \\frac{1}{3} b\\right)^{3} + \\frac{1}{4} \\left(\\frac{2}{27} a^{3} - \\frac{1}{3} a b + c\\right)^{2}}}, & - \\frac{1}{3} a + \\frac{- \\frac{1}{9} a^{2} + \\frac{1}{3} b}{\\left(- \\frac{1}{2} + \\frac{1}{2} \\sqrt{3} \\mathbf{\\imath}\\right) \\sqrt[3]{\\frac{1}{27} a^{3} - \\frac{1}{6} a b + \\frac{1}{2} c + \\sqrt{\\left(- \\frac{1}{9} a^{2} + \\frac{1}{3} b\\right)^{3} + \\frac{1}{4} \\left(\\frac{2}{27} a^{3} - \\frac{1}{3} a b + c\\right)^{2}}}} - \\left(- \\frac{1}{2} + \\frac{1}{2} \\sqrt{3} \\mathbf{\\imath}\\right) \\sqrt[3]{\\frac{1}{27} a^{3} - \\frac{1}{6} a b + \\frac{1}{2} c + \\sqrt{\\left(- \\frac{1}{9} a^{2} + \\frac{1}{3} b\\right)^{3} + \\frac{1}{4} \\left(\\frac{2}{27} a^{3} - \\frac{1}{3} a b + c\\right)^{2}}}\\end{bmatrix}$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 6,
-       "text": [
-        "\u23a1                                                                             \n",
-        "\u23a2                                                                             \n",
-        "\u23a2                                                                             \n",
-        "\u23a2                                       2                                     \n",
-        "\u23a2                                      a    b                                 \n",
-        "\u23a2                                    - \u2500\u2500 + \u2500                                 \n",
-        "\u23a2  a                                   9    3                                 \n",
-        "\u23a2- \u2500 + \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500 - 3\n",
-        "\u23a2  3            __________________________________________________________   \u2572\n",
-        "\u23a2              \u2571                        _________________________________     \n",
-        "\u23a2             \u2571                        \u2571                               2      \n",
-        "\u23a2            \u2571                        \u2571                \u239b   3          \u239e       \n",
-        "\u23a2           \u2571                        \u2571             3   \u239c2\u22c5a    a\u22c5b    \u239f       \n",
-        "\u23a2          \u2571      3                 \u2571    \u239b   2    \u239e    \u239c\u2500\u2500\u2500\u2500 - \u2500\u2500\u2500 + c\u239f       \n",
-        "\u23a2         \u2571      a    a\u22c5b   c      \u2571     \u239c  a    b\u239f    \u239d 27     3     \u23a0       \n",
-        "\u23a2      3 \u2571       \u2500\u2500 - \u2500\u2500\u2500 + \u2500 +   \u2571      \u239c- \u2500\u2500 + \u2500\u239f  + \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500      \n",
-        "\u23a3      \u2572\u2571        27    6    2   \u2572\u2571       \u239d  9    3\u23a0            4              \n",
-        "\n",
-        "        __________________________________________________________            \n",
-        "       \u2571                        _________________________________             \n",
-        "      \u2571                        \u2571                               2              \n",
-        "     \u2571                        \u2571                \u239b   3          \u239e               \n",
-        "    \u2571                        \u2571             3   \u239c2\u22c5a    a\u22c5b    \u239f               \n",
-        "   \u2571      3                 \u2571    \u239b   2    \u239e    \u239c\u2500\u2500\u2500\u2500 - \u2500\u2500\u2500 + c\u239f               \n",
-        "  \u2571      a    a\u22c5b   c      \u2571     \u239c  a    b\u239f    \u239d 27     3     \u23a0       a       \n",
-        " \u2571       \u2500\u2500 - \u2500\u2500\u2500 + \u2500 +   \u2571      \u239c- \u2500\u2500 + \u2500\u239f  + \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500  , - \u2500 + \u2500\u2500\u2500\u2500\n",
-        "\u2571        27    6    2   \u2572\u2571       \u239d  9    3\u23a0            4              3       \n",
-        "                                                                              \n",
-        "                                                                              \n",
-        "                                                                              \n",
-        "                                                                              \n",
-        "                                                                          \u239b   \n",
-        "                                                                          \u239c  1\n",
-        "                                                                          \u239c- \u2500\n",
-        "                                                                          \u239d  2\n",
-        "\n",
-        "                                                                              \n",
-        "                                                                              \n",
-        "                                                                              \n",
-        "                                     2                                        \n",
-        "                                    a    b                                    \n",
-        "                                  - \u2500\u2500 + \u2500                                    \n",
-        "                                    9    3                                    \n",
-        "\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n",
-        "                     _________________________________________________________\n",
-        "                    \u2571                        _________________________________\n",
-        "                   \u2571                        \u2571                               2 \n",
-        "                  \u2571                        \u2571                \u239b   3          \u239e  \n",
-        "                 \u2571                        \u2571             3   \u239c2\u22c5a    a\u22c5b    \u239f  \n",
-        "     ___  \u239e     \u2571      3                 \u2571    \u239b   2    \u239e    \u239c\u2500\u2500\u2500\u2500 - \u2500\u2500\u2500 + c\u239f  \n",
-        "   \u2572\u2571 3 \u22c5\u2148\u239f    \u2571      a    a\u22c5b   c      \u2571     \u239c  a    b\u239f    \u239d 27     3     \u23a0  \n",
-        " - \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u239f\u22c53 \u2571       \u2500\u2500 - \u2500\u2500\u2500 + \u2500 +   \u2571      \u239c- \u2500\u2500 + \u2500\u239f  + \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500 \n",
-        "      2   \u23a0 \u2572\u2571        27    6    2   \u2572\u2571       \u239d  9    3\u23a0            4         \n",
-        "\n",
-        "                             _________________________________________________\n",
-        "                            \u2571                        _________________________\n",
-        "                           \u2571                        \u2571                         \n",
-        "                          \u2571                        \u2571                \u239b   3     \n",
-        "                         \u2571                        \u2571             3   \u239c2\u22c5a    a\u22c5\n",
-        "    \u239b        ___  \u239e     \u2571      3                 \u2571    \u239b   2    \u239e    \u239c\u2500\u2500\u2500\u2500 - \u2500\u2500\n",
-        "    \u239c  1   \u2572\u2571 3 \u22c5\u2148\u239f    \u2571      a    a\u22c5b   c      \u2571     \u239c  a    b\u239f    \u239d 27     3\n",
-        "\u2500 - \u239c- \u2500 - \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u239f\u22c53 \u2571       \u2500\u2500 - \u2500\u2500\u2500 + \u2500 +   \u2571      \u239c- \u2500\u2500 + \u2500\u239f  + \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n",
-        "_   \u239d  2      2   \u23a0 \u2572\u2571        27    6    2   \u2572\u2571       \u239d  9    3\u23a0            4 \n",
-        "                                                                              \n",
-        "                                                                              \n",
-        "                                                                              \n",
-        "                                                                              \n",
-        "                                                                              \n",
-        "                                                                              \n",
-        "                                                                              \n",
-        "                                                                              \n",
-        "\n",
-        "_________                                                                     \n",
-        "________                                                                      \n",
-        "      2                                                                       \n",
-        "     \u239e                                                    2                   \n",
-        "b    \u239f                                                   a    b               \n",
-        "\u2500 + c\u239f                                                 - \u2500\u2500 + \u2500               \n",
-        "     \u23a0       a                                           9    3               \n",
-        "\u2500\u2500\u2500\u2500\u2500\u2500\u2500  , - \u2500 + \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n",
-        "             3                            ____________________________________\n",
-        "                                         \u2571                        ____________\n",
-        "                                        \u2571                        \u2571            \n",
-        "                                       \u2571                        \u2571             \n",
-        "                                      \u2571                        \u2571             3\n",
-        "                 \u239b        ___  \u239e     \u2571      3                 \u2571    \u239b   2    \u239e \n",
-        "                 \u239c  1   \u2572\u2571 3 \u22c5\u2148\u239f    \u2571      a    a\u22c5b   c      \u2571     \u239c  a    b\u239f \n",
-        "                 \u239c- \u2500 + \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u239f\u22c53 \u2571       \u2500\u2500 - \u2500\u2500\u2500 + \u2500 +   \u2571      \u239c- \u2500\u2500 + \u2500\u239f \n",
-        "                 \u239d  2      2   \u23a0 \u2572\u2571        27    6    2   \u2572\u2571       \u239d  9    3\u23a0 \n",
-        "\n",
-        "                                                  ____________________________\n",
-        "                                                 \u2571                        ____\n",
-        "                                                \u2571                        \u2571    \n",
-        "                                               \u2571                        \u2571     \n",
-        "                                              \u2571                        \u2571      \n",
-        "                         \u239b        ___  \u239e     \u2571      3                 \u2571    \u239b  \n",
-        "                         \u239c  1   \u2572\u2571 3 \u22c5\u2148\u239f    \u2571      a    a\u22c5b   c      \u2571     \u239c  \n",
-        "\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500 - \u239c- \u2500 + \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u239f\u22c53 \u2571       \u2500\u2500 - \u2500\u2500\u2500 + \u2500 +   \u2571      \u239c- \n",
-        "______________________   \u239d  2      2   \u23a0 \u2572\u2571        27    6    2   \u2572\u2571       \u239d  \n",
-        "_____________________                                                         \n",
-        "                   2                                                          \n",
-        "   \u239b   3          \u239e                                                           \n",
-        "   \u239c2\u22c5a    a\u22c5b    \u239f                                                           \n",
-        "   \u239c\u2500\u2500\u2500\u2500 - \u2500\u2500\u2500 + c\u239f                                                           \n",
-        "   \u239d 27     3     \u23a0                                                           \n",
-        " + \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500                                                          \n",
-        "           4                                                                  \n",
-        "\n",
-        "______________________________\u23a4\n",
-        "_____________________________ \u23a5\n",
-        "                           2  \u23a5\n",
-        "           \u239b   3          \u239e   \u23a5\n",
-        "       3   \u239c2\u22c5a    a\u22c5b    \u239f   \u23a5\n",
-        " 2    \u239e    \u239c\u2500\u2500\u2500\u2500 - \u2500\u2500\u2500 + c\u239f   \u23a5\n",
-        "a    b\u239f    \u239d 27     3     \u23a0   \u23a5\n",
-        "\u2500\u2500 + \u2500\u239f  + \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500  \u23a5\n",
-        "9    3\u23a0            4          \u23a5\n",
-        "                              \u23a5\n",
-        "                              \u23a5\n",
-        "                              \u23a5\n",
-        "                              \u23a5\n",
-        "                              \u23a5\n",
-        "                              \u23a5\n",
-        "                              \u23a5\n",
-        "                              \u23a6"
-       ]
-      }
-     ],
-     "prompt_number": 6
-    },
-    {
-     "cell_type": "heading",
-     "level": 2,
-     "metadata": {},
-     "source": [
-      "Differential Equations"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "A population that grows without bound is modeled by the differential equation\n",
-      "\n",
-      "$$f'(t)=af(t)$$\n",
-      "\n",
-      "Solve this differential equation using SymPy."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "dsolve(f(t).diff(t) - a*f(t), f(t))"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\operatorname{f}{\\left (t \\right )} = C_{1} e^{a t}$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAFwAAAAbCAYAAADxsuiMAAAABHNCSVQICAgIfAhkiAAAA/VJREFU\naIHt2GlsVFUUwPEfUhCURaF1iSQqitGgBTWUEKspqUvUaF0+4BpQSTSuuJLoB4wmRg180GgU6wZf\nLHHf4hYwrsEt0RC1xrjvC1axrqj1w3kTXqdvZtrODCUw/2SSd8+ce+9555577rmPGjU2M/bCrFxj\nqyE0ZEthIfYdaiO2JD7DrrlGXT867Imb8C7G4VzshJ/wZ5F+9fgXXYO1tEymYq7Yzn8ldvyM6/Ap\n7hXR920Zc9RhEb7ACByFC/FR8nykyCIn4+XkV5SRSeczsRz/iNW6IEN3D3xtw2oOwzWJIRuTcWjH\n5zgNW6f+a8BDuAedFZjrTixInieKRU2n6fm4fSADHoMe4cwmHCZWdEyG7gIR8aNSssm4YiATlsnu\neA+vCgdksbd4p1vKnKsR3RidtGfj0Tyd5ZiTFpQ6NFvwo4jy1/G2cGh3hu7BeE3vNPOxeMGRpayv\nABPwtNhRR2NtAb1OfICVZc53qEgRfyTtVqzC9imdZjwv/DyR0g5vwhup9hEierJoxosZ8jViMarN\nraIEO0fpc+MH4Yhy6MI3yfMYnIhXcEoiq8ff+F6ktlFEns1iGXYUDu4UJ+0nYivekLSJ7XKGWNWm\nZMJuPC4cQGy1mbi+vPcrykysxks4pB/6c7Cin2NPF4VCl9g99TgP60VaWinSyi6J/pt4ShyoHXhC\nHKold9Rk4eATUrKHsW2G7tmiEhid8V+j4vnybpGqBvJryRtjaWLr3CLzDIZ5eMcGZxJnUluF50E4\nukc4PsezskvJDoVLnim4o7Km9eFDYeukCo45S0TxQSlZE57EDoMdtFgdPh3rRCrJsRbj9T2QWnBX\ngXHGi4O3mkzCb/iyH7pTxAKV4mqRRo7D8RiO90VNvW5QVpbgMbyQJ7sW++XJporoOrzAOMeKOr6a\nfCfuAKUYiZv7oTdC3DmWlmNUFsUifBoeyZOtElttTUo2WxiXq162w1hxUEj024vM0479+2lvjkv1\nDobV4ma3DX4v0u8iccNMM1ZchC4RlyWihBsuyuGNwgQRtfmRWafvAbhC79JxEXZOnoepfv4mUtp/\nopooRBsuzpPNF6mjB7ul5HX4BVdmjLNP0q+itCZGHJjx30k4INV+APcnzzP0vlm26VtRVIvL8Kuo\nedP3iwaRCrM+R+TIdzjcKO4V6dK5VVRVo1SYy8WHnkIp56zUpNNE/b1EODv3sg3igNmYNIsAeAvP\niEBYIg7KYmQ5vC7p24HFIvfPU/juUhb34cFqDLyJkuXwqpDeegvxXPI8Q0RKjQqTdvjp4u7fKAr+\nmsOrQNrhi/EVrhIfYtYPiUU1NmtOxW0ih3fg/KE1p0aNGjVqbMr8DwW0z+R+rnD8AAAAAElFTkSu\nQmCC\n",
-       "prompt_number": 7,
-       "text": [
-        "           a\u22c5t\n",
-        "f(t) = C\u2081\u22c5\u212f   "
-       ]
-      }
-     ],
-     "prompt_number": 7
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "If the population growth is bounded, it is modeled by \n",
-      "\n",
-      "$$f'(t) = f(t)(1 - f(t))$$\n",
-      "\n",
-      "Solve this differential equation using SymPy."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "dsolve(f(t).diff(t) - f(t)*(1 - f(t)), f(t))"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "$$\\log{\\left (\\operatorname{f}{\\left (t \\right )} -1 \\right )} - \\log{\\left (\\operatorname{f}{\\left (t \\right )} \\right )} = C_{1} - t$$"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAO4AAAAYCAYAAAD9JcEmAAAABHNCSVQICAgIfAhkiAAABrpJREFU\neJzt23usHVUVx/GPFCsWCqVwCzYE6OUdlBYRCE2rLUYkGlDhDyH4qEVEo1IVkPiPT9RgUhsVEKxi\na3yQ+A7R0OAbMUSDAXlYUtQbBQ22DYpAIVbrH2vGO2fuzJmhd2bObTLf5OZk9qxz957123vN2o9D\nT0/PHstrcQc24/KO6jwCb6xhdzR+gE/hBuyFhdin4nsH48DpNLAGc/C7gvJZuArPabi+UehEPa2K\ndGL3tWrLh8+GE8Xz3I4f4ZtYj0VJuzbi0JG1LuFIPIkPd1DXPHwVz62wm40/YDW+gp2iE727wPYo\n/DW5Tzj2ozXq2F1OxW+wq+T+S3F1C/UeqTudqKdVkU4HYn/T06otH1axvxigf8Yb8LzMvTF8B18W\nAbQL8v6awoRuOsQNeHENu3PEwDgKp+EV+BD2K7B9D542GN3H8f5ptXQqJ4g3ywbcqXzgwmexrOH6\n6U4n6mlVpBPNaNWWD8tYhAfwKxxUYnO8eN5rO2pTkb8GmNB+hzgOP65puxZbM9dj+GSJ7bfx84Ly\nm8QboQ02GD5wx/HTFuqd0M3AratVXiea06otHxYxHw9ii+pp1ma8rvUWBVP8tVeJYZtcJtKpOpwm\n0tGUV4pIWMQy/KKg/F4sr926Zvmj8PGSEdU/XepqldeJ5rTq0ofX4Vi8HY9V2G7VXUCZ4q+9a3zp\ndDFPeTSxn4dPiMiUZTXOxl9wGG4TKcVLcLNIuSQ2n66ocyMOSRq8GbfiT+Ltdk3G7vV4i4iOC7Ay\nsb1FiAB3J89Q9y3fNHfgvKQdbdO1VmU6vQNLNadVFz48HReIhag6feVa/KPF9tTx1/+ZMJiCnSNE\nH8uUnZDYnZwpuxRP4IDk+hj8R3SEs3FuUn4Ettds+LgYqOdlyr6LfQtsL8UzeH7BvZO0NxfZYHiq\nTKRTtzVc74SpqfKotCrSiWa1qvLhTWJQP5u/Fbn/cWPyHG8eUs8oKPTXsDfufmLl7GqD85ff4/vJ\nvTR9eSfuxz+T6y3YhjUGtxEOx99rNjj939kou2/yEHlWilRtR8G9Hdqb49ZhqxhAbTJKrYp0olmt\nqny4uqKNdTgz+RxVZlZGob+GzXFfLVbVipa8H8RinJJcbzO4ZC65zgeGBSY7TBVL8LhIvVK2m3xT\nZFmheLFDYr+tZp1t8JhY9GiTUWpVpBPNatWFDw8T22wP17A9puW2ZFmhwF/D3rjjyefOgnv/Tj6P\nxl0i0t8qNqzvFynXbLHamGUW/luzwUtEFM+mog+JDf1sCneimGeVdYaFyfdSXoQvqL+xf7dYrNhd\n8v5ro/5RalWkE81olVL0XE3zuJgyVDFbrCNcVsN2ulqX+mvYwP1b8rmg4F66v/Vo8vk0PohLREeZ\nLfb+8m+AreqfZlqM7+XKfoIzxOpjykohbLqCOQ9zxcKLxH59xv7epKwr5htMOduof5RaFelEM1ql\n5H2YZ73BeXwdLjc4IO7Eq8RpuKeGfG+NWNvIMldMR94nDm2kTFfrUn8NG7i3iAc4ruDeKSKl+GVy\nvRQ/VHz8L8sjyje1s8wXc6x7cuW34/xc2XIRqZ5IrteIKEdEuoPElsKomC9OvbTJqLQq04lmtary\n4SUV7azDOrHAtwrXl9i8Rgyk32bK3irS7PNxRQPtyFLqr/wcd2+Tb+HteBsuxgsyNotEJHiTyRTm\nEXwcL8fLRAQ/1NQUYYtIRxZWNDiNnvkOsVN0wOxJnlli5ZQ4hrjD5BvoXHy9oq7pkJ5kmTPE5mT8\nuuF6szoxOq3KdKJZrdrwYZ6fiZNb14hjjtmxMYaPiSC1Lve9L2rvMMwwfyEiyV1invKkSCHSTrlc\nOPR6fA5fErl7loNF59mV+3sYF+VsN4o9qmFcKfbIyjKCizPtWyz2+dYKx6cOH8OFFfXsDguwCfeZ\nfM50Mz7/rMR8cmVDdQ/Tie61qtKJZrRq0odVLMO3hJ83iR8WrFW9ILVLnCNvkjJ/NcLhYn50logQ\nhFDjYh7xjDiNknKmcMYwviGOee3pjIm50yh/4ZKlaa260Gmm+bCMNgZuq7xX7BWWcY+pc51N4kB6\nlqtMbrI/pJ23Zdd8xOSBhplAE1p1rdNM82EZe9zAfaFYFVxacO8ssdhwSK58Eb5mMIreJ351c5I4\nONDWz/G64ljxc7iZRBNadanTTPRhGZ0O3KbSj3ERzefiXyIXnyNWAtcp3lQ/Q4h/Y3K9SnSoA0SU\nfaChto2CWfgMPiD8MZOYrlardKPTTPZhEbtEkJsYcTt6enpqcBE+LwbuzXjXaJvT09PT09PT09PT\n09PT07Nn8T9EbAbRBz88IwAAAABJRU5ErkJggg==\n",
-       "prompt_number": 8,
-       "text": [
-        "log(f(t) - 1) - log(f(t)) = C\u2081 - t"
-       ]
-      }
-     ],
-     "prompt_number": 8
+     "output_type": "execute_result"
     }
    ],
-   "metadata": {}
+   "source": [
+    "def quadratic():\n",
+    "    return solve(a*x**2 + b*x + c, x)\n",
+    "quadratic()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Write a function that computes the general solution to the cubic $x^3 + ax^2 + bx + c$."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$$\\begin{bmatrix}- \\frac{1}{3} a + \\frac{- \\frac{1}{9} a^{2} + \\frac{1}{3} b}{\\sqrt[3]{\\frac{1}{27} a^{3} - \\frac{1}{6} a b + \\frac{1}{2} c + \\sqrt{\\left(- \\frac{1}{9} a^{2} + \\frac{1}{3} b\\right)^{3} + \\frac{1}{4} \\left(\\frac{2}{27} a^{3} - \\frac{1}{3} a b + c\\right)^{2}}}} - \\sqrt[3]{\\frac{1}{27} a^{3} - \\frac{1}{6} a b + \\frac{1}{2} c + \\sqrt{\\left(- \\frac{1}{9} a^{2} + \\frac{1}{3} b\\right)^{3} + \\frac{1}{4} \\left(\\frac{2}{27} a^{3} - \\frac{1}{3} a b + c\\right)^{2}}}, & - \\frac{1}{3} a + \\frac{- \\frac{1}{9} a^{2} + \\frac{1}{3} b}{\\left(- \\frac{1}{2} - \\frac{1}{2} \\sqrt{3} \\mathbf{\\imath}\\right) \\sqrt[3]{\\frac{1}{27} a^{3} - \\frac{1}{6} a b + \\frac{1}{2} c + \\sqrt{\\left(- \\frac{1}{9} a^{2} + \\frac{1}{3} b\\right)^{3} + \\frac{1}{4} \\left(\\frac{2}{27} a^{3} - \\frac{1}{3} a b + c\\right)^{2}}}} - \\left(- \\frac{1}{2} - \\frac{1}{2} \\sqrt{3} \\mathbf{\\imath}\\right) \\sqrt[3]{\\frac{1}{27} a^{3} - \\frac{1}{6} a b + \\frac{1}{2} c + \\sqrt{\\left(- \\frac{1}{9} a^{2} + \\frac{1}{3} b\\right)^{3} + \\frac{1}{4} \\left(\\frac{2}{27} a^{3} - \\frac{1}{3} a b + c\\right)^{2}}}, & - \\frac{1}{3} a + \\frac{- \\frac{1}{9} a^{2} + \\frac{1}{3} b}{\\left(- \\frac{1}{2} + \\frac{1}{2} \\sqrt{3} \\mathbf{\\imath}\\right) \\sqrt[3]{\\frac{1}{27} a^{3} - \\frac{1}{6} a b + \\frac{1}{2} c + \\sqrt{\\left(- \\frac{1}{9} a^{2} + \\frac{1}{3} b\\right)^{3} + \\frac{1}{4} \\left(\\frac{2}{27} a^{3} - \\frac{1}{3} a b + c\\right)^{2}}}} - \\left(- \\frac{1}{2} + \\frac{1}{2} \\sqrt{3} \\mathbf{\\imath}\\right) \\sqrt[3]{\\frac{1}{27} a^{3} - \\frac{1}{6} a b + \\frac{1}{2} c + \\sqrt{\\left(- \\frac{1}{9} a^{2} + \\frac{1}{3} b\\right)^{3} + \\frac{1}{4} \\left(\\frac{2}{27} a^{3} - \\frac{1}{3} a b + c\\right)^{2}}}\\end{bmatrix}$$"
+      ],
+      "text/plain": [
+       "⎡                                                                             \n",
+       "⎢                                                                             \n",
+       "⎢                                                                             \n",
+       "⎢                                       2                                     \n",
+       "⎢                                      a    b                                 \n",
+       "⎢                                    - ── + ─                                 \n",
+       "⎢  a                                   9    3                                 \n",
+       "⎢- ─ + ─────────────────────────────────────────────────────────────────── - 3\n",
+       "⎢  3            __________________________________________________________   ╲\n",
+       "⎢              ╱                        _________________________________     \n",
+       "⎢             ╱                        ╱                               2      \n",
+       "⎢            ╱                        ╱                ⎛   3          ⎞       \n",
+       "⎢           ╱                        ╱             3   ⎜2⋅a    a⋅b    ⎟       \n",
+       "⎢          ╱      3                 ╱    ⎛   2    ⎞    ⎜──── - ─── + c⎟       \n",
+       "⎢         ╱      a    a⋅b   c      ╱     ⎜  a    b⎟    ⎝ 27     3     ⎠       \n",
+       "⎢      3 ╱       ── - ─── + ─ +   ╱      ⎜- ── + ─⎟  + ─────────────────      \n",
+       "⎣      ╲╱        27    6    2   ╲╱       ⎝  9    3⎠            4              \n",
+       "\n",
+       "        __________________________________________________________            \n",
+       "       ╱                        _________________________________             \n",
+       "      ╱                        ╱                               2              \n",
+       "     ╱                        ╱                ⎛   3          ⎞               \n",
+       "    ╱                        ╱             3   ⎜2⋅a    a⋅b    ⎟               \n",
+       "   ╱      3                 ╱    ⎛   2    ⎞    ⎜──── - ─── + c⎟               \n",
+       "  ╱      a    a⋅b   c      ╱     ⎜  a    b⎟    ⎝ 27     3     ⎠       a       \n",
+       " ╱       ── - ─── + ─ +   ╱      ⎜- ── + ─⎟  + ─────────────────  , - ─ + ────\n",
+       "╱        27    6    2   ╲╱       ⎝  9    3⎠            4              3       \n",
+       "                                                                              \n",
+       "                                                                              \n",
+       "                                                                              \n",
+       "                                                                              \n",
+       "                                                                          ⎛   \n",
+       "                                                                          ⎜  1\n",
+       "                                                                          ⎜- ─\n",
+       "                                                                          ⎝  2\n",
+       "\n",
+       "                                                                              \n",
+       "                                                                              \n",
+       "                                                                              \n",
+       "                                     2                                        \n",
+       "                                    a    b                                    \n",
+       "                                  - ── + ─                                    \n",
+       "                                    9    3                                    \n",
+       "──────────────────────────────────────────────────────────────────────────────\n",
+       "                     _________________________________________________________\n",
+       "                    ╱                        _________________________________\n",
+       "                   ╱                        ╱                               2 \n",
+       "                  ╱                        ╱                ⎛   3          ⎞  \n",
+       "                 ╱                        ╱             3   ⎜2⋅a    a⋅b    ⎟  \n",
+       "     ___  ⎞     ╱      3                 ╱    ⎛   2    ⎞    ⎜──── - ─── + c⎟  \n",
+       "   ╲╱ 3 ⋅ⅈ⎟    ╱      a    a⋅b   c      ╱     ⎜  a    b⎟    ⎝ 27     3     ⎠  \n",
+       " - ───────⎟⋅3 ╱       ── - ─── + ─ +   ╱      ⎜- ── + ─⎟  + ───────────────── \n",
+       "      2   ⎠ ╲╱        27    6    2   ╲╱       ⎝  9    3⎠            4         \n",
+       "\n",
+       "                             _________________________________________________\n",
+       "                            ╱                        _________________________\n",
+       "                           ╱                        ╱                         \n",
+       "                          ╱                        ╱                ⎛   3     \n",
+       "                         ╱                        ╱             3   ⎜2⋅a    a⋅\n",
+       "    ⎛        ___  ⎞     ╱      3                 ╱    ⎛   2    ⎞    ⎜──── - ──\n",
+       "    ⎜  1   ╲╱ 3 ⋅ⅈ⎟    ╱      a    a⋅b   c      ╱     ⎜  a    b⎟    ⎝ 27     3\n",
+       "─ - ⎜- ─ - ───────⎟⋅3 ╱       ── - ─── + ─ +   ╱      ⎜- ── + ─⎟  + ──────────\n",
+       "_   ⎝  2      2   ⎠ ╲╱        27    6    2   ╲╱       ⎝  9    3⎠            4 \n",
+       "                                                                              \n",
+       "                                                                              \n",
+       "                                                                              \n",
+       "                                                                              \n",
+       "                                                                              \n",
+       "                                                                              \n",
+       "                                                                              \n",
+       "                                                                              \n",
+       "\n",
+       "_________                                                                     \n",
+       "________                                                                      \n",
+       "      2                                                                       \n",
+       "     ⎞                                                    2                   \n",
+       "b    ⎟                                                   a    b               \n",
+       "─ + c⎟                                                 - ── + ─               \n",
+       "     ⎠       a                                           9    3               \n",
+       "───────  , - ─ + ─────────────────────────────────────────────────────────────\n",
+       "             3                            ____________________________________\n",
+       "                                         ╱                        ____________\n",
+       "                                        ╱                        ╱            \n",
+       "                                       ╱                        ╱             \n",
+       "                                      ╱                        ╱             3\n",
+       "                 ⎛        ___  ⎞     ╱      3                 ╱    ⎛   2    ⎞ \n",
+       "                 ⎜  1   ╲╱ 3 ⋅ⅈ⎟    ╱      a    a⋅b   c      ╱     ⎜  a    b⎟ \n",
+       "                 ⎜- ─ + ───────⎟⋅3 ╱       ── - ─── + ─ +   ╱      ⎜- ── + ─⎟ \n",
+       "                 ⎝  2      2   ⎠ ╲╱        27    6    2   ╲╱       ⎝  9    3⎠ \n",
+       "\n",
+       "                                                  ____________________________\n",
+       "                                                 ╱                        ____\n",
+       "                                                ╱                        ╱    \n",
+       "                                               ╱                        ╱     \n",
+       "                                              ╱                        ╱      \n",
+       "                         ⎛        ___  ⎞     ╱      3                 ╱    ⎛  \n",
+       "                         ⎜  1   ╲╱ 3 ⋅ⅈ⎟    ╱      a    a⋅b   c      ╱     ⎜  \n",
+       "────────────────────── - ⎜- ─ + ───────⎟⋅3 ╱       ── - ─── + ─ +   ╱      ⎜- \n",
+       "______________________   ⎝  2      2   ⎠ ╲╱        27    6    2   ╲╱       ⎝  \n",
+       "_____________________                                                         \n",
+       "                   2                                                          \n",
+       "   ⎛   3          ⎞                                                           \n",
+       "   ⎜2⋅a    a⋅b    ⎟                                                           \n",
+       "   ⎜──── - ─── + c⎟                                                           \n",
+       "   ⎝ 27     3     ⎠                                                           \n",
+       " + ─────────────────                                                          \n",
+       "           4                                                                  \n",
+       "\n",
+       "______________________________⎤\n",
+       "_____________________________ ⎥\n",
+       "                           2  ⎥\n",
+       "           ⎛   3          ⎞   ⎥\n",
+       "       3   ⎜2⋅a    a⋅b    ⎟   ⎥\n",
+       " 2    ⎞    ⎜──── - ─── + c⎟   ⎥\n",
+       "a    b⎟    ⎝ 27     3     ⎠   ⎥\n",
+       "── + ─⎟  + ─────────────────  ⎥\n",
+       "9    3⎠            4          ⎥\n",
+       "                              ⎥\n",
+       "                              ⎥\n",
+       "                              ⎥\n",
+       "                              ⎥\n",
+       "                              ⎥\n",
+       "                              ⎥\n",
+       "                              ⎥\n",
+       "                              ⎦"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "def cubic():\n",
+    "    return solve(x**3 + a*x**2 + b*x + c, x)\n",
+    "cubic()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Differential Equations"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A population that grows without bound is modeled by the differential equation\n",
+    "\n",
+    "$$f'(t)=af(t)$$\n",
+    "\n",
+    "Solve this differential equation using SymPy."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAFwAAAAbCAYAAADxsuiMAAAABHNCSVQICAgIfAhkiAAAA/VJREFU\naIHt2GlsVFUUwPEfUhCURaF1iSQqitGgBTWUEKspqUvUaF0+4BpQSTSuuJLoB4wmRg180GgU6wZf\nLHHf4hYwrsEt0RC1xrjvC1axrqj1w3kTXqdvZtrODCUw/2SSd8+ce+9555577rmPGjU2M/bCrFxj\nqyE0ZEthIfYdaiO2JD7DrrlGXT867Imb8C7G4VzshJ/wZ5F+9fgXXYO1tEymYq7Yzn8ldvyM6/Ap\n7hXR920Zc9RhEb7ACByFC/FR8nykyCIn4+XkV5SRSeczsRz/iNW6IEN3D3xtw2oOwzWJIRuTcWjH\n5zgNW6f+a8BDuAedFZjrTixInieKRU2n6fm4fSADHoMe4cwmHCZWdEyG7gIR8aNSssm4YiATlsnu\neA+vCgdksbd4p1vKnKsR3RidtGfj0Tyd5ZiTFpQ6NFvwo4jy1/G2cGh3hu7BeE3vNPOxeMGRpayv\nABPwtNhRR2NtAb1OfICVZc53qEgRfyTtVqzC9imdZjwv/DyR0g5vwhup9hEierJoxosZ8jViMarN\nraIEO0fpc+MH4Yhy6MI3yfMYnIhXcEoiq8ff+F6ktlFEns1iGXYUDu4UJ+0nYivekLSJ7XKGWNWm\nZMJuPC4cQGy1mbi+vPcrykysxks4pB/6c7Cin2NPF4VCl9g99TgP60VaWinSyi6J/pt4ShyoHXhC\nHKold9Rk4eATUrKHsW2G7tmiEhid8V+j4vnybpGqBvJryRtjaWLr3CLzDIZ5eMcGZxJnUluF50E4\nukc4PsezskvJDoVLnim4o7Km9eFDYeukCo45S0TxQSlZE57EDoMdtFgdPh3rRCrJsRbj9T2QWnBX\ngXHGi4O3mkzCb/iyH7pTxAKV4mqRRo7D8RiO90VNvW5QVpbgMbyQJ7sW++XJporoOrzAOMeKOr6a\nfCfuAKUYiZv7oTdC3DmWlmNUFsUifBoeyZOtElttTUo2WxiXq162w1hxUEj024vM0479+2lvjkv1\nDobV4ma3DX4v0u8iccNMM1ZchC4RlyWihBsuyuGNwgQRtfmRWafvAbhC79JxEXZOnoepfv4mUtp/\nopooRBsuzpPNF6mjB7ul5HX4BVdmjLNP0q+itCZGHJjx30k4INV+APcnzzP0vlm26VtRVIvL8Kuo\nedP3iwaRCrM+R+TIdzjcKO4V6dK5VVRVo1SYy8WHnkIp56zUpNNE/b1EODv3sg3igNmYNIsAeAvP\niEBYIg7KYmQ5vC7p24HFIvfPU/juUhb34cFqDLyJkuXwqpDeegvxXPI8Q0RKjQqTdvjp4u7fKAr+\nmsOrQNrhi/EVrhIfYtYPiUU1NmtOxW0ih3fg/KE1p0aNGjVqbMr8DwW0z+R+rnD8AAAAAElFTkSu\nQmCC\n",
+      "text/latex": [
+       "$$\\operatorname{f}{\\left (t \\right )} = C_{1} e^{a t}$$"
+      ],
+      "text/plain": [
+       "           a⋅t\n",
+       "f(t) = C₁⋅ℯ   "
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dsolve(f(t).diff(t) - a*f(t), f(t))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If the population growth is bounded, it is modeled by \n",
+    "\n",
+    "$$f'(t) = f(t)(1 - f(t))$$\n",
+    "\n",
+    "Solve this differential equation using SymPy."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAO4AAAAYCAYAAAD9JcEmAAAABHNCSVQICAgIfAhkiAAABrpJREFU\neJzt23usHVUVx/GPFCsWCqVwCzYE6OUdlBYRCE2rLUYkGlDhDyH4qEVEo1IVkPiPT9RgUhsVEKxi\na3yQ+A7R0OAbMUSDAXlYUtQbBQ22DYpAIVbrH2vGO2fuzJmhd2bObTLf5OZk9qxz957123vN2o9D\nT0/PHstrcQc24/KO6jwCb6xhdzR+gE/hBuyFhdin4nsH48DpNLAGc/C7gvJZuArPabi+UehEPa2K\ndGL3tWrLh8+GE8Xz3I4f4ZtYj0VJuzbi0JG1LuFIPIkPd1DXPHwVz62wm40/YDW+gp2iE727wPYo\n/DW5Tzj2ozXq2F1OxW+wq+T+S3F1C/UeqTudqKdVkU4HYn/T06otH1axvxigf8Yb8LzMvTF8B18W\nAbQL8v6awoRuOsQNeHENu3PEwDgKp+EV+BD2K7B9D542GN3H8f5ptXQqJ4g3ywbcqXzgwmexrOH6\n6U4n6mlVpBPNaNWWD8tYhAfwKxxUYnO8eN5rO2pTkb8GmNB+hzgOP65puxZbM9dj+GSJ7bfx84Ly\nm8QboQ02GD5wx/HTFuqd0M3AratVXiea06otHxYxHw9ii+pp1ma8rvUWBVP8tVeJYZtcJtKpOpwm\n0tGUV4pIWMQy/KKg/F4sr926Zvmj8PGSEdU/XepqldeJ5rTq0ofX4Vi8HY9V2G7VXUCZ4q+9a3zp\ndDFPeTSxn4dPiMiUZTXOxl9wGG4TKcVLcLNIuSQ2n66ocyMOSRq8GbfiT+Ltdk3G7vV4i4iOC7Ay\nsb1FiAB3J89Q9y3fNHfgvKQdbdO1VmU6vQNLNadVFz48HReIhag6feVa/KPF9tTx1/+ZMJiCnSNE\nH8uUnZDYnZwpuxRP4IDk+hj8R3SEs3FuUn4Ettds+LgYqOdlyr6LfQtsL8UzeH7BvZO0NxfZYHiq\nTKRTtzVc74SpqfKotCrSiWa1qvLhTWJQP5u/Fbn/cWPyHG8eUs8oKPTXsDfufmLl7GqD85ff4/vJ\nvTR9eSfuxz+T6y3YhjUGtxEOx99rNjj939kou2/yEHlWilRtR8G9Hdqb49ZhqxhAbTJKrYp0olmt\nqny4uqKNdTgz+RxVZlZGob+GzXFfLVbVipa8H8RinJJcbzO4ZC65zgeGBSY7TBVL8LhIvVK2m3xT\nZFmheLFDYr+tZp1t8JhY9GiTUWpVpBPNatWFDw8T22wP17A9puW2ZFmhwF/D3rjjyefOgnv/Tj6P\nxl0i0t8qNqzvFynXbLHamGUW/luzwUtEFM+mog+JDf1sCneimGeVdYaFyfdSXoQvqL+xf7dYrNhd\n8v5ro/5RalWkE81olVL0XE3zuJgyVDFbrCNcVsN2ulqX+mvYwP1b8rmg4F66v/Vo8vk0PohLREeZ\nLfb+8m+AreqfZlqM7+XKfoIzxOpjykohbLqCOQ9zxcKLxH59xv7epKwr5htMOduof5RaFelEM1ql\n5H2YZ73BeXwdLjc4IO7Eq8RpuKeGfG+NWNvIMldMR94nDm2kTFfrUn8NG7i3iAc4ruDeKSKl+GVy\nvRQ/VHz8L8sjyje1s8wXc6x7cuW34/xc2XIRqZ5IrteIKEdEuoPElsKomC9OvbTJqLQq04lmtary\n4SUV7azDOrHAtwrXl9i8Rgyk32bK3irS7PNxRQPtyFLqr/wcd2+Tb+HteBsuxgsyNotEJHiTyRTm\nEXwcL8fLRAQ/1NQUYYtIRxZWNDiNnvkOsVN0wOxJnlli5ZQ4hrjD5BvoXHy9oq7pkJ5kmTPE5mT8\nuuF6szoxOq3KdKJZrdrwYZ6fiZNb14hjjtmxMYaPiSC1Lve9L2rvMMwwfyEiyV1invKkSCHSTrlc\nOPR6fA5fErl7loNF59mV+3sYF+VsN4o9qmFcKfbIyjKCizPtWyz2+dYKx6cOH8OFFfXsDguwCfeZ\nfM50Mz7/rMR8cmVDdQ/Tie61qtKJZrRq0odVLMO3hJ83iR8WrFW9ILVLnCNvkjJ/NcLhYn50logQ\nhFDjYh7xjDiNknKmcMYwviGOee3pjIm50yh/4ZKlaa260Gmm+bCMNgZuq7xX7BWWcY+pc51N4kB6\nlqtMbrI/pJ23Zdd8xOSBhplAE1p1rdNM82EZe9zAfaFYFVxacO8ssdhwSK58Eb5mMIreJ351c5I4\nONDWz/G64ljxc7iZRBNadanTTPRhGZ0O3KbSj3ERzefiXyIXnyNWAtcp3lQ/Q4h/Y3K9SnSoA0SU\nfaChto2CWfgMPiD8MZOYrlardKPTTPZhEbtEkJsYcTt6enpqcBE+LwbuzXjXaJvT09PT09PT09PT\n09PT07Nn8T9EbAbRBz88IwAAAABJRU5ErkJggg==\n",
+      "text/latex": [
+       "$$\\log{\\left (\\operatorname{f}{\\left (t \\right )} -1 \\right )} - \\log{\\left (\\operatorname{f}{\\left (t \\right )} \\right )} = C_{1} - t$$"
+      ],
+      "text/plain": [
+       "log(f(t) - 1) - log(f(t)) = C₁ - t"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dsolve(f(t).diff(t) - f(t)*(1 - f(t)), f(t))"
+   ]
   }
- ]
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 0
 }

--- a/tutorial_exercises/Advanced-Solvers.ipynb
+++ b/tutorial_exercises/Advanced-Solvers.ipynb
@@ -1,168 +1,157 @@
 {
- "metadata": {
-  "name": "",
-  "signature": "sha256:52b4e1b925439cea7aece0b55434232104d00ffa41479c5f22ca5baf2f38e001"
- },
- "nbformat": 3,
- "nbformat_minor": 0,
- "worksheets": [
+ "cells": [
   {
-   "cells": [
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Solvers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from sympy import *\n",
+    "init_printing()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For each exercise, fill in the function according to its docstring. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "a, b, c, d, x, y, z, t = symbols('a b c d x y z t')\n",
+    "f, g, h = symbols('f g h', cls=Function)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Algebraic Equations"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Write a function that computes the [quadratic equation](http://en.wikipedia.org/wiki/Quadratic_equation)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
     {
-     "cell_type": "heading",
-     "level": 1,
-     "metadata": {},
-     "source": [
-      "Solvers"
+     "ename": "SyntaxError",
+     "evalue": "invalid syntax (<ipython-input-7-99cd274c3f68>, line 2)",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;36m  File \u001b[0;32m\"<ipython-input-7-99cd274c3f68>\"\u001b[0;36m, line \u001b[0;32m2\u001b[0m\n\u001b[0;31m    return ???\u001b[0m\n\u001b[0m           ^\u001b[0m\n\u001b[0;31mSyntaxError\u001b[0m\u001b[0;31m:\u001b[0m invalid syntax\n"
      ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "from sympy import *\n",
-      "init_printing()"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 8
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "For each exercise, fill in the function according to its docstring. "
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "a, b, c, d, x, y, z, t = symbols('a b c d x y z t')\n",
-      "f, g, h = symbols('f g h', cls=Function)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 9
-    },
-    {
-     "cell_type": "heading",
-     "level": 2,
-     "metadata": {},
-     "source": [
-      "Algebraic Equations"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Write a function that computes the [quadratic equation](http://en.wikipedia.org/wiki/Quadratic_equation)."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def quadratic():\n",
-      "    return ???\n",
-      "quadratic()"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "ename": "SyntaxError",
-       "evalue": "invalid syntax (<ipython-input-7-99cd274c3f68>, line 2)",
-       "output_type": "pyerr",
-       "traceback": [
-        "\u001b[0;36m  File \u001b[0;32m\"<ipython-input-7-99cd274c3f68>\"\u001b[0;36m, line \u001b[0;32m2\u001b[0m\n\u001b[0;31m    return ???\u001b[0m\n\u001b[0m           ^\u001b[0m\n\u001b[0;31mSyntaxError\u001b[0m\u001b[0;31m:\u001b[0m invalid syntax\n"
-       ]
-      }
-     ],
-     "prompt_number": 7
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Write a function that computes the general solution to the cubic $x^3 + ax^2 + bx + c$."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def cubic():\n",
-      "    return ???\n",
-      "cubic()"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "ename": "SyntaxError",
-       "evalue": "invalid syntax (<ipython-input-10-258b5a2454f9>, line 2)",
-       "output_type": "pyerr",
-       "traceback": [
-        "\u001b[0;36m  File \u001b[0;32m\"<ipython-input-10-258b5a2454f9>\"\u001b[0;36m, line \u001b[0;32m2\u001b[0m\n\u001b[0;31m    return ???\u001b[0m\n\u001b[0m           ^\u001b[0m\n\u001b[0;31mSyntaxError\u001b[0m\u001b[0;31m:\u001b[0m invalid syntax\n"
-       ]
-      }
-     ],
-     "prompt_number": 10
-    },
-    {
-     "cell_type": "heading",
-     "level": 2,
-     "metadata": {},
-     "source": [
-      "Differential Equations"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "A population that grows without bound is modeled by the differential equation\n",
-      "\n",
-      "$$f'(t)=af(t)$$\n",
-      "\n",
-      "Solve this differential equation using SymPy."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 7
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "If the population growth is bounded, it is modeled by \n",
-      "\n",
-      "$$f'(t) = f(t)(1 - f(t))$$\n",
-      "\n",
-      "Solve this differential equation using SymPy."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 7
     }
    ],
-   "metadata": {}
+   "source": [
+    "def quadratic():\n",
+    "    return ???\n",
+    "quadratic()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Write a function that computes the general solution to the cubic $x^3 + ax^2 + bx + c$."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "ename": "SyntaxError",
+     "evalue": "invalid syntax (<ipython-input-10-258b5a2454f9>, line 2)",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;36m  File \u001b[0;32m\"<ipython-input-10-258b5a2454f9>\"\u001b[0;36m, line \u001b[0;32m2\u001b[0m\n\u001b[0;31m    return ???\u001b[0m\n\u001b[0m           ^\u001b[0m\n\u001b[0;31mSyntaxError\u001b[0m\u001b[0;31m:\u001b[0m invalid syntax\n"
+     ]
+    }
+   ],
+   "source": [
+    "def cubic():\n",
+    "    return ???\n",
+    "cubic()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Differential Equations"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A population that grows without bound is modeled by the differential equation\n",
+    "\n",
+    "$$f'(t)=af(t)$$\n",
+    "\n",
+    "Solve this differential equation using SymPy."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If the population growth is bounded, it is modeled by \n",
+    "\n",
+    "$$f'(t) = f(t)(1 - f(t))$$\n",
+    "\n",
+    "Solve this differential equation using SymPy."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": []
   }
- ]
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 0
 }

--- a/tutorial_exercises/examples-code-generation.ipynb
+++ b/tutorial_exercises/examples-code-generation.ipynb
@@ -1,404 +1,426 @@
 {
- "metadata": {
-  "name": "",
-  "signature": "sha256:d1c82017224d0c9a84cea8e4b6c0b3e3b3277c83922ded5c17cf0838d9e6e825"
- },
- "nbformat": 3,
- "nbformat_minor": 0,
- "worksheets": [
+ "cells": [
   {
-   "cells": [
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "from sympy import *\n",
-      "init_printing(use_latex='mathjax')\n",
-      "\n",
-      "x = symbols('x')"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "# Code Generation"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "expr = R_nl(3, 1, x, 6)\n",
-      "expr"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "from sympy.utilities.autowrap import ufuncify\n",
-      "from sympy.utilities.lambdify import lambdify\n",
-      "\n",
-      "fn_numpy   = lambdify(x, expr, 'numpy')\n",
-      "fn_fortran = ufuncify([x], expr)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "### They work the same"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "from numpy import linspace\n",
-      "xx = linspace(0, 1, 5)\n",
-      "fn_numpy(xx)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "fn_fortran(xx)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "### Plot form with matplotlib"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "from matplotlib.pyplot import plot, show, legend\n",
-      "%matplotlib inline"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "xx = linspace(0, 5, 50000)  # A bigger \n",
-      "plot(xx, fn_numpy(xx))"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "# Time fn_numpy"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "# Time fn_fortran"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "## Theano"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "import theano.tensor as T\n",
-      "import theano"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "tx = T.vector('x')\n",
-      "ty = T.vector('y')\n",
-      "tz = tx + 2 * ty\n",
-      "tz"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "# Print z, see expression"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "# Make function\n",
-      "f = theano.function([tx, ty], tz)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "import numpy as np\n",
-      "xx = np.array([1, 2, 3], dtype=np.float32)\n",
-      "yy = np.array([10, 20, 30], dtype=np.float32)\n",
-      "f(xx, yy)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Theano compiles symbolic trees down to numeric C and CUDA code\n",
-      "\n",
-      "Less sophisticated mathematics but more sophisticated code generation\n",
-      "\n",
-      "(Almost) all SymPy expressions can be transformed into Theano Expressions."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "a = Symbol('a')\n",
-      "from sympy.printing.theanocode import theano_code\n",
-      "theano_code(a)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "theano.printing.debugprint(theano_code(expr))"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "from sympy.printing.theanocode import theano_function\n",
-      "\n",
-      "fn_theano  = theano_function([x], [expr], dims={x: 1}, dtypes={x: 'float64'})"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "theano.printing.debugprint(fn_theano)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "fn_theano(xx)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "# More complex problem\n",
-      "\n",
-      "Lets compute both the expression and its derivative simultaneously. "
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "outputs = expr, simplify(expr.diff(x))\n",
-      "outputs"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "fn_numpy  = lambdify([x], outputs, 'numpy')\n",
-      "fn_theano = theano_function([x], outputs, dims={x: 1}, dtypes={x: 'float64'})\n",
-      "\n",
-      "fns_fortran = [ufuncify([x], output) for output in outputs]\n",
-      "fn_fortran  = lambda xx: [fn_fortran(xx) for fn_fortran in fns_fortran]"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "xx = linspace(0, 5, 50000)\n",
-      "\n",
-      "for y in fn_theano(xx):\n",
-      "    plot(xx, y)\n",
-      "legend(['$R_{31}$', \"$R'_{31}$\"])"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "timeit fn_numpy(xx)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "timeit fn_fortran(xx)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "timeit fn_theano(xx)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "# Matrices"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "n = Symbol('n', integer=True)\n",
-      "X = MatrixSymbol('X', n, n)\n",
-      "y = MatrixSymbol('y', n, 1)\n",
-      "\n",
-      "f = theano_function([X, y], [X*y])"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "nX = np.array([[1, 0], [0, 1]], dtype=np.float32)\n",
-      "ny = np.array([[10], [1]], dtype=np.float32)\n",
-      "\n",
-      "f(nX, ny)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    }
-   ],
-   "metadata": {}
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from sympy import *\n",
+    "init_printing(use_latex='mathjax')\n",
+    "\n",
+    "x = symbols('x')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Code Generation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "expr = R_nl(3, 1, x, 6)\n",
+    "expr"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from sympy.utilities.autowrap import ufuncify\n",
+    "from sympy.utilities.lambdify import lambdify\n",
+    "\n",
+    "fn_numpy   = lambdify(x, expr, 'numpy')\n",
+    "fn_fortran = ufuncify([x], expr)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### They work the same"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from numpy import linspace\n",
+    "xx = linspace(0, 1, 5)\n",
+    "fn_numpy(xx)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "fn_fortran(xx)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Plot form with matplotlib"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from matplotlib.pyplot import plot, show, legend\n",
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "xx = linspace(0, 5, 50000)  # A bigger \n",
+    "plot(xx, fn_numpy(xx))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Time fn_numpy"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Time fn_fortran"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Theano"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import theano.tensor as T\n",
+    "import theano"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "tx = T.vector('x')\n",
+    "ty = T.vector('y')\n",
+    "tz = tx + 2 * ty\n",
+    "tz"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Print z, see expression"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Make function\n",
+    "f = theano.function([tx, ty], tz)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "xx = np.array([1, 2, 3], dtype=np.float32)\n",
+    "yy = np.array([10, 20, 30], dtype=np.float32)\n",
+    "f(xx, yy)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Theano compiles symbolic trees down to numeric C and CUDA code\n",
+    "\n",
+    "Less sophisticated mathematics but more sophisticated code generation\n",
+    "\n",
+    "(Almost) all SymPy expressions can be transformed into Theano Expressions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "a = Symbol('a')\n",
+    "from sympy.printing.theanocode import theano_code\n",
+    "theano_code(a)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "theano.printing.debugprint(theano_code(expr))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from sympy.printing.theanocode import theano_function\n",
+    "\n",
+    "fn_theano  = theano_function([x], [expr], dims={x: 1}, dtypes={x: 'float64'})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "theano.printing.debugprint(fn_theano)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "fn_theano(xx)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# More complex problem\n",
+    "\n",
+    "Lets compute both the expression and its derivative simultaneously. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "outputs = expr, simplify(expr.diff(x))\n",
+    "outputs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "fn_numpy  = lambdify([x], outputs, 'numpy')\n",
+    "fn_theano = theano_function([x], outputs, dims={x: 1}, dtypes={x: 'float64'})\n",
+    "\n",
+    "fns_fortran = [ufuncify([x], output) for output in outputs]\n",
+    "fn_fortran  = lambda xx: [fn_fortran(xx) for fn_fortran in fns_fortran]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "xx = linspace(0, 5, 50000)\n",
+    "\n",
+    "for y in fn_theano(xx):\n",
+    "    plot(xx, y)\n",
+    "legend(['$R_{31}$', \"$R'_{31}$\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "timeit fn_numpy(xx)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "timeit fn_fortran(xx)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "timeit fn_theano(xx)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Matrices"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "n = Symbol('n', integer=True)\n",
+    "X = MatrixSymbol('X', n, n)\n",
+    "y = MatrixSymbol('y', n, 1)\n",
+    "\n",
+    "f = theano_function([X, y], [X*y])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "nX = np.array([[1, 0], [0, 1]], dtype=np.float32)\n",
+    "ny = np.array([[10], [1]], dtype=np.float32)\n",
+    "\n",
+    "f(nX, ny)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": []
   }
- ]
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 0
 }

--- a/tutorial_exercises/examples-stats.ipynb
+++ b/tutorial_exercises/examples-stats.ipynb
@@ -1,203 +1,211 @@
 {
- "metadata": {
-  "name": "",
-  "signature": "sha256:e3ce43cfe316eb6d34b0182a55b6000fa21f67a57b43e6d1c738137f3d16da27"
- },
- "nbformat": 3,
- "nbformat_minor": 0,
- "worksheets": [
+ "cells": [
   {
-   "cells": [
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "from sympy import *\n",
-      "init_printing(use_latex='mathjax')\n",
-      "x, y, z = symbols('x,y,z')"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "# Probability Modeling"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "from sympy.stats import *"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "X = Normal('X', 0, 1)\n",
-      "X"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "# Density"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "# Density of expressions"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "# Probability"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "# Sampling"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "## Dice"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "A = Die('A', 6)\n",
-      "B = Die('B', 6)\n",
-      "\n",
-      "density(A+B)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "### Evaluate = False"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "## More distributions"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "from sympy.stats import Gamma\n",
-      "Gamma?"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "k = Symbol('k', positive=True)\n",
-      "theta = Symbol('theta', positive=True)\n",
-      "A = Gamma('A', k, theta)\n",
-      "A"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "density(A**2)(x)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    }
-   ],
-   "metadata": {}
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from sympy import *\n",
+    "init_printing(use_latex='mathjax')\n",
+    "x, y, z = symbols('x,y,z')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Probability Modeling"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from sympy.stats import *"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "X = Normal('X', 0, 1)\n",
+    "X"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Density"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Density of expressions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Probability"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Sampling"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Dice"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "A = Die('A', 6)\n",
+    "B = Die('B', 6)\n",
+    "\n",
+    "density(A+B)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Evaluate = False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## More distributions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from sympy.stats import Gamma\n",
+    "Gamma?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "k = Symbol('k', positive=True)\n",
+    "theta = Symbol('theta', positive=True)\n",
+    "A = Gamma('A', k, theta)\n",
+    "A"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "density(A**2)(x)"
+   ]
   }
- ]
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 0
 }


### PR DESCRIPTION
Tutorial notebook use old v3 format for notebook. The PR converts every notebook into new v4 format. The conversion has been done using `jupyter nbconvert --inplace --to=notebook *.ipynb` suggested on this [SO answer](http://stackoverflow.com/questions/30310262/how-do-i-convert-ipython-v3-notebooks-to-jupyter-v4). Not converting is not a very practical option as jupyter does it automatically every-time you open an older notebook.
